### PR TITLE
Show app version in footer on DEV envs

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,13 @@ export const DEBUG = process.env.VUE_APP_DEBUG
 export const IS_TESTING_WITH_CYPRESS = !!window.Cypress
 
 /**
+ * Current app version (from package.json)
+ *
+ * @type {String}
+ */
+export const APP_VERSION = process.env.PACKAGE_VERSION
+
+/**
  * Adds a slash at the end of the URL if there is none
  *
  * @param {String} url

--- a/src/modules/menu/MenuModule.vue
+++ b/src/modules/menu/MenuModule.vue
@@ -8,6 +8,7 @@
                 <slot />
                 <HeaderMenuButton />
                 <MenuTray class="menu-tray" />
+                <div v-if="showAppVersion" class="app-version small">v{{ appVersion }}</div>
             </div>
             <HeaderLoadingBar v-if="showLoadingBar" />
         </div>
@@ -51,6 +52,13 @@
             max-width: 40rem;
         }
     }
+    .app-version {
+        position: fixed;
+        bottom: 0.1rem;
+        left: 50%;
+        transform: translate(-50%, 0);
+        color: $gray-400;
+    }
 }
 .slide-up-leave-active,
 .slide-up-enter-active {
@@ -91,6 +99,7 @@ import HeaderSwissConfederationText from './components/header/HeaderSwissConfede
 
 import MenuTray from './components/MenuTray'
 import HeaderLoadingBar from '@/modules/menu/components/header/HeaderLoadingBar'
+import { APP_VERSION, DEBUG } from '@/config'
 
 export default {
     components: {
@@ -100,11 +109,19 @@ export default {
         SwissFlag,
         MenuTray,
     },
+    data() {
+        return {
+            appVersion: APP_VERSION,
+        }
+    },
     computed: {
         ...mapState({
             showHeader: (state) => state.ui.showHeader,
             showLoadingBar: (state) => state.ui.showLoadingBar,
         }),
+        showAppVersion: function () {
+            return DEBUG
+        },
     },
 }
 </script>

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,6 @@
 const { resolve } = require('path')
+const fs = require('fs')
+const { DefinePlugin } = require('webpack')
 
 // loading external utility function to read git metadata
 const gitBranch = require('git-branch')
@@ -16,6 +18,19 @@ if (process.env.DEPLOY && branch !== 'master' && branch !== 'develop') {
     publicPath = `/${branch}/`
 }
 
+// Getting package.json version in order to expose it to the app
+const packageJson = JSON.parse(fs.readFileSync('./package.json'))
+const version = packageJson.version || 0
+
 module.exports = {
     publicPath,
+    configureWebpack: {
+        plugins: [
+            new DefinePlugin({
+                'process.env': {
+                    PACKAGE_VERSION: '"' + version + '"',
+                },
+            }),
+        ],
+    },
 }


### PR DESCRIPTION
some kind of end-of-line issue in `vue.config.js`, maybe I pushed it last time with Window carriage return... This time I fixed it with `ESLint` so it should not change like that anymore

[Test link](https://web-mapviewer.dev.bgdi.ch/feature_BGDIINF_SB-1501/index.html)