### PR TITLE
Prepare buildspec.yml for latest AWS Codebuild image

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -12,10 +12,6 @@ phases:
     runtime-versions:
       nodejs: latest
     commands:
-      # ensuring we have the latest libs on this Ubuntu
-      - apt-get update -y
-      # install libs needed by Cypress
-      - apt-get install -y libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 xvfb
       # npm ci reads only the package-lock.json file (not the package.json) to be sure to have exactly the same libraries
       # that were used last time npm install was done on the developer's device.
       - npm ci


### PR DESCRIPTION
Removing everything `apt-get` as it's not required for Cypress to run properly (and it makes the CI fail)

[Test link](https://web-mapviewer.dev.bgdi.ch/try_latest_codebuild_image/index.html)