### PR TITLE
Browserlist proposition

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,3 +1,5 @@
 > 1%
 last 2 versions
 not dead
+not IE 11
+Firefox ESR

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=no">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title><%= htmlWebpackPlugin.options.title %></title>


### PR DESCRIPTION
It looks like current version of browserlist includes the not supported IE11.
Here is a proposition of update:
```bash
node_modules/.bin/browserslist 
and_chr 89
and_ff 86
and_qq 10.4
and_uc 12.12
android 89
baidu 7.12
chrome 89
chrome 88
chrome 87
edge 89
edge 88
firefox 86
firefox 85
firefox 78
ios_saf 14.0-14.5
ios_saf 13.4-13.7
kaios 2.5
op_mini all
op_mob 62
opera 73
opera 72
safari 14
safari 13.1
samsung 13.0
samsung 12.0
```

[Test link](https://web-mapviewer.dev.bgdi.ch/browserlist_update/index.html)