### PR TITLE
Lower branch name in deploy script

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -4,7 +4,7 @@
 // a S3 bucket, defined by the target given as a script argument.
 
 // describing possible arguments for this script (launch with --help to see the doc)
-const yargs = require('yargs');
+const yargs = require('yargs')
 const argv = yargs
     .usage('Usage: $0 <target> [options]')
     .command('dev', 'Deploy dist/* files to DEV bucket')
@@ -13,127 +13,140 @@ const argv = yargs
     .option('role', {
         describe: 'AWS ARN for the role to use (will switch to role before uploading)',
         default: null,
-        type: 'string'
+        type: 'string',
     })
     .option('region', {
         describe: 'AWS Region (default is Frankfurt)',
         default: 'eu-central-1',
-        type: 'string'
+        type: 'string',
     })
     .option('branch', {
-        describe: 'Git branch. Will be used as the root folder in S3. This script will try to automatically find the branch name if this option is not given.',
+        describe:
+            'Git branch. Will be used as the root folder in S3. This script will try to automatically find the branch name if this option is not given.',
         default: null,
-        type: 'string'
+        type: 'string',
     })
     .demandCommand()
     .help()
-    .showHelpOnFail(true, 'a target is needed')
-    .argv;
+    .showHelpOnFail(true, 'a target is needed').argv
 
 // Declaring all possible buckets (keys are targets)
 const buckets = {
     dev: 'web-mapviewer-dev',
     int: 'web-mapviewer-int',
-    prod: 'web-mapviewer-prod'
-};
+    prod: 'web-mapviewer-prod',
+}
 
 // checking that the target is valid
 if (argv._.length > 1) {
     console.error('To many arguments, only one target must be provided')
-    process.exit(1);
+    process.exit(1)
 }
-const target = argv._[0];
+const target = argv._[0]
 if (!target || !(target in buckets)) {
-    console.error(`Non-existing target specified: "${target}"`);
-    yargs.showHelp();
-    process.exit(1);
+    console.error(`Non-existing target specified: "${target}"`)
+    yargs.showHelp()
+    process.exit(1)
 }
 
 // Load the AWS SDK for Node.js
-const AWS = require('aws-sdk');
+const AWS = require('aws-sdk')
 // Set the region
-AWS.config.update({region: argv.region});
+AWS.config.update({ region: argv.region })
 
 // Loading filesystem API
-const { resolve } = require('path');
+const { resolve } = require('path')
 
 // loading external utility function to read git metadata
-const gitBranch = require('git-branch');
+const gitBranch = require('git-branch')
 
 // Loading internal utility functions
-const s3Utils = require('./s3-utils');
-const fileUtils = require('./file-utils');
+const s3Utils = require('./s3-utils')
+const fileUtils = require('./file-utils')
 
 // Checking if index.html file is present in dist folder (if build has been done beforehand)
 if (!fileUtils.fileExists('./dist/index.html')) {
     console.error('Please build the project before trying to deploy')
-    process.exit(1);
+    process.exit(1)
 }
 
 // Create S3 service object
-s3Utils.getS3(argv.region, argv.role)
-.then(s3 => {
-
-    (async () => {
-
-        // Checking current branch
-        let branch = argv.branch;
-        if (!branch) {
-            branch = await gitBranch();
-        }
-        if (!branch) {
-            console.error('Failed to read automatically on which git branch this script has been launched, please specify option --branch and relaunch the script');
-            process.exit(1);
-        }
-
-        // if branch is not master and target is prod, we exit
-        if (branch !== 'master' && target === 'prod') {
-            console.error('It is forbidden to deploy anything else than `master` on the PROD environment');
-            process.exit(1);
-        }
-        // if branch is develop and target is not dev, we exit (if it was permitted to deploy on INT for instance, it would
-        // not be a viable build as vue.config.js sets the publicPath to the root of the bucket for develop and master branch
-        // but the code would be deployed in a /develop folder on INT, breaking all links to JS and CSS files)
-        if (branch === 'develop' && target !== 'dev') {
-            console.error('Branch `develop` can only be deployed on DEV environment');
-            process.exit(1);
-        }
-        // bucket folder will be branch name expect if we are on `master` and target is INT or PROD, or if we are on `develop` and target is DEV
-        let bucketFolder;
-        if (branch === 'master' && (target === 'int' || target === 'prod') || branch === 'develop' && target === 'dev') {
-            bucketFolder = '';
-        } else {
-            bucketFolder = branch;
-        }
-
-        const distFolderRelativePath = './dist/';
-        const distFolderFullPath = resolve(distFolderRelativePath);
-
-        let countFileBeingUploaded = 0;
-        for await (const file of fileUtils.getFiles(distFolderRelativePath)) {
-            // file paths returned by fileUtils are absolute paths, we need to get rid of the project directory part to have a valid S3 path.
-            let bucketFilePath = bucketFolder + file.replace(distFolderFullPath, '');
-            countFileBeingUploaded++;
-            // removing any slash at the beginning so that it doesn't create a / folder (can happen if we are deploying something at the root of the bucket)
-            // and a slash has been left by the dist path removal).
-            if (bucketFilePath.startsWith('/')) {
-                bucketFilePath = bucketFilePath.substring(1);
+s3Utils
+    .getS3(argv.region, argv.role)
+    .then((s3) => {
+        ;(async () => {
+            // Checking current branch
+            let branch = argv.branch
+            if (!branch) {
+                branch = await gitBranch()
             }
-            // just to be extra careful, replacing any // by a single / in the filepath
-            bucketFilePath = bucketFilePath.replace('//', '/');
+            if (!branch) {
+                console.error(
+                    'Failed to read automatically on which git branch this script has been launched, please specify option --branch and relaunch the script'
+                )
+                process.exit(1)
+            }
 
-            s3Utils.uploadFileToS3(s3, file, buckets[target], bucketFilePath, () => {
-                countFileBeingUploaded--;
-                // checking if all files are done being uploaded
-                if (countFileBeingUploaded === 0) {
-                    // outputs a URL to the index.html file hosted on the bucket in the console.
-                    const appUrl = `https://web-mapviewer.${target}.bgdi.ch/${bucketFolder + (bucketFolder !== '' ? '/' : '')}index.html`;
-                    console.log('');
-                    console.log('*************************************************************************************')
-                    console.log(`Success, your deployment is now available at : ${appUrl}`);
-                    console.log('*************************************************************************************')
+            // if branch is not master and target is prod, we exit
+            if (branch !== 'master' && target === 'prod') {
+                console.error(
+                    'It is forbidden to deploy anything else than `master` on the PROD environment'
+                )
+                process.exit(1)
+            }
+            // if branch is develop and target is not dev, we exit (if it was permitted to deploy on INT for instance, it would
+            // not be a viable build as vue.config.js sets the publicPath to the root of the bucket for develop and master branch
+            // but the code would be deployed in a /develop folder on INT, breaking all links to JS and CSS files)
+            if (branch === 'develop' && target !== 'dev') {
+                console.error('Branch `develop` can only be deployed on DEV environment')
+                process.exit(1)
+            }
+            // bucket folder will be branch name expect if we are on `master` and target is INT or PROD, or if we are on `develop` and target is DEV
+            let bucketFolder
+            if (
+                (branch === 'master' && (target === 'int' || target === 'prod')) ||
+                (branch === 'develop' && target === 'dev')
+            ) {
+                bucketFolder = ''
+            } else {
+                bucketFolder = branch
+            }
+
+            const distFolderRelativePath = './dist/'
+            const distFolderFullPath = resolve(distFolderRelativePath)
+
+            let countFileBeingUploaded = 0
+            for await (const file of fileUtils.getFiles(distFolderRelativePath)) {
+                // file paths returned by fileUtils are absolute paths, we need to get rid of the project directory part to have a valid S3 path.
+                let bucketFilePath = bucketFolder + file.replace(distFolderFullPath, '')
+                countFileBeingUploaded++
+                // removing any slash at the beginning so that it doesn't create a / folder (can happen if we are deploying something at the root of the bucket)
+                // and a slash has been left by the dist path removal).
+                if (bucketFilePath.startsWith('/')) {
+                    bucketFilePath = bucketFilePath.substring(1)
                 }
-            });
-        }
-    })()
-}).catch(console.error)
+                // just to be extra careful, replacing any // by a single / in the filepath
+                bucketFilePath = bucketFilePath.replace('//', '/')
+
+                s3Utils.uploadFileToS3(s3, file, buckets[target], bucketFilePath, () => {
+                    countFileBeingUploaded--
+                    // checking if all files are done being uploaded
+                    if (countFileBeingUploaded === 0) {
+                        // outputs a URL to the index.html file hosted on the bucket in the console.
+                        const appUrl = `https://web-mapviewer.${target}.bgdi.ch/${
+                            bucketFolder + (bucketFolder !== '' ? '/' : '')
+                        }index.html`
+                        console.log('')
+                        console.log(
+                            '*************************************************************************************'
+                        )
+                        console.log(`Success, your deployment is now available at : ${appUrl}`)
+                        console.log(
+                            '*************************************************************************************'
+                        )
+                    }
+                })
+            }
+        })()
+    })
+    .catch(console.error)

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -86,6 +86,8 @@ s3Utils
                 )
                 process.exit(1)
             }
+            // lowering case for branch name
+            branch = branch.toLowerCase()
 
             // if branch is not master and target is prod, we exit
             if (branch !== 'master' && target === 'prod') {


### PR DESCRIPTION
as the GitHub action that creates the test link lowers the branch name while generating the URL.
It doesn't work well when we uses Jira numbers that contains uppercase characters.

I've also linted the file in the first commit, so look at the second for the real change.

[Test link](https://web-mapviewer.dev.bgdi.ch/fix_deploy_script/index.html)