### PR TITLE
Feature BGDIINF_SB-1704: transferring lang selection to settings section

### DIFF
--- a/src/modules/menu/components/MenuSettings.vue
+++ b/src/modules/menu/components/MenuSettings.vue
@@ -1,0 +1,17 @@
+<template>
+    <div id="menu-settings" data-cy="menu-settings-content">
+        <div id="menu-lang-selector">
+            <LangSwitchToolbar />
+        </div>
+    </div>
+</template>
+
+<script>
+import LangSwitchToolbar from '@/modules/i18n/components/LangSwitchToolbar'
+
+export default {
+    components: {
+        LangSwitchToolbar,
+    },
+}
+</script>

--- a/src/modules/menu/components/MenuTray.vue
+++ b/src/modules/menu/components/MenuTray.vue
@@ -11,6 +11,13 @@
             <MenuSection :title="$t('layers_displayed')" :show-content="true">
                 <MenuActiveLayersList />
             </MenuSection>
+            <MenuSection
+                :title="$t('settings')"
+                :show-content="false"
+                data-cy="menu-settings-section"
+            >
+                <MenuSettings />
+            </MenuSection>
         </div>
     </transition>
 </template>
@@ -32,7 +39,7 @@
 
 <script>
 import { mapActions, mapState } from 'vuex'
-import MenuLangSelector from '@/modules/menu/components/MenuLangSelector'
+import MenuSettings from '@/modules/menu/components/MenuSettings.vue'
 import MenuActiveLayersList from '@/modules/menu/components/activeLayers/MenuActiveLayersList'
 import MenuSection from '@/modules/menu/components/MenuSection'
 import MenuTopicSection from '@/modules/menu/components/topics/MenuTopicSection'
@@ -42,7 +49,7 @@ export default {
         MenuTopicSection,
         MenuSection,
         MenuActiveLayersList,
-        MenuLangSelector,
+        MenuSettings,
     },
     computed: {
         ...mapState({

--- a/tests/e2e/specs/header.spec.js
+++ b/tests/e2e/specs/header.spec.js
@@ -2,6 +2,8 @@
 
 const overlaySelector = '[data-cy="overlay"]'
 const menuButtonSelector = '[data-cy="menu-button"]'
+const menuSettingsContentSelector = '[data-cy="menu-settings-content"]'
+const menuSettingsSectionSelector = '[data-cy="menu-settings-section"]'
 
 describe('Test functions for the header / search bar', () => {
     beforeEach(() => {
@@ -13,27 +15,49 @@ describe('Test functions for the header / search bar', () => {
     const checkMenuTrayValue = (value) => {
         cy.readStoreValue('state.ui.showMenuTray').should('eq', value)
     }
-    it("doesn't show the menu and overlay at app startup", () => {
-        checkStoreOverlayValue(false)
-        checkMenuTrayValue(false)
+
+    context('Menu basic functionalities', () => {
+        it("doesn't show the menu and overlay at app startup", () => {
+            checkStoreOverlayValue(false)
+            checkMenuTrayValue(false)
+        })
+
+        it('shows the menu and the overlay when the menu button is pressed', () => {
+            cy.get(menuButtonSelector).click()
+            checkStoreOverlayValue(true)
+            checkMenuTrayValue(true)
+        })
+
+        it('hides the menu and the overlay if the menu button is clicked again', () => {
+            cy.get(menuButtonSelector).click().click()
+            checkStoreOverlayValue(false)
+            checkMenuTrayValue(false)
+        })
+
+        it('hides the menu and the overlay when the overlay is clicked', () => {
+            cy.get(menuButtonSelector).click()
+            cy.get(overlaySelector).click()
+            checkStoreOverlayValue(false)
+            checkMenuTrayValue(false)
+        })
     })
 
-    it('shows the menu and the overlay when the menu button is pressed', () => {
-        cy.get(menuButtonSelector).click()
-        checkStoreOverlayValue(true)
-        checkMenuTrayValue(true)
-    })
+    context('Settings Menu Section', () => {
+        it('does not show the settings sections on opening the menu', () => {
+            cy.get(menuButtonSelector).click()
+            cy.get(menuSettingsContentSelector).should('be.hidden')
+        })
 
-    it('hides the menu and the overlay if the menu button is clicked again', () => {
-        cy.get(menuButtonSelector).click().click()
-        checkStoreOverlayValue(false)
-        checkMenuTrayValue(false)
-    })
+        it('shows the settings on clicking on the settings section', () => {
+            cy.get(menuButtonSelector).click()
+            cy.get(menuSettingsSectionSelector).click()
+            cy.get(menuSettingsContentSelector).should('be.visible')
+        })
 
-    it('hides the menu and the overlay when the overlay is clicked', () => {
-        cy.get(menuButtonSelector).click()
-        cy.get(overlaySelector).click()
-        checkStoreOverlayValue(false)
-        checkMenuTrayValue(false)
+        it('hides the settings section if clicked again', () => {
+            cy.get(menuButtonSelector).click()
+            cy.get(menuSettingsSectionSelector).click().click()
+            cy.get(menuSettingsContentSelector).should('be.hidden')
+        })
     })
 })


### PR DESCRIPTION
Issue : We wanted the language selection to be part of a settings section

Fix : We created a settings sections and placed the language selection within it.
We added some tests to make sure the settings section is closed on opening the menu, that it opens on clicking on it and it closes on clicking again.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature_lang_selection_in_settings_menu/index.html)