### PR TITLE
BGDIING_SB-1788: BUGFIX - ordering arrows not disabled when useless

### DIFF
--- a/src/modules/menu/components/activeLayers/MenuActiveLayersList.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersList.vue
@@ -9,6 +9,8 @@
             :name="layer.name"
             :time-config="layer.timeConfig"
             :show-details="showLayerDetailsForId === layer.getID()"
+            :is-first-layer="isFirstLayer(layer.getID())"
+            :is-last-layer="isLastLayer(layer.getID())"
             @removeLayer="onRemoveLayer"
             @toggleLayerVisibility="onToggleLayerVisibility"
             @toggleLayerDetails="onToggleLayerDetails"
@@ -83,6 +85,12 @@ export default {
         },
         onTimestampChange: function (layerId, timestamp) {
             this.setTimedLayerCurrentTimestamp({ layerId, timestamp })
+        },
+        isFirstLayer: function (layerId) {
+            return this.activeLayers[0].getID() === layerId
+        },
+        isLastLayer: function (layerId) {
+            return this.activeLayers[this.activeLayers.length - 1].getID() === layerId
         },
     },
 }

--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
@@ -57,6 +57,7 @@
             </div>
             <div class="menu-layer-list-item-details-order">
                 <button
+                    :disabled="isFirstLayer"
                     class="btn btn-default"
                     :data-cy="`button-raise-order-layer-${id}`"
                     @click="onOrderChange(1)"
@@ -64,6 +65,7 @@
                     <font-awesome-icon size="lg" :icon="['fas', 'arrow-up']" />
                 </button>
                 <button
+                    :disabled="isLastLayer"
                     class="btn btn-default"
                     :data-cy="`button-lower-order-layer-${id}`"
                     @click="onOrderChange(-1)"
@@ -137,6 +139,14 @@ export default {
             default: null,
         },
         showDetails: {
+            type: Boolean,
+            default: false,
+        },
+        isFirstLayer: {
+            type: Boolean,
+            default: false,
+        },
+        isLastLayer: {
             type: Boolean,
             default: false,
         },

--- a/tests/e2e/specs/layers.spec.js
+++ b/tests/e2e/specs/layers.spec.js
@@ -113,9 +113,11 @@ describe('Test of layer handling', () => {
             cy.get('[data-cy="menu-button"]').click()
         })
         const openLayerSettings = (layerId) => {
+            cy.get(`[data-cy="div-layer-settings-${layerId}"]`).should('be.hidden')
             cy.get(`[data-cy="button-open-visible-layer-settings-${layerId}"]`)
                 .should('be.visible')
                 .click()
+            cy.get(`[data-cy="div-layer-settings-${layerId}"]`).should('be.visible')
         }
         it('shows a visible layer in the menu', () => {
             visibleLayerIds.forEach((layerId) => {
@@ -224,6 +226,59 @@ describe('Test of layer handling', () => {
                         }
                     })
                 })
+            })
+        })
+        context('Re-ordering of layers', () => {
+            const checkOrderButtons = (layerId, raiseShouldBeDisabled, lowerShouldBeDisabled) => {
+                cy.get(`[data-cy="button-raise-order-layer-${layerId}"]`)
+                    .should('be.visible')
+                    .should(`${!raiseShouldBeDisabled ? 'not.' : ''}be.disabled`)
+                cy.get(`[data-cy="button-lower-order-layer-${layerId}"]`)
+                    .should('be.visible')
+                    .should(`${!lowerShouldBeDisabled ? 'not.' : ''}be.disabled`)
+            }
+            it('Disable the "Raise Order" arrow on the top layer', () => {
+                const layerId = visibleLayerIds[0]
+                openLayerSettings(layerId)
+                checkOrderButtons(layerId, true, false)
+            })
+            it('Disable the "Lower Order" arrow on the bottom layer', () => {
+                const layerId = visibleLayerIds[2]
+                openLayerSettings(layerId)
+                checkOrderButtons(layerId, false, true)
+            })
+            it('enables both button for any other layer', () => {
+                const layerId = visibleLayerIds[1]
+                openLayerSettings(layerId)
+                checkOrderButtons(layerId, false, false)
+            })
+            it('disable the "raise order" arrow on a layer which gets to the top layer', () => {
+                const layerId = visibleLayerIds[1]
+                openLayerSettings(layerId)
+                checkOrderButtons(layerId, false, false)
+                cy.get(`[data-cy="button-raise-order-layer-${layerId}"]`).click()
+                checkOrderButtons(layerId, true, false)
+            })
+            it('disable the "lower order" arrow on a layer which gets to the bottom layer', () => {
+                const layerId = visibleLayerIds[1]
+                openLayerSettings(layerId)
+                checkOrderButtons(layerId, false, false)
+                cy.get(`[data-cy="button-lower-order-layer-${layerId}"]`).click()
+                checkOrderButtons(layerId, false, true)
+            })
+            it('enable the "lower order" arrow on a layer which is raised from the bottom', () => {
+                const layerId = visibleLayerIds[2]
+                openLayerSettings(layerId)
+                checkOrderButtons(layerId, false, true)
+                cy.get(`[data-cy="button-raise-order-layer-${layerId}"]`).click()
+                checkOrderButtons(layerId, false, false)
+            })
+            it('enable the "raise order" arrow on a layer which is lowered from the top', () => {
+                const layerId = visibleLayerIds[0]
+                openLayerSettings(layerId)
+                checkOrderButtons(layerId, true, false)
+                cy.get(`[data-cy="button-lower-order-layer-${layerId}"]`).click()
+                checkOrderButtons(layerId, false, false)
             })
         })
     })


### PR DESCRIPTION
Issue : The layer ordering arrows buttons were not disabled when the layer was already at the top or the bottom of the list and the arrow became useless.

Fix : 
Adding a new property to check if we should disable the button
e2e tests.

[Test link](https://web-mapviewer.dev.bgdi.ch/issue_1788/index.html)