### PR TITLE
Update pr-labeler.yml

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - edited
+  push:
 
 jobs:
   pr-labeler:


### PR DESCRIPTION
Also trigger the PR Auto Labeler on push event
    
 Because the PR auto labeler workflow is required before merging, it needs to be runned
 also each time a push on the PR is done, otherwise the merge gets
 blocked until the workflow has been runned.

[Test link](https://web-mapviewer.dev.bgdi.ch/bug-workflow/index.html)