### PR TITLE
BGDIINF_SB-2023: bugfix ; applying drawing module css correctly

### DIFF
--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -293,7 +293,7 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 .tooltip-measure,
 .draw-measure-tmp,
 .draw-help-popup {

--- a/src/modules/drawing/components/SharePopup.vue
+++ b/src/modules/drawing/components/SharePopup.vue
@@ -3,13 +3,20 @@
         <div class="form-group">
             <label>{{ $t('draw_share_user_link') }}:</label>
             <div class="input-group input-group-sm mb-3">
-                <input type="text" class="form-control" :value="fileUrl" disabled />
+                <input
+                    type="text"
+                    class="form-control"
+                    :value="fileUrl"
+                    readonly
+                    @focus="$event.target.select()"
+                    @click="copyUrl(false)"
+                />
                 <div class="input-group-append">
                     <button
                         class="btn btn-outline-secondary"
                         type="button"
                         data-cy="drawing-share-normal-link"
-                        @click="copyUrl"
+                        @click="copyUrl(false)"
                     >
                         {{ fileUrlCopied ? $t('copy_success') : $t('copy_url') }}
                     </button>
@@ -19,13 +26,20 @@
         <div v-if="adminUrl" class="form-group">
             <label>{{ $t('draw_share_admin_link') }}:</label>
             <div class="input-group input-group-sm mb-3">
-                <input type="text" class="form-control" :value="adminUrl" disabled />
+                <input
+                    type="text"
+                    class="form-control"
+                    :value="adminUrl"
+                    readonly
+                    @focus="$event.target.select()"
+                    @click="copyUrl(true)"
+                />
                 <div class="input-group-append">
                     <button
                         class="btn btn-outline-secondary"
                         type="button"
                         data-cy="drawing-share-admin-link"
-                        @click="(e) => copyUrl(e, true)"
+                        @click="copyUrl(true)"
                     >
                         {{ adminUrlCopied ? $t('copy_success') : $t('copy_url') }}
                     </button>
@@ -72,7 +86,7 @@ export default {
         },
     },
     methods: {
-        copyUrl: async function (event, adminUrl = false) {
+        copyUrl: async function (adminUrl = false) {
             if (adminUrl) {
                 await navigator.clipboard.writeText(this.adminUrl)
                 this.adminUrlCopied = true

--- a/src/modules/drawing/components/styling/DrawingStyleColorSelector.vue
+++ b/src/modules/drawing/components/styling/DrawingStyleColorSelector.vue
@@ -64,6 +64,7 @@ export default {
         height: 2rem;
         border-radius: 1rem;
         border: 1px solid black;
+        cursor: pointer;
     }
 }
 </style>

--- a/src/modules/overlay/components/ModalWithOverlay.vue
+++ b/src/modules/overlay/components/ModalWithOverlay.vue
@@ -2,7 +2,7 @@
     <portal to="modal-container">
         <div class="modal-popup">
             <div class="card">
-                <div class="card-header">
+                <div class="card-header user-select-none">
                     <span v-if="title" class="float-start align-middle">{{ title }}</span>
                     <ButtonWithIcon
                         :button-font-awesome-icon="['fa', 'times']"


### PR DESCRIPTION
So, I was on the disclaimer branch while working on this, thus I think it's better to merge this in the disclaimer branch, then merge the full drawing module.

Issue: drawing module CSS did not display cursors correctly

Fix: removed the css scope from the drawing module css definition
Also added a functionality where users clicking the link in the drawing sharing popup will copy the link to the clipboard and select the whole link at the same time.


[Test link](https://web-mapviewer.dev.bgdi.ch/bgdiinf_sb_2023/index.html)