### PR TITLE
BGDIINF_SB-2089: Fixed drawing measurement

### DIFF
--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -314,7 +314,7 @@ export default {
         position: absolute;
         left: 50%;
         bottom: -6px;
-        margin-left: -7px;
+        margin-left: -6px;
         content: '';
         border-top: 6px solid rgba(255, 0, 0, 0.9);
         border-right: 6px solid transparent;

--- a/src/modules/drawing/lib/MeasureManager.js
+++ b/src/modules/drawing/lib/MeasureManager.js
@@ -33,7 +33,7 @@ export default class MeasureManager {
     }
 
     // Creates a new measure tooltip
-    createOverlay(cssClass, stopEvent = true) {
+    createOverlay(cssClass, stopEvent = false) {
         const tooltipElement = document.createElement('div')
         tooltipElement.className = cssClass || 'tooltip-measure'
         return new Overlay({


### PR DESCRIPTION
The drawing measurement click and double click action were not
triggered, which means that we could not end the measurement drawing
tool nor add subsequent measurement point.

This was due to the fact that the measurement tooltip was over the
drawing measurement and that this overlay did not pass the click event
futher. Moving the tooltip away from the measurement line would also
have fixed the issue but the display wouldn't have been niche (also not
sure if this would have worked on a touch display).

Also center the measurement tooltip on the line, it was one pixel off.

[Test link](https://web-mapviewer.dev.bgdi.ch/bug-bgdiinf_sb-2089-drawing-ruler/index.html)