### PR TITLE
BGDIINF_SB-1993: Added support for legacy KML adminid query parameter

### DIFF
--- a/src/api/files.api.js
+++ b/src/api/files.api.js
@@ -117,8 +117,8 @@ export const getKmlMetadataUrl = (id) => {
 /**
  * Publish KML on backend
  *
- * @param {string} kml
- * @returns {Promise<FilesResponse>}
+ * @param {string} kml KML content
+ * @returns {Promise<KmlMetadata>}
  */
 export const createKml = (kml) => {
     return new Promise((resolve, reject) => {
@@ -150,10 +150,10 @@ export const createKml = (kml) => {
 /**
  * Update KML on backend
  *
- * @param {string} id 'id' from FilesResponse
- * @param {string} adminId 'admin_id' from FilesResponse
- * @param {string} kml
- * @returns {Promise<FilesResponse>}
+ * @param {string} id KML ID
+ * @param {string} adminId KML admin ID
+ * @param {string} kml KML content
+ * @returns {Promise<KmlMetadata>}
  */
 export const updateKml = (id, adminId, kml) => {
     return new Promise((resolve, reject) => {
@@ -187,7 +187,7 @@ export const updateKml = (id, adminId, kml) => {
 /**
  * Get KML file
  *
- * @param {string} id From FilesResponse
+ * @param {string} id KML ID
  * @returns {Promise<string>} KML file content
  */
 export const getKml = (id) => {

--- a/src/api/files.api.js
+++ b/src/api/files.api.js
@@ -210,3 +210,30 @@ export const getKml = (id) => {
             })
     })
 }
+
+/**
+ * Get KML metadata by adminId
+ *
+ * @param {string} adminId KML admin ID
+ * @returns {Promise<KmlMetadata>} KML metadata
+ */
+export const getKmlMetadataByAdminId = (adminId) => {
+    return new Promise((resolve, reject) => {
+        validateAdminId(adminId, reject)
+        axios
+            .get(`${API_SERVICE_KML_BASE_URL}${urlPrefix}admin?admin_id=${adminId}`)
+            .then((response) => {
+                if (response.status === 200 && response.data) {
+                    resolve(KmlMetadata.fromApiData(response.data))
+                } else {
+                    const msg = `Incorrect response while getting metadata for kml admin_id=${adminId}`
+                    log('error', msg, response)
+                    reject(msg)
+                }
+            })
+            .catch((error) => {
+                log('error', `Error while getting metadata for kml admin_id=${adminId}`)
+                reject(error)
+            })
+    })
+}

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -26,6 +26,130 @@ const parseLegacyParams = (search) => {
     return params
 }
 
+const handleLegacyKmlAdminIdParam = async (legacyParams, newQuery) => {
+    log('debug', 'Transforming legacy kml adminid, get KML ID from adminId...')
+    const kmlLayer = await getKmlLayerFromLegacyAdminIdParam(legacyParams['adminid'])
+    log('debug', 'Adding KML layer from legacy kml adminid')
+    if (newQuery.layers) {
+        newQuery.layers = `${newQuery.layers};${transformLayerIntoUrlString(kmlLayer)}`
+    } else {
+        newQuery.layers = transformLayerIntoUrlString(kmlLayer)
+    }
+
+    // remove the legacy param from the newQuery
+    delete newQuery.adminid
+
+    return newQuery
+}
+
+const handleLegacyParams = (legacyParams, store, to, next) => {
+    log('info', `Legacy permalink with param=`, legacyParams, ' to.query=', to.query)
+    // if so, we transfer all old param (stored before vue-router's /#) and transfer them to the MapView
+    // we will also transform legacy zoom level here (see comment below)
+    const newQuery = { ...to.query }
+    const legacyCoordinates = []
+    Object.keys(legacyParams).forEach((param) => {
+        let value
+        let key = param
+        switch (param) {
+            // we need te re-evaluate LV95 zoom, as it was a zoom level tailor made for this projection
+            // (and not made to cover the whole globe)
+            case 'zoom':
+                value = translateSwisstopoPyramidZoomToMercatorZoom(legacyParams[param])
+                if (!value) {
+                    // if the value is not defined in the old zoom system, we use the 'default' zoom level
+                    // of 8 (which will roughly show the whole territory of Switzerland)
+                    value = 8
+                }
+                key = 'z'
+                break
+
+            // storing coordinate parts for later conversion
+            case 'E':
+            case 'X':
+                legacyCoordinates[0] = Number(legacyParams[param])
+                break
+            case 'N':
+            case 'Y':
+                legacyCoordinates[1] = Number(legacyParams[param])
+                break
+
+            // taking all layers related param aside so that they can be processed later (see below)
+            // this only occurs if the syntax is recognized as a mf-geoadmin3 syntax (or legacy)
+            case 'layers':
+                if (isLayersUrlParamLegacy(legacyParams[param])) {
+                    // for legacy layers param, we need to give the whole search query
+                    // as it needs to look for layers, layers_visibility, layers_opacity and
+                    // layers_timestamp param altogether
+                    const layers = getLayersFromLegacyUrlParams(
+                        store.state.layers.config,
+                        window.location.search
+                    )
+                    value = layers.map((layer) => transformLayerIntoUrlString(layer)).join(';')
+                    log('debug', 'Importing legacy layers as', value)
+                } else {
+                    // if not legacy, we let it go as it is
+                    value = legacyParams[param]
+                }
+                break
+            case 'layers_opacity':
+            case 'layers_visibility':
+            case 'layers_timestamp':
+                // we ignore those params as they are now obsolete
+                // see adr/2021_03_16_url_param_structure.md
+                break
+
+            // if no special work to do, we just copy past legacy params to the new viewer
+            default:
+                value = legacyParams[param]
+        }
+
+        // if a legacy coordinate (x,y or N,E) was used, we need to guess the SRS used (either LV95 or LV03)
+        // and covert it back to EPSG:4326 (Mercator)
+        if (legacyCoordinates.length === 2 && legacyCoordinates[0] && legacyCoordinates[1]) {
+            const center = reprojectUnknownSrsCoordsToWebMercator(
+                legacyCoordinates[0],
+                legacyCoordinates[1]
+            )
+            newQuery['lon'] = round(center[0], 6)
+            newQuery['lat'] = round(center[1], 6)
+        }
+        if (value) {
+            newQuery[key] = value
+        }
+    })
+
+    // removing old query part (new ones will be added by vue-router after the /# part of the URL)
+    const urlWithoutQueryParam = window.location.href.substr(0, window.location.href.indexOf('?'))
+    window.history.replaceState({}, document.title, urlWithoutQueryParam)
+
+    if ('adminid' in legacyParams) {
+        // adminid legacy param cannot be handle above in the loop because it needs to add a layer
+        // to the layers param, thats why we do handle after.
+        handleLegacyKmlAdminIdParam(legacyParams, newQuery)
+            .then((updatedQuery) => {
+                next({
+                    name: 'MapView',
+                    query: updatedQuery,
+                })
+            })
+            .catch((error) => {
+                log('error', `Failed to retrieve KML from admin_id: ${error}`)
+                // make sure to remove the adminid from the query
+                delete newQuery.adminid
+                next({
+                    name: 'MapView',
+                    query: newQuery,
+                })
+            })
+    } else {
+        next({
+            name: 'MapView',
+            query: newQuery,
+        })
+    }
+}
+
 /**
  * Loads all URL parameters before the hash and adds them after the hash.
  *
@@ -61,127 +185,7 @@ const legacyPermalinkManagementRouterPlugin = (router, store) => {
             // before the first request, we check out if we need to manage any legacy params (from the old viewer)
             isFirstRequest = false
             if (legacyParams) {
-                log('info', `Legacy permalink with param=`, legacyParams, ' to.query=', to.query)
-                // if so, we transfer all old param (stored before vue-router's /#) and transfer them to the MapView
-                // we will also transform legacy zoom level here (see comment below)
-                const newQuery = { ...to.query }
-                const legacyCoordinates = []
-                Object.keys(legacyParams).forEach((param) => {
-                    let value
-                    let key = param
-                    switch (param) {
-                        // we need te re-evaluate LV95 zoom, as it was a zoom level tailor made for this projection
-                        // (and not made to cover the whole globe)
-                        case 'zoom':
-                            value = translateSwisstopoPyramidZoomToMercatorZoom(legacyParams[param])
-                            if (!value) {
-                                // if the value is not defined in the old zoom system, we use the 'default' zoom level
-                                // of 8 (which will roughly show the whole territory of Switzerland)
-                                value = 8
-                            }
-                            key = 'z'
-                            break
-
-                        // storing coordinate parts for later conversion
-                        case 'E':
-                        case 'X':
-                            legacyCoordinates[0] = Number(legacyParams[param])
-                            break
-                        case 'N':
-                        case 'Y':
-                            legacyCoordinates[1] = Number(legacyParams[param])
-                            break
-
-                        // taking all layers related param aside so that they can be processed later (see below)
-                        // this only occurs if the syntax is recognized as a mf-geoadmin3 syntax (or legacy)
-                        case 'layers':
-                            if (isLayersUrlParamLegacy(legacyParams[param])) {
-                                // for legacy layers param, we need to give the whole search query
-                                // as it needs to look for layers, layers_visibility, layers_opacity and
-                                // layers_timestamp param altogether
-                                const layers = getLayersFromLegacyUrlParams(
-                                    store.state.layers.config,
-                                    window.location.search
-                                )
-                                value = layers
-                                    .map((layer) => transformLayerIntoUrlString(layer))
-                                    .join(';')
-                                log('debug', 'Importing legacy layers as', value)
-                            } else {
-                                // if not legacy, we let it go as it is
-                                value = legacyParams[param]
-                            }
-                            break
-                        case 'layers_opacity':
-                        case 'layers_visibility':
-                        case 'layers_timestamp':
-                        case 'adminid':
-                            // we ignore those params as they are now obsolete
-                            // see adr/2021_03_16_url_param_structure.md
-                            break
-
-                        // if no special work to do, we just copy past legacy params to the new viewer
-                        default:
-                            value = legacyParams[param]
-                    }
-
-                    // if a legacy coordinate (x,y or N,E) was used, we need to guess the SRS used (either LV95 or LV03)
-                    // and covert it back to EPSG:4326 (Mercator)
-                    if (
-                        legacyCoordinates.length === 2 &&
-                        legacyCoordinates[0] &&
-                        legacyCoordinates[1]
-                    ) {
-                        const center = reprojectUnknownSrsCoordsToWebMercator(
-                            legacyCoordinates[0],
-                            legacyCoordinates[1]
-                        )
-                        newQuery['lon'] = round(center[0], 6)
-                        newQuery['lat'] = round(center[1], 6)
-                    }
-                    if (value) {
-                        newQuery[key] = value
-                    }
-                })
-
-                // removing old query part (new ones will be added by vue-router after the /# part of the URL)
-                const urlWithoutQueryParam = window.location.href.substr(
-                    0,
-                    window.location.href.indexOf('?')
-                )
-                window.history.replaceState({}, document.title, urlWithoutQueryParam)
-
-                if ('adminid' in legacyParams) {
-                    log('debug', 'Transforming legacy kml adminid...')
-                    getKmlLayerFromLegacyAdminIdParam(legacyParams['adminid'])
-                        .then((kmlLayer) => {
-                            log('debug', 'Adding KML layer from legacy kml adminid')
-                            if (newQuery.layers) {
-                                newQuery.layers = `${newQuery.layers};${transformLayerIntoUrlString(
-                                    kmlLayer
-                                )}`
-                            } else {
-                                newQuery.layers = transformLayerIntoUrlString(kmlLayer)
-                            }
-
-                            next({
-                                name: 'MapView',
-                                query: newQuery,
-                            })
-                        })
-                        .catch((error) => {
-                            log('error', `Failed to retrieve KML from admin_id: ${error}`)
-                            next({
-                                name: 'MapView',
-                                query: newQuery,
-                            })
-                        })
-                } else {
-                    next({
-                        name: 'MapView',
-                        query: newQuery,
-                    })
-                }
+                handleLegacyParams(legacyParams, store, to, next)
             } else {
                 next()
             }

--- a/src/router/storeSync/storeSync.routerPlugin.js
+++ b/src/router/storeSync/storeSync.routerPlugin.js
@@ -47,13 +47,13 @@ const storeSyncRouterPlugin = (router, store) => {
         ) {
             // if the value in the store differs from the one in the URL
             if (isRoutePushNeeded(store, router.currentRoute)) {
-                routeChangeIsTriggeredByThisModule = true
                 const query = {}
                 // extracting all param from the store
                 storeSyncConfig.forEach((paramConfig) =>
                     paramConfig.populateQueryWithStoreValue(query, store)
                 )
                 log('debug', 'store has changed, rerouting app to query', query)
+                routeChangeIsTriggeredByThisModule = true
                 router
                     .replace({
                         name: 'MapView',
@@ -61,6 +61,7 @@ const storeSyncRouterPlugin = (router, store) => {
                     })
                     .catch((error) => {
                         log('info', 'Error while routing to', query, error)
+                        routeChangeIsTriggeredByThisModule = false
                     })
             }
         }
@@ -70,6 +71,7 @@ const storeSyncRouterPlugin = (router, store) => {
         if (routeChangeIsTriggeredByThisModule) {
             routeChangeIsTriggeredByThisModule = false
         } else if (store.state.app.isReady) {
+            log('debug', 'Sync the store with the new URL', to.query)
             // if the route change is not made by this module we need to check if a store change is needed
             storeSyncConfig.forEach((paramConfig) => {
                 const queryValue = paramConfig.readValueFromQuery(to.query)

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -1,4 +1,5 @@
 import KMLLayer from '@/api/layers/KMLLayer.class'
+import { getKmlMetadataByAdminId } from '@/api/files.api'
 import i18n from '@/modules/i18n'
 
 function readUrlParamValue(url, paramName) {
@@ -124,4 +125,22 @@ export function getBackgroundLayerFromLegacyUrlParams(layersConfig, legacyUrlPar
         }
     }
     return undefined
+}
+
+/**
+ * Returns a KML Layer from the legacy adminid url param.
+ *
+ * @param {String} adminId KML admin ID
+ * @returns {Promise<AbstractLayer>} KML Layer
+ */
+export async function getKmlLayerFromLegacyAdminIdParam(adminId) {
+    const kmlMetaData = await getKmlMetadataByAdminId(adminId)
+
+    return new KMLLayer(
+        i18n.t('draw_layer_label'),
+        1.0,
+        kmlMetaData.links.kml,
+        kmlMetaData.id,
+        kmlMetaData.adminId
+    )
 }


### PR DESCRIPTION
The legacy URL for KML admin was as follow:

?adminid=ADMIN_ID

And now this needs to be transformed to

?layers=KML|https://public.geo.admin.ch/api/kml/files/KML_ID@adminid=ADMIN_ID

Also reorganized the code for a better readability.

And finally fixed a bug in the store sync.