### PR TITLE
BGDIINF_SB-2021: Clear the drawing on removing the layer

### DIFF
--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -103,6 +103,14 @@ export default {
         currentDrawingMode: function (mode) {
             this.manager.toggleTool(mode)
         },
+        kmlIds: function (kmlIds) {
+            // When removing a Drawing layer, the kmlIds are cleared. In this case
+            // we also need to clear the drawing in the manager which still contain
+            // the last drawing.
+            if (!kmlIds) {
+                this.manager.clearDrawing()
+            }
+        },
     },
     mounted() {
         /** @type {import('ol/Map').default} */
@@ -172,6 +180,15 @@ export default {
         }
         this.manager.on('change', () => {
             this.triggerKMLUpdate()
+        })
+        this.manager.on('clear', () => {
+            // Only trigger the kml update if we have an active open drawing. The clear
+            // event also happens when removing a drawing layer when the drawing menu
+            // is closed and in this condition we don't want to re-created now a new KML
+            // until the menu is opened again.
+            if (this.show) {
+                this.triggerKMLUpdate()
+            }
         })
         this.manager.on('select', (event) => {
             /** @type {import('./lib/DrawingManager.js').SelectEvent} */

--- a/src/modules/drawing/lib/DrawingManager.js
+++ b/src/modules/drawing/lib/DrawingManager.js
@@ -39,6 +39,12 @@ const cssGrabbing = 'cursor-grabbing'
 
 const nameInKml = 'Drawing'
 
+export class ClearEvent extends Event {
+    constructor() {
+        super('clear')
+    }
+}
+
 export class ChangeEvent extends Event {
     constructor() {
         super('change')
@@ -309,6 +315,10 @@ export default class DrawingManager extends Observable {
         return kmlString
     }
 
+    dispatchClearEvent_() {
+        this.dispatchEvent(new ClearEvent())
+    }
+
     dispatchChangeEvent_() {
         this.dispatchEvent(new ChangeEvent())
     }
@@ -557,7 +567,7 @@ export default class DrawingManager extends Observable {
     clearDrawing() {
         this.source.clear()
         this.deselect()
-        this.dispatchChangeEvent_()
+        this.dispatchClearEvent_()
     }
 
     async addKmlLayer(layer) {

--- a/src/modules/store/index.js
+++ b/src/modules/store/index.js
@@ -23,7 +23,7 @@ import geolocationManagementPlugin from './plugins/geolocation-management.plugin
 import topicChangeManagementPlugin from '@/modules/store/plugins/topic-change-management.plugin'
 import loadingBarManagementPlugin from '@/modules/store/plugins/loading-bar-management.plugin'
 import drawingOverlayAndMenuManagementPlugin from '@/modules/store/plugins/drawing-overlay-menu-management.plugin'
-import drawingAddLayerWhenDrawingDonePlugin from '@/modules/store/plugins/drawing-add-layer-when-drawing-done.plugin'
+import drawingLayerManagementPlugin from '@/modules/store/plugins/drawing-layer-management.plugin'
 
 Vue.use(Vuex)
 
@@ -39,7 +39,7 @@ export default new Vuex.Store({
         topicChangeManagementPlugin,
         loadingBarManagementPlugin,
         drawingOverlayAndMenuManagementPlugin,
-        drawingAddLayerWhenDrawingDonePlugin,
+        drawingLayerManagementPlugin,
     ],
     modules: {
         app,

--- a/src/modules/store/plugins/drawing-layer-management.plugin.js
+++ b/src/modules/store/plugins/drawing-layer-management.plugin.js
@@ -7,14 +7,19 @@ const generateKmlLayer = (kmlUrl, fileId, adminId) => {
 
 /**
  * Plugin that adds the drawing KML in the layer stack when the drawing is done (or when the KML
- * file id changes).
+ * file id changes), or that removes the drawing KML from the drawing module when the layer is
+ * removed from the layers stack.
  *
  * It will store the KML layer as soon as the file ID is available, and only add it to the layer
- * stack when the drawing is finished (when the drawing UI is being hidden)
+ * stack when the drawing is finished (when the drawing UI is being hidden).
+ *
+ * In opposite when the drawing UI is closed and the KML layer is removed from the stack, the
+ * drawing is then cleared by clearing the drawing KmlIds from the UI. This allow the creation of a
+ * new drawing.
  *
  * @param {Vuex.Store} store
  */
-const drawingAddLayerWhenDrawingDonePlugin = (store) => {
+const drawingLayerManagementPlugin = (store) => {
     let kmlLayer = null
     store.subscribe((mutation, state) => {
         if (mutation.type === 'setKmlIds') {
@@ -38,8 +43,22 @@ const drawingAddLayerWhenDrawingDonePlugin = (store) => {
                     store.dispatch('addLayer', kmlLayer)
                 }
             }
+        } else if (
+            mutation.type == 'removeLayerWithId' &&
+            !state.ui.showDrawingOverlay &&
+            !state.layers.activeLayers.find(
+                (layer) => layer.kmlFileUrl === store.getters.getDrawingPublicFileUrl
+            )
+        ) {
+            // When removing the drawing layer and the drawing menu is closed we
+            // need to clear the kml IDs of the drawing module in order to clear the
+            // kml drawing manager, this way when opening the drawing menu again we
+            // start with a new empty KML.
+            store.dispatch('setKmlIds', null)
+        } else if (mutation.type == 'clearLayers' && !state.ui.showDrawingOverlay) {
+            store.dispatch('setKmlIds', null)
         }
     })
 }
 
-export default drawingAddLayerWhenDrawingDonePlugin
+export default drawingLayerManagementPlugin

--- a/tests/e2e/specs/drawing/drawing-layer.spec.js
+++ b/tests/e2e/specs/drawing/drawing-layer.spec.js
@@ -12,3 +12,23 @@ describe('A drawing layer is added at the end of the drawing session', () => {
         })
     })
 })
+
+describe('A drawing is cleared on layer removal', () => {
+    it('clear the drawing when the drawing layer is removed', () => {
+        cy.goToDrawing()
+        cy.drawGeoms()
+        cy.get('[data-cy="drawing-toolbox-close-button"]').click()
+        cy.get(`[data-cy^="button-remove-layer-"]`).click()
+        cy.readStoreValue('state.layers.activeLayers').then((layers) => {
+            expect(layers).to.be.an('Array').lengthOf(0)
+        })
+        cy.readStoreValue('state.drawing').then((drawing) => {
+            expect(drawing.drawingKmlIds).to.be.null
+        })
+        cy.readWindowValue('drawingManager')
+            .then((manager) => manager.source.getFeatures())
+            .then((features) => {
+                expect(features).to.have.length(0)
+            })
+    })
+})


### PR DESCRIPTION
When removing a drawing layer, the drawing is cleared allow the creation
of a new drawing. Note the actual drawing file on the backend is not
touched ! This only clear the drawing from the frontend module and the
drawing can still be retrieved via its ID from the backend.

For this I needed to add a new event in the drawing manager to
differenciate the clear event from other change event. The clear event
would then only trigger a kml update when the drawing mode is active
(drawing menu open). This avoid creating empty kml by removing a drawing
layer.

[Test link](https://web-mapviewer.dev.bgdi.ch/bug-bgdiinf_sb-2021-remove-kml-layer/index.html)