### PR TITLE
Fix bootstrap import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7833,17 +7833,6 @@
             "color-convert": "^2.0.1"
           }
         },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -7881,25 +7870,6 @@
             "universalify": "^0.1.0"
           }
         },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
-        "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
         "ssri": {
           "version": "8.0.1",
           "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -7907,28 +7877,6 @@
           "dev": true,
           "requires": {
             "minipass": "^3.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "vue-loader-v16": {
-          "version": "npm:vue-loader@16.8.3",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
-          "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "hash-sum": "^2.0.0",
-            "loader-utils": "^2.0.0"
           }
         },
         "wrap-ansi": {
@@ -25248,6 +25196,87 @@
           "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
+        }
+      }
+    },
+    "vue-loader-v16": {
+      "version": "npm:vue-loader@16.8.3",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
+      "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "hash-sum": "^2.0.0",
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "loader-utils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },

--- a/src/App.vue
+++ b/src/App.vue
@@ -36,7 +36,10 @@ export default {
 </script>
 
 <style lang="scss">
-@import 'scss/bootstrap-theme';
+@import 'src/scss/webmapviewer-bootstrap-theme';
+// this import needs to happen only once, otherwise bootstrap is import/added
+// to the output CSS as many time as this file is imported
+@import 'node_modules/bootstrap/scss/bootstrap';
 #app {
     font-family: Avenir, Helvetica, Arial, sans-serif;
     -webkit-font-smoothing: antialiased;

--- a/src/modules/drawing/components/ProfilePopup.vue
+++ b/src/modules/drawing/components/ProfilePopup.vue
@@ -350,7 +350,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
+@import 'src/scss/webmapviewer-bootstrap-theme';
 
 .profile-popup {
     position: absolute;
@@ -405,7 +405,7 @@ export default {
             }
         }
         .profile-area {
-            fill: $red;
+            fill: $primary;
             fill-opacity: 0.5;
         }
         .profile-legend,

--- a/src/modules/drawing/components/styling/DrawingStyleColorSelector.vue
+++ b/src/modules/drawing/components/styling/DrawingStyleColorSelector.vue
@@ -49,7 +49,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
+@import 'src/scss/webmapviewer-bootstrap-theme';
 
 .color-select-box {
     border-radius: 2px;

--- a/src/modules/drawing/components/styling/DrawingStyleIconSelector.vue
+++ b/src/modules/drawing/components/styling/DrawingStyleIconSelector.vue
@@ -154,7 +154,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
+@import 'src/scss/webmapviewer-bootstrap-theme';
 
 .transparent-overlay {
     display: none;

--- a/src/modules/map/MapModule.vue
+++ b/src/modules/map/MapModule.vue
@@ -26,7 +26,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
+@import 'src/scss/webmapviewer-bootstrap-theme';
 
 .full-screen-map {
     position: relative;

--- a/src/modules/map/components/Footer.vue
+++ b/src/modules/map/components/Footer.vue
@@ -30,7 +30,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
+@import 'src/scss/webmapviewer-bootstrap-theme';
 
 #footer {
     position: absolute;

--- a/src/modules/map/components/openlayers/VisibleLayersCopyrights.vue
+++ b/src/modules/map/components/openlayers/VisibleLayersCopyrights.vue
@@ -58,7 +58,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
+@import 'src/scss/webmapviewer-bootstrap-theme';
 #visible-layers-copyrights {
     position: absolute;
     bottom: $footer-height;

--- a/src/modules/menu/MenuModule.vue
+++ b/src/modules/menu/MenuModule.vue
@@ -61,6 +61,7 @@ export default {
 
 <style lang="scss" scoped>
 @import 'src/scss/media-query.mixin';
+@import 'src/scss/variables';
 
 .header {
     position: fixed;

--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
@@ -172,8 +172,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
-@import '../../scss/menu-items';
+@import 'src/scss/webmapviewer-bootstrap-theme';
+@import 'src/modules/menu/scss/menu-items';
 .menu-layer-list-item {
     @extend .menu-list-item;
     .menu-layer-list-item-details {

--- a/src/modules/menu/components/header/HeaderLoadingBar.vue
+++ b/src/modules/menu/components/header/HeaderLoadingBar.vue
@@ -10,7 +10,7 @@ export default {}
 </script>
 
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
+@import 'src/scss/webmapviewer-bootstrap-theme';
 $loading-element-width: 40rem;
 $loading-bar-animation-duration: 2s;
 

--- a/src/modules/menu/components/header/SwissFlag.vue
+++ b/src/modules/menu/components/header/SwissFlag.vue
@@ -14,7 +14,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
+@import 'src/scss/webmapviewer-bootstrap-theme';
 .swiss-flag {
     height: 2em;
     width: 2em;

--- a/src/modules/menu/components/topics/MenuTopicTreeItem.vue
+++ b/src/modules/menu/components/topics/MenuTopicTreeItem.vue
@@ -91,8 +91,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
-@import '../../scss/menu-items';
+@import 'src/scss/webmapviewer-bootstrap-theme';
+@import 'src/modules/menu/scss/menu-items';
 .menu-topic-tree-item {
     @extend .menu-list-item;
     border-bottom: none;

--- a/src/modules/search/components/SearchBar.vue
+++ b/src/modules/search/components/SearchBar.vue
@@ -53,7 +53,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
+@import 'src/scss/webmapviewer-bootstrap-theme';
 #clear-search-button {
     margin-left: -40px;
     z-index: $zindex-map + 1;

--- a/src/modules/search/components/SearchResultCategory.vue
+++ b/src/modules/search/components/SearchResultCategory.vue
@@ -4,10 +4,10 @@
         class="search-category"
         :class="{ 'search-category-half-size': halfSize }"
     >
-        <div class="search-category-header">
+        <div class="search-category-header p-2 bg-light h5 mb-0 fw-bold">
             {{ title }}
         </div>
-        <div class="search-category-body">
+        <div class="search-category-body bg-white">
             <SearchResultListEntry
                 v-for="(entry, index) in entries"
                 :key="`${index}-${entry.getId()}`"
@@ -44,17 +44,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
 .search-category {
-    .search-category-header {
-        @extend .p-2;
-        @extend .bg-light;
-        @extend .h5;
-        @extend .mb-0;
-        @extend .fw-bold;
-    }
     .search-category-body {
-        @extend .bg-white;
         max-height: 15rem;
         overflow-y: scroll;
         font-size: 0.8rem;

--- a/src/modules/search/components/SearchResultListEntry.vue
+++ b/src/modules/search/components/SearchResultListEntry.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="search-category-entry"
+        class="search-category-entry p-2 ps-4 border-bottom border-light"
         data-cy="search-result-entry"
         @click="onClick"
         @mouseover="onMouseOver"
@@ -35,13 +35,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
+@import 'src/scss/webmapviewer-bootstrap-theme';
 .search-category-entry {
-    @extend .p-2;
-    @extend .ps-4;
-    @extend .border-bottom;
-    @extend .border-light;
-
     @include media-breakpoint-up(sm) {
         &:hover {
             background-color: $dark;

--- a/src/modules/toolbox/ToolboxModule.vue
+++ b/src/modules/toolbox/ToolboxModule.vue
@@ -29,6 +29,7 @@ export default {
 
 <style lang="scss" scoped>
 @import 'src/scss/media-query.mixin';
+@import 'src/scss/variables';
 
 #right-toolbox,
 #toolbox-bg-buttons {

--- a/src/modules/toolbox/components/BackgroundSelectorButton.vue
+++ b/src/modules/toolbox/components/BackgroundSelectorButton.vue
@@ -74,7 +74,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
+@import 'src/scss/webmapviewer-bootstrap-theme';
 
 $bg-button-border-size: 8px;
 $bg-button-border-size-in-wheel: 3px;

--- a/src/modules/toolbox/components/GeolocButton.vue
+++ b/src/modules/toolbox/components/GeolocButton.vue
@@ -27,7 +27,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
+@import 'src/scss/webmapviewer-bootstrap-theme';
 
 $normal-color: $gray-800;
 $active-color: $primary;

--- a/src/modules/toolbox/components/ZoomButtons.vue
+++ b/src/modules/toolbox/components/ZoomButtons.vue
@@ -30,7 +30,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
+@import 'src/scss/webmapviewer-bootstrap-theme';
 $normal-color: $gray-800;
 $active-color: $primary;
 $disabled-color: $gray-300;

--- a/src/modules/tooltip/components/SwipableBottomSheet.vue
+++ b/src/modules/tooltip/components/SwipableBottomSheet.vue
@@ -153,7 +153,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
+@import 'src/scss/webmapviewer-bootstrap-theme';
 .card {
     width: 100%;
     height: 100%;

--- a/src/scss/bootstrap-theme.scss
+++ b/src/scss/bootstrap-theme.scss
@@ -1,6 +1,0 @@
-
-$primary: #dc3545;
-
-@import 'src/scss/variables';
-
-@import "node_modules/bootstrap/scss/bootstrap";

--- a/src/scss/media-query.mixin.scss
+++ b/src/scss/media-query.mixin.scss
@@ -1,6 +1,6 @@
 // from https://glennmccomb.com/articles/useful-sass-scss-media-query-mixins-for-bootstrap/
 
-@import "src/scss/bootstrap-theme";
+@import 'node_modules/bootstrap/scss/bootstrap-grid';
 
 // Respond above.
 @mixin respond-above($breakpoint) {

--- a/src/scss/webmapviewer-bootstrap-theme.scss
+++ b/src/scss/webmapviewer-bootstrap-theme.scss
@@ -1,0 +1,7 @@
+$red: #dc3545 !default;
+$primary: $red;
+
+@import 'src/scss/variables';
+@import 'node_modules/bootstrap/scss/functions';
+@import 'node_modules/bootstrap/scss/variables';
+@import 'node_modules/bootstrap/scss/mixins';

--- a/src/utils/ButtonWithIcon.vue
+++ b/src/utils/ButtonWithIcon.vue
@@ -72,6 +72,3 @@ export default {
     },
 }
 </script>
-<style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
-</style>

--- a/src/views/LoadingView.vue
+++ b/src/views/LoadingView.vue
@@ -15,7 +15,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'src/scss/bootstrap-theme';
+@import 'src/scss/webmapviewer-bootstrap-theme';
 #splashscreen {
     position: fixed;
     top: 0;

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,4 @@
 const fs = require('fs')
-const { DefinePlugin } = require('webpack')
 
 // loading external utility function to read git metadata
 const gitBranch = require('git-branch')
@@ -23,13 +22,13 @@ const version = packageJson.version || 0
 
 module.exports = {
     publicPath,
-    configureWebpack: {
-        plugins: [
-            new DefinePlugin({
-                'process.env': {
-                    PACKAGE_VERSION: '"' + version + '"',
-                },
-            }),
-        ],
+    chainWebpack: (config) => {
+        config
+            .plugin('define')
+            .tap((definitions) => {
+                definitions[0]['process.env']['PACKAGE_VERSION'] = `"${version}"`
+                return definitions
+            })
+            .end()
     },
 }


### PR DESCRIPTION
Only import the lib once, import only variable in other places when they were needed
Replace @extends by using the wanted classes directly in the template
Changing the webpack config Vue's using so that we may later more easily add monitoring tools (such as 'speed-measure-webpack-plugin')

[Test link](https://web-mapviewer.dev.bgdi.ch/fix_bootstrap_import/index.html)