### PR TITLE
BGDIINF_SB-2120: Fixed scale-line not showing

### DIFF
--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -4,7 +4,11 @@
         <!-- So that external modules can have access to the map instance through the provided 'getMap' -->
         <slot />
         <portal to="footer" :order="1">
-            <div v-if="zoom >= 9" id="scale-line" ref="scaleLine" data-cy="scaleline" />
+            <!-- 
+                It is necessary to use `v-show` instead of `v-if`. Otherwise, 
+                the scale-line will never show if the initial zoom was too low. 
+            -->
+            <div v-show="zoom >= 9" id="scale-line" ref="scaleLine" data-cy="scaleline" />
         </portal>
         <OpenLayersMousePosition v-if="!isMobile" />
         <VisibleLayersCopyrights :layers="backgroundAndVisibleLayers" />

--- a/tests/e2e/specs/footer.spec.js
+++ b/tests/e2e/specs/footer.spec.js
@@ -11,16 +11,16 @@ describe('Testing the footer content', () => {
 
     context('Checking the scale line behave as expected', () => {
         it('Should not be visible on standard startup, as the zoom level is 7', () => {
-            cy.get(scaleLineSelector).should('not.exist')
+            cy.get(scaleLineSelector).should('not.be.visible')
         })
         it('Should appear when we zoom a bit (zoom level 10)', () => {
             cy.get(zoomSelector).click().click().click()
-            cy.get(scaleLineSelector).should('exist')
+            cy.get(scaleLineSelector).should('be.visible')
         })
         it('Should disappear again if we zoom out again after zooming', () => {
             cy.get(zoomSelector).click().click().click()
             cy.get(dezoomSelector).click().click().click()
-            cy.get(scaleLineSelector).should('not.exist')
+            cy.get(scaleLineSelector).should('not.be.visible')
         })
     })
 })


### PR DESCRIPTION
If the initial zoom was below the threshold set in the template,
the scale-line would not show after zooming in past the threshold.

It seems as if a portal-target with multiple portals combined with
the lazy nature of v-if causes the target to get confused and mix
the markup/DOM of the different portals.

Using v-show instead of v-if fixes the issue.

[Test link](https://web-mapviewer.dev.bgdi.ch/bugfix-jira-bgdiinf_sb-2120-scale-line-not-showing/index.html)