### PR TITLE
BGDIINF_SB-2143: Removed double ?? in query param

### DIFF
--- a/src/router/stringifyQuery.js
+++ b/src/router/stringifyQuery.js
@@ -56,6 +56,6 @@ const stringifyQuery = (query) => {
               .filter((x) => x.length > 0)
               .join('&')
         : null
-    return res ? `?${res}` : ''
+    return res ? res : ''
 }
 export default stringifyQuery


### PR DESCRIPTION
The new vue-router v4 stringifyQuery behavior has changed and this
method should not add the ? to the query.

[Test link](https://web-mapviewer.dev.bgdi.ch/feat-bgdiinf_sb-2143-double-question-mark/index.html)