### PR TITLE
BGDIINF_SB-2015: Added info-button to search results

### DIFF
--- a/src/modules/menu/components/activeLayers/MenuActiveLayersList.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersList.vue
@@ -24,7 +24,7 @@
                 @timestampChange="onTimestampChange"
                 @showLayerLegendPopup="showLayerLegendForId = layer.getID()"
             />
-            <MenuActiveLayersLegendPopup
+            <LayerLegendPopup
                 v-if="showLayerLegendForId"
                 :layer-id="showLayerLegendForId"
                 @close="showLayerLegendForId = null"
@@ -37,14 +37,14 @@
 <script>
 import { mapState, mapActions } from 'vuex'
 import MenuActiveLayersListItem from './MenuActiveLayersListItem.vue'
-import MenuActiveLayersLegendPopup from '@/modules/menu/components/activeLayers/MenuActiveLayersLegendPopup.vue'
+import LayerLegendPopup from '@/modules/overlay/components/LayerLegendPopup.vue'
 
 /**
  * Component that maps the active layers from the state to the menu (and also forwards user
  * interactions to the state)
  */
 export default {
-    components: { MenuActiveLayersLegendPopup, MenuActiveLayersListItem },
+    components: { LayerLegendPopup, MenuActiveLayersListItem },
     data() {
         return {
             showLayerLegendForId: null,

--- a/src/modules/overlay/components/LayerLegendPopup.vue
+++ b/src/modules/overlay/components/LayerLegendPopup.vue
@@ -12,8 +12,8 @@
 </template>
 
 <script>
-import ModalWithOverlay from '@/modules/overlay/components/ModalWithOverlay.vue'
 import { getLayerLegend } from '@/api/layers/layers.api'
+import ModalWithOverlay from './ModalWithOverlay.vue'
 
 export default {
     components: { ModalWithOverlay },
@@ -35,7 +35,7 @@ export default {
         })
     },
     methods: {
-        onClose: function () {
+        onClose() {
             this.$emit('close', this.layerId)
         },
     },

--- a/src/modules/search/components/SearchResultCategory.vue
+++ b/src/modules/search/components/SearchResultCategory.vue
@@ -12,20 +12,28 @@
                 v-for="(entry, index) in entries"
                 :key="`${index}-${entry.getId()}`"
                 :entry="entry"
+                @showLayerLegendPopup="showLayerLegendPopup"
             />
         </div>
+
+        <LayerLegendPopup
+            v-if="showLayerLegendForId"
+            :layer-id="showLayerLegendForId"
+            @close="closeLayerLegendPopup"
+        />
     </div>
 </template>
 
 <script>
 import SearchResultListEntry from './SearchResultListEntry.vue'
+import LayerLegendPopup from '@/modules/overlay/components/LayerLegendPopup.vue'
 
 /**
  * Search results from the backend are sorted in two categories : layers and locations, this
  * component is there to show one of those category at a time
  */
 export default {
-    components: { SearchResultListEntry },
+    components: { SearchResultListEntry, LayerLegendPopup },
     props: {
         entries: {
             type: Array,
@@ -38,6 +46,19 @@ export default {
         halfSize: {
             type: Boolean,
             default: false,
+        },
+    },
+    data() {
+        return {
+            showLayerLegendForId: null,
+        }
+    },
+    methods: {
+        showLayerLegendPopup(id) {
+            this.showLayerLegendForId = id
+        },
+        closeLayerLegendPopup() {
+            this.showLayerLegendForId = null
         },
     },
 }

--- a/src/modules/search/components/SearchResultList.vue
+++ b/src/modules/search/components/SearchResultList.vue
@@ -7,12 +7,12 @@
     >
         <SearchResultCategory
             :title="$t('locations_results_header')"
-            :half-size="results.layerResults.length > 0"
+            :half-size="results.locationResults.length > 0"
             :entries="results.locationResults"
         />
         <SearchResultCategory
             :title="$t('layers_results_header')"
-            :half-size="results.locationResults.length > 0"
+            :half-size="results.layerResults.length > 0"
             :entries="results.layerResults"
         />
     </div>

--- a/src/modules/search/components/SearchResultListEntry.vue
+++ b/src/modules/search/components/SearchResultListEntry.vue
@@ -1,13 +1,22 @@
 <template>
     <div
-        class="search-category-entry p-2 ps-4 border-bottom border-light"
-        data-cy="search-result-entry"
-        @click="onClick"
-        @mouseover="onMouseOver"
-        @mouseleave="onMouseLeave"
+        class="search-category-entry border-bottom border-light"
+        :data-cy="`search-result-entry-${resultType}`"
     >
-        <!-- eslint-disable-next-line vue/no-v-html-->
-        <span v-html="entry.title"></span>
+        <div class="search-category-entry-main p-2 ps-4" @click="onClick">
+            <!-- eslint-disable-next-line vue/no-v-html-->
+            <span v-html="entry.title"></span>
+        </div>
+
+        <div v-if="resultType == 'layer'" class="search-category-entry-controls">
+            <button
+                class="btn btn-default"
+                :data-cy="`button-show-legend-layer-${entry.layerId}`"
+                @click="showLayerLegendPopup"
+            >
+                <font-awesome-icon size="lg" :icon="['fas', 'info-circle']" />
+            </button>
+        </div>
     </div>
 </template>
 
@@ -23,13 +32,20 @@ export default {
             required: true,
         },
     },
+    emits: ['showLayerLegendPopup'],
+    computed: {
+        resultType() {
+            return this.entry.resultType.toLowerCase()
+        },
+    },
     methods: {
         ...mapActions(['selectResultEntry']),
-        onClick: function () {
+        onClick() {
             this.selectResultEntry(this.entry)
         },
-        onMouseOver: function () {},
-        onMouseLeave: function () {},
+        showLayerLegendPopup() {
+            this.$emit('showLayerLegendPopup', this.entry.layerId)
+        },
     },
 }
 </script>
@@ -37,10 +53,25 @@ export default {
 <style lang="scss" scoped>
 @import 'src/scss/webmapviewer-bootstrap-theme';
 .search-category-entry {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 3rem;
+    &-main {
+        flex-grow: 1;
+        cursor: pointer;
+    }
     @include media-breakpoint-up(sm) {
         &:hover {
             background-color: $dark;
             color: $light;
+            .btn {
+                color: $light;
+            }
+        }
+        .btn {
+            // Same (no) transition on button and list-item.
+            transition: unset;
         }
     }
 }

--- a/tests/e2e/specs/search.spec.js
+++ b/tests/e2e/specs/search.spec.js
@@ -212,10 +212,12 @@ describe('Test the search bar', () => {
     })
     context('Search result handling', () => {
         const acceptedDelta = 0.1
-        const expectedLabel = '<b>Expected result</b>'
+        const expectedLocationLabel = '<b>Test location</b>'
+        const expectedLayerLabel = '<b>Test layer</b>'
+        const expectedLegendContent = '<div>Test</div>'
         const expectedCenterEpsg4326 = [7.0, 47.0] // lon/lat
         const expectedCenterEpsg3857 = proj4(proj4.WGS84, 'EPSG:3857', expectedCenterEpsg4326)
-        const response = {
+        const locationResponse = {
             results: [
                 {
                     id: 1234,
@@ -228,7 +230,19 @@ describe('Test the search bar', () => {
                         geom_st_box2d: `BOX(${expectedCenterEpsg3857[0] - 500} ${
                             expectedCenterEpsg3857[1] - 500
                         },${expectedCenterEpsg3857[0] + 500} ${expectedCenterEpsg3857[1] + 500})`,
-                        label: expectedLabel,
+                        label: expectedLocationLabel,
+                    },
+                },
+            ],
+        }
+        const layerResponse = {
+            results: [
+                {
+                    id: 4321,
+                    weight: 1,
+                    attrs: {
+                        label: expectedLayerLabel,
+                        layer: 'ch.swisstopo.test',
                     },
                 },
             ],
@@ -252,23 +266,27 @@ describe('Test the search bar', () => {
             // setting viewport size so that resolution calculation made above is correct
             cy.viewport(widthAndHeight, widthAndHeight)
             // mocking up all possible search backend response
-            cy.mockupBackendResponse('rest/services/ech/SearchServer*?type=layers*', {}, 'search')
+            cy.mockupBackendResponse(
+                'rest/services/ech/SearchServer*?type=layers*',
+                layerResponse,
+                'search-layers'
+            )
             cy.mockupBackendResponse(
                 'rest/services/ech/SearchServer*?type=locations*',
-                response,
-                'search'
+                locationResponse,
+                'search-locations'
             )
         })
 
         it('handles search result thoroughly (zoom, center, pin)', () => {
             cy.goToMapView()
             cy.get(searchbarSelector).paste('test')
-            cy.wait(`@search`)
-            cy.get('[data-cy="search-result-entry"]')
+            cy.wait(`@search-locations`)
+            cy.get('[data-cy="search-result-entry-location"]')
                 .then((entries) => {
                     expect(entries.length).to.eq(1)
                     const entry = entries[0]
-                    expect(entry.innerHTML).to.contain(expectedLabel)
+                    expect(entry.innerHTML).to.contain(expectedLocationLabel)
                 })
                 .click()
             // checking that the view has centered on the feature
@@ -293,9 +311,41 @@ describe('Test the search bar', () => {
             cy.goToMapView('en', {
                 swisssearch: 'Test',
             })
-            cy.wait('@search')
+            cy.wait(['@search-locations', '@search-layers'])
             cy.readStoreValue('state.search.query').should('eq', 'Test')
-            cy.get('[data-cy="search-result-entry"]').should('be.visible')
+            cy.get('[data-cy="search-result-entry-location"]').should('be.visible')
+        })
+        it('displays layer results with info-buttons', () => {
+            cy.goToMapView()
+            cy.get(searchbarSelector).paste('test')
+            cy.wait(['@search-locations', '@search-layers'])
+            // Ensure that all layers have been added and contain an info-button.
+            cy.get('[data-cy="search-result-entry-layer"]')
+                .should('have.length', layerResponse.results.length)
+                .then(([entry]) => {
+                    expect(entry.innerHTML).to.contain(expectedLayerLabel)
+                })
+                .find('[data-cy^="button-show-legend-layer-"]')
+                .should('exist')
+        })
+        it('shows a legend when clicking an info-button', () => {
+            // As we only test one of the buttons we can send the same content for all legends.
+            cy.intercept('**/rest/services/all/MapServer/*/legend**', expectedLegendContent).as(
+                'legend'
+            )
+            cy.goToMapView()
+            cy.get(searchbarSelector).paste('test')
+            cy.wait(['@search-locations', '@search-layers'])
+            // Click on the first info-button and check if the legend loads correctly.
+            cy.get('[data-cy="search-result-entry-layer"] [data-cy^="button-show-legend-layer-"]')
+                .first()
+                .click()
+            cy.wait('@legend')
+            cy.get('[data-cy="layer-legend"]')
+                .should('be.visible')
+                .then(([legend]) => {
+                    expect(legend.innerHTML).to.contain(expectedLegendContent)
+                })
         })
     })
 })


### PR DESCRIPTION
We allow the user to add some layers through the search results. Analog to the layer selection/settings in the menu we want to provide a button that opens a modal with information about the layer. As is the case in the current production version.

This change adds that button and refactors/moves the modal used in the menu in order to avoid having a dependency between the search and the menu components.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-2015-search-info-button/index.html)