### PR TITLE
BGDIINF_SB-2134: Added e2e test for layer toggling from topic menu

### DIFF
--- a/tests/e2e/specs/layers.spec.js
+++ b/tests/e2e/specs/layers.spec.js
@@ -270,16 +270,17 @@ describe('Test of layer handling', () => {
                 })
             })
         })
-        it.only('allows toggling layers from the topic menu', () => {
+        it('allows toggling layers from the topic menu', () => {
             const testLayerId = 'test.wmts.layer'
+            const testLayerSelector = `[data-cy="topic-tree-item-${testLayerId}"]`
             cy.get('[data-cy="menu-topic-section"]').click()
             // Find the test layer and open the appropriate menu entries.
-            cy.get(`[data-cy="topic-tree-item-${testLayerId}"]`)
+            cy.get(testLayerSelector)
                 .parentsUntil('[data-cy="menu-topic-section"]')
                 .filter('.menu-topic-tree-item')
                 .then((menuItems) => {
                     menuItems
-                        .get()
+                        .toArray()
                         // The first match is the layer itself which we'll handle separately.
                         .slice(1)
                         // We need to reverse the menu items as we started at the layer.
@@ -287,13 +288,13 @@ describe('Test of layer handling', () => {
                         .forEach((menuItem) => cy.wrap(menuItem).click())
                 })
             // Toggle (hide) the test layer.
-            cy.get(`[data-cy="topic-tree-item-${testLayerId}"]`).click()
+            cy.get(testLayerSelector).click()
             cy.readStoreValue('getters.visibleLayers').then((visibleLayers) => {
                 const visibleIds = visibleLayers.map((layer) => layer.getID())
                 expect(visibleIds).to.not.contain(testLayerId)
             })
             // Toggle (show) the test layer.
-            cy.get(`[data-cy="topic-tree-item-${testLayerId}"]`).click()
+            cy.get(testLayerSelector).click()
             cy.readStoreValue('getters.visibleLayers').then((visibleLayers) => {
                 const visibleIds = visibleLayers.map((layer) => layer.getID())
                 expect(visibleIds).to.contain(testLayerId)

--- a/tests/e2e/specs/layers.spec.js
+++ b/tests/e2e/specs/layers.spec.js
@@ -270,6 +270,35 @@ describe('Test of layer handling', () => {
                 })
             })
         })
+        it.only('allows toggling layers from the topic menu', () => {
+            const testLayerId = 'test.wmts.layer'
+            cy.get('[data-cy="menu-topic-section"]').click()
+            // Find the test layer and open the appropriate menu entries.
+            cy.get(`[data-cy="topic-tree-item-${testLayerId}"]`)
+                .parentsUntil('[data-cy="menu-topic-section"]')
+                .filter('.menu-topic-tree-item')
+                .then((menuItems) => {
+                    menuItems
+                        .get()
+                        // The first match is the layer itself which we'll handle separately.
+                        .slice(1)
+                        // We need to reverse the menu items as we started at the layer.
+                        .reverse()
+                        .forEach((menuItem) => cy.wrap(menuItem).click())
+                })
+            // Toggle (hide) the test layer.
+            cy.get(`[data-cy="topic-tree-item-${testLayerId}"]`).click()
+            cy.readStoreValue('getters.visibleLayers').then((visibleLayers) => {
+                const visibleIds = visibleLayers.map((layer) => layer.getID())
+                expect(visibleIds).to.not.contain(testLayerId)
+            })
+            // Toggle (show) the test layer.
+            cy.get(`[data-cy="topic-tree-item-${testLayerId}"]`).click()
+            cy.readStoreValue('getters.visibleLayers').then((visibleLayers) => {
+                const visibleIds = visibleLayers.map((layer) => layer.getID())
+                expect(visibleIds).to.contain(testLayerId)
+            })
+        })
         context('Re-ordering of layers', () => {
             const checkOrderButtons = (layerId, raiseShouldBeDisabled, lowerShouldBeDisabled) => {
                 cy.get(`[data-cy="button-raise-order-layer-${layerId}"]`)


### PR DESCRIPTION
During the update to Vue3 a bug was fixed that prevented unchecking a layer via the topic menu.

This adds an e2e test to check that the bug has been fixed and the layers can be toggled via the topic menu.

[Test link](https://web-mapviewer.dev.bgdi.ch/bugfix-jira-bgdiinf_sb-2134-e2e-toggle-layer-topicmenu/index.html)