### PR TITLE
[Draft] Mobile tooltip

### DIFF
--- a/src/api/features.api.js
+++ b/src/api/features.api.js
@@ -1,9 +1,92 @@
 import { API_BASE_URL } from '@/config'
 import axios from 'axios'
 import log from '@/utils/logging'
+import EventEmitter from '@/utils/EventEmitter.class'
+
+/**
+ * Representation of a feature that can be selected by the user on the map. This feature can be
+ * edited if the corresponding flag says so (it will then fires "change" events any time one
+ * property of the instance has changed)
+ *
+ * This will then be specialized in (at least) two flavor of features, layer feature (coming from
+ * our backend, with extra information attached) and drawing feature (that can be modified by the user)
+ *
+ * @abstract
+ */
+export class Feature extends EventEmitter {
+    /**
+     * @param {String | Number} id Unique identifier for this feature (unique in the context it
+     *   comes from, not for the whole app)
+     * @param {Number[]} coordinate [x,y] coordinates of this feature in EPSG:3857 (metric mercator)
+     * @param {String} title Title of this feature
+     * @param {String} description A description of this feature, can not be HTML content (only text)
+     * @param {Boolean} isEditable Whether this feature is editable when selected (color, size, etc...)
+     */
+    constructor(id, coordinate, title, description, isEditable) {
+        super()
+        this._id = id
+        this._coordinate = [...coordinate]
+        this._title = title
+        this._description = description
+        this._isEditable = !!isEditable
+    }
+
+    emitChangeEvent() {
+        this.emit('change', this)
+    }
+
+    get id() {
+        return this._id
+    }
+    // ID is immutable, no setter
+
+    get coordinate() {
+        return this._coordinate
+    }
+    set coordinate(newCoordinate) {
+        if (Array.isArray(newCoordinate) && newCoordinate.length === 2) {
+            this._coordinate = newCoordinate
+            this.emitChangeEvent()
+        }
+    }
+
+    get title() {
+        return this._title
+    }
+    set title(newTitle) {
+        this._title = newTitle
+        this.emitChangeEvent()
+    }
+
+    get description() {
+        return this._description
+    }
+    set description(newDescription) {
+        this._description = newDescription
+        this.emitChangeEvent()
+    }
+
+    get isEditable() {
+        return this._isEditable
+    }
+    // isEditable is immutable, no setter
+}
+
+export class EditableFeature extends Feature {
+    /**
+     * @param {String | Number} id Unique identifier for this feature (unique in the context it
+     *   comes from, not for the whole app)
+     * @param {Number[]} coordinate [x,y] coordinates of this feature in EPSG:3857 (metric mercator)
+     * @param {String} title Title of this feature
+     * @param {String} description A description of this feature, can not be HTML content (only text)
+     */
+    constructor(id, coordinate, title, description) {
+        super(id, coordinate, title, description, true)
+    }
+}
 
 /** Describe a feature from the backend (see {@link getFeature}) below */
-export class Feature {
+export class LayerFeature extends Feature {
     /**
      * @param {GeoAdminLayer} layer The layer in which this feature belongs
      * @param {Number | String} id The unique feature ID in the layer it is part of
@@ -14,10 +97,11 @@ export class Feature {
      * @param {Object} geometry GeoJSON geometry (if exists)
      */
     constructor(layer, id, htmlPopup, coordinate, extent, geometry = null) {
+        super(id, coordinate, null, null, false)
         this.layer = layer
-        this.id = id
+        // for now the backend gives us the description of the feature as HTML
+        // it would be good to change that to only data in the future
         this.htmlPopup = htmlPopup
-        this.coordinate = coordinate
         this.extent = extent
         this.geometry = geometry
     }
@@ -38,7 +122,7 @@ export class Feature {
  * @param {Number} screenWidth
  * @param {Number} screenHeight
  * @param {String} lang
- * @returns {Promise<Feature[]>}
+ * @returns {Promise<LayerFeature[]>}
  */
 export const identify = (layer, coordinate, mapExtent, screenWidth, screenHeight, lang) => {
     return new Promise((resolve, reject) => {
@@ -107,7 +191,7 @@ export const identify = (layer, coordinate, mapExtent, screenWidth, screenHeight
  * @param {GeoAdminLayer} layer The layer from which the feature is part of
  * @param {String | Number} featureID The feature ID in the BGDI
  * @param {String} lang The language for the HTML popup
- * @returns {Promise<Feature>}
+ * @returns {Promise<LayerFeature>}
  */
 const getFeature = (layer, featureID, lang = 'en') => {
     return new Promise((resolve, reject) => {
@@ -164,7 +248,7 @@ const getFeature = (layer, featureID, lang = 'en') => {
                     ]
                 }
                 resolve(
-                    new Feature(
+                    new LayerFeature(
                         layer,
                         featureID,
                         featureHtmlPopup,

--- a/src/modules/map/components/openlayers/OpenLayersHighlightedFeature.vue
+++ b/src/modules/map/components/openlayers/OpenLayersHighlightedFeature.vue
@@ -15,7 +15,7 @@ import { Vector as VectorSource } from 'ol/source'
 import OpenLayersFeature from 'ol/Feature'
 import GeoJSON from 'ol/format/GeoJSON'
 import Style from 'ol/style/Style'
-import { Feature } from '@/api/features.api'
+import { LayerFeature } from '@/api/features.api'
 import OpenLayersMarker, {
     highlightedFill,
     highlightedStroke,
@@ -54,7 +54,7 @@ export default {
     mixins: [addLayerToMapMixin],
     props: {
         feature: {
-            type: Feature,
+            type: LayerFeature,
             required: true,
         },
         zIndex: {

--- a/src/modules/store/modules/feature.store.js
+++ b/src/modules/store/modules/feature.store.js
@@ -1,0 +1,18 @@
+export class Feature {
+    constructor(coordinate, title, description, isEditable) {
+        this.coordinate = [...coordinate]
+        this.title = title
+        this.description = description
+        this.isEditable = !!isEditable
+    }
+}
+
+export default {
+    state: {
+        /** @type Array<Feature> */
+        selectedFeatures: [],
+    },
+    getters: {},
+    actions: {},
+    mutations: {},
+}

--- a/src/modules/store/plugins/ui-mode-change-management.plugin.js
+++ b/src/modules/store/plugins/ui-mode-change-management.plugin.js
@@ -1,0 +1,46 @@
+import { UIModes } from '@/modules/store/modules/ui.store'
+import { screenThresholdToShowTheSideMenu } from '@/config'
+
+/** @param store */
+const uiModeChangeManagementPlugin = (store) => {
+    store.subscribe((mutation, state) => {
+        if (mutation.type === 'setUiMode') {
+            switch (state.ui.mode) {
+                case UIModes.MENU_OPENED_THROUGH_BUTTON:
+                    // we need to show the overlay if the menu is shown
+                    if (state.ui.showMenuTray && !state.ui.showDrawingOverlay) {
+                        store.dispatch('showOverlay', () => {
+                            // hiding the menu tray whenever the user clicks on the overlay
+                            if (state.ui.showMenuTray) {
+                                store.dispatch('toggleMenuTray')
+                            }
+                            return false
+                        })
+                    }
+                    break
+                case UIModes.MENU_ALWAYS_OPEN:
+                    // we need to hide the overlay if it is shown
+                    if (state.overlay.show) {
+                        store.dispatch('hideOverlayIgnoringCallbacks')
+                    }
+                    break
+            }
+        } else if (mutation.type === 'setSize') {
+            // listening to screen size change to decide if we should switch UI mode too
+            let wantedUiMode
+            if (
+                state.ui.width >= screenThresholdToShowTheSideMenu.width &&
+                state.ui.height > screenThresholdToShowTheSideMenu.height
+            ) {
+                wantedUiMode = UIModes.MENU_ALWAYS_OPEN
+            } else {
+                wantedUiMode = UIModes.MENU_OPENED_THROUGH_BUTTON
+            }
+            if (wantedUiMode !== state.ui.mode) {
+                store.dispatch('setUiMode', wantedUiMode)
+            }
+        }
+    })
+}
+
+export default uiModeChangeManagementPlugin

--- a/src/utils/EventEmitter.class.js
+++ b/src/utils/EventEmitter.class.js
@@ -1,0 +1,40 @@
+// from https://gist.github.com/mudge/5830382#gistcomment-2691957
+/** Enables an instance of a class to emit its own events (and be listened to) */
+export default class EventEmitter {
+    constructor() {
+        this.events = {}
+    }
+
+    _getEventListByName(eventName) {
+        if (typeof this.events[eventName] === 'undefined') {
+            this.events[eventName] = new Set()
+        }
+        return this.events[eventName]
+    }
+
+    on(eventName, fn) {
+        this._getEventListByName(eventName).add(fn)
+    }
+
+    once(eventName, fn) {
+        const self = this
+
+        const onceFn = function (...args) {
+            self.removeListener(eventName, onceFn)
+            fn.apply(self, args)
+        }
+        this.on(eventName, onceFn)
+    }
+
+    emit(eventName, ...args) {
+        this._getEventListByName(eventName).forEach(
+            function (fn) {
+                fn.apply(this, args)
+            }.bind(this)
+        )
+    }
+
+    removeListener(eventName, fn) {
+        this._getEventListByName(eventName).delete(fn)
+    }
+}


### PR DESCRIPTION
Change the way features are handled after a click, so that the app can show them either in a floating popup (desktop) or in a bottom tray (mobile).

This also affects how the drawing is working, as we also want to have features from the drawing side in the mobile tray.

[Test link](https://web-mapviewer.dev.bgdi.ch/feat-jira-bgdiinf_sb-1857-mobile-tooltip/index.html)