### PR TITLE
BGDIINF_SB-2133: Added e2e test for language switch

### DIFF
--- a/src/modules/i18n/components/LangSwitchToolbar.vue
+++ b/src/modules/i18n/components/LangSwitchToolbar.vue
@@ -8,6 +8,7 @@
             :transparent="lang !== currentLang"
             :button-title="lang.toUpperCase()"
             :small="isUIinDesktopMode"
+            :data-cy="'menu-lang-' + lang"
             @click="changeLang(lang)"
         />
     </div>

--- a/src/modules/store/modules/layers.store.js
+++ b/src/modules/store/modules/layers.store.js
@@ -1,3 +1,5 @@
+import axios from 'axios'
+import { IS_TESTING_WITH_CYPRESS } from '@/config'
 import log from '@/utils/logging'
 import AbstractLayer from '@/api/layers/AbstractLayer.class'
 
@@ -139,6 +141,12 @@ const actions = {
                 commit('addLayerWithConfig', layer)
             }
         })
+        // In case we are testing with Cypress, we trigger a fake request to
+        // a localhost endpoint so that Cypress can intercept it and know the
+        // layers have been updated. Intercepted as @layers-configured in goToMapView.
+        if (IS_TESTING_WITH_CYPRESS) {
+            axios.get('/tell-cypress-layers-are-configured')
+        }
     },
     setBackground({ commit }, bgLayerId) {
         if (bgLayerId === 'void') {

--- a/tests/e2e/specs/layers.spec.js
+++ b/tests/e2e/specs/layers.spec.js
@@ -402,7 +402,7 @@ describe('Test of layer handling', () => {
                     })
                 })
                 context('Language settings in menu', () => {
-                    it.only('keeps the layer settings when changing language', () => {
+                    it('keeps the layer settings when changing language', () => {
                         const langBefore = 'en'
                         const langAfter = 'de'
                         const visibleLayerIds = [
@@ -431,7 +431,7 @@ describe('Test of layer handling', () => {
                         })
 
                         // Open the menu and change the language.
-                        cy.get('[data-cy="menu-button"]').click()
+                        clickOnMenuButtonIfMobile()
                         cy.get('[data-cy="menu-settings-section"]').click()
                         cy.get(`[data-cy="menu-lang-${langAfter}"`).click()
 

--- a/tests/e2e/specs/layers.spec.js
+++ b/tests/e2e/specs/layers.spec.js
@@ -25,6 +25,15 @@ describe('Test of layer handling', () => {
         } while (randomTimestampFromLayer === defaultTimestamp)
         return randomTimestampFromLayer
     }
+    /**
+     * This function is used as a parameter to `JSON.stringify` to remove all properties with the name `lang`.
+     *
+     * @param {String} key The current property name.
+     * @param {any} value The current value to stringify.
+     * @returns {String} The string representation of the object.
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_replacer_parameter
+     */
+    const stringifyWithoutLang = (key, value) => (key === 'lang' ? undefined : value)
 
     forEachTestViewport((viewport, isMobile, isTablet, dimensions) => {
         context(
@@ -389,6 +398,59 @@ describe('Test of layer handling', () => {
                             checkOrderButtons(layerId, true, false)
                             cy.get(`[data-cy="button-lower-order-layer-${layerId}"]`).click()
                             checkOrderButtons(layerId, false, false)
+                        })
+                    })
+                })
+                context('Language settings in menu', () => {
+                    it.only('keeps the layer settings when changing language', () => {
+                        const langBefore = 'en'
+                        const langAfter = 'de'
+                        const visibleLayerIds = [
+                            'test.wms.layer',
+                            'test.wmts.layer',
+                            'test.timeenabled.wmts.layer',
+                        ]
+                        let activeLayersConfigBefore
+
+                        cy.goToMapView(langBefore, {
+                            layers: visibleLayerIds.map((layer) => `${layer},f,0.1`).join(';'),
+                        })
+
+                        // CHECK before
+                        cy.readStoreValue('state').then((state) => {
+                            // Check the language before the switch.
+                            expect(state.i18n.lang).to.eq(langBefore)
+                            state.layers.activeLayers
+                                .filter((layer) => 'lang' in layer)
+                                .forEach((layer) => expect(layer.lang).to.eq(langBefore))
+                            // Save the layer configuration before the switch.
+                            activeLayersConfigBefore = JSON.stringify(
+                                state.layers.activeLayers,
+                                stringifyWithoutLang
+                            )
+                        })
+
+                        // Open the menu and change the language.
+                        cy.get('[data-cy="menu-button"]').click()
+                        cy.get('[data-cy="menu-settings-section"]').click()
+                        cy.get(`[data-cy="menu-lang-${langAfter}"`).click()
+
+                        // Wait until the layers fully configured with the new configuration.
+                        cy.wait('@layers-configured')
+
+                        // CHECK after
+                        cy.readStoreValue('state').then((state) => {
+                            // Check the language after the switch.
+                            expect(state.i18n.lang).to.eq(langAfter)
+                            state.layers.activeLayers
+                                .filter((layer) => 'lang' in layer)
+                                .forEach((layer) => expect(layer.lang).to.eq(langAfter))
+                            // Compare the layer configuration (except the language)
+                            const activeLayersConfigAfter = JSON.stringify(
+                                state.layers.activeLayers,
+                                stringifyWithoutLang
+                            )
+                            expect(activeLayersConfigAfter).to.eq(activeLayersConfigBefore)
                         })
                     })
                 })

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -95,9 +95,12 @@ Cypress.Commands.add('goToMapView', (lang = 'en', otherParams = {}, withHash = f
     })
     // see app.store.js
     cy.intercept('**/tell-cypress-app-is-done-loading', {}).as('app-done-loading')
+    // Alias used to wait until layers have been updated after loading configuration.
+    cy.intercept('**/tell-cypress-layers-are-configured', {}).as('layers-configured')
     cy.visit(`/${withHash ? '#/' : ''}?lang=${lang}${flattenedOtherParams}`)
-    // waiting for the app to load
+    // waiting for the app to load and layers to be configured.
     cy.wait('@app-done-loading')
+    cy.wait('@layers-configured')
     // we leave some room for the CI to catch the DOM element (can be a bit slow depending on the CPU power of CI's VM)
     cy.get('[data-cy="map"]', { timeout: 10000 }).should('be.visible')
 })


### PR DESCRIPTION
During the update to Vue3 a bug was fixed that reverted the configuration to its initial state and prevented the displayed language in the active layers and topic menu to change when the user switched the language in the settings.

The test changes the layer configuration after the initial load and checks if the configuration persists after changing the language.

This commit also introduces a new fake request so we can wait until the layers have been configured (@layers-configured).

[Test link](https://web-mapviewer.dev.bgdi.ch/bugfix-jira-bgdiinf_sb-2133-e2e-change-language/index.html)