### PR TITLE
BGDIINF_SB-2161: Fixed calls to non-existant error function

### DIFF
--- a/src/api/features.api.js
+++ b/src/api/features.api.js
@@ -43,19 +43,19 @@ export class Feature {
 export const identify = (layer, coordinate, mapExtent, screenWidth, screenHeight, lang) => {
     return new Promise((resolve, reject) => {
         if (!layer || !layer.getID()) {
-            log('error', 'Invalid layer', layer)
+            log.error('Invalid layer', layer)
             reject('Needs a valid layer with an ID')
         }
         if (!Array.isArray(coordinate) || coordinate.length !== 2) {
-            log('error', 'Invalid coordinate', coordinate)
+            log.error('Invalid coordinate', coordinate)
             reject('Needs a valid coordinate to run identification')
         }
         if (!Array.isArray(mapExtent) || mapExtent.length !== 4) {
-            log('error', 'Invalid extent', mapExtent)
+            log.error('Invalid extent', mapExtent)
             reject('Needs a valid map extent to run identification')
         }
         if (screenWidth <= 0 || screenHeight <= 0) {
-            log('error', 'Invalid screen size', screenWidth, screenHeight)
+            log.error('Invalid screen size', screenWidth, screenHeight)
             reject('Needs valid screen width and height to run identification')
         }
         axios
@@ -89,7 +89,7 @@ export const identify = (layer, coordinate, mapExtent, screenWidth, screenHeight
                             resolve(values)
                         })
                         .catch((error) => {
-                            log('error', "Wasn't able to get feature", error)
+                            log.error("Wasn't able to get feature", error)
                         })
                 } else {
                     resolve([])

--- a/src/api/files.api.js
+++ b/src/api/files.api.js
@@ -65,7 +65,7 @@ const urlPrefix = 'api/kml/'
 function validateId(id, reject) {
     if (!id) {
         const errorMessage = `Needs a valid kml ID`
-        log('error', errorMessage)
+        log.error(errorMessage)
         reject(errorMessage)
     }
 }
@@ -73,7 +73,7 @@ function validateId(id, reject) {
 function validateAdminId(adminId, reject) {
     if (!adminId) {
         const errorMessage = `Needs a valid kml adminId`
-        log('error', errorMessage)
+        log.error(errorMessage)
         reject(errorMessage)
     }
 }
@@ -81,7 +81,7 @@ function validateAdminId(adminId, reject) {
 function validateKml(kml, reject) {
     if (!kml || !kml.length) {
         const errorMessage = `Needs a valid KML`
-        log('error', errorMessage)
+        log.error(errorMessage)
         reject(errorMessage)
     }
 }
@@ -136,12 +136,12 @@ export const createKml = (kml) => {
                     resolve(KmlMetadata.fromApiData(response.data))
                 } else {
                     const msg = 'Incorrect response while creating a file'
-                    log('error', msg, response)
+                    log.error(msg, response)
                     reject(msg)
                 }
             })
             .catch((error) => {
-                log('error', 'Error while creating a file', kml)
+                log.error('Error while creating a file', kml)
                 reject(error)
             })
     })
@@ -173,12 +173,12 @@ export const updateKml = (id, adminId, kml) => {
                     resolve(KmlMetadata.fromApiData(response.data))
                 } else {
                     const msg = `Incorrect response while updating file with id=${id}`
-                    log('error', msg, response)
+                    log.error(msg, response)
                     reject(msg)
                 }
             })
             .catch((error) => {
-                log('error', `Error while updating file with id=${id}`, kml)
+                log.error(`Error while updating file with id=${id}`, kml)
                 reject(error)
             })
     })
@@ -200,12 +200,12 @@ export const getKml = (id) => {
                     resolve(response.data)
                 } else {
                     const msg = `Incorrect response while getting file with id=${id}`
-                    log('error', msg, response)
+                    log.error(msg, response)
                     reject(msg)
                 }
             })
             .catch((error) => {
-                log('error', `Error while getting file with id=${id}`)
+                log.error(`Error while getting file with id=${id}`)
                 reject(error)
             })
     })
@@ -227,12 +227,12 @@ export const getKmlMetadataByAdminId = (adminId) => {
                     resolve(KmlMetadata.fromApiData(response.data))
                 } else {
                     const msg = `Incorrect response while getting metadata for kml admin_id=${adminId}`
-                    log('error', msg, response)
+                    log.error(msg, response)
                     reject(msg)
                 }
             })
             .catch((error) => {
-                log('error', `Error while getting metadata for kml admin_id=${adminId}`)
+                log.error(`Error while getting metadata for kml admin_id=${adminId}`)
                 reject(error)
             })
     })

--- a/src/api/height.api.js
+++ b/src/api/height.api.js
@@ -39,12 +39,12 @@ export const requestHeight = (coordinates) => {
                     resolve(new HeightForPosition(coordinates, heightResponse.data.height))
                 })
                 .catch((error) => {
-                    log('error', 'Error while retrieving height for', coordinates, error)
+                    log.error('Error while retrieving height for', coordinates, error)
                     reject(error)
                 })
         } else {
             const errorMessage = 'Invalid coordinates, no height requested'
-            log('error', 'Invalid coordinates, no height requested', coordinates)
+            log.error('Invalid coordinates, no height requested', coordinates)
             reject(errorMessage)
         }
     })

--- a/src/api/height.api.js
+++ b/src/api/height.api.js
@@ -39,12 +39,12 @@ export const requestHeight = (coordinates) => {
                     resolve(new HeightForPosition(coordinates, heightResponse.data.height))
                 })
                 .catch((error) => {
-                    log.error('Error while retrieving height for', coordinates, error)
+                    log('error', 'Error while retrieving height for', coordinates, error)
                     reject(error)
                 })
         } else {
             const errorMessage = 'Invalid coordinates, no height requested'
-            log.error('Invalid coordinates, no height requested', coordinates)
+            log('error', 'Invalid coordinates, no height requested', coordinates)
             reject(errorMessage)
         }
     })

--- a/src/api/icon.api.js
+++ b/src/api/icon.api.js
@@ -80,7 +80,7 @@ function getIcons(url) {
             )
         )
         .catch((error) => {
-            log('error', 'Error getting icons', url)
+            log.error('Error getting icons', url)
             return Promise.reject(error)
         })
 }

--- a/src/api/layers/layers.api.js
+++ b/src/api/layers/layers.api.js
@@ -138,7 +138,7 @@ const generateClassForLayerConfig = (layerConfig, id, allOtherLayers, lang) => {
 
                 break
             default:
-                log('error', 'Unknown layer type', type)
+                log.error('Unknown layer type', type)
         }
     }
     return layer
@@ -157,7 +157,7 @@ export const getLayerLegend = (lang, layerId) => {
             .get(`${API_BASE_URL}rest/services/all/MapServer/${layerId}/legend?lang=${lang}`)
             .then((response) => resolve(response.data))
             .catch((error) => {
-                log('error', 'Error while retrieving the legend for the layer', layerId, error)
+                log.error('Error while retrieving the legend for the layer', layerId, error)
                 reject(error)
             })
     })
@@ -199,7 +199,7 @@ export const loadLayersConfigFromBackend = (lang) => {
                 })
                 .catch((error) => {
                     const message = 'Error while loading layers config from backend'
-                    log('error', message, error)
+                    log.error(message, error)
                     reject(message)
                 })
         }

--- a/src/api/profile.api.js
+++ b/src/api/profile.api.js
@@ -40,7 +40,7 @@ export const profile = (data) => {
     return new Promise((resolve, reject) => {
         if (!data || !data.geom) {
             const errorMessage = `Geom not provided`
-            log('error', errorMessage)
+            log.error(errorMessage)
             reject(errorMessage)
         }
         const params = new URLSearchParams(data)
@@ -53,12 +53,12 @@ export const profile = (data) => {
                     resolve(response.data)
                 } else {
                     const msg = 'Incorrect response while getting profile'
-                    log('error', msg, response)
+                    log.error(msg, response)
                     reject(msg)
                 }
             })
             .catch((error) => {
-                log('error', 'Error while getting profile', data)
+                log.error('Error while getting profile', data)
                 reject(error)
             })
     })

--- a/src/api/qrcode.api.js
+++ b/src/api/qrcode.api.js
@@ -14,7 +14,7 @@ export const generateQrCode = (url) => {
             new URL(url)
         } catch (e) {
             const errorMessage = 'Invalid URL, no QR code generated'
-            log('error', errorMessage, url)
+            log.error(errorMessage, url)
             reject(errorMessage)
         }
         axios
@@ -37,7 +37,7 @@ export const generateQrCode = (url) => {
                 )
             })
             .catch((error) => {
-                log('error', 'Error while retrieving qrCode for', url, error)
+                log.error('Error while retrieving qrCode for', url, error)
                 reject(error)
             })
     })

--- a/src/api/search.api.js
+++ b/src/api/search.api.js
@@ -131,12 +131,12 @@ const search = (queryString = '', lang = '') => {
     return new Promise((resolve, reject) => {
         if (!lang || lang.length !== 2) {
             const errorMessage = `A valid lang ISO code is required to start a search request, received: ${lang}`
-            log('error', errorMessage)
+            log.error(errorMessage)
             reject(errorMessage)
         }
         if (!queryString || queryString.length < 2) {
             const errorMessage = `At least to character are needed to launch a backend search, received: ${queryString}`
-            log('error', errorMessage)
+            log.error(errorMessage)
             reject(errorMessage)
         }
         // if a request is currently pending, we cancel it to start the new one

--- a/src/api/what3words.api.js
+++ b/src/api/what3words.api.js
@@ -47,7 +47,7 @@ export const retrieveWhat3WordsLocation = (what3wordsString) => {
                     ])
                 })
                 .catch((error) => {
-                    log('error', 'Error while fetching What3Words location', error)
+                    log.error('Error while fetching What3Words location', error)
                     reject(error)
                 })
         }
@@ -80,7 +80,7 @@ export const registerWhat3WordsLocation = (location, lang = 'en') => {
                 // Response structure in the doc : https://developer.what3words.com/public-api/docs#convert-to-3wa
                 .then((response) => resolve(response.data.words))
                 .catch((error) => {
-                    log('error', 'Error while saving location as a What3words', error)
+                    log.error('Error while saving location as a What3words', error)
                     reject(error)
                 })
         }

--- a/src/modules/i18n/components/LangSwitchToolbar.vue
+++ b/src/modules/i18n/components/LangSwitchToolbar.vue
@@ -39,7 +39,7 @@ export default {
     },
     methods: {
         changeLang: function (lang) {
-            log('debug', 'switching locale', lang)
+            log.debug('switching locale', lang)
             this.setLang(lang)
         },
         ...mapActions(['setLang']),

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -300,7 +300,7 @@ export default {
                                     featureGeometry.flatCoordinates,
                                     featureGeometry.getExtent()
                                 )
-                                log('debug', 'GeoJSON feature found', geoJsonFeature)
+                                log.debug('GeoJSON feature found', geoJsonFeature)
                                 geoJsonFeatures.push(geoJsonFeature)
                             })
                     }

--- a/src/modules/store/modules/geolocation.store.js
+++ b/src/modules/store/modules/geolocation.store.js
@@ -55,7 +55,7 @@ const actions = {
         if (Array.isArray(position) && position.length === 2) {
             commit('setGeolocationPosition', position)
         } else {
-            log('debug', 'Invalid geolocation position received, ignoring', position)
+            log.debug('Invalid geolocation position received, ignoring', position)
         }
     },
     setGeolocationAccuracy: ({ commit }, accuracy) => {

--- a/src/modules/store/modules/layers.store.js
+++ b/src/modules/store/modules/layers.store.js
@@ -85,7 +85,7 @@ const actions = {
         if ('visible' in payload && 'layerId' in payload) {
             commit('setLayerVisibility', payload)
         } else {
-            log('error', 'Failed to set layer visibility, invalid payload', payload)
+            log.error('Failed to set layer visibility, invalid payload', payload)
         }
     },
     addLayer({ commit, getters }, layerIdOrConfig) {
@@ -98,7 +98,7 @@ const actions = {
         if (layerConfig) {
             commit('addLayerWithConfig', layerConfig)
         } else {
-            log('error', 'no layer found with ID', layerIdOrConfig)
+            log.error('no layer found with ID', layerIdOrConfig)
         }
     },
     addLocation({ commit }, coordsEPSG3857) {
@@ -110,7 +110,7 @@ const actions = {
         } else if (layerIdOrConfig instanceof AbstractLayer) {
             commit('removeLayerWithId', layerIdOrConfig.getID())
         } else {
-            log('error', 'Can not remove layer that is not yet added', layerIdOrConfig)
+            log.error('Can not remove layer that is not yet added', layerIdOrConfig)
         }
     },
     clearLayers({ commit }) {
@@ -162,7 +162,7 @@ const actions = {
                 opacity: Number(payload.opacity),
             })
         } else {
-            log('error', 'Cannot set layer opacity invalid payload', payload)
+            log.error('Cannot set layer opacity invalid payload', payload)
         }
     },
     setTimedLayerCurrentTimestamp({ commit, getters }, payload) {
@@ -189,7 +189,7 @@ const actions = {
                 )
             }
         } else {
-            log('error', 'Failed to set layer timestamp, invalid payload', payload)
+            log.error('Failed to set layer timestamp, invalid payload', payload)
         }
     },
     moveActiveLayerBack({ commit, state, getters }, layerId) {

--- a/src/modules/store/modules/topics.store.js
+++ b/src/modules/store/modules/topics.store.js
@@ -56,7 +56,7 @@ const actions = {
         if (topic) {
             commit(CHANGE_TOPIC_MUTATION, topic)
         } else {
-            log.error('No topic found with ID', topicId)
+            log('error', 'No topic found with ID', topicId)
         }
     },
 }

--- a/src/modules/store/modules/topics.store.js
+++ b/src/modules/store/modules/topics.store.js
@@ -56,7 +56,7 @@ const actions = {
         if (topic) {
             commit(CHANGE_TOPIC_MUTATION, topic)
         } else {
-            log('error', 'No topic found with ID', topicId)
+            log.error('No topic found with ID', topicId)
         }
     },
 }

--- a/src/modules/store/plugins/click-on-map-management.plugin.js
+++ b/src/modules/store/plugins/click-on-map-management.plugin.js
@@ -33,7 +33,7 @@ const runIdentify = (store, clickInfo, visibleLayers, lang) => {
                     )
                 )
             } else {
-                log('debug', 'ignoring layer', layer, 'no tooltip')
+                log.debug('ignoring layer', layer, 'no tooltip')
             }
         })
         Promise.all(allRequests).then((values) => {

--- a/src/modules/store/plugins/geolocation-management.plugin.js
+++ b/src/modules/store/plugins/geolocation-management.plugin.js
@@ -28,7 +28,7 @@ const handlePositionAndDispatchToStore = (position, store) => {
  * @param {Vuex.Store} store
  */
 const handlePositionError = (error, store) => {
-    log('error', 'Geolocation activation failed', error)
+    log.error('Geolocation activation failed', error)
     switch (error.code) {
         case error.PERMISSION_DENIED:
             store.dispatch('setGeolocationDenied', true)

--- a/src/modules/store/plugins/load-layersconfig-on-lang-change.js
+++ b/src/modules/store/plugins/load-layersconfig-on-lang-change.js
@@ -46,7 +46,7 @@ const loadLayersAndTopicsConfigAndDispatchToStore = (store) => {
                 }
             })
         })
-        .catch((error) => log('error', error))
+        .catch((error) => log.error(error))
 }
 
 /**

--- a/src/router/appLoadingManagement.routerPlugin.js
+++ b/src/router/appLoadingManagement.routerPlugin.js
@@ -18,7 +18,7 @@ import log from '@/utils/logging'
 const appLoadingManagementRouterPlugin = (router, store) => {
     const unRegisterRouterHook = router.beforeEach((to) => {
         if (to.meta.requiresAppReady && !store.state.app.isReady) {
-            log('debug', `App is not ready redirect to /#/startup?redirect=${to.fullPath}`)
+            log.debug(`App is not ready redirect to /#/startup?redirect=${to.fullPath}`)
             return { name: 'LoadingView', query: { redirect: to.fullPath }, replace: true }
         }
         return
@@ -30,7 +30,7 @@ const appLoadingManagementRouterPlugin = (router, store) => {
             unRegisterRouterHook()
             unSubscribeStore()
             const redirect = router.currentRoute.value.query.redirect || '/map'
-            log('info', 'App is ready redirect to ', redirect)
+            log.info('App is ready redirect to ', redirect)
             router.replace(redirect)
         }
     })

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -27,9 +27,9 @@ const parseLegacyParams = (search) => {
 }
 
 const handleLegacyKmlAdminIdParam = async (legacyParams, newQuery) => {
-    log('debug', 'Transforming legacy kml adminid, get KML ID from adminId...')
+    log.debug('Transforming legacy kml adminid, get KML ID from adminId...')
     const kmlLayer = await getKmlLayerFromLegacyAdminIdParam(legacyParams['adminid'])
-    log('debug', 'Adding KML layer from legacy kml adminid')
+    log.debug('Adding KML layer from legacy kml adminid')
     if (newQuery.layers) {
         newQuery.layers = `${newQuery.layers};${transformLayerIntoUrlString(kmlLayer)}`
     } else {
@@ -43,7 +43,7 @@ const handleLegacyKmlAdminIdParam = async (legacyParams, newQuery) => {
 }
 
 const handleLegacyParams = (legacyParams, store, to, next) => {
-    log('info', `Legacy permalink with param=`, legacyParams)
+    log.info(`Legacy permalink with param=`, legacyParams)
     // if so, we transfer all old param (stored before vue-router's /#) and transfer them to the MapView
     // we will also transform legacy zoom level here (see comment below)
     const newQuery = { ...to.query }
@@ -86,7 +86,7 @@ const handleLegacyParams = (legacyParams, store, to, next) => {
                         window.location.search
                     )
                     value = layers.map((layer) => transformLayerIntoUrlString(layer)).join(';')
-                    log('debug', 'Importing legacy layers as', value)
+                    log.debug('Importing legacy layers as', value)
                 } else {
                     // if not legacy, we let it go as it is
                     value = legacyParams[param]
@@ -134,7 +134,7 @@ const handleLegacyParams = (legacyParams, store, to, next) => {
                 })
             })
             .catch((error) => {
-                log('error', `Failed to retrieve KML from admin_id: ${error}`)
+                log.error(`Failed to retrieve KML from admin_id: ${error}`)
                 // make sure to remove the adminid from the query
                 delete newQuery.adminid
                 next({

--- a/src/router/storeSync/storeSync.routerPlugin.js
+++ b/src/router/storeSync/storeSync.routerPlugin.js
@@ -42,7 +42,7 @@ let routeChangeIsTriggeredByThisModule = false
  * @param {Router} router
  */
 function storeMutationWatcher(store, mutation, router) {
-    log('debug', 'Store mutation', mutation, 'Current route', router.currentRoute.value)
+    log.debug('Store mutation', mutation, 'Current route', router.currentRoute.value)
 
     // Ignore mutation that has been triggered by the router.beforeEach below.
     if (mutationNotTriggeredByModule(mutation) && mutationWatched(mutation)) {
@@ -53,7 +53,7 @@ function storeMutationWatcher(store, mutation, router) {
             storeSyncConfig.forEach((paramConfig) =>
                 paramConfig.populateQueryWithStoreValue(query, store)
             )
-            log('info', 'Store has changed, rerouting app to query', query)
+            log.info('Store has changed, rerouting app to query', query)
             routeChangeIsTriggeredByThisModule = true
             router
                 .push({
@@ -61,7 +61,7 @@ function storeMutationWatcher(store, mutation, router) {
                     query,
                 })
                 .catch((error) => {
-                    log('info', 'Error while routing to', query, error)
+                    log.info('Error while routing to', query, error)
                     routeChangeIsTriggeredByThisModule = false
                 })
         }
@@ -79,7 +79,7 @@ function storeMutationWatcher(store, mutation, router) {
  *   query changes), false to cancel the navigation or RouteLocationRaw to change url query parameter.
  */
 function urlQueryWatcher(store, to) {
-    log('debug', 'Url query watcher', routeChangeIsTriggeredByThisModule, to)
+    log.debug('Url query watcher', routeChangeIsTriggeredByThisModule, to)
     if (routeChangeIsTriggeredByThisModule) {
         // Only sync route params when the route change has not been
         // triggered by the sync from store mutations watcher above.
@@ -119,7 +119,7 @@ function urlQueryWatcher(store, to) {
         }
     })
     if (requireQueryUpdate) {
-        log('debug', 'Update URL query to', newQuery)
+        log.debug('Update URL query to', newQuery)
         // NOTE: this rewrite of query currently don't work when navigating manually got the `/#/`
         // URL. This should actually change the url to `/#/map?...` with the correct query, but it
         // stays on `/#/`. When manually chaning any query param it works though.
@@ -143,7 +143,7 @@ const storeSyncRouterPlugin = (router, store) => {
     let unsubscribeStoreMutation = null
     router.beforeEach((to, from) => {
         if (to.name === 'MapView' && from.name !== to.name) {
-            log('debug', 'Entering MapView, register store mutation watcher')
+            log.debug('Entering MapView, register store mutation watcher')
             // listening to store mutation in order to update URL
             unsubscribeStoreMutation = store.subscribe((mutation) =>
                 storeMutationWatcher(store, mutation, router)

--- a/src/utils/coordinateUtils.js
+++ b/src/utils/coordinateUtils.js
@@ -93,7 +93,7 @@ export const reprojectUnknownSrsCoordsToWebMercator = (x, y) => {
         // if it's already a lat/lon we return it as is
         return [x, y]
     } else {
-        log('debug', `Unknown coordinate type [${x}, ${y}]`)
+        log.debug(`Unknown coordinate type [${x}, ${y}]`)
         return undefined
     }
 }

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -20,7 +20,7 @@ const log = function (level, ...message) {
                 console.debug(...message)
                 break
             default:
-                console.log(...message)
+                console.log(level, ...message)
         }
     }
     /* eslint-enable  no-console */

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -1,22 +1,32 @@
 import { DEBUG } from '../config'
 
 /**
- * Logs something if the env is not PROD, otherwise does nothing
+ * A logging level reference can be passed as first parameter to the log function. The levels
+ * correspond to the nativr console methods.
+ */
+export const LOGLEVEL = {
+    ERROR: 'ERROR',
+    INFO: 'INFO',
+    DEBUG: 'DEBUG',
+}
+
+/**
+ * Logs something if the env is not PROD, otherwise does nothing.
  *
- * @param {String} level
+ * @param {String} [level]
  * @param {Boolean | String | Number | Object} message
  */
 const log = function (level, ...message) {
     /* eslint-disable no-console */
     if (DEBUG) {
         switch (level) {
-            case 'error':
+            case LOGLEVEL.ERROR:
                 console.error(...message)
                 break
-            case 'info':
+            case LOGLEVEL.INFO:
                 console.info(...message)
                 break
-            case 'debug':
+            case LOGLEVEL.DEBUG:
                 console.debug(...message)
                 break
             default:
@@ -25,4 +35,14 @@ const log = function (level, ...message) {
     }
     /* eslint-enable  no-console */
 }
+
+/* eslint-disable no-console */
+/** Same as console.error but doesn't log in production. */
+log.error = (...message) => console.error(...message)
+/** Same as console.info but doesn't log in production. */
+log.info = (...message) => console.info(...message)
+/** Same as console.debug but doesn't log in production. */
+log.debug = (...message) => console.debug(...message)
+/* eslint-enable  no-console */
+
 export default log

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -1,48 +1,54 @@
 import { DEBUG } from '../config'
 
 /**
- * A logging level reference can be passed as first parameter to the log function. The levels
- * correspond to the nativr console methods.
+ * A log level reference that can be passed as first parameter to the log function. The levels
+ * correspond to the native console methods and their log level.
+ *
+ * @enum {String}
+ * @readonly
  */
-export const LOGLEVEL = {
-    ERROR: 'ERROR',
-    INFO: 'INFO',
-    DEBUG: 'DEBUG',
+export const LogLevel = {
+    ERROR: 'error',
+    INFO: 'info',
+    DEBUG: 'debug',
 }
 
 /**
- * Logs something if the env is not PROD, otherwise does nothing.
+ * Logs the provided parameters to the console. To set a different log level pass the desired
+ * LogLevel as first parameter.
  *
- * @param {String} [level]
- * @param {Boolean | String | Number | Object} message
+ * In production builds only calls with LogLevel.ERROR will be logged!
+ *
+ * @param {LogLevel} level
+ * @param {...any} message
  */
-const log = function (level, ...message) {
+export default function log(level, ...message) {
+    // In production we only log errors.
+    if (!DEBUG && level !== LogLevel.ERROR) {
+        return
+    }
+
     /* eslint-disable no-console */
-    if (DEBUG) {
-        switch (level) {
-            case LOGLEVEL.ERROR:
-                console.error(...message)
-                break
-            case LOGLEVEL.INFO:
-                console.info(...message)
-                break
-            case LOGLEVEL.DEBUG:
-                console.debug(...message)
-                break
-            default:
-                console.log(level, ...message)
-        }
+    switch (level) {
+        case LogLevel.ERROR:
+            console.error(...message)
+            break
+        case LogLevel.INFO:
+            console.info(...message)
+            break
+        case LogLevel.DEBUG:
+            console.debug(...message)
+            break
+        default:
+            // We assume that the first parameter wasn't the level but part of the message.
+            console.log(level, ...message)
     }
     /* eslint-enable  no-console */
 }
 
-/* eslint-disable no-console */
-/** Same as console.error but doesn't log in production. */
-log.error = (...message) => console.error(...message)
-/** Same as console.info but doesn't log in production. */
-log.info = (...message) => console.info(...message)
-/** Same as console.debug but doesn't log in production. */
-log.debug = (...message) => console.debug(...message)
-/* eslint-enable  no-console */
-
-export default log
+/** Shorthand for log('error', ...message) */
+log.error = (...message) => log(LogLevel.ERROR, ...message)
+/** Shorthand for log('info', ...message) */
+log.info = (...message) => log(LogLevel.INFO, ...message)
+/** Shorthand for log('debug', ...message) */
+log.debug = (...message) => log(LogLevel.DEBUG, ...message)


### PR DESCRIPTION
Probably due to a change of the log function we have calls to `log.error` which doesn't exist.

This modifies the calls to work with the current implementation of the log function.

It also modifies the function's default handling to include/preserve the fist parameter passed to the function.

[Test link](https://web-mapviewer.dev.bgdi.ch/bugfix-jira-bgdiinf_sb-2161-log-function/index.html)