### PR TITLE
BGDIINF_SB-2154: Use icon anchors from backend

### DIFF
--- a/src/api/icon.api.js
+++ b/src/api/icon.api.js
@@ -13,10 +13,11 @@ export class IconSet {
 }
 
 export class Icon {
-    constructor(name, imageURL, imageTemplateURL) {
+    constructor(name, imageURL, imageTemplateURL, anchor) {
         this.name = name
         this.imageURL = imageURL
         this.imageTemplateURL = imageTemplateURL
+        this.anchor = anchor
     }
 
     /**
@@ -72,13 +73,12 @@ export async function getAllIconSets() {
 function getIcons(url) {
     return axios
         .get(url)
-        .then((rawIcons) => {
-            const icons = []
-            rawIcons.data.items.forEach((rawIcon) => {
-                icons.push(new Icon(rawIcon.name, rawIcon.url, rawIcon.template_url))
-            })
-            return icons
-        })
+        .then((rawIcons) =>
+            rawIcons.data.items.map(
+                (rawIcon) =>
+                    new Icon(rawIcon.name, rawIcon.url, rawIcon.template_url, rawIcon.anchor)
+            )
+        )
         .catch((error) => {
             log('error', 'Error getting icons', url)
             return Promise.reject(error)

--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -33,7 +33,7 @@
 
 <script>
 import { mapActions, mapState } from 'vuex'
-import { API_SERVICES_BASE_URL, IS_TESTING_WITH_CYPRESS } from '@/config'
+import { IS_TESTING_WITH_CYPRESS } from '@/config'
 import { drawingModes } from '@/modules/store/modules/drawing.store'
 import DrawingToolbox from '@/modules/drawing/components/DrawingToolbox.vue'
 import DrawingManager from '@/modules/drawing/lib/DrawingManager'
@@ -45,7 +45,7 @@ import OverlayPositioning from 'ol/OverlayPositioning'
 import { Point } from 'ol/geom'
 import ProfilePopup from '@/modules/drawing/components/ProfilePopup.vue'
 import { saveAs } from 'file-saver'
-import { SMALL } from '@/modules/drawing/lib/drawingStyleSizes'
+import { SMALL, MEDIUM } from '@/modules/drawing/lib/drawingStyleSizes'
 import { RED } from '@/modules/drawing/lib/drawingStyleColor'
 
 const overlay = new Overlay({
@@ -128,14 +128,23 @@ export default {
                     drawOptions: {
                         type: 'Point',
                     },
-                    properties: {
-                        color: RED.fill,
-                        font: 'normal 16px Helvetica',
-                        icon: `${API_SERVICES_BASE_URL}icons/sets/default/icons/001-marker@1x-255,0,0.png`,
-                        anchor: [0.5, 0.9],
-                        text: '',
-                        description: '',
-                        textScale: SMALL.textScale,
+                    // These properties need to be evaluated later as the
+                    // availableIconSets aren't ready when this component is mounted.
+                    properties: () => {
+                        const defaultIconSet = this.availableIconSets.find(
+                            (set) => set.name === 'default'
+                        )
+                        const defaultIcon = defaultIconSet.icons[0]
+
+                        return {
+                            color: RED.fill,
+                            font: 'normal 16px Helvetica',
+                            icon: defaultIcon.generateURL(defaultIconSet.name, MEDIUM, RED),
+                            anchor: defaultIcon.anchor,
+                            text: '',
+                            description: '',
+                            textScale: SMALL.textScale,
+                        }
                     },
                 },
                 [drawingModes.MEASURE]: {

--- a/src/modules/drawing/components/styling/DrawingStyleIconSelector.vue
+++ b/src/modules/drawing/components/styling/DrawingStyleIconSelector.vue
@@ -133,6 +133,7 @@ export default {
                     this.currentIconColor
                 )
             )
+            this.feature.set('anchor', this.currentIcon.anchor)
             this.triggerChangeEvent()
         },
         setCurrentIconColor(color) {

--- a/src/modules/drawing/lib/DrawingManager.js
+++ b/src/modules/drawing/lib/DrawingManager.js
@@ -25,6 +25,7 @@ import Feature from 'ol/Feature'
 import Style from 'ol/style/Style'
 import { GPX, KML, GeoJSON } from 'ol/format'
 import { getKml } from '@/api/files.api'
+import { serializeAnchor, deserializeAnchor } from '@/utils/featureAnchor'
 
 const typesInTranslation = {
     MARKER: 'marker',
@@ -266,6 +267,8 @@ export default class DrawingManager extends Observable {
         let exportFeatures = []
         this.source.forEachFeature(function (f) {
             const clone = f.clone()
+            // The following serialization is a hack. See @module comment in file.
+            serializeAnchor(clone)
             clone.set('type', clone.get('type').toLowerCase())
             clone.setId(f.getId())
             clone.getGeometry().setProperties(f.getGeometry().getProperties())
@@ -574,6 +577,8 @@ export default class DrawingManager extends Observable {
             featureProjection: layer.projection,
         })
         features.forEach((f) => {
+            // The following deserialization is a hack. See @module comment in file.
+            deserializeAnchor(f)
             f.set('type', f.get('type').toUpperCase())
             f.setStyle((feature) => featureStyle(feature))
             if (f.get('type') === 'MEASURE') {

--- a/src/modules/drawing/lib/DrawingManager.js
+++ b/src/modules/drawing/lib/DrawingManager.js
@@ -107,12 +107,10 @@ export default class DrawingManager extends Observable {
         this.sketchPoints = 0
         for (let [type, options] of Object.entries(tools)) {
             // use the default styling if no specific draw style is set
-            const drawOptions = Object.assign(
-                {
-                    style: (feature) => featureStyle(feature),
-                },
-                options.drawOptions
-            )
+            const drawOptions = {
+                style: (feature) => featureStyle(feature),
+                ...options.drawOptions,
+            }
             const tool = new DrawInteraction({
                 ...drawOptions,
                 source: this.source,
@@ -339,11 +337,13 @@ export default class DrawingManager extends Observable {
 
     onAddFeature_(event, properties) {
         const feature = event.feature
+        const props = typeof properties === 'function' ? properties() : properties
 
         feature.setId(getUid(feature))
-        feature.setProperties(
-            Object.assign({ type: this.activeInteraction.get('type') }, properties)
-        )
+        feature.setProperties({
+            type: this.activeInteraction.get('type'),
+            ...props,
+        })
 
         this.updateDrawHelpTooltip(feature)
     }

--- a/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
@@ -9,6 +9,7 @@ import VectorSource from 'ol/source/Vector'
 import KML from 'ol/format/KML'
 import addLayerToMapMixin from './utils/addLayerToMap-mixins'
 import { featureStyle } from '@/modules/drawing/lib/style'
+import { deserializeAnchor } from '@/utils/featureAnchor'
 
 /** Renders a KML file on the map */
 export default {
@@ -53,6 +54,8 @@ export default {
         })
         this.layer.getSource().on('addfeature', (event) => {
             const f = event.feature
+            // The following deserialization is a hack. See @module comment in file.
+            deserializeAnchor(f)
             f.set('type', f.get('type').toUpperCase())
             f.setStyle((feature) => featureStyle(feature))
         })

--- a/src/modules/store/modules/drawing.store.js
+++ b/src/modules/store/modules/drawing.store.js
@@ -1,3 +1,5 @@
+import axios from 'axios'
+import { IS_TESTING_WITH_CYPRESS } from '@/config'
 import { getAllIconSets } from '@/api/icon.api'
 import { getKmlUrl } from '@/api/files.api'
 
@@ -66,6 +68,12 @@ export default {
             getAllIconSets().then((iconSets) => {
                 if (iconSets && iconSets.length > 0) {
                     commit('setIconSets', iconSets)
+                }
+                // We have a race condition during testing where the icons are
+                // needed after being loaded from the backend but before being
+                // committed to the store. Intercept and wait are in goToDrawing.
+                if (IS_TESTING_WITH_CYPRESS) {
+                    axios.get('/tell-cypress-icon-sets-available')
                 }
             })
         },

--- a/src/utils/featureAnchor.js
+++ b/src/utils/featureAnchor.js
@@ -1,0 +1,35 @@
+/**
+ * We currently have a problem with the KML serialization where we loose the anchor values. This
+ * seems to be a problem with the treatment by OpenLayers of the hotSpot KML tag. The helper
+ * functions provided by this module are hacks intended to be used until we can push a fix to
+ * {ol.format.KML} upstream.
+ *
+ * @module utils/featureAnchor
+ * @see {@link https://jira.swisstopo.ch/browse/BGDIINF_SB-2109}
+ * @see {@link https://jira.swisstopo.ch/browse/BGDIINF_SB-2165}
+ * @see {@link https://github.com/openlayers/openlayers/blob/v6.10.0/src/ol/format/KML.js#L2624-L2654}
+ * @see {@link ol.format.KML}
+ */
+
+/**
+ * Serializes the feature's anchor and stores it in a separate property.
+ *
+ * @param {ol.Feature} feature The feature to serialize.
+ * @returns {void}
+ */
+export function serializeAnchor(feature) {
+    feature.set('anchorString', JSON.stringify(feature.get('anchor')))
+}
+
+/**
+ * Deserializes the anchor from the separate property and updates the original property.
+ *
+ * @param {ol.Feature} feature The feature to serialize.
+ * @returns {void}
+ */
+export function deserializeAnchor(feature) {
+    const anchorString = feature.get('anchorString')
+    if (/\[\d+(\.\d+)?,\d+(\.\d+)?\]/.test(anchorString)) {
+        feature.set('anchor', JSON.parse(feature.get('anchorString')))
+    }
+}

--- a/tests/e2e/support/drawing.js
+++ b/tests/e2e/support/drawing.js
@@ -50,6 +50,9 @@ Cypress.on('uncaught:exception', () => {
 })
 
 Cypress.Commands.add('goToDrawing', (isMobileViewport = false) => {
+    // see drawing.store.js (wait is at the end of this function)
+    cy.intercept('**/tell-cypress-icon-sets-available', {}).as('icon-sets-available')
+
     addIconFixtureAndIntercept()
     addIconSetsFixtureAndIntercept()
     addDefaultIconsFixtureAndIntercept()
@@ -60,6 +63,7 @@ Cypress.Commands.add('goToDrawing', (isMobileViewport = false) => {
     }
     cy.get('[data-cy="menu-tray-drawing-section"]').click()
     cy.readStoreValue('state.ui.showDrawingOverlay').should('be.true')
+    cy.wait('@icon-sets-available')
 })
 
 Cypress.Commands.add('clickDrawingTool', (name) => {


### PR DESCRIPTION
Until now we used hard-coded anchors to position the icons on the map.

The backend service has been updated to provide an anchor for each icon and this change updates the code to make use of this information.

This PR also includes the fix for the missing anchors.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-2154-icon-anchor-from-backend/index.html)