### PR TITLE
BGDIINF_SB-2163: Fixed CI branch name resolution

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,6 +1,7 @@
 version: 0.2
 
 env:
+  shell: bash
   variables:
     AWS_DEFAULT_REGION: eu-central-1
   parameter-store:
@@ -24,23 +25,18 @@ phases:
 
   post_build:
     commands:
-      # Reading git branch (the utility in the deploy script is unable to read it automatically on CodeBuild)
-      # see https://stackoverflow.com/questions/47657423/get-github-git-branch-for-aws-codebuild
-      - export CODEBUILD_GIT_BRANCH="$(git symbolic-ref HEAD --short 2>/dev/null)"
-      - if [ "$CODEBUILD_GIT_BRANCH" = "" ] ; then
-          CODEBUILD_GIT_BRANCH="$(git branch -a --contains HEAD | sed -n 2p | awk '{ printf $1 }')";
-          export CODEBUILD_GIT_BRANCH=${CODEBUILD_GIT_BRANCH#remotes/origin/};
-        fi
+      - echo "CODEBUILD_WEBHOOK_HEAD_REF=${CODEBUILD_WEBHOOK_HEAD_REF} CODEBUILD_WEBHOOK_BASE_REF=${CODEBUILD_WEBHOOK_BASE_REF}"
+      - export GITHUB_BRANCH="${CODEBUILD_WEBHOOK_HEAD_REF#refs/heads/}"
       # if this build has been triggered by a push on master (PR merge on master), we deploy on INT (otherwise everything goes to dev)
-      - export CODEBUILD_DEPLOY_TARGET="dev"
-      - if [ "$CODEBUILD_GIT_BRANCH" = "master" ] ; then
-          export CODEBUILD_DEPLOY_TARGET="int";
+      - export DEPLOY_TARGET="dev"
+      - if [ "${GITHUB_BRANCH}" = "master" ] ; then
+          export DEPLOY_TARGET="int";
         fi
       # if we are on DEV, we have to switch to the account "swisstopo-bgdi-dev", otherwise the account is "swisstopo-bgdi"
-      - export AWS_ACCOUNT_TO_USE="$AWS_SWISSTOPO_BGDI_DEV_ACCOUNT_ID:role/BgdiDevCodebuildAccess"
-      - if [ "$CODEBUILD_DEPLOY_TARGET" = "int" ] ; then
-          export AWS_ACCOUNT_TO_USE="$AWS_SWISSTOPO_BGDI_ACCOUNT_ID:role/BgdiCodebuildAccess";
+      - export AWS_ACCOUNT_TO_USE="${AWS_SWISSTOPO_BGDI_DEV_ACCOUNT_ID}:role/BgdiDevCodebuildAccess"
+      - if [ "${DEPLOY_TARGET}" = "int" ] ; then
+          export AWS_ACCOUNT_TO_USE="${AWS_SWISSTOPO_BGDI_ACCOUNT_ID}:role/BgdiCodebuildAccess";
         fi
       # switching role for deploy (otherwise the S3 bucket won't be visible as it's another account)
       # the application will be built by the npm target before deploying
-      - npm run deploy:$CODEBUILD_DEPLOY_TARGET -- --role=arn:aws:iam::$AWS_ACCOUNT_TO_USE --branch=$CODEBUILD_GIT_BRANCH
+      - npm run deploy:${DEPLOY_TARGET} -- --role=arn:aws:iam::${AWS_ACCOUNT_TO_USE} --branch=${GITHUB_BRANCH}

--- a/vue.config.js
+++ b/vue.config.js
@@ -4,9 +4,7 @@ const fs = require('fs')
 const gitBranch = require('git-branch')
 
 // if we are building from the CI, we should receive the git branch through ENV variable, otherwise we use the node git-branch utility to read it.
-const branch = process.env.CODEBUILD_GIT_BRANCH
-    ? process.env.CODEBUILD_GIT_BRANCH
-    : gitBranch.sync()
+const branch = process.env.GITHUB_BRANCH ? process.env.GITHUB_BRANCH : gitBranch.sync()
 
 // defines the base URL the application bundle will be deployed at
 let publicPath = '/' // default to root of the bucket URL (or local address if served locally)


### PR DESCRIPTION
Removed old hack for branch name resolution. This hack did not work with
PR from fork as well as by some PR from dependabot.

Use the newest Codebuild variable instead and make sure that the branch
name used in docker tag don't contains `/` by replacing them to `_`
(`/` is not allowed in docker tag name). For this replacement we need
bash so make sure that Codebuild use bash instead of the default hash.

Also based on the AWS Codebuild documentation
(https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html)
don't use `CODEBUILD_` environment variable prefix which is reserved for
internal use by CodeBuild.

[Test link](https://web-mapviewer.dev.bgdi.ch/bug-bgdiinf_sb-2163-ci-branch/index.html)