### PR TITLE
BGDIINF_SB-2119: Replaced portal-vue with Vue teleport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
                 "jquery": "^3.6.0",
                 "mobile-device-detect": "^0.4.3",
                 "ol": "^6.10.0",
-                "portal-vue": "next",
                 "proj4": "^2.7.5",
                 "register-service-worker": "^1.7.2",
                 "reproject": "^1.2.6",
@@ -17198,17 +17197,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/portal-vue": {
-            "version": "3.0.0-beta.0",
-            "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-3.0.0-beta.0.tgz",
-            "integrity": "sha512-ktV+Q0fwlsjeF+2xGebMxrN6xH8yMdmbLzYbd2OfcgU4OmzSmkj6iP3kBQRGa+7A5WZlqCHWaFfecNs9Igsv9w==",
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "vue": "^3.0.4"
             }
         },
         "node_modules/portfinder": {
@@ -35821,12 +35809,6 @@
             "requires": {
                 "find-up": "^4.0.0"
             }
-        },
-        "portal-vue": {
-            "version": "3.0.0-beta.0",
-            "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-3.0.0-beta.0.tgz",
-            "integrity": "sha512-ktV+Q0fwlsjeF+2xGebMxrN6xH8yMdmbLzYbd2OfcgU4OmzSmkj6iP3kBQRGa+7A5WZlqCHWaFfecNs9Igsv9w==",
-            "requires": {}
         },
         "portfinder": {
             "version": "1.0.28",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
         "jquery": "^3.6.0",
         "mobile-device-detect": "^0.4.3",
         "ol": "^6.10.0",
-        "portal-vue": "next",
         "proj4": "^2.7.5",
         "register-service-worker": "^1.7.2",
         "reproject": "^1.2.6",

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,6 @@ import 'bootstrap'
 import 'animate.css'
 
 import { createApp } from 'vue'
-import PortalVuePlugin from 'portal-vue'
 
 import App from './App.vue'
 import store from '@/modules/store'
@@ -21,7 +20,6 @@ const app = createApp(App)
 app.use(router)
 app.use(i18n)
 app.use(store)
-app.use(PortalVuePlugin)
 
 // setting up font awesome vue component
 require('./setup-fontawesome')

--- a/src/modules/map/components/MapFooter.vue
+++ b/src/modules/map/components/MapFooter.vue
@@ -1,9 +1,9 @@
 <template>
     <div id="footer" class="align-items-center">
-        <portal-target multiple class="flex-grow-1 d-flex align-items-center" name="footer" />
-        <div v-if="showAppVersion" class="mx-3 app-version small pe-none">v{{ appVersion }}</div>
+        <div id="footer-target-scale"></div>
+        <div id="footer-target-mouse" class="flex-grow-1"></div>
+        <div v-if="showAppVersion" class="mx-3 app-version small">v{{ appVersion }}</div>
         <a
-            class="copyright align-self-center user-select-none"
             :href="`https://www.geo.admin.ch/${$i18n.locale}/about-swiss-geoportal/impressum.html#copyright`"
             target="_blank"
         >

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -3,13 +3,13 @@
     <div id="ol-map" ref="map" @contextmenu="showLocationPopup">
         <!-- So that external modules can have access to the map instance through the provided 'getMap' -->
         <slot />
-        <portal to="footer" :order="1">
+        <teleport v-if="readyForTeleport" to="#footer-target-scale">
             <!--
                 It is necessary to use `v-show` instead of `v-if`. Otherwise,
                 the scale-line will never show if the initial zoom was too low.
             -->
             <div v-show="zoom >= 9" id="scale-line" ref="scaleLine" data-cy="scaleline" />
-        </portal>
+        </teleport>
         <OpenLayersMousePosition v-if="isUIinDesktopMode" />
         <VisibleLayersCopyrights
             :layers="backgroundAndVisibleLayers"
@@ -119,6 +119,8 @@ export default {
             markerStyles,
             /** Keeping trace of the starting center in order to place the cross hair */
             initialCenter: null,
+            /** Delay teleport until view is rendered. Updated in mounted-hook. */
+            readyForTeleport: false,
         }
     },
     computed: {
@@ -241,6 +243,8 @@ export default {
         // see https://portal-vue.linusb.org/guide/caveats.html#refs
         // for the reason this double $nextTick is here
         this.$nextTick().then(() => {
+            // We can enable the teleport after the view has been rendered.
+            this.readyForTeleport = true
             this.$nextTick(() => {
                 const scaleLine = new ScaleLine({
                     target: this.$refs.scaleLine,

--- a/src/modules/map/components/openlayers/OpenLayersMousePosition.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMousePosition.vue
@@ -1,5 +1,5 @@
 <template>
-    <portal to="footer" :order="2">
+    <teleport v-if="readyForTeleport" to="#footer-target-mouse">
         <div ref="mousePosition" class="d-flex align-items-center" data-cy="mouse-position">
             <select
                 v-model="currentProjectionId"
@@ -13,7 +13,7 @@
             </select>
             <!-- Here OpenLayers will inject a div with the class mouse-position -->
         </div>
-    </portal>
+    </teleport>
 </template>
 
 <script>
@@ -27,6 +27,8 @@ export default {
         return {
             currentProjectionId: CoordinateSystems.LV95.id,
             availableProjections: CoordinateSystems,
+            /** Delay teleport until view is rendered. Updated in mounted-hook. */
+            readyForTeleport: false,
         }
     },
     created() {
@@ -40,6 +42,8 @@ export default {
         const map = this.getMap()
         // see https://portal-vue.linusb.org/guide/caveats.html#refs
         this.$nextTick().then(() => {
+            // We can enable the teleport after the view has been rendered.
+            this.readyForTeleport = true
             this.$nextTick(() => {
                 this.mousePositionControl.setTarget(this.$refs.mousePosition)
                 this.mousePositionControl.setCoordinateFormat(CoordinateSystems.LV95.format)

--- a/src/utils/PopoverButton.vue
+++ b/src/utils/PopoverButton.vue
@@ -8,7 +8,6 @@
             :small="small"
             :danger="danger"
         ></ButtonWithIcon>
-        <!--        <portal to="modal-container">-->
         <div
             ref="popoverContent"
             class="popover-container"
@@ -38,9 +37,9 @@
                 </div>
             </div>
         </div>
-        <!--        </portal>-->
     </div>
 </template>
+
 <script>
 import tippy from 'tippy.js'
 import ButtonWithIcon from '@/utils/ButtonWithIcon.vue'
@@ -152,6 +151,7 @@ export default {
     },
 }
 </script>
+
 <style scoped>
 @import '~tippy.js/dist/svg-arrow.css';
 </style>


### PR DESCRIPTION
As Vue3 comes with its own teleport feature we want to get rid of the portal-vue plugin. However, because the destination has to be mounted before the teleport and the order is on a first-come basis, this isn't a drop-in replacement.

This change adds a delay (through nextTick) before the teleports are attempted and to guarantee the correct order I added dedicated destinations for each teleport.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-2119-replace-portals-with-teleports/index.html)