### PR TITLE
BGDIINF_SB-2014: Added transparency to footer

### DIFF
--- a/src/modules/map/components/MapFooter.vue
+++ b/src/modules/map/components/MapFooter.vue
@@ -41,7 +41,7 @@ export default {
     height: $footer-height;
     font-size: 0.6rem;
     padding: 0 0.2rem;
-    background: $white;
+    background: rgba($white, 0.9);
     display: flex;
     .app-version {
         color: $gray-400;

--- a/src/modules/map/components/openlayers/VisibleLayersCopyrights.vue
+++ b/src/modules/map/components/openlayers/VisibleLayersCopyrights.vue
@@ -74,7 +74,7 @@ export default {
     right: 0;
     z-index: $zindex-copyrights;
     font-size: 0.7rem;
-    background: rgba(255, 255, 255, 0.7);
+    background: rgba($white, 0.7);
     &.footer-visible {
         bottom: $footer-height;
     }

--- a/src/modules/menu/MenuModule.vue
+++ b/src/modules/menu/MenuModule.vue
@@ -126,7 +126,7 @@ export default {
     height: $header-height;
     transition: height 0.3s;
     width: 100%;
-    background: rgba(255, 255, 255, 0.9);
+    background: rgba($white, 0.9);
     box-shadow: 6px 6px 12px rgb(0 0 0 / 18%);
     // so that the menu is above the map overlay
     z-index: $zindex-overlay-default + 2;


### PR DESCRIPTION
We wanted transparent header, footer, and copyright notice.

The header and copyright already had the transparency so this change
only adds it to the footer. While I was at it I changed the existing
transparency to use SCSS variables and rgba() function.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-2014-footer-transparency/index.html)