### PR TITLE
BGDIINF_SB-2170: Changed layer copyright position

### DIFF
--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -22,12 +22,14 @@
             @change="triggerKMLUpdate"
         />
         <div ref="draw-help" class="draw-help-popup"></div>
-        <ProfilePopup
-            :feature="selectedFeature"
-            :ui-mode="uiMode"
-            @delete="deleteSelectedFeature"
-            @close="deactivateFeature"
-        />
+        <teleport v-if="readyForTeleport" to="#map-target-profile">
+            <ProfilePopup
+                :feature="selectedFeature"
+                :ui-mode="uiMode"
+                @delete="deleteSelectedFeature"
+                @close="deactivateFeature"
+            />
+        </teleport>
     </div>
 </template>
 
@@ -62,6 +64,8 @@ export default {
             selectedFeature: null,
             drawingModes: Object.values(drawingModes),
             drawingNotEmpty: false,
+            /** Delay teleport until view is rendered. Updated in mounted-hook. */
+            readyForTeleport: false,
         }
     },
     computed: {
@@ -185,6 +189,11 @@ export default {
         this.manager.on('select', this.onSelect)
         this.manager.on('drawEnd', () => {
             this.setDrawingMode(null)
+        })
+
+        // We can enable the teleport after the view has been rendered.
+        this.$nextTick(() => {
+            this.readyForTeleport = true
         })
     },
     methods: {

--- a/src/modules/drawing/components/ProfilePopup.vue
+++ b/src/modules/drawing/components/ProfilePopup.vue
@@ -352,10 +352,6 @@ export default {
 @import 'src/scss/webmapviewer-bootstrap-theme';
 
 .profile-popup {
-    position: absolute;
-    z-index: $zindex-map + 2; // so that we are above the map toolbox (background wheel, zoom buttons, etc...)
-    top: auto;
-    bottom: $footer-height;
     width: 100%;
     max-height: 380px;
 

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -11,11 +11,8 @@
             <div v-show="zoom >= 9" id="scale-line" ref="scaleLine" data-cy="scaleline" />
         </teleport>
         <OpenLayersMousePosition v-if="isUIinDesktopMode" />
-        <div id="map-target-profile">
-            <VisibleLayersCopyrights
-                :layers="backgroundAndVisibleLayers"
-                :is-footer-visible="isFooterVisible"
-            />
+        <div id="map-target-profile" :class="{ 'footer-visible': isFooterVisible }">
+            <VisibleLayersCopyrights />
         </div>
         <!-- Adding background layer -->
         <OpenLayersInternalLayer
@@ -181,16 +178,6 @@ export default {
         },
         visibleGeoJsonLayers: function () {
             return this.visibleLayers.filter((layer) => layer.type === LayerTypes.GEOJSON)
-        },
-        backgroundAndVisibleLayers: function () {
-            const layers = []
-            if (this.currentBackgroundLayer) {
-                layers.push(this.currentBackgroundLayer)
-            }
-            if (this.visibleLayers.length > 0) {
-                layers.push(...this.visibleLayers)
-            }
-            return layers
         },
         isUIinDesktopMode: function () {
             return this.uiMode === UIModes.MENU_ALWAYS_OPEN
@@ -399,12 +386,15 @@ export default {
 #map-target-profile {
     position: absolute;
     right: 0;
-    bottom: $footer-height;
     left: 0;
     z-index: $zindex-copyrights;
 
     display: flex;
     flex-direction: column;
     align-items: end;
+
+    &.footer-visible {
+        bottom: $footer-height;
+    }
 }
 </style>

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -11,10 +11,12 @@
             <div v-show="zoom >= 9" id="scale-line" ref="scaleLine" data-cy="scaleline" />
         </teleport>
         <OpenLayersMousePosition v-if="isUIinDesktopMode" />
-        <VisibleLayersCopyrights
-            :layers="backgroundAndVisibleLayers"
-            :is-footer-visible="isFooterVisible"
-        />
+        <div id="map-target-profile">
+            <VisibleLayersCopyrights
+                :layers="backgroundAndVisibleLayers"
+                :is-footer-visible="isFooterVisible"
+            />
+        </div>
         <!-- Adding background layer -->
         <OpenLayersInternalLayer
             v-if="currentBackgroundLayer"
@@ -393,5 +395,16 @@ export default {
             max-width: 150px;
         }
     }
+}
+#map-target-profile {
+    position: absolute;
+    right: 0;
+    bottom: $footer-height;
+    left: 0;
+    z-index: $zindex-copyrights;
+
+    display: flex;
+    flex-direction: column;
+    align-items: end;
 }
 </style>

--- a/src/modules/map/components/openlayers/VisibleLayersCopyrights.vue
+++ b/src/modules/map/components/openlayers/VisibleLayersCopyrights.vue
@@ -69,10 +69,6 @@ export default {
 <style lang="scss" scoped>
 @import 'src/scss/webmapviewer-bootstrap-theme';
 #visible-layers-copyrights {
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    z-index: $zindex-copyrights;
     font-size: 0.7rem;
     background: rgba($white, 0.7);
     &.footer-visible {

--- a/src/modules/map/components/openlayers/VisibleLayersCopyrights.vue
+++ b/src/modules/map/components/openlayers/VisibleLayersCopyrights.vue
@@ -1,10 +1,5 @@
 <template>
-    <div
-        id="visible-layers-copyrights"
-        class="d-flex p-1"
-        :class="{ 'footer-visible': isFooterVisible }"
-        data-cy="layers-copyrights"
-    >
+    <div id="visible-layers-copyrights" class="d-flex p-1" data-cy="layers-copyrights">
         <div v-if="copyrights.length > 0">{{ $t('copyright_data') }}</div>
         <div v-for="(copyright, index) in copyrights" :key="copyright.attributionName">
             <a
@@ -27,20 +22,15 @@
     </div>
 </template>
 <script>
+import { mapGetters } from 'vuex'
+
 export default {
-    props: {
-        /** @type {GeoAdminLayer[]} */
-        layers: {
-            type: Array,
-            required: true,
-        },
-        isFooterVisible: {
-            type: Boolean,
-            default: true,
-        },
-    },
     computed: {
-        copyrights: function () {
+        ...mapGetters(['visibleLayers', 'currentBackgroundLayer']),
+        layers() {
+            return [this.currentBackgroundLayer, ...this.visibleLayers].filter(Boolean)
+        },
+        copyrights() {
             const copyrights = []
             this.layers.forEach((layer) => {
                 // only keeping one of each occurrence of the same data owner
@@ -71,9 +61,6 @@ export default {
 #visible-layers-copyrights {
     font-size: 0.7rem;
     background: rgba($white, 0.7);
-    &.footer-visible {
-        bottom: $footer-height;
-    }
     .copyright {
         color: $black;
         text-decoration: none;


### PR DESCRIPTION
The problem with the force-click in the test had already been addressed via a z-index. But that hides the copyright notice if the profile is present (minimized or not).

This change positions the copyright notice above the profile so that it is always in the bottom right-hand corner of the visible part of the map. That not only makes Cypress happy but also copyright holders.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-2170-copyright-position/index.html)