### PR TITLE
BGDIINF_SB-2132: Changed text-add icon (drawing)

### DIFF
--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -7,6 +7,7 @@
             :delete-last-point-callback="deleteLastPointCallback"
             :drawing-not-empty="drawingNotEmpty"
             :kml-ids="kmlIds"
+            :ui-mode="uiMode"
             @close="hideDrawingOverlay"
             @set-drawing-mode="changeDrawingMode"
             @export="exportDrawing"

--- a/src/modules/drawing/components/DrawingToolbox.vue
+++ b/src/modules/drawing/components/DrawingToolbox.vue
@@ -16,6 +16,7 @@
                             :key="drawingMode"
                             :drawing-mode="drawingMode"
                             :is-active="currentDrawingMode === drawingMode"
+                            :ui-mode="uiMode"
                             :data-cy="`drawing-toolbox-mode-button-${drawingMode}`"
                             class="m-1"
                             @set-drawing-mode="bubbleSetDrawingEventToParent"
@@ -123,6 +124,7 @@ import DrawingToolboxButton from '@/modules/drawing/components/DrawingToolboxBut
 import ShareForm from '@/modules/drawing/components/SharePopup.vue'
 import ButtonWithIcon from '@/utils/ButtonWithIcon.vue'
 import ModalWithBackdrop from '@/utils/ModalWithBackdrop.vue'
+import { UIModes } from '@/modules/store/modules/ui.store'
 
 export default {
     components: {
@@ -151,6 +153,10 @@ export default {
         deleteLastPointCallback: {
             type: Function,
             default: undefined,
+        },
+        uiMode: {
+            type: String,
+            default: UIModes.MENU_ALWAYS_OPEN,
         },
     },
     emits: ['close', 'setDrawingMode', 'export', 'clearDrawing'],

--- a/src/modules/drawing/components/DrawingToolboxButton.vue
+++ b/src/modules/drawing/components/DrawingToolboxButton.vue
@@ -2,19 +2,18 @@
     <ButtonWithIcon
         small
         outline-light
-        :button-title="drawingModeToLabel(drawingMode)"
+        :button-title="buttonLabel"
         :danger="isActive"
         :button-font-awesome-icon="buttonIcon"
         :icons-before-text="true"
         direction="column"
-        :style="buttonStyle"
+        :class="buttonClasses"
         :data-cy="`drawing-${drawingMode.toLowerCase()}`"
         @click="emitSetDrawingMode"
     />
 </template>
 
 <script>
-import { mapState } from 'vuex'
 import { drawingModes } from '@/modules/store/modules/drawing.store'
 import ButtonWithIcon from '@/utils/ButtonWithIcon.vue'
 import { UIModes } from '@/modules/store/modules/ui.store'
@@ -30,12 +29,13 @@ export default {
             type: Boolean,
             default: false,
         },
+        uiMode: {
+            type: String,
+            default: UIModes.MENU_ALWAYS_OPEN,
+        },
     },
     emits: ['setDrawingMode'],
     computed: {
-        ...mapState({
-            uiMode: (state) => state.ui.mode,
-        }),
         buttonIcon() {
             switch (this.drawingMode) {
                 case drawingModes.LINE:
@@ -49,23 +49,24 @@ export default {
             }
             return null
         },
-        buttonStyle() {
-            return {
-                // The buttons having different/dynamic widths looks unintentional.
-                // While inline styles are bad, there is no Bootstrap class we can
-                // apply to the component and this width is too use-case specific
-                // to be added as a class in the ButtonWithIcon component.
-                width: this.uiMode === 'MENU_ALWAYS_OPEN' ? '4.5em' : '',
+        buttonLabel() {
+            // Don't show a label on small viewports.
+            if (this.uiMode === UIModes.MENU_ALWAYS_OPEN) {
+                return this.$t(`draw_${this.drawingMode.toLowerCase()}`)
+            } else {
+                return undefined
+            }
+        },
+        buttonClasses() {
+            // Set a fixed width on large viewports for a consistent look.
+            if (this.uiMode === UIModes.MENU_ALWAYS_OPEN) {
+                return 'button-with-icon-w5'
+            } else {
+                return undefined
             }
         },
     },
     methods: {
-        drawingModeToLabel(mode) {
-            // Don't show a label on small viewports.
-            if (this.uiMode === UIModes.MENU_ALWAYS_OPEN) {
-                return this.$t(`draw_${mode.toLowerCase()}`)
-            }
-        },
         emitSetDrawingMode() {
             this.$emit('setDrawingMode', this.drawingMode)
         },

--- a/src/modules/drawing/components/DrawingToolboxButton.vue
+++ b/src/modules/drawing/components/DrawingToolboxButton.vue
@@ -60,7 +60,7 @@ export default {
         buttonClasses() {
             // Set a fixed width on large viewports for a consistent look.
             if (this.uiMode === UIModes.MENU_ALWAYS_OPEN) {
-                return 'button-with-icon-w5'
+                return 'button-with-icon-uniform'
             } else {
                 return undefined
             }
@@ -73,3 +73,9 @@ export default {
     },
 }
 </script>
+
+<style lang="scss" scoped>
+.button-with-icon-uniform {
+    width: 5em;
+}
+</style>

--- a/src/modules/drawing/components/DrawingToolboxButton.vue
+++ b/src/modules/drawing/components/DrawingToolboxButton.vue
@@ -1,17 +1,23 @@
 <template>
     <ButtonWithIcon
-        large
+        small
         outline-light
+        :button-title="drawingModeToLabel(drawingMode)"
         :danger="isActive"
         :button-font-awesome-icon="buttonIcon"
+        :icons-before-text="true"
+        direction="column"
+        :style="buttonStyle"
         :data-cy="`drawing-${drawingMode.toLowerCase()}`"
         @click="emitSetDrawingMode"
     />
 </template>
 
 <script>
+import { mapState } from 'vuex'
 import { drawingModes } from '@/modules/store/modules/drawing.store'
 import ButtonWithIcon from '@/utils/ButtonWithIcon.vue'
+import { UIModes } from '@/modules/store/modules/ui.store'
 
 export default {
     components: { ButtonWithIcon },
@@ -27,7 +33,10 @@ export default {
     },
     emits: ['setDrawingMode'],
     computed: {
-        buttonIcon: function () {
+        ...mapState({
+            uiMode: (state) => state.ui.mode,
+        }),
+        buttonIcon() {
             switch (this.drawingMode) {
                 case drawingModes.LINE:
                     return ['fa', 'draw-polygon']
@@ -40,9 +49,24 @@ export default {
             }
             return null
         },
+        buttonStyle() {
+            return {
+                // The buttons having different/dynamic widths looks unintentional.
+                // While inline styles are bad, there is no Bootstrap class we can
+                // apply to the component and this width is too use-case specific
+                // to be added as a class in the ButtonWithIcon component.
+                width: this.uiMode === 'MENU_ALWAYS_OPEN' ? '4.5em' : '',
+            }
+        },
     },
     methods: {
-        emitSetDrawingMode: function () {
+        drawingModeToLabel(mode) {
+            // Don't show a label on small viewports.
+            if (this.uiMode === UIModes.MENU_ALWAYS_OPEN) {
+                return this.$t(`draw_${mode.toLowerCase()}`)
+            }
+        },
+        emitSetDrawingMode() {
             this.$emit('setDrawingMode', this.drawingMode)
         },
     },

--- a/src/modules/drawing/components/DrawingToolboxButton.vue
+++ b/src/modules/drawing/components/DrawingToolboxButton.vue
@@ -36,10 +36,7 @@ export default {
                 case drawingModes.MEASURE:
                     return ['fa', 'ruler']
                 case drawingModes.TEXT:
-                    // TODO: Redo a T+ logo somehow (T text sign is only included in pro version)
-                    // so either go pro, and stack icons to achieve this or go the old way :
-                    // it was injected as a custom FA icon in the old viewer
-                    return ['fa', 'plus']
+                    return ['fa', 't']
             }
             return null
         },

--- a/src/setup-fontawesome.js
+++ b/src/setup-fontawesome.js
@@ -1,73 +1,73 @@
 import { library } from '@fortawesome/fontawesome-svg-core'
 import {
-    faTimes,
-    faTimesCircle,
-    faSpinner,
-    faCog,
-    faArrowUp,
     faArrowDown,
+    faArrowUp,
+    faArrowsAltH,
+    faArrowsAltV,
+    faCaretDown,
     faCaretRight,
     faCaretUp,
-    faCaretDown,
-    faPlusCircle,
-    faPlus,
-    faMinusCircle,
-    faInfoCircle,
-    faPrint,
-    faMapMarkerAlt,
+    faChevronDown,
+    faChevronUp,
+    faCog,
     faDrawPolygon,
-    faRuler,
-    faArrowsAltH,
-    faSquareFull,
     faFont,
+    faInfoCircle,
+    faMapMarkerAlt,
+    faMinusCircle,
     faPaintBrush,
-    faArrowsAltV,
+    faPlusCircle,
+    faPrint,
+    faRuler,
     faSearch,
     faSortAmountUpAlt,
     faSortAmountDownAlt,
-    faChevronUp,
-    faChevronDown,
+    faSpinner,
+    faSquareFull,
+    faT,
+    faTimes,
+    faTimesCircle,
     faWindowMinimize,
 } from '@fortawesome/free-solid-svg-icons'
 import {
     faCheckSquare,
+    faClock,
+    faEye,
     faSquare,
     faTrashAlt,
-    faEye,
-    faClock,
 } from '@fortawesome/free-regular-svg-icons'
 
-library.add(faPaintBrush)
-library.add(faSquare)
-library.add(faSquareFull)
-library.add(faTrashAlt)
-library.add(faTimes)
-library.add(faTimesCircle)
-library.add(faSpinner)
-library.add(faCog)
+library.add(faArrowDown)
 library.add(faArrowUp)
 library.add(faArrowsAltH)
-library.add(faArrowDown)
+library.add(faArrowsAltV)
+library.add(faCaretDown)
 library.add(faCaretRight)
 library.add(faCaretUp)
-library.add(faCaretDown)
-library.add(faPlusCircle)
-library.add(faPlus)
-library.add(faMinusCircle)
-library.add(faInfoCircle)
-library.add(faPrint)
-library.add(faMapMarkerAlt)
+library.add(faChevronDown)
+library.add(faChevronUp)
+library.add(faCog)
 library.add(faDrawPolygon)
-library.add(faRuler)
-library.add(faCheckSquare)
-library.add(faSquare)
 library.add(faFont)
-library.add(faArrowsAltV)
+library.add(faInfoCircle)
+library.add(faMapMarkerAlt)
+library.add(faMinusCircle)
+library.add(faPaintBrush)
+library.add(faPlusCircle)
+library.add(faPrint)
+library.add(faRuler)
 library.add(faSearch)
 library.add(faSortAmountUpAlt)
 library.add(faSortAmountDownAlt)
-library.add(faChevronUp)
-library.add(faChevronDown)
-library.add(faEye)
-library.add(faClock)
+library.add(faSpinner)
+library.add(faSquareFull)
+library.add(faT)
+library.add(faTimes)
+library.add(faTimesCircle)
 library.add(faWindowMinimize)
+
+library.add(faCheckSquare)
+library.add(faClock)
+library.add(faEye)
+library.add(faSquare)
+library.add(faTrashAlt)

--- a/src/utils/ButtonWithIcon.vue
+++ b/src/utils/ButtonWithIcon.vue
@@ -101,17 +101,9 @@ export default {
         labelClasses() {
             let className
             if (this.direction === 'column') {
-                if (this.iconsBeforeText) {
-                    className = 'mt-1'
-                } else {
-                    className = 'mb-1'
-                }
+                className = this.iconsBeforeText ? 'mt-1' : 'mb-1'
             } else {
-                if (this.iconsBeforeText) {
-                    className = 'ms-1'
-                } else {
-                    className = 'me-1'
-                }
+                className = this.iconsBeforeText ? 'ms-1' : 'me-1'
             }
             return className
         },
@@ -130,6 +122,9 @@ export default {
     &.btn-no-style {
         background: none;
         border: none;
+    }
+    &-w5 {
+        width: 5em;
     }
 }
 svg {

--- a/src/utils/ButtonWithIcon.vue
+++ b/src/utils/ButtonWithIcon.vue
@@ -123,9 +123,6 @@ export default {
         background: none;
         border: none;
     }
-    &-w5 {
-        width: 5em;
-    }
 }
 svg {
     transition: transform 0.2s, color 0.2s;

--- a/src/utils/ButtonWithIcon.vue
+++ b/src/utils/ButtonWithIcon.vue
@@ -4,7 +4,7 @@
             v-if="iconsBeforeText && buttonFontAwesomeIcon && buttonFontAwesomeIcon.length > 0"
             :icon="buttonFontAwesomeIcon"
         />
-        <span :class="{ 'ms-1': iconsBeforeText }">
+        <span v-if="buttonTitle" :class="labelClasses">
             {{ buttonTitle }}
         </span>
         <FontAwesomeIcon
@@ -13,6 +13,7 @@
         />
     </button>
 </template>
+
 <script>
 export default {
     props: {
@@ -27,6 +28,13 @@ export default {
         iconsBeforeText: {
             type: Boolean,
             default: false,
+        },
+        direction: {
+            type: String,
+            default: 'row',
+            validator(value) {
+                return ['row', 'column'].includes(value)
+            },
         },
         small: {
             type: Boolean,
@@ -63,7 +71,7 @@ export default {
     },
     emits: ['click'],
     computed: {
-        buttonClasses: function () {
+        buttonClasses() {
             const classes = []
             if (this.small) {
                 classes.push('btn-sm')
@@ -85,11 +93,31 @@ export default {
             } else {
                 classes.push('btn-light')
             }
+            if (this.direction === 'column') {
+                classes.push('flex-column')
+            }
             return classes
+        },
+        labelClasses() {
+            let className
+            if (this.direction === 'column') {
+                if (this.iconsBeforeText) {
+                    className = 'mt-1'
+                } else {
+                    className = 'mb-1'
+                }
+            } else {
+                if (this.iconsBeforeText) {
+                    className = 'ms-1'
+                } else {
+                    className = 'me-1'
+                }
+            }
+            return className
         },
     },
     methods: {
-        forwardClickEvent: function (event) {
+        forwardClickEvent(event) {
             this.$emit('click', event)
         },
     },

--- a/src/utils/ButtonWithIcon.vue
+++ b/src/utils/ButtonWithIcon.vue
@@ -1,13 +1,13 @@
 <template>
     <button class="button-with-icon d-flex btn" :class="buttonClasses" @click="forwardClickEvent">
-        <font-awesome-icon
+        <FontAwesomeIcon
             v-if="iconsBeforeText && buttonFontAwesomeIcon && buttonFontAwesomeIcon.length > 0"
             :icon="buttonFontAwesomeIcon"
         />
         <span :class="{ 'ms-1': iconsBeforeText }">
             {{ buttonTitle }}
         </span>
-        <font-awesome-icon
+        <FontAwesomeIcon
             v-if="!iconsBeforeText && buttonFontAwesomeIcon && buttonFontAwesomeIcon.length > 0"
             :icon="buttonFontAwesomeIcon"
         />


### PR DESCRIPTION
We currently use a plus icon for the text-add button which doesn't
communicate the purpose of the button as the other buttons from the
drawing toolbox also add things.

This changes the icon from a "+" to a "T".

More information about the choice can be found in the Jira ticket.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-2132-drawing-text-icon/index.html)