### PR TITLE
BGDIINF_SB-2212: Made position content selectable

### DIFF
--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -1,5 +1,4 @@
 <template>
-    <!-- Stop right click propagation to allow the user to interact with the popup. -->
     <div v-if="isRightClick" class="location-popup" data-cy="location-popup" @contextmenu.stop>
         <div class="card">
             <div class="card-header d-flex">

--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -164,7 +164,9 @@ export default {
         this.overlay = new Overlay({
             offset: [0, 15],
             positioning: OverlayPositioning.TOP_CENTER,
-            className: 'location-popup-overlay',
+            // Selection of overlay content was broken in OL v4.1 so we need an extra class.
+            // https://github.com/openlayers/openlayers/pull/6741
+            className: 'location-popup-overlay ol-selectable',
         })
     },
     mounted() {

--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -1,5 +1,6 @@
 <template>
-    <div v-if="isRightClick" class="location-popup" data-cy="location-popup">
+    <!-- Stop right click propagation to allow the user to interact with the popup. -->
+    <div v-if="isRightClick" class="location-popup" data-cy="location-popup" @contextmenu.stop>
         <div class="card">
             <div class="card-header d-flex">
                 <span class="flex-grow-1 align-self-center">
@@ -217,7 +218,17 @@ export default {
     width: auto;
     max-width: 450px;
     height: auto;
-
+    &::before {
+        $arrow-height: 15px;
+        position: absolute;
+        top: -($arrow-height * 2);
+        left: 50%;
+        margin-left: -$arrow-height;
+        border: $arrow-height solid transparent;
+        border-bottom-color: $light;
+        pointer-events: none;
+        content: '';
+    }
     .coordinates-list {
         display: grid;
         grid-template-columns: 1fr 2fr;


### PR DESCRIPTION
Currently, the content of the position overlay is not selectable.

This seems to have been broken in OpenLayers 4.1 and since then we need to add an extra class to make the content selectable again.

I added the class and a comment and the content is now selectable.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-2212-position-selectable-content/index.html)