### PR TITLE
BGDIINF_SB-2013: Updated mouse position coordinate formats

### DIFF
--- a/src/modules/map/components/footer/MapFooterMousePosition.vue
+++ b/src/modules/map/components/footer/MapFooterMousePosition.vue
@@ -40,9 +40,13 @@ export default {
     },
     methods: {
         setProjection() {
-            const { format, epsg } = CoordinateSystems[this.displayedProjectionId]
+            const { id, format, epsg } = CoordinateSystems[this.displayedProjectionId]
 
-            this.mousePositionControl.setCoordinateFormat(format)
+            const displayFormat = id.startsWith('LV')
+                ? (coordinate) => `${this.$t('coordinates_label')} ${format(coordinate)}`
+                : format
+
+            this.mousePositionControl.setCoordinateFormat(displayFormat)
             this.mousePositionControl.setProjection(getProjection(epsg))
         },
     },

--- a/src/utils/militaryGridProjection.js
+++ b/src/utils/militaryGridProjection.js
@@ -39,7 +39,7 @@ const Z = 90 // Z
  *
  * @param {[number, number]} ll Array with longitude and latitude on a WGS84 ellipsoid.
  * @param {number} [accuracy=5] Accuracy in digits (5 for 1 m, 4 for 10 m, 3 for 100 m, 2 for 1 km,
- *   1 for 10 km or 0 for 100 km). Optional, default is 5. Default is `5`
+ *   1 for 10 km or 0 for 100 km). Default is `5`
  * @returns {string} The MGRS string for the given location and accuracy.
  */
 export function forward(ll, accuracy) {

--- a/tests/e2e/specs/mouseposition.spec.js
+++ b/tests/e2e/specs/mouseposition.spec.js
@@ -3,7 +3,6 @@
 import proj4 from 'proj4'
 
 import { CoordinateSystems } from '../../../src/utils/coordinateUtils'
-import { round } from '../../../src/utils/numberUtils'
 import setupProj4 from '../../../src/utils/setupProj4'
 
 setupProj4()
@@ -16,20 +15,44 @@ function getMousePositionAndSelect(coordinateSystem) {
 
 const defaultCenter = [47.5, 7.5]
 
-function checkMousePositionStringValue(coordStr = `${defaultCenter[0]}, ${defaultCenter[1]}`) {
+/**
+ * Extracts an LV coordinate from a formatted string.
+ *
+ * @param {String} text A string containing an LV95 or LV03 coordinate.
+ */
+function parseLV(text) {
+    const matches = text.match(/([-\d'.]+), ([-\d'.]+)$/)
+    return matches
+        .slice(1)
+        .map((value) => value.replace(/'/g, ''))
+        .map(parseFloat)
+}
+
+/**
+ * Checks if a coordinate is close to the expected values.
+ *
+ * @param {Number} expectedX The expected x value.
+ * @param {Number} expectedY The expected y value.
+ */
+function checkXY(expectedX, expectedY) {
+    return function (coordinate) {
+        const [x, y] = coordinate
+        expect(x).to.be.closeTo(expectedX, 0.1)
+        expect(y).to.be.closeTo(expectedY, 0.1)
+    }
+}
+
+function checkMousePositionStringValue(coordStr) {
     cy.get('[data-cy="map"]').click()
     cy.get('[data-cy="mouse-position"]').should('contain.text', coordStr)
 }
 
-function checkMousePositionNumberValue(expectedX = defaultCenter[0], expectedY = defaultCenter[1]) {
+function checkMousePositionNumberValue(expectedX, expectedY, parser) {
     cy.get('[data-cy="map"]').click()
     cy.get('[data-cy="mouse-position"]')
         .invoke('text')
-        .then((text) => {
-            const [x, y] = text.split(',').map((textValue) => parseFloat(textValue))
-            expect(x).to.be.closeTo(expectedX, 0.1)
-            expect(y).to.be.closeTo(expectedY, 0.1)
-        })
+        .then(parser)
+        .then(checkXY(expectedX, expectedY))
 }
 
 describe('Test mouse position', () => {
@@ -43,11 +66,11 @@ describe('Test mouse position', () => {
             })
         })
         it('Shows LV95 coordinates by default', () => {
-            checkMousePositionNumberValue(2604624.64, 1261029.16)
+            checkMousePositionNumberValue(2604624.64, 1261029.16, parseLV)
         })
         it('switches to LV03 when this SRS is selected in the UI', () => {
             getMousePositionAndSelect(CoordinateSystems.LV03)
-            checkMousePositionNumberValue(604624.6, 261029.21)
+            checkMousePositionNumberValue(604624.6, 261029.21, parseLV)
         })
         it('switches to MGRS when this SRS is selected in the UI', () => {
             getMousePositionAndSelect(CoordinateSystems.MGRS)
@@ -55,13 +78,13 @@ describe('Test mouse position', () => {
         })
         it('switches to WebMercator when this SRS is selected in the UI', () => {
             getMousePositionAndSelect(CoordinateSystems.WGS84)
-            checkMousePositionStringValue('47° 30′ 00.00″ N 7° 30′ 00.00″ E')
+            checkMousePositionStringValue('47° 30′ 00.00″ N 7° 30′ 00.00″ E (47.50000, 7.50000)')
         })
         it('goes back to LV95 display if selected again', () => {
             // Change display projection without moving the mouse
             getMousePositionAndSelect(CoordinateSystems.MGRS)
             getMousePositionAndSelect(CoordinateSystems.LV95)
-            checkMousePositionNumberValue(2604624.64, 1261029.16)
+            checkMousePositionNumberValue(2604624.64, 1261029.16, parseLV)
         })
     })
     context('LocationPopUp when rightclick on the map', function () {
@@ -90,20 +113,18 @@ describe('Test mouse position', () => {
         })
         context('Coordinates system tests', () => {
             it('Uses the coordination system LV95 in the popup', () => {
-                const LV95cord = proj4(proj4.WGS84, 'EPSG:2056', [lon, lat]).map((value) =>
-                    round(value, 2)
-                )
-                cy.get('[data-cy="location-popup-coordinates-lv95"]').contains(
-                    `${LV95cord[0]}, ${LV95cord[1]}`
-                )
+                const LV95cord = proj4(proj4.WGS84, 'EPSG:2056', [lon, lat])
+                cy.get('[data-cy="location-popup-coordinates-lv95"]')
+                    .invoke('text')
+                    .then(parseLV)
+                    .then(checkXY(...LV95cord))
             })
             it('Uses the coordination system LV03 in the popup', () => {
-                const LV03cord = proj4(proj4.WGS84, 'EPSG:21781', [lon, lat]).map((value) =>
-                    round(value, 2)
-                )
-                cy.get('[data-cy="location-popup-coordinates-lv03"]').contains(
-                    `${LV03cord[0]}, ${LV03cord[1]}`
-                )
+                const LV03cord = proj4(proj4.WGS84, 'EPSG:21781', [lon, lat])
+                cy.get('[data-cy="location-popup-coordinates-lv03"]')
+                    .invoke('text')
+                    .then(parseLV)
+                    .then(checkXY(...LV03cord))
             })
             it('Uses the coordination system Plain WGS84 in the popup', () => {
                 cy.get('[data-cy="location-popup-coordinates-plain-wgs84"]').contains(
@@ -117,7 +138,7 @@ describe('Test mouse position', () => {
             })
             it('Uses the coordination system UTM in the popup', () => {
                 cy.get('[data-cy="location-popup-coordinates-utm"]').contains(
-                    `32T 421'184 4'983'436`
+                    `421'184 4'983'436 (32T)`
                 )
             })
             it('Uses the coordination system MGRS in the popup', () => {


### PR DESCRIPTION
This adjusts the format of the mouse position as displayed in the
footer to match the format of mf-geoadmin3.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-2013-mouse-position-formats/index.html)