### PR TITLE
BGDIINF_SB-2016: Added keyboard navigation to search results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
                 "cypress": "^9.4.1",
                 "cypress-browser-permissions": "^1.1.0",
                 "cypress-recurse": "^1.13.1",
+                "cypress-wait-until": "^1.7.2",
                 "eslint": "^7.32.0",
                 "eslint-config-prettier": "^8.3.0",
                 "eslint-import-resolver-alias": "^1.1.2",
@@ -6162,6 +6163,12 @@
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/cypress-recurse/-/cypress-recurse-1.13.1.tgz",
             "integrity": "sha512-re0djeUInv0JwxhFBSIiZmrJfvUaLTjK9jWsD0oqpnvG1UXGWR69rkXMtMK5HZhxkL7GSk9JiIpm49aWpOnsFA==",
+            "dev": true
+        },
+        "node_modules/cypress-wait-until": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz",
+            "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==",
             "dev": true
         },
         "node_modules/cypress/node_modules/@types/node": {
@@ -23714,6 +23721,12 @@
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/cypress-recurse/-/cypress-recurse-1.13.1.tgz",
             "integrity": "sha512-re0djeUInv0JwxhFBSIiZmrJfvUaLTjK9jWsD0oqpnvG1UXGWR69rkXMtMK5HZhxkL7GSk9JiIpm49aWpOnsFA==",
+            "dev": true
+        },
+        "cypress-wait-until": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz",
+            "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==",
             "dev": true
         },
         "d3": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
         "cypress": "^9.4.1",
         "cypress-browser-permissions": "^1.1.0",
         "cypress-recurse": "^1.13.1",
+        "cypress-wait-until": "^1.7.2",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-import-resolver-alias": "^1.1.2",

--- a/src/modules/menu/components/header/HeaderWithSearch.vue
+++ b/src/modules/menu/components/header/HeaderWithSearch.vue
@@ -17,7 +17,7 @@
             </div>
             <div class="mx-2 flex-grow-1 position-relative">
                 <span class="float-start d-none d-lg-block">{{ $t('search_title') }}</span>
-                <SearchBar class="search-bar" />
+                <SearchBar />
                 <!-- eslint-disable vue/no-v-html-->
                 <div
                     v-if="devSiteWarning"
@@ -25,7 +25,6 @@
                     v-html="$t('test_host_warning')"
                 ></div>
                 <!-- eslint-enable vue/no-v-html-->
-                <SearchResultList />
             </div>
             <HeaderMenuButton v-if="showMenuButton" />
         </div>
@@ -39,12 +38,10 @@ import HeaderMenuButton from '@/modules/menu/components/header/HeaderMenuButton.
 import HeaderSwissConfederationText from '@/modules/menu/components/header/HeaderSwissConfederationText.vue'
 import SwissFlag from '@/modules/menu/components/header/SwissFlag.vue'
 import SearchBar from '@/modules/menu/components/search/SearchBar.vue'
-import SearchResultList from '@/modules/menu/components/search/SearchResultList.vue'
 
 export default {
     components: {
         SearchBar,
-        SearchResultList,
         HeaderMenuButton,
         HeaderSwissConfederationText,
         SwissFlag,

--- a/src/modules/menu/components/search/SearchResultCategory.vue
+++ b/src/modules/menu/components/search/SearchResultCategory.vue
@@ -7,14 +7,15 @@
         <div class="search-category-header p-2 bg-light h5 mb-0 fw-bold">
             {{ title }}
         </div>
-        <div class="search-category-body bg-white">
+        <ul class="search-category-body bg-white">
             <SearchResultListEntry
                 v-for="(entry, index) in entries"
-                :key="`${index}-${entry.getId()}`"
+                :key="index"
+                :index="index"
                 :entry="entry"
                 @show-layer-legend-popup="showLayerLegendPopup"
             />
-        </div>
+        </ul>
 
         <LayerLegendPopup
             v-if="showLayerLegendForId"
@@ -66,13 +67,18 @@ export default {
 
 <style lang="scss" scoped>
 .search-category {
-    .search-category-body {
+    &-body {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+
         max-height: 15rem;
         overflow-y: scroll;
         font-size: 0.8rem;
-    }
-    &.search-category-half-size .search-category-body {
-        max-height: 7rem;
+
+        .search-category-half-size & {
+            max-height: 7rem;
+        }
     }
 }
 </style>

--- a/src/modules/menu/components/search/SearchResultList.vue
+++ b/src/modules/menu/components/search/SearchResultList.vue
@@ -10,11 +10,13 @@
             :title="$t('locations_results_header')"
             :half-size="results.locationResults.length > 0"
             :entries="results.locationResults"
+            data-cy="search-results-locations"
         />
         <SearchResultCategory
             :title="$t('layers_results_header')"
             :half-size="results.layerResults.length > 0"
             :entries="results.layerResults"
+            data-cy="search-results-layers"
         />
     </div>
 </template>

--- a/src/modules/menu/components/search/SearchResultList.vue
+++ b/src/modules/menu/components/search/SearchResultList.vue
@@ -4,6 +4,7 @@
         id="search-results"
         class="bg-light rounded-bottom"
         data-cy="search-results"
+        @keydown.esc.prevent="$emit('close')"
     >
         <SearchResultCategory
             :title="$t('locations_results_header')"
@@ -25,6 +26,7 @@ import SearchResultCategory from './SearchResultCategory.vue'
 /** Component showing all results from the search, divided in two groups (categories) : layers and locations */
 export default {
     components: { SearchResultCategory },
+    emits: ['close'],
     computed: {
         ...mapState({
             results: (state) => state.search.results,
@@ -45,7 +47,7 @@ export default {
     max-height: calc(75vh - 3rem);
     text-align: center;
 }
-@include respond-above(sm) {
+@include respond-above(lg) {
     #search-results {
         max-height: calc(75vh - 6rem);
     }

--- a/src/modules/menu/components/search/SearchResultListEntry.vue
+++ b/src/modules/menu/components/search/SearchResultListEntry.vue
@@ -1,23 +1,33 @@
 <template>
-    <div
+    <li
+        ref="item"
         class="search-category-entry border-bottom border-light"
         :data-cy="`search-result-entry-${resultType}`"
+        :tabindex="index === 0 ? 0 : -1"
+        @keydown.up.prevent="goToPrevious"
+        @keydown.down.prevent="goToNext"
+        @keydown.home.prevent="goToFirst"
+        @keydown.end.prevent="goToLast"
+        @keypress.enter.prevent="selectItem"
     >
-        <div class="search-category-entry-main p-2 ps-4" @click="onClick">
-            <!-- eslint-disable-next-line vue/no-v-html-->
-            <span v-html="entry.title"></span>
-        </div>
+        <!-- eslint-disable vue/no-v-html-->
+        <div
+            class="search-category-entry-main p-2 ps-4"
+            @click="selectItem"
+            v-html="entry.title"
+        ></div>
 
         <div v-if="resultType === 'layer'" class="search-category-entry-controls">
             <button
                 class="btn btn-default"
                 :data-cy="`button-show-legend-layer-${entry.layerId}`"
+                tabindex="-1"
                 @click="showLayerLegendPopup"
             >
-                <font-awesome-icon size="lg" :icon="['fas', 'info-circle']" />
+                <FontAwesomeIcon size="lg" :icon="['fas', 'info-circle']" />
             </button>
         </div>
-    </div>
+    </li>
 </template>
 
 <script>
@@ -27,6 +37,10 @@ import { SearchResult } from '@/api/search.api'
 /** Component showing one search result entry (and dispatching its selection to the store) */
 export default {
     props: {
+        index: {
+            type: Number,
+            required: true,
+        },
         entry: {
             type: SearchResult,
             required: true,
@@ -40,11 +54,30 @@ export default {
     },
     methods: {
         ...mapActions(['selectResultEntry']),
-        onClick() {
+        selectItem() {
             this.selectResultEntry(this.entry)
         },
         showLayerLegendPopup() {
             this.$emit('showLayerLegendPopup', this.entry.layerId)
+        },
+        goToPrevious() {
+            this.changeFocus(this.$refs.item.previousElementSibling)
+        },
+        goToNext() {
+            this.changeFocus(this.$refs.item.nextElementSibling)
+        },
+        goToFirst() {
+            this.changeFocus(this.$refs.item.parentElement.firstElementChild)
+        },
+        goToLast() {
+            this.changeFocus(this.$refs.item.parentElement.lastElementChild)
+        },
+        changeFocus(target) {
+            if (target) {
+                target.tabIndex = '0'
+                target.focus()
+                this.$refs.item.tabIndex = '-1'
+            }
         },
     },
 }

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -1,3 +1,5 @@
+import 'cypress-wait-until';
+
 // ***********************************************
 // For more comprehensive examples of custom
 // commands please read more here:


### PR DESCRIPTION
This adds listeners to the search input and the list items to
enable navigating / controlling the search input and results.

* <kbd>ArrowDown</kbd> on **input** leads to first result.
* <kbd>Tab</kbd> on **input** leads to first result.
* <kbd>Escape</kbd> on **input or results** closes results and gives input focus.
* <kbd>Tab</kbd> on **result** leads to next category / exists the results.
* <kbd>ArrowUp</kbd> on **result** leads to previous result in category.
* <kbd>ArrowDown</kbd> on **result** leads to next result in category.
* <kbd>Home</kbd> on **result** leads to first result in category.
* <kbd>End</kbd> on **result** leads to last result in category.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-2016-search-results-keyboard-navigation/index.html)