### PR TITLE
BGDIINF_SB-2227: Fixed w3w coords and added link

### DIFF
--- a/src/api/what3words.api.js
+++ b/src/api/what3words.api.js
@@ -68,7 +68,7 @@ export const registerWhat3WordsLocation = (location, lang = 'en') => {
             reject('Bad location, must be a coordinate array')
         } else {
             // transforming EPSG:3857 coordinates into EPGS:4326 (WGS84)
-            const [lat, lon] = proj4('EPSG:3857', proj4.WGS84, location)
+            const [lon, lat] = proj4('EPSG:3857', proj4.WGS84, location)
             axios
                 .get(`${WHAT_3_WORDS_API_BASE_URL}/convert-to-3wa`, {
                     params: {

--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -49,9 +49,14 @@
                     <a href="http://what3words.com/" target="_blank">what3words</a>
                 </div>
                 <div>
-                    <span v-show="clickWhat3Words" data-cy="location-popup-w3w">{{
-                        clickWhat3Words
-                    }}</span>
+                    <a
+                        v-show="clickWhat3Words"
+                        :href="`https://what3words.com/${clickWhat3Words}`"
+                        target="_blank"
+                        data-cy="location-popup-w3w"
+                    >
+                        {{ clickWhat3Words }}
+                    </a>
                 </div>
                 <div>{{ $t('elevation') }}</div>
                 <div>


### PR DESCRIPTION
We had a mix-up with the coordinate values which resulted in positions around Somalia. And one had to manually copy/paste the words from the pop-up to the website to see the result.

This fixes (turns around) the coordinate values and adds a link to the three words that leads to the website.

[Test link](https://web-mapviewer.dev.bgdi.ch/bugfix-jira-bgdiinf_sb-2227-w3w-position-and-link/index.html)