### PR TITLE
BGDIINF_SB-2226: Fixed position of share link

### DIFF
--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -90,6 +90,7 @@ import { registerWhat3WordsLocation } from '@/api/what3words.api'
 import { requestHeight } from '@/api/height.api'
 import { generateQrCode } from '@/api/qrcode.api'
 import { round } from '@/utils/numberUtils'
+import stringifyQuery from '@/router/stringifyQuery'
 
 /** Right click pop up which shows the coordinates of the position under the cursor. */
 export default {
@@ -148,7 +149,14 @@ export default {
             return this.clickInfo && this.clickInfo.clickType === ClickType.RIGHT_CLICK
         },
         shareLinkUrl: function () {
-            return `${window.location}&crosshair=marker`
+            let [lon, lat] = this.reprojectClickCoordinates('EPSG:4326')
+            let query = {
+                ...this.$route.query,
+                crosshair: 'marker',
+                lat,
+                lon,
+            }
+            return `${location.origin}/#/map?${stringifyQuery(query)}`
         },
     },
     watch: {

--- a/tests/e2e/specs/mouseposition.spec.js
+++ b/tests/e2e/specs/mouseposition.spec.js
@@ -144,11 +144,14 @@ describe('Test mouse position', () => {
             it('Uses the coordination system MGRS in the popup', () => {
                 cy.get('[data-cy="location-popup-coordinates-mgrs"]').contains('32TMQ 21184 83436')
             })
-            it('Test the link with bowl crosshair gives the right coordinates', () => {
-                cy.get('[data-cy="location-popup-link-bowl-crosshair"] a').then((link) => {
-                    expect(link[0].href).to.contains(`lat=${lat}`)
-                    expect(link[0].href).to.contains(`lon=${lon}`)
-                })
+            it.only('Test the link with bowl crosshair gives the right coordinates', () => {
+                cy.get('[data-cy="location-popup-link-bowl-crosshair"] a')
+                    .then((link) => {
+                        const search = link[0].href.split('?')[1]
+                        const params = new URLSearchParams(search)
+                        return [parseFloat(params.get('lat')), parseFloat(params.get('lon'))]
+                    })
+                    .then(checkXY(lat, lon))
             })
         })
     })


### PR DESCRIPTION
The link to share the current position points to the center of the
map. This is because the link uses the current URL as-is instead
of the ClickInfo position.

This replaces lat/lon when generating the URL so that the marker
is at the expected position when opening the link.

[Test link](https://web-mapviewer.dev.bgdi.ch/bugfix-jira-bgdiinf_sb-2226-share-link-clickinfo/index.html)