### PR TITLE
Replacing in-house print code with lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "hammerjs": "^2.0.8",
                 "jquery": "^3.6.0",
                 "ol": "^6.12.0",
+                "print-js": "^1.6.0",
                 "proj4": "^2.7.5",
                 "register-service-worker": "^1.7.2",
                 "reproject": "^1.2.6",
@@ -14387,6 +14388,11 @@
                 "lodash": "^4.17.20",
                 "renderkid": "^3.0.0"
             }
+        },
+        "node_modules/print-js": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/print-js/-/print-js-1.6.0.tgz",
+            "integrity": "sha512-BfnOIzSKbqGRtO4o0rnj/K3681BSd2QUrsIZy/+WdCIugjIswjmx3lDEZpXB2ruGf9d4b3YNINri81+J0FsBWg=="
         },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
@@ -29781,6 +29787,11 @@
                 "lodash": "^4.17.20",
                 "renderkid": "^3.0.0"
             }
+        },
+        "print-js": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/print-js/-/print-js-1.6.0.tgz",
+            "integrity": "sha512-BfnOIzSKbqGRtO4o0rnj/K3681BSd2QUrsIZy/+WdCIugjIswjmx3lDEZpXB2ruGf9d4b3YNINri81+J0FsBWg=="
         },
         "process-nextick-args": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "hammerjs": "^2.0.8",
         "jquery": "^3.6.0",
         "ol": "^6.12.0",
+        "print-js": "^1.6.0",
         "proj4": "^2.7.5",
         "register-service-worker": "^1.7.2",
         "reproject": "^1.2.6",

--- a/src/modules/infobox/components/TooltipBox.vue
+++ b/src/modules/infobox/components/TooltipBox.vue
@@ -25,7 +25,7 @@ export default {
             this.$emit('close')
         },
         printTooltip: function () {
-            promptUserToPrintHtmlContent(this.$refs.tooltipContent.outerHTML)
+            promptUserToPrintHtmlContent(this.$refs.tooltipContent)
         },
     },
 }

--- a/src/utils/ModalWithBackdrop.vue
+++ b/src/utils/ModalWithBackdrop.vue
@@ -72,7 +72,7 @@ export default {
         },
         printModalContent: function () {
             if (this.$refs.modalContent) {
-                promptUserToPrintHtmlContent(this.$refs.modalContent.outerHTML)
+                promptUserToPrintHtmlContent(this.$refs.modalContent)
             }
         },
     },

--- a/src/utils/print.js
+++ b/src/utils/print.js
@@ -1,4 +1,4 @@
-import jQuery from 'jquery'
+import printJS from 'print-js'
 /**
  * Creates a new window (popup) with the content given in param. It will copy all the <style> tags
  * from the app in this popup and then trigger a print request to the browser (waiting for any image
@@ -7,41 +7,12 @@ import jQuery from 'jquery'
  * The popup will be automatically closed after printing (also closed if the user cancels the print)
  * so that the user may never se the little popup
  *
- * @param {String} htmlContent Some HTML, as String, to be added as content for the print popup
+ * @param {HTMLElement} htmlContent Some HTML, as String, to be added as content for the print popup
  */
 const promptUserToPrintHtmlContent = (htmlContent) => {
-    const hiddenWindowWithContent = window.open('', '', 'height=500, width=500')
-    const document = hiddenWindowWithContent.document
-    document.write('<html><head>')
-    // grabbing all styles from main document and copying them here (to have the same styling)
-    jQuery('style').each(function () {
-        document.write(jQuery(this).clone()[0].outerHTML)
+    printJS({
+        printable: htmlContent,
+        type: 'html',
     })
-    document.write('</head><body>')
-    document.write(htmlContent)
-    document.write('</body></html>')
-    document.close()
-
-    const printAndClose = () => {
-        hiddenWindowWithContent.print()
-        hiddenWindowWithContent.close()
-    }
-    // checking if there are images or iframe in the content
-    let pendingImageOriFrameLoading = 0
-    const images = jQuery(document).find('img,iframe')
-    if (images.length > 0) {
-        // if so we wait for them to load before printing
-        images.each(function () {
-            pendingImageOriFrameLoading++
-            this.onload = () => {
-                pendingImageOriFrameLoading--
-                if (pendingImageOriFrameLoading === 0) {
-                    printAndClose()
-                }
-            }
-        })
-    } else {
-        printAndClose()
-    }
 }
 export default promptUserToPrintHtmlContent

--- a/src/utils/print.js
+++ b/src/utils/print.js
@@ -1,13 +1,9 @@
 import printJS from 'print-js'
 /**
- * Creates a new window (popup) with the content given in param. It will copy all the <style> tags
- * from the app in this popup and then trigger a print request to the browser (waiting for any image
- * to finish loading before doing so)
+ * Prints the content of the given HTML element through the browser print prompt. The user can then
+ * decide to export that as a PDF or print it physically.
  *
- * The popup will be automatically closed after printing (also closed if the user cancels the print)
- * so that the user may never se the little popup
- *
- * @param {HTMLElement} htmlContent Some HTML, as String, to be added as content for the print popup
+ * @param {HTMLElement} htmlContent Some HTML, to be printed separately (no app GUI)
  */
 const promptUserToPrintHtmlContent = (htmlContent) => {
     printJS({


### PR DESCRIPTION
As this will be much more reliable with future browser changes. The current in house code wasn't working anymore on the latest Chrome version anyway.

[Test link](https://web-mapviewer.dev.bgdi.ch/replace_print_by_lib/index.html)