### PR TITLE
BGDIINF_SB-2159: add a new popover OL component

### DIFF
--- a/src/api/features.api.js
+++ b/src/api/features.api.js
@@ -1,25 +1,116 @@
 import { API_BASE_URL } from '@/config'
 import axios from 'axios'
 import log from '@/utils/logging'
+import EventEmitter from '@/utils/EventEmitter.class'
 
-/** Describe a feature from the backend (see {@link getFeature}) below */
-export class Feature {
+/**
+ * Representation of a feature that can be selected by the user on the map. This feature can be
+ * edited if the corresponding flag says so (it will then fires "change" events any time one
+ * property of the instance has changed)
+ *
+ * This will then be specialized in (at least) two flavor of features, layer feature (coming from
+ * our backend, with extra information attached) and drawing feature (that can be modified by the user)
+ *
+ * @abstract
+ */
+export class Feature extends EventEmitter {
+    /**
+     * @param {String | Number} id Unique identifier for this feature (unique in the context it
+     *   comes from, not for the whole app)
+     * @param {Number[]} coordinate [x,y] coordinates of this feature in EPSG:3857 (metric mercator)
+     * @param {String} title Title of this feature
+     * @param {String} description A description of this feature, can not be HTML content (only text)
+     * @param {Boolean} isEditable Whether this feature is editable when selected (color, size, etc...)
+     */
+    constructor(id, coordinate, title, description, isEditable = false) {
+        super()
+        this._id = id
+        this._coordinate = [...coordinate]
+        this._title = title
+        this._description = description
+        this._isEditable = !!isEditable
+    }
+
+    emitChangeEvent() {
+        this.emit('change', this)
+    }
+
+    get id() {
+        return this._id
+    }
+    // ID is immutable, no setter
+
+    get coordinate() {
+        return this._coordinate
+    }
+    set coordinate(newCoordinate) {
+        if (Array.isArray(newCoordinate) && newCoordinate.length === 2) {
+            this._coordinate = newCoordinate
+            this.emitChangeEvent()
+        }
+    }
+
+    get title() {
+        return this._title
+    }
+    set title(newTitle) {
+        this._title = newTitle
+        this.emitChangeEvent()
+    }
+
+    get description() {
+        return this._description
+    }
+    set description(newDescription) {
+        this._description = newDescription
+        this.emitChangeEvent()
+    }
+
+    get isEditable() {
+        return this._isEditable
+    }
+    // isEditable is immutable, no setter
+}
+
+/** Describe a feature that can be edited by the user, such as feature from the current drawing */
+export class EditableFeature extends Feature {
+    /**
+     * @param {String | Number} id Unique identifier for this feature (unique in the context it
+     *   comes from, not for the whole app)
+     * @param {Number[]} coordinate [x,y] coordinates of this feature in EPSG:3857 (metric mercator)
+     * @param {String} title Title of this feature
+     * @param {String} description A description of this feature, can not be HTML content (only text)
+     */
+    constructor(id, coordinate, title, description) {
+        super(id, coordinate, title, description, true)
+    }
+}
+
+/** Describe a feature from the backend, so a feature linked to a backend layer (see {@link getFeature}) below */
+export class LayerFeature extends Feature {
     /**
      * @param {GeoAdminLayer} layer The layer in which this feature belongs
      * @param {Number | String} id The unique feature ID in the layer it is part of
+     * @param {String} name The name (localized) of this feature
      * @param {String} htmlPopup HTML code for this feature's popup (or tooltip)
      * @param {Number[]} coordinate [x,y] coordinate in EPSG:3857
      * @param {Number[]} extent Extent of the feature expressed with two point, bottom left and top
      *   right, in EPSG:3857
      * @param {Object} geometry GeoJSON geometry (if exists)
      */
-    constructor(layer, id, htmlPopup, coordinate, extent, geometry = null) {
+    constructor(layer, id, name, htmlPopup, coordinate, extent, geometry = null) {
+        super(id, coordinate, name, null, false)
         this.layer = layer
-        this.id = id
+        // for now the backend gives us the description of the feature as HTML
+        // it would be good to change that to only data in the future
         this.htmlPopup = htmlPopup
-        this.coordinate = coordinate
         this.extent = extent
         this.geometry = geometry
+    }
+
+    // overwriting get ID so that we use the layer ID with the feature ID
+    get id() {
+        return `${this.layer.getID()}-${this._id}`
     }
 
     /** @returns {LayerTypes} */
@@ -38,7 +129,7 @@ export class Feature {
  * @param {Number} screenWidth
  * @param {Number} screenHeight
  * @param {String} lang
- * @returns {Promise<Feature[]>}
+ * @returns {Promise<LayerFeature[]>}
  */
 export const identify = (layer, coordinate, mapExtent, screenWidth, screenHeight, lang) => {
     return new Promise((resolve, reject) => {
@@ -107,7 +198,7 @@ export const identify = (layer, coordinate, mapExtent, screenWidth, screenHeight
  * @param {GeoAdminLayer} layer The layer from which the feature is part of
  * @param {String | Number} featureID The feature ID in the BGDI
  * @param {String} lang The language for the HTML popup
- * @returns {Promise<Feature>}
+ * @returns {Promise<LayerFeature>}
  */
 const getFeature = (layer, featureID, lang = 'en') => {
     return new Promise((resolve, reject) => {
@@ -163,10 +254,12 @@ const getFeature = (layer, featureID, lang = 'en') => {
                         (featureMetadata.bbox[1] + featureMetadata.bbox[3]) / 2,
                     ]
                 }
+                const featureName = featureMetadata?.properties?.name
                 resolve(
-                    new Feature(
+                    new LayerFeature(
                         layer,
                         featureID,
+                        featureName,
                         featureHtmlPopup,
                         featureCoordinate,
                         featureExtent,

--- a/src/modules/drawing/components/DrawingToolbox.vue
+++ b/src/modules/drawing/components/DrawingToolbox.vue
@@ -96,7 +96,7 @@
                         </button>
                     </div>
                     <!-- eslint-disable-next-line -->
-                    <div class="d-none d-sm-block" v-html="$t('share_file_disclaimer')"></div>
+                    <small class="d-none d-sm-block text-center text-muted" v-html="$t('share_file_disclaimer')"></small>
                 </div>
             </div>
         </div>

--- a/src/modules/infobox/components/HighlightedFeatureList.vue
+++ b/src/modules/infobox/components/HighlightedFeatureList.vue
@@ -1,14 +1,12 @@
 <template>
-    <div class="highlighted-feature-list">
-        <!-- eslint-disable vue/no-v-html-->
-        <div
-            v-for="(feature, index) in highlightedFeatures"
-            :key="`${feature.layer.id}-${feature.id ? feature.id : index}`"
-            class="tooltip-feature"
-            v-html="feature.htmlPopup"
-        />
-        <!-- eslint-enable vue/no-v-html-->
-    </div>
+    <!-- eslint-disable vue/no-v-html-->
+    <div
+        v-for="(feature, index) in highlightedFeatures"
+        :key="`${feature.layer.id}-${feature.id ? feature.id : index}`"
+        class="tooltip-feature"
+        v-html="feature.htmlPopup"
+    />
+    <!-- eslint-enable vue/no-v-html-->
 </template>
 <script>
 export default {

--- a/src/modules/infobox/components/TooltipBox.vue
+++ b/src/modules/infobox/components/TooltipBox.vue
@@ -1,26 +1,29 @@
 <template>
-    <div class="tooltip-box">
-        <div class="tooltip-header">
-            <div class="tooltip-toolbox text-right">
-                <span class="mx-2" @click="printTooltip">
-                    <font-awesome-icon :icon="['fa', 'print']" />
-                </span>
-                <span @click="closeTooltip">
-                    <font-awesome-icon :icon="['fa', 'times']" />
-                </span>
-            </div>
+    <div class="tooltip-box card">
+        <div class="tooltip-box-header card-header d-flex justify-content-end">
+            <ButtonWithIcon
+                :button-font-awesome-icon="['fa', 'caret-up']"
+                @click="toggleTooltipInFooter"
+            />
+            <ButtonWithIcon :button-font-awesome-icon="['fa', 'print']" @click="printTooltip" />
+            <ButtonWithIcon :button-font-awesome-icon="['fa', 'times']" @click="closeTooltip" />
         </div>
-        <div ref="tooltipContent" class="tooltip-content">
+        <div ref="tooltipContent" class="tooltip-box-content card-body">
             <slot />
         </div>
     </div>
 </template>
 
 <script>
+import ButtonWithIcon from '@/utils/ButtonWithIcon.vue'
 import promptUserToPrintHtmlContent from '@/utils/print'
 export default {
-    emits: ['close'],
+    components: { ButtonWithIcon },
+    emits: ['close', 'toggleTooltipInFooter'],
     methods: {
+        toggleTooltipInFooter: function () {
+            this.$emit('toggleTooltipInFooter')
+        },
         closeTooltip: function () {
             this.$emit('close')
         },
@@ -33,32 +36,23 @@ export default {
 
 <style lang="scss" scoped>
 @import 'src/scss/variables';
+@import 'src/scss/media-query.mixin';
+
+// a typical html popup content is 314 per 230px on mf-geoadmin3 (public transport stops)
+$maxTooltipHeight: 230px;
+$maxTooltipWidth: 314px;
+
 .tooltip-box {
-    position: absolute;
-    z-index: $zindex-map + 1;
-    max-width: 450px;
     width: 100%;
-    bottom: 0;
-    right: 0;
-    overflow: hidden;
-    background: white;
-    .tooltip-header {
-        padding: 8px 14px;
-        margin: 0;
-        font-size: 14px;
-        background-color: #f7f7f7;
-        border-bottom: 1px solid #ebebeb;
-        border-radius: 5px 5px 0 0;
-        .tooltip-toolbox {
-            font-size: 20px;
-            font-weight: 400;
-            opacity: 0.3;
-        }
-    }
-    .tooltip-content {
-        max-height: 50vh;
+    &-content {
+        max-height: $maxTooltipHeight;
         overflow-y: auto;
         overflow-x: hidden;
+        display: grid;
+        // on mobile (default size) only one column
+        // see media query under for other screen sizes
+        grid-template-columns: 1fr;
+        grid-gap: 8px;
     }
     .tooltip-feature:not(:last-child) {
         border-bottom-style: solid;
@@ -84,6 +78,25 @@ export default {
                 border: 0;
             }
         }
+    }
+}
+
+@include respond-above(md) {
+    .tooltip-box-content {
+        // with screen larger than 768px we can afford to have two tooltip side by side
+        grid-template-columns: 1fr 1fr;
+    }
+}
+@include respond-above(lg) {
+    .tooltip-box-content {
+        // with screen larger than 992px we can place 3 tooltips
+        grid-template-columns: 1fr 1fr 1fr;
+    }
+}
+@include respond-above(xl) {
+    .tooltip-box-content {
+        // anything above 1200px will have 4 tooltips in a row
+        grid-template-columns: 1fr 1fr 1fr 1fr;
     }
 }
 </style>

--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -1,17 +1,13 @@
 <template>
-    <div v-if="isRightClick" class="location-popup" data-cy="location-popup" @contextmenu.stop>
-        <div class="card">
-            <div class="card-header d-flex">
-                <span class="flex-grow-1 align-self-center">
-                    {{ $t('position') }}
-                </span>
-                <ButtonWithIcon
-                    data-cy="profile-popup-close-button"
-                    :button-font-awesome-icon="['fa', 'times']"
-                    @click="onClose"
-                />
-            </div>
-            <div class="card-body coordinates-list text-start">
+    <div v-if="isRightClick" class="location-popup" @contextmenu.stop>
+        <OpenLayersPopover
+            v-if="clickCoordinates"
+            data-cy="location-popup"
+            :title="$t('position')"
+            :coordinates="clickCoordinates"
+            @close="clearClick"
+        >
+            <div class="coordinates-list text-start">
                 <div>
                     <a :href="$t('contextpopup_lv95_url')" target="_blank">CH1903+ / LV95</a>
                 </div>
@@ -78,27 +74,28 @@
                     />
                 </div>
             </div>
-        </div>
+        </OpenLayersPopover>
     </div>
 </template>
 
 <script>
 import proj4 from 'proj4'
 import { mapState, mapActions } from 'vuex'
-import { ClickType } from '@/modules/map/store/map.store'
 import Overlay from 'ol/Overlay'
 import OverlayPositioning from 'ol/OverlayPositioning'
-import { printHumanReadableCoordinates, CoordinateSystems } from '@/utils/coordinateUtils'
-import ButtonWithIcon from '@/utils/ButtonWithIcon.vue'
+
 import { registerWhat3WordsLocation } from '@/api/what3words.api'
 import { requestHeight } from '@/api/height.api'
 import { generateQrCode } from '@/api/qrcode.api'
+import { ClickType } from '@/modules/map/store/map.store'
+import OpenLayersPopover from '@/modules/map/components/openlayers/OpenLayersPopover.vue'
+import { printHumanReadableCoordinates, CoordinateSystems } from '@/utils/coordinateUtils'
 import { round } from '@/utils/numberUtils'
 import stringifyQuery from '@/router/stringifyQuery'
 
 /** Right click pop up which shows the coordinates of the position under the cursor. */
 export default {
-    components: { ButtonWithIcon },
+    components: { OpenLayersPopover },
     inject: ['getMap'],
     data() {
         return {
@@ -231,30 +228,26 @@ export default {
 
 <style lang="scss" scoped>
 @import 'src/scss/webmapviewer-bootstrap-theme';
-.location-popup {
-    width: auto;
+.location-popup::before {
+    $arrow-height: 15px;
+    position: absolute;
+    top: -($arrow-height * 2);
+    left: 50%;
+    margin-left: -$arrow-height;
+    border: $arrow-height solid transparent;
+    border-bottom-color: $light;
+    pointer-events: none;
+    content: '';
+}
+.coordinates-list {
     max-width: 450px;
-    height: auto;
-    &::before {
-        $arrow-height: 15px;
-        position: absolute;
-        top: -($arrow-height * 2);
-        left: 50%;
-        margin-left: -$arrow-height;
-        border: $arrow-height solid transparent;
-        border-bottom-color: $light;
-        pointer-events: none;
-        content: '';
-    }
-    .coordinates-list {
-        display: grid;
-        grid-template-columns: 1fr 2fr;
-        grid-column-gap: 5px;
-        grid-row-gap: 5px;
-    }
-    .qrcode-container {
-        grid-column: 1 / 3;
-        text-align: center;
-    }
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    grid-column-gap: 5px;
+    grid-row-gap: 5px;
+}
+.qrcode-container {
+    grid-column: 1 / 3;
+    text-align: center;
 }
 </style>

--- a/src/modules/map/components/openlayers/OpenLayersHighlightedFeature.vue
+++ b/src/modules/map/components/openlayers/OpenLayersHighlightedFeature.vue
@@ -15,7 +15,7 @@ import { Vector as VectorSource } from 'ol/source'
 import OpenLayersFeature from 'ol/Feature'
 import GeoJSON from 'ol/format/GeoJSON'
 import Style from 'ol/style/Style'
-import { Feature } from '@/api/features.api'
+import { LayerFeature } from '@/api/features.api'
 import OpenLayersMarker, {
     highlightedFill,
     highlightedStroke,
@@ -54,7 +54,7 @@ export default {
     mixins: [addLayerToMapMixin],
     props: {
         feature: {
-            type: Feature,
+            type: LayerFeature,
             required: true,
         },
         zIndex: {

--- a/src/modules/map/components/openlayers/OpenLayersPopover.vue
+++ b/src/modules/map/components/openlayers/OpenLayersPopover.vue
@@ -1,0 +1,111 @@
+<template>
+    <div ref="mapPopover" class="map-popover">
+        <div class="card">
+            <div class="card-header d-flex">
+                <span class="flex-grow-1 align-self-center">
+                    {{ title }}
+                </span>
+                <slot name="extra-buttons"></slot>
+                <ButtonWithIcon
+                    v-if="authorizePrint"
+                    :button-font-awesome-icon="['fa', 'print']"
+                    @click="printContent"
+                />
+                <ButtonWithIcon
+                    data-cy="map-popover-close-button"
+                    :button-font-awesome-icon="['fa', 'times']"
+                    @click="onClose"
+                />
+            </div>
+            <div ref="mapPopoverContent" class="card-body">
+                <slot></slot>
+            </div>
+        </div>
+    </div>
+</template>
+<script>
+import Overlay from 'ol/Overlay'
+import OverlayPositioning from 'ol/OverlayPositioning'
+
+import ButtonWithIcon from '@/utils/ButtonWithIcon.vue'
+import promptUserToPrintHtmlContent from '@/utils/print'
+
+/**
+ * Shows a popover on the map at the given position (coordinates) and with the slot as the content
+ * of the popover
+ */
+export default {
+    components: { ButtonWithIcon },
+    inject: ['getMap'],
+    props: {
+        coordinates: {
+            type: Array,
+            required: true,
+        },
+        authorizePrint: {
+            type: Boolean,
+            default: false,
+        },
+        title: {
+            type: String,
+            default: '',
+        },
+    },
+    emits: ['close'],
+    watch: {
+        coordinates: function (newCoordinates) {
+            this.overlay.setPosition(newCoordinates)
+        },
+    },
+    beforeCreate() {
+        this.overlay = new Overlay({
+            offset: [0, 15],
+            positioning: OverlayPositioning.TOP_CENTER,
+            className: 'map-popover-overlay',
+        })
+    },
+    mounted() {
+        const olMap = this.getMap()
+        if (olMap) {
+            this.overlay.setElement(this.$refs.mapPopover)
+            olMap.addOverlay(this.overlay)
+            this.overlay.setPosition(this.coordinates)
+        }
+    },
+    beforeUnmount() {
+        const olMap = this.getMap()
+        if (olMap) {
+            olMap.removeOverlay(this.overlay)
+        }
+    },
+    methods: {
+        onClose() {
+            this.$emit('close')
+        },
+        printContent: function () {
+            promptUserToPrintHtmlContent(this.$refs.mapPopoverContent.outerHTML)
+        },
+    },
+}
+</script>
+
+<style lang="scss" scoped>
+@import 'src/scss/webmapviewer-bootstrap-theme';
+.map-popover {
+    .card-body {
+        max-height: 400px;
+        overflow-y: auto;
+    }
+    &::before {
+        $arrow-height: 15px;
+        position: absolute;
+        top: -($arrow-height * 2);
+        left: 50%;
+        margin-left: -$arrow-height;
+        border: $arrow-height solid transparent;
+        border-bottom-color: $light;
+        pointer-events: none;
+        content: '';
+    }
+}
+</style>

--- a/src/modules/map/store/map.store.js
+++ b/src/modules/map/store/map.store.js
@@ -81,20 +81,6 @@ export default {
          */
         highlightLayer: ({ commit }, layer) => commit('setHighlightedFeature', layer),
         /**
-         * Tells the map to highlight a list of features (place a round marker at their location).
-         * Those features are currently shown by the tooltip.
-         *
-         * @param commit
-         * @param {Feature[]} features A list of feature we want to highlight on the map
-         */
-        setHighlightedFeatures: ({ commit }, features) => {
-            if (Array.isArray(features)) {
-                commit('setHighlightedFeatures', features)
-            }
-        },
-        /** Removes all highlighted features from the map */
-        clearHighlightedFeatures: ({ commit }) => commit('setHighlightedFeatures', []),
-        /**
          * Sets all information about the last click that occurred on the map
          *
          * @param commit
@@ -125,7 +111,6 @@ export default {
     },
     mutations: {
         setHighlightedLayer: (state, layer) => (state.highlightedLayer = layer),
-        setHighlightedFeatures: (state, features) => (state.highlightedFeatures = features),
         setClickInfo: (state, clickInfo) => (state.clickInfo = clickInfo),
         mapStartBeingDragged: (state) => (state.isBeingDragged = true),
         mapStoppedBeingDragged: (state) => (state.isBeingDragged = false),

--- a/src/modules/store/index.js
+++ b/src/modules/store/index.js
@@ -7,6 +7,7 @@ import position from './modules/position.store'
 import topics from './modules/topics.store'
 import ui from './modules/ui.store'
 import drawing from './modules/drawing.store'
+import feature from './modules/feature.store'
 
 import map from '@/modules/map/store'
 import search from '@/modules/menu/store'
@@ -47,6 +48,7 @@ export default createStore({
         ui,
         drawing,
         map,
+        feature,
         search,
         i18n,
     },

--- a/src/modules/store/modules/feature.store.js
+++ b/src/modules/store/modules/feature.store.js
@@ -1,0 +1,35 @@
+export class Feature {
+    constructor(coordinate, title, description, isEditable) {
+        this.coordinate = [...coordinate]
+        this.title = title
+        this.description = description
+        this.isEditable = !!isEditable
+    }
+}
+
+export default {
+    state: {
+        /** @type Array<Feature> */
+        selectedFeatures: [],
+    },
+    getters: {},
+    actions: {
+        /**
+         * Tells the map to highlight a list of features (place a round marker at their location).
+         * Those features are currently shown by the tooltip.
+         *
+         * @param commit
+         * @param {Feature[]} features A list of feature we want to highlight/select on the map
+         */
+        setSelectedFeatures: ({ commit }, features) => {
+            if (Array.isArray(features)) {
+                commit('setSelectedFeatures', features)
+            }
+        },
+        /** Removes all selected features from the map */
+        clearSelectedFeatures: ({ commit }) => commit('setSelectedFeatures', []),
+    },
+    mutations: {
+        setSelectedFeatures: (state, features) => (state.selectedFeatures = features),
+    },
+}

--- a/src/modules/store/modules/ui.store.js
+++ b/src/modules/store/modules/ui.store.js
@@ -68,9 +68,16 @@ export default {
          * @type UIModes
          */
         mode: UIModes.MENU_OPENED_THROUGH_BUTTON,
+        /**
+         * Flag telling if the tooltip should be displayed over the map, floating and positioned at
+         * the feature's coordinates. If false, the tooltip will be displayed in the footer
+         *
+         * @type Boolean
+         */
+        floatingTooltip: true,
     },
     getters: {
-        screenDensity: (state) => {
+        screenDensity(state) {
             if (state.height === 0) {
                 return 0
             }
@@ -78,33 +85,55 @@ export default {
         },
     },
     actions: {
-        setSize: ({ commit }, { width, height }) => {
+        setSize({ commit }, { width, height }) {
             commit('setSize', {
                 height,
                 width,
             })
         },
-        toggleMenuTray: ({ commit, state }) => commit('setShowMenuTray', !state.showMenuTray),
-        toggleFullscreenMode: ({ commit, state }) =>
-            commit('setFullscreenMode', !state.fullscreenMode),
-        toggleLoadingBar: ({ commit, state }) => commit('setShowLoadingBar', !state.showLoadingBar),
-        toggleDrawingOverlay: ({ commit, state }) =>
-            commit('setShowDrawingOverlay', !state.showDrawingOverlay),
-        setUiMode: ({ commit }, mode) => {
+        toggleMenuTray({ commit, state }) {
+            commit('setShowMenuTray', !state.showMenuTray)
+        },
+        toggleFullscreenMode({ commit, state }) {
+            commit('setFullscreenMode', !state.fullscreenMode)
+        },
+        toggleLoadingBar({ commit, state }) {
+            commit('setShowLoadingBar', !state.showLoadingBar)
+        },
+        toggleDrawingOverlay({ commit, state }) {
+            commit('setShowDrawingOverlay', !state.showDrawingOverlay)
+        },
+        toggleFloatingTooltip({ commit, state }) {
+            commit('setFloatingTooltip', !state.floatingTooltip)
+        },
+        setUiMode({ commit }, mode) {
             if (mode in UIModes) {
                 commit('setUiMode', mode)
             }
         },
     },
     mutations: {
-        setSize: (state, { height, width }) => {
+        setSize(state, { height, width }) {
             state.height = height
             state.width = width
         },
-        setShowMenuTray: (state, flagValue) => (state.showMenuTray = flagValue),
-        setFullscreenMode: (state, flagValue) => (state.fullscreenMode = flagValue),
-        setShowLoadingBar: (state, flagValue) => (state.showLoadingBar = flagValue),
-        setShowDrawingOverlay: (state, flagValue) => (state.showDrawingOverlay = flagValue),
-        setUiMode: (state, mode) => (state.mode = mode),
+        setShowMenuTray(state, flagValue) {
+            state.showMenuTray = flagValue
+        },
+        setFullscreenMode(state, flagValue) {
+            state.fullscreenMode = flagValue
+        },
+        setShowLoadingBar(state, flagValue) {
+            state.showLoadingBar = flagValue
+        },
+        setShowDrawingOverlay(state, flagValue) {
+            state.showDrawingOverlay = flagValue
+        },
+        setFloatingTooltip(state, flagValue) {
+            state.floatingTooltip = flagValue
+        },
+        setUiMode(state, mode) {
+            state.mode = mode
+        },
     },
 }

--- a/src/modules/store/plugins/click-on-map-management.plugin.js
+++ b/src/modules/store/plugins/click-on-map-management.plugin.js
@@ -41,7 +41,7 @@ const runIdentify = (store, clickInfo, visibleLayers, lang) => {
             const allFeatures = values.flat()
             // dispatching all features by going through them in order to keep only one time each of them (no double)
             store.dispatch(
-                'setHighlightedFeatures',
+                'setSelectedFeatures',
                 allFeatures.filter((feature, index) => allFeatures.indexOf(feature) === index)
             )
         })

--- a/src/modules/store/plugins/screen-size-management.plugin.js
+++ b/src/modules/store/plugins/screen-size-management.plugin.js
@@ -17,6 +17,18 @@ const screenSizeManagementPlugin = (store) => {
             }
             if (wantedUiMode !== state.ui.mode) {
                 store.dispatch('setUiMode', wantedUiMode)
+                // if the UI mode is set to "menu opened through a button" (mobile)
+                // and that the tooltip is still set to floating, we set it in the footer
+                // or
+                // if the UI mode is set to "menu always open" (desktop) and the
+                // tooltip is fixed at the bottom (in the footer) we set it to floating
+                if (
+                    (wantedUiMode === UIModes.MENU_OPENED_THROUGH_BUTTON &&
+                        state.ui.floatingTooltip) ||
+                    (wantedUiMode === UIModes.MENU_ALWAYS_OPEN && !state.ui.floatingTooltip)
+                ) {
+                    store.dispatch('toggleFloatingTooltip')
+                }
             }
         }
     })

--- a/src/utils/EventEmitter.class.js
+++ b/src/utils/EventEmitter.class.js
@@ -1,0 +1,38 @@
+// from https://gist.github.com/mudge/5830382#gistcomment-2691957
+/** Enables an instance of a class to emit its own events (and be listened to) */
+export default class EventEmitter {
+    constructor() {
+        this.events = {}
+    }
+
+    _getEventListByName(eventName) {
+        if (typeof this.events[eventName] === 'undefined') {
+            this.events[eventName] = new Set()
+        }
+        return this.events[eventName]
+    }
+
+    on(eventName, fn) {
+        this._getEventListByName(eventName).add(fn)
+    }
+
+    once(eventName, fn) {
+        const onceFn = (...args) => {
+            this.removeListener(eventName, onceFn)
+            fn.apply(this, args)
+        }
+        this.on(eventName, onceFn)
+    }
+
+    emit(eventName, ...args) {
+        this._getEventListByName(eventName).forEach(
+            function (fn) {
+                fn.apply(this, args)
+            }.bind(this)
+        )
+    }
+
+    removeListener(eventName, fn) {
+        this._getEventListByName(eventName).delete(fn)
+    }
+}

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -3,6 +3,7 @@
         <MapModule>
             <!-- we place the drawing module here so that it can receive the OpenLayers map instance through provide/inject -->
             <DrawingModule />
+            <!-- The footer also need to receive the map (for mouse position) -->
             <MapFooter />
         </MapModule>
         <MenuModule />


### PR DESCRIPTION
Use this new popover in the LocationPopup component
Use this new popover to show highlighted features on the map (with absolute positioning on the coordinates of the feature)
Add in this popover for features a button (in header) that enables the user to place the tooltip at the bottom of the app (with a grid system that gets wider as the screen gets bigger)
Switch to this footer tooltip when on mobile (and back to floating tooltip if going back to desktop)
Removing the usage of the swipe tray (needs more work if we want to use it)

[Test link](https://web-mapviewer.dev.bgdi.ch/feat-jira-bgdiinf_sb-2159_highlighted_feature_overhaul/index.html)