### PR TITLE
BGDIINF_SB-2237: Updated QR code link

### DIFF
--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -96,7 +96,7 @@ import stringifyQuery from '@/router/stringifyQuery'
 export default {
     components: { ButtonWithIcon },
     inject: ['getMap'],
-    data: function () {
+    data() {
         return {
             clickWhat3Words: null,
             height: null,
@@ -108,44 +108,47 @@ export default {
             clickInfo: (state) => state.map.clickInfo,
             currentLang: (state) => state.i18n.lang,
         }),
-        clickCoordinates: function () {
-            return this.clickInfo && this.clickInfo.coordinate
+        clickCoordinates() {
+            return this.clickInfo?.coordinate
         },
-        clickCoordinatesLV95: function () {
+        clickCoordinatesLV95() {
             return printHumanReadableCoordinates(
                 this.reprojectClickCoordinates('EPSG:2056'),
                 CoordinateSystems.LV95
             )
         },
-        clickCoordinatesLV03: function () {
+        clickCoordinatesLV03() {
             return printHumanReadableCoordinates(
                 this.reprojectClickCoordinates('EPSG:21781'),
                 CoordinateSystems.LV03
             )
         },
-        clickCoordinatesPlainWGS84: function () {
+        clickCoordinatesPlainWGS84() {
             const wgsMetric = this.reprojectClickCoordinates('EPSG:4326')
             return `${round(wgsMetric[1], 5)}, ${round(wgsMetric[0], 5)}`
         },
-        clickCoordinatesWGS84: function () {
-            return printHumanReadableCoordinates(
+        clickCoordinatesWGS84() {
+            const complete = printHumanReadableCoordinates(
                 this.reprojectClickCoordinates('EPSG:4326'),
                 CoordinateSystems.WGS84
             )
+            // Only return the first (HDMS) part here. The other part is in:
+            // this.clickCoordinatesPlainWGS84
+            return complete.split(' (')[0]
         },
-        clickCoordinatesUTM: function () {
+        clickCoordinatesUTM() {
             return printHumanReadableCoordinates(
                 this.reprojectClickCoordinates('EPSG:4326'),
                 CoordinateSystems.UTM
             )
         },
-        clickCoordinatesMGRS: function () {
+        clickCoordinatesMGRS() {
             return printHumanReadableCoordinates(
                 this.reprojectClickCoordinates('EPSG:4326'),
                 CoordinateSystems.MGRS
             )
         },
-        isRightClick: function () {
+        isRightClick() {
             return this.clickInfo && this.clickInfo.clickType === ClickType.RIGHT_CLICK
         },
         shareLinkUrl: function () {
@@ -160,7 +163,7 @@ export default {
         },
     },
     watch: {
-        clickCoordinates: function (newClickCoordinates) {
+        clickCoordinates(newClickCoordinates) {
             this.requestWhat3WordBackend()
             this.registerHeigthFromBackend()
             this.generateQrCodeFromBackend()
@@ -168,7 +171,7 @@ export default {
                 this.overlay.setPosition(newClickCoordinates)
             }
         },
-        currentLang: function () {
+        currentLang() {
             this.requestWhat3WordBackend()
             this.generateQrCodeFromBackend()
         },
@@ -191,13 +194,13 @@ export default {
     },
     methods: {
         ...mapActions(['clearClick']),
-        onClose: function () {
+        onClose() {
             this.clearClick()
         },
-        reprojectClickCoordinates: function (targetEpsg) {
+        reprojectClickCoordinates(targetEpsg) {
             return proj4('EPSG:3857', targetEpsg, this.clickCoordinates)
         },
-        requestWhat3WordBackend: function () {
+        requestWhat3WordBackend() {
             if (this.clickCoordinates) {
                 registerWhat3WordsLocation(this.clickCoordinates, this.currentLang).then(
                     (what3word) => {
@@ -206,18 +209,16 @@ export default {
                 )
             }
         },
-        registerHeigthFromBackend: function () {
+        registerHeigthFromBackend() {
             if (this.clickCoordinates) {
                 requestHeight(this.clickCoordinates).then((height) => {
                     this.height = height
                 })
             }
         },
-        generateQrCodeFromBackend: function () {
+        async generateQrCodeFromBackend() {
             if (this.clickCoordinates) {
-                generateQrCode(window.location.href).then((qrCode) => {
-                    this.qrCodeImageSrc = qrCode
-                })
+                this.qrCodeImageSrc = await generateQrCode(this.shareLinkUrl)
             }
         },
     },


### PR DESCRIPTION
During the review of BGDIINF_SB-2226 Brice noticed that the QR code was missing the crosshair and that the link wouldn't update when clicking on a different spot on the map.

With this update the QR code uses the same link as the "share link" which also fixed the reactivity problem.

And while I was at it I also removed a redundant WGS84 format and did some minor refactoring.

PS: The actual change is the use of `this.shareLinkUrl` on line 221.

[Test link](https://web-mapviewer.dev.bgdi.ch/bugfix-jira-bgdiinf_sb-2237-share-link-qr-code/index.html)