### PR TITLE
BGDIINF_SB-2236: Hid mouse position on mobile

### DIFF
--- a/src/modules/map/components/footer/MapFooter.vue
+++ b/src/modules/map/components/footer/MapFooter.vue
@@ -12,18 +12,15 @@
             <!-- Infobox, Profile, ... -->
         </div>
         <div class="map-footer-bottom">
-            <div class="map-footer-bottom-left">
-                <MapFooterScale :current-zoom="zoom" />
-                <MapFooterProjection
-                    :displayed-projection-id="displayedProjectionId"
-                    @projection-change="setDisplayedProjectionWithId"
-                />
-            </div>
-            <div class="map-footer-bottom-right">
-                <MapFooterMousePosition :displayed-projection-id="displayedProjectionId" />
-                <MapFooterAppVersion />
-                <MapFooterAppCopyright />
-            </div>
+            <MapFooterScale :current-zoom="zoom" />
+            <MapFooterProjection
+                :displayed-projection-id="displayedProjectionId"
+                @projection-change="setDisplayedProjectionWithId"
+            />
+            <MapFooterMousePosition :displayed-projection-id="displayedProjectionId" />
+            <span class="map-footer-bottom-spacer" />
+            <MapFooterAppVersion />
+            <MapFooterAppCopyright />
         </div>
     </div>
 </template>
@@ -115,53 +112,28 @@ $flex-gap: 1em;
     }
 
     &-bottom {
-        height: $footer-height * 2;
-        padding: 0 0.6em;
+        width: 100%;
+        padding: 0.6em;
         background-color: rgba($white, 0.9);
         font-size: 0.6rem;
 
         display: flex;
-        justify-content: space-around;
-        flex-direction: column;
+        align-items: center;
+        gap: 0 $flex-gap;
+        flex-wrap: wrap;
 
-        &-left,
-        &-right {
-            display: flex;
-            align-items: center;
-            gap: $flex-gap;
+        &-spacer {
+            flex-grow: 1;
         }
     }
 }
 
 .map-footer-fullscreen {
-    transform: translateY($footer-height * 2);
+    transform: translateY(100%);
 
     .map-footer-top-left {
+        // Translation is needed if the background selection wheel is open.
         transform: translateX(-100%);
-    }
-}
-
-@include respond-above(sm) {
-    .map-footer {
-        &-fullscreen {
-            transform: translateY($footer-height);
-        }
-
-        &-top,
-        &-bottom {
-            display: flex;
-            justify-content: space-between;
-        }
-
-        &-bottom {
-            height: $footer-height;
-            flex-direction: row;
-            gap: $flex-gap;
-
-            &-right {
-                flex-grow: 1;
-            }
-        }
     }
 }
 </style>

--- a/src/modules/map/components/footer/MapFooterMousePosition.vue
+++ b/src/modules/map/components/footer/MapFooterMousePosition.vue
@@ -54,10 +54,17 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'src/scss/media-query.mixin';
+
 .mouse-position {
+    display: none;
     min-width: 10em;
-    flex-grow: 1;
     text-align: left;
     white-space: nowrap;
+}
+@include respond-above(lg) {
+    .mouse-position {
+        display: block;
+    }
 }
 </style>

--- a/src/modules/map/components/footer/MapFooterMousePosition.vue
+++ b/src/modules/map/components/footer/MapFooterMousePosition.vue
@@ -62,7 +62,7 @@ export default {
     text-align: left;
     white-space: nowrap;
 }
-@include respond-above(lg) {
+@include respond-above(md) {
     .mouse-position {
         display: block;
     }

--- a/src/modules/map/components/footer/MapFooterProjection.vue
+++ b/src/modules/map/components/footer/MapFooterProjection.vue
@@ -1,6 +1,6 @@
 <template>
     <select
-        class="form-control-xs"
+        class="map-projection form-control-xs"
         :value="displayedProjectionId"
         data-cy="mouse-position-select"
         @change="onProjectionChange"
@@ -39,3 +39,16 @@ export default {
     },
 }
 </script>
+
+<style lang="scss" scoped>
+@import 'src/scss/media-query.mixin';
+
+.map-projection {
+    display: none;
+}
+@include respond-above(md) {
+    .map-projection {
+        display: block;
+    }
+}
+</style>

--- a/tests/e2e/specs/mouseposition.spec.js
+++ b/tests/e2e/specs/mouseposition.spec.js
@@ -78,7 +78,8 @@ describe('Test mouse position', () => {
         })
         it('switches to WebMercator when this SRS is selected in the UI', () => {
             getMousePositionAndSelect(CoordinateSystems.WGS84)
-            checkMousePositionStringValue('47° 30′ 00.00″ N 7° 30′ 00.00″ E (47.50000, 7.50000)')
+            let dd = defaultCenter.map((value) => value.toFixed(5)).join(', ')
+            checkMousePositionStringValue(`47° 30′ 00.00″ N 7° 30′ 00.00″ E (${dd})`)
         })
         it('goes back to LV95 display if selected again', () => {
             // Change display projection without moving the mouse
@@ -144,14 +145,14 @@ describe('Test mouse position', () => {
             it('Uses the coordination system MGRS in the popup', () => {
                 cy.get('[data-cy="location-popup-coordinates-mgrs"]').contains('32TMQ 21184 83436')
             })
-            it.only('Test the link with bowl crosshair gives the right coordinates', () => {
+            it('Test the link with bowl crosshair gives the right coordinates', () => {
                 cy.get('[data-cy="location-popup-link-bowl-crosshair"] a')
                     .then((link) => {
                         const search = link[0].href.split('?')[1]
                         const params = new URLSearchParams(search)
-                        return [parseFloat(params.get('lat')), parseFloat(params.get('lon'))]
+                        return [parseFloat(params.get('lon')), parseFloat(params.get('lat'))]
                     })
-                    .then(checkXY(lat, lon))
+                    .then(checkXY(lon, lat))
             })
         })
     })


### PR DESCRIPTION
As we don't have a mouse (hover) on mobile devices
we can hide the mouse position in the footer.

This makes that change and includes some improvements
to the footer's CSS to make it more flexible to cope
with the disappearing mouse position and map scale.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-2236-hide-mouse-position/index.html)