### PR TITLE
BGDIINF_SB-2232: Removed fake tell-cypress requests

### DIFF
--- a/src/modules/menu/components/header/HeaderSwissConfederationText.vue
+++ b/src/modules/menu/components/header/HeaderSwissConfederationText.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script>
-import { ENVIRONMENT } from '@/config'
+import { ENVIRONMENT, IS_TESTING_WITH_CYPRESS } from '@/config'
 export default {
     props: {
         currentLang: {
@@ -24,7 +24,7 @@ export default {
     emits: ['click'],
     data() {
         return {
-            devSiteWarning: ENVIRONMENT !== 'production',
+            devSiteWarning: !IS_TESTING_WITH_CYPRESS && ENVIRONMENT !== 'production',
         }
     },
 }

--- a/src/modules/menu/components/header/HeaderWithSearch.vue
+++ b/src/modules/menu/components/header/HeaderWithSearch.vue
@@ -32,7 +32,8 @@
 </template>
 
 <script>
-import { ENVIRONMENT } from '@/config'
+import { ENVIRONMENT, IS_TESTING_WITH_CYPRESS } from '@/config'
+
 import HeaderLoadingBar from '@/modules/menu/components/header/HeaderLoadingBar.vue'
 import HeaderMenuButton from '@/modules/menu/components/header/HeaderMenuButton.vue'
 import HeaderSwissConfederationText from '@/modules/menu/components/header/HeaderSwissConfederationText.vue'
@@ -67,7 +68,7 @@ export default {
     },
     data() {
         return {
-            devSiteWarning: ENVIRONMENT !== 'production',
+            devSiteWarning: !IS_TESTING_WITH_CYPRESS && ENVIRONMENT !== 'production',
         }
     },
     methods: {

--- a/src/modules/menu/components/header/SwissFlag.vue
+++ b/src/modules/menu/components/header/SwissFlag.vue
@@ -10,13 +10,13 @@
 
 <script>
 import swissFlagIcon from '@/assets/svg/swiss-flag.svg'
-import { ENVIRONMENT } from '@/config'
+import { ENVIRONMENT, IS_TESTING_WITH_CYPRESS } from '@/config'
 export default {
     emits: ['click'],
     data() {
         return {
             swissFlagIcon,
-            devSiteWarning: ENVIRONMENT !== 'production',
+            devSiteWarning: !IS_TESTING_WITH_CYPRESS && ENVIRONMENT !== 'production',
         }
     },
 }

--- a/src/modules/store/modules/app.store.js
+++ b/src/modules/store/modules/app.store.js
@@ -1,6 +1,3 @@
-import axios from 'axios'
-import { IS_TESTING_WITH_CYPRESS } from '@/config'
-
 /** Vuex module that tells if the app has finished loading (is ready to show stuff) */
 export default {
     state: {
@@ -15,12 +12,6 @@ export default {
     actions: {
         setAppIsReady: ({ commit }) => {
             commit('setAppIsReady')
-            // in case we are testing with Cypress, we trigger a fake request to
-            // a localhost endpoint so that Cypress can intercept it and know the
-            // app is done loading
-            if (IS_TESTING_WITH_CYPRESS) {
-                axios.get('/tell-cypress-app-is-done-loading')
-            }
         },
     },
     mutations: {

--- a/src/modules/store/modules/drawing.store.js
+++ b/src/modules/store/modules/drawing.store.js
@@ -1,5 +1,3 @@
-import axios from 'axios'
-import { IS_TESTING_WITH_CYPRESS } from '@/config'
 import { getAllIconSets } from '@/api/icon.api'
 import { getKmlUrl } from '@/api/files.api'
 
@@ -45,37 +43,30 @@ export default {
         iconSets: [],
     },
     getters: {
-        getDrawingPublicFileUrl: (state) => {
+        getDrawingPublicFileUrl(state) {
             if (state.drawingKmlIds) {
                 return getKmlUrl(state.drawingKmlIds.fileId)
             }
             return null
         },
-        isCurrentlyDrawing: (state) => {
+        isCurrentlyDrawing(state) {
             return state.mode !== null
         },
     },
     actions: {
-        setDrawingMode: ({ commit }, mode) => {
+        setDrawingMode({ commit }, mode) {
             if (mode in drawingModes || mode === null) {
                 commit('setDrawingMode', mode)
             }
         },
-        setKmlIds: ({ commit }, drawingKmlIds) => {
+        setKmlIds({ commit }, drawingKmlIds) {
             commit('setKmlIds', drawingKmlIds)
         },
-        loadAvailableIconSets: ({ commit }) => {
-            getAllIconSets().then((iconSets) => {
-                if (iconSets && iconSets.length > 0) {
-                    commit('setIconSets', iconSets)
-                }
-                // We have a race condition during testing where the icons are
-                // needed after being loaded from the backend but before being
-                // committed to the store. Intercept and wait are in goToDrawing.
-                if (IS_TESTING_WITH_CYPRESS) {
-                    axios.get('/tell-cypress-icon-sets-available')
-                }
-            })
+        async loadAvailableIconSets({ commit }) {
+            const iconSets = await getAllIconSets()
+            if (iconSets?.length > 0) {
+                commit('setIconSets', iconSets)
+            }
         },
     },
     mutations: {

--- a/src/modules/store/modules/layers.store.js
+++ b/src/modules/store/modules/layers.store.js
@@ -1,5 +1,3 @@
-import axios from 'axios'
-import { IS_TESTING_WITH_CYPRESS } from '@/config'
 import log from '@/utils/logging'
 import AbstractLayer from '@/api/layers/AbstractLayer.class'
 
@@ -141,12 +139,6 @@ const actions = {
                 commit('addLayerWithConfig', layer)
             }
         })
-        // In case we are testing with Cypress, we trigger a fake request to
-        // a localhost endpoint so that Cypress can intercept it and know the
-        // layers have been updated. Intercepted as @layers-configured in goToMapView.
-        if (IS_TESTING_WITH_CYPRESS) {
-            axios.get('/tell-cypress-layers-are-configured')
-        }
     },
     setBackground({ commit }, bgLayerId) {
         if (bgLayerId === 'void') {
@@ -181,8 +173,7 @@ const actions = {
                     })
                 }
             } else {
-                log(
-                    'error',
+                log.error(
                     'Failed to set layer timestamp, layer not found or has not time config',
                     layerId,
                     layer

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -17,11 +17,7 @@ const newLayerParamRegex = /^[\w.]+[@\w=]*[,ft]*[,?\d.]*$/
 
 export function isLayersUrlParamLegacy(layersParamValue) {
     const layers = layersParamValue.split(';')
-    let isNewSyntax = false
-    layers.forEach((layerUrlString) => {
-        isNewSyntax |= newLayerParamRegex.test(layerUrlString)
-    })
-    return !isNewSyntax
+    return !layers.some((layer) => newLayerParamRegex.test(layer))
 }
 
 /**

--- a/tests/e2e/specs/layers.spec.js
+++ b/tests/e2e/specs/layers.spec.js
@@ -456,8 +456,12 @@ describe('Test of layer handling', () => {
                         cy.get('[data-cy="menu-settings-section"]').click()
                         cy.get(`[data-cy="menu-lang-${langAfter}"`).click()
 
-                        // Wait until the layers fully configured with the new configuration.
-                        cy.wait('@layers-configured')
+                        // Wait until the active layers are updated.
+                        cy.waitUntilState((state) => {
+                            return state.layers.activeLayers.some(
+                                (layer) => layer.lang === langAfter
+                            )
+                        })
 
                         // CHECK after
                         cy.readStoreValue('state').then((state) => {

--- a/tests/e2e/support/drawing.js
+++ b/tests/e2e/support/drawing.js
@@ -50,9 +50,6 @@ Cypress.on('uncaught:exception', () => {
 })
 
 Cypress.Commands.add('goToDrawing', (isMobileViewport = false) => {
-    // see drawing.store.js (wait is at the end of this function)
-    cy.intercept('**/tell-cypress-icon-sets-available', {}).as('icon-sets-available')
-
     addIconFixtureAndIntercept()
     addIconSetsFixtureAndIntercept()
     addDefaultIconsFixtureAndIntercept()
@@ -63,7 +60,7 @@ Cypress.Commands.add('goToDrawing', (isMobileViewport = false) => {
     }
     cy.get('[data-cy="menu-tray-drawing-section"]').click()
     cy.readStoreValue('state.ui.showDrawingOverlay').should('be.true')
-    cy.wait('@icon-sets-available')
+    cy.waitUntilState((state) => state.drawing.iconSets.length > 0)
 })
 
 Cypress.Commands.add('clickDrawingTool', (name) => {

--- a/vue.config.js
+++ b/vue.config.js
@@ -18,8 +18,11 @@ if (process.env.DEPLOY && branch !== 'master' && branch !== 'develop') {
 const packageJson = JSON.parse(fs.readFileSync('./package.json'))
 const version = packageJson.version || 0
 
-// Mapping between deployment environment and Webpack optimizations.
-// https://webpack.js.org/configuration/mode/
+/**
+ * Mapping between deployment environment and Webpack optimizations.
+ *
+ * @see https://webpack.js.org/configuration/mode/
+ */
 const modes = {
     development: 'development',
     integration: 'production',


### PR DESCRIPTION
Until now we had some fake requests that we intercepted
in order to be able to wait for certain events.

This removes those requests and replaces the waiting with
the Cypress plugin waitUntil. This also removes the warning
about this being a test site. The warning obscured a button
and we should test for what we deploy in production.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-2232-dont-tell-cypress/index.html)