### PR TITLE
BGDIINF_SB-2105: Send drawings as KMZ (gzipped)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "hammerjs": "^2.0.8",
                 "jquery": "^3.6.0",
                 "ol": "^6.12.0",
+                "pako": "^2.0.4",
                 "print-js": "^1.6.0",
                 "proj4": "^2.7.5",
                 "register-service-worker": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "hammerjs": "^2.0.8",
         "jquery": "^3.6.0",
         "ol": "^6.12.0",
+        "pako": "^2.0.4",
         "print-js": "^1.6.0",
         "proj4": "^2.7.5",
         "register-service-worker": "^1.7.2",

--- a/src/api/files.api.js
+++ b/src/api/files.api.js
@@ -1,5 +1,6 @@
 import { API_SERVICE_KML_BASE_URL, API_SERVICE_KML_STORAGE_BASE_URL } from '@/config'
 import axios from 'axios'
+import pako from 'pako'
 import log from '@/utils/logging'
 import FormData from 'form-data'
 
@@ -89,7 +90,8 @@ function validateKml(kml, reject) {
 function buildKmlForm(kml, reject) {
     validateKml(kml, reject)
     const form = new FormData()
-    const blob = new Blob([kml], { type: 'application/vnd.google-earth.kml+xml' })
+    const kmz = pako.gzip(kml)
+    const blob = new Blob([kmz], { type: 'application/vnd.google-earth.kml+xml' })
     form.append('kml', blob)
     return form
 }

--- a/tests/e2e/specs/drawing/line-polygon.spec.js
+++ b/tests/e2e/specs/drawing/line-polygon.spec.js
@@ -53,9 +53,9 @@ describe('Line/Polygon tool', () => {
                     cy.get(`${drawingStyleLinePopup} [data-cy="color-selector-black"]`).click()
                     cy.checkDrawnGeoJsonProperty('color', '#000000')
                     cy.wait('@update-kml').then((interception) =>
-                        expect(interception.request.body).to.contain(
-                            '<Data name="color"><value>#000000</value>'
-                        )
+                        cy.checkKMLRequest(interception, [
+                            '<Data name="color"><value>#000000</value>',
+                        ])
                     )
                 })
                 it('creates a line with double click', () => {

--- a/tests/e2e/specs/drawing/marker-text.spec.js
+++ b/tests/e2e/specs/drawing/marker-text.spec.js
@@ -162,10 +162,11 @@ describe('Drawing marker/points', () => {
                     context('marker styling popup', () => {
                         const checkIconInKml = (expectedIconUrl) => {
                             cy.wait('@update-kml').then((interception) => {
-                                const body = interception.request.body
-                                let icon = body.substr(body.indexOf('<Data name="icon">'))
-                                icon = icon.substr(0, icon.indexOf('</Data>'))
-                                expect(icon).to.contain(expectedIconUrl)
+                                cy.checkKMLRequest(interception, [
+                                    new RegExp(
+                                        `<Data name="icon">.+?${expectedIconUrl}.+?<\\/Data>`
+                                    ),
+                                ])
                             })
                         }
 

--- a/tests/e2e/support/multipart.js
+++ b/tests/e2e/support/multipart.js
@@ -1,0 +1,153 @@
+// https://gist.github.com/dcollien/76d17f69afe748afad7ff3a15ff9a08a
+
+class Parser {
+    constructor(byteArray, boundary) {
+        this.byteArray = byteArray
+        this.current = null
+        this.index = 0
+        this.boundary = boundary
+    }
+
+    skipPastNextBoundary() {
+        let index = 0
+        let isBoundary = false
+
+        while (!isBoundary) {
+            if (this.next() === null) {
+                return false
+            }
+
+            if (this.current === this.boundary[index]) {
+                index++
+                if (index === this.boundary.length) {
+                    isBoundary = true
+                }
+            } else {
+                index = 0
+            }
+        }
+
+        return true
+    }
+
+    parseHeader() {
+        let header = ''
+        const skipUntilNextLine = () => {
+            header += this.next()
+            while (this.current !== '\n' && this.current !== null) {
+                header += this.next()
+            }
+            if (this.current === null) {
+                return null
+            }
+        }
+
+        let hasSkippedHeader = false
+        while (!hasSkippedHeader) {
+            skipUntilNextLine()
+            header += this.next()
+            if (this.current === '\r') {
+                header += this.next() // skip
+            }
+
+            if (this.current === '\n') {
+                hasSkippedHeader = true
+            } else if (this.current === null) {
+                return null
+            }
+        }
+
+        return header
+    }
+
+    next() {
+        if (this.index >= this.byteArray.byteLength) {
+            this.current = null
+            return null
+        }
+
+        this.current = String.fromCharCode(this.byteArray[this.index])
+        this.index++
+        return this.current
+    }
+}
+
+function processSections(byteArray, sections) {
+    for (const section of sections) {
+        if (section.header['content-type'] === 'text/plain') {
+            const slice = byteArray.slice(section.bodyStart, section.end)
+            section.text = Array.from(slice)
+                .map((byte) => String.fromCharCode(byte))
+                .join('')
+        } else {
+            const slice = byteArray.slice(section.bodyStart, section.end)
+            section.file = new Blob([slice], { type: section.header['content-type'] })
+            const fileNameMatching =
+                /\bfilename="([^"]*)"/g.exec(section.header['content-disposition']) || []
+            section.fileName = fileNameMatching[1] || ''
+        }
+        const matching = /\bname="([^"]*)"/g.exec(section.header['content-disposition']) || []
+        section.name = matching[1] || ''
+
+        delete section.headerStart
+        delete section.bodyStart
+        delete section.end
+    }
+
+    return sections
+}
+
+function multiparts(byteArray, boundary) {
+    boundary = '--' + boundary
+    const parser = new Parser(byteArray, boundary)
+
+    let sections = []
+    while (parser.skipPastNextBoundary()) {
+        const header = parser.parseHeader()
+
+        if (header !== null) {
+            const headerParts = header.trim().split('\n')
+
+            const headerObj = {}
+            for (let i = 0; i !== headerParts.length; ++i) {
+                const parts = headerParts[i].split(':')
+                headerObj[parts[0].trim().toLowerCase()] = (parts[1] || '').trim()
+            }
+
+            sections.push({
+                bodyStart: parser.index,
+                header: headerObj,
+                headerStart: parser.index - header.length,
+            })
+        }
+    }
+
+    // add dummy section for end
+    sections.push({
+        headerStart: byteArray.byteLength - boundary.length - 2, // 2 hyphens at end
+    })
+    for (let i = 0; i !== sections.length - 1; ++i) {
+        sections[i].end = sections[i + 1].headerStart - boundary.length - 2
+    }
+    // remove dummy section
+    sections.pop()
+
+    return processSections(byteArray, sections)
+}
+
+export function parse(byteArray, boundary) {
+    return multiparts(byteArray, boundary).reduce((hash, section) => {
+        hash[section.name] = {
+            blob: section.file,
+            fileName: section.fileName,
+        }
+
+        return hash
+    }, {})
+}
+
+export function parseInterception(interception) {
+    const byteArray = new Uint8Array(interception.request.body)
+    const boundary = interception.request.headers['content-type'].split('boundary=')[1]
+    return parse(byteArray, boundary)
+}


### PR DESCRIPTION
To enable the migration of the service-kml it was requested that
we send the drawings gzipped (i.e. as KMZ).

This commit introduces pako (as pure JS library) to compress the
KML before sending it to the backend.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-2105-send-as-kmz/index.html)