### PR TITLE
BGDIINF_SB-2272: Inverted menu button on mobile

### DIFF
--- a/src/modules/menu/components/header/HeaderMenuButton.vue
+++ b/src/modules/menu/components/header/HeaderMenuButton.vue
@@ -1,5 +1,11 @@
 <template>
-    <button type="button" data-cy="menu-button" class="btn btn-default" @click="toggleMenuTray">
+    <button
+        type="button"
+        data-cy="menu-button"
+        class="btn"
+        :class="{ 'btn-dark': isOpen }"
+        @click="toggleMenuTray"
+    >
         <strong>{{ $t(menuButtonText) }}</strong>
     </button>
 </template>
@@ -11,6 +17,7 @@ export default {
     computed: {
         ...mapState({
             menuButtonText: (state) => (state.ui.showMenuTray ? 'close' : 'menu'),
+            isOpen: (state) => state.ui.showMenuTray,
         }),
     },
     methods: {

--- a/src/modules/menu/components/header/HeaderMenuButton.vue
+++ b/src/modules/menu/components/header/HeaderMenuButton.vue
@@ -2,11 +2,11 @@
     <button
         type="button"
         data-cy="menu-button"
-        class="btn"
-        :class="{ 'btn-dark': isOpen }"
+        class="btn menu-button"
+        :class="{ 'menu-button-active': isOpen }"
         @click="toggleMenuTray"
     >
-        <strong>{{ $t(menuButtonText) }}</strong>
+        {{ $t(menuButtonText) }}
     </button>
 </template>
 
@@ -25,3 +25,14 @@ export default {
     },
 }
 </script>
+
+<style lang="scss" scoped>
+.menu-button {
+    font-weight: bold;
+
+    &-active {
+        background-color: #474949;
+        color: #fff;
+    }
+}
+</style>


### PR DESCRIPTION
This changes the color of the menu button on mobile when the menu is open to further indicate the toggled state.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-2272-invert-menu-button/index.html)