### PR TITLE
BGDIINF_SB-2268: Added info-button to layers

### DIFF
--- a/src/modules/menu/components/BlackBackdrop.vue
+++ b/src/modules/menu/components/BlackBackdrop.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="app-backdrop" :class="{ front: front }" data-cy="black-backdrop"></div>
+    <div class="app-backdrop" :class="{ front }" data-cy="black-backdrop"></div>
 </template>
 <script>
 export default {

--- a/src/modules/menu/components/LayerLegendPopup.vue
+++ b/src/modules/menu/components/LayerLegendPopup.vue
@@ -1,6 +1,6 @@
 <template>
     <ModalWithBackdrop :title="$t('metadata_window_title')" :allow-print="true" @close="onClose">
-        <div class="layer-legend">
+        <div class="layer-legend" data-cy="layer-legend-popup">
             <h4 v-if="!content" class="mb-0">
                 <font-awesome-icon spin :icon="['fa', 'spinner']" />
             </h4>
@@ -29,10 +29,8 @@ export default {
             content: null,
         }
     },
-    mounted() {
-        getLayerLegend(this.$i18n.lang, this.layerId).then((layerLegend) => {
-            this.content = layerLegend
-        })
+    async mounted() {
+        this.content = await getLayerLegend(this.$i18n.lang, this.layerId)
     },
     methods: {
         onClose() {

--- a/src/modules/menu/components/topics/MenuTopicSection.vue
+++ b/src/modules/menu/components/topics/MenuTopicSection.vue
@@ -27,21 +27,33 @@
                 :item="item"
                 :active-layers="activeLayers"
                 :compact="compact"
-                @click-on-layer-topic-item="onClickOnLayerTopicItem"
+                @click-on-topic-item="onClickTopicItem"
+                @click-on-layer-info="onClickLayerInfo"
             />
         </ul>
+        <LayerLegendPopup
+            v-if="showLayerInfoFor"
+            :layer-id="showLayerInfoFor"
+            @close="showLayerInfoFor = null"
+        />
     </MenuSection>
 </template>
 
 <script>
 import { mapState, mapGetters, mapActions } from 'vuex'
+import LayerLegendPopup from '@/modules/menu/components/LayerLegendPopup.vue'
 import MenuSection from '@/modules/menu/components/menu/MenuSection.vue'
 import MenuTopicTreeItem from '@/modules/menu/components/topics/MenuTopicTreeItem.vue'
 import MenuTopicSelectionPopup from '@/modules/menu/components/topics/MenuTopicSelectionPopup.vue'
 
 /** Menu section for topics, responsible to communicate user interactions on topics with the store */
 export default {
-    components: { MenuTopicSelectionPopup, MenuTopicTreeItem, MenuSection },
+    components: {
+        LayerLegendPopup,
+        MenuTopicSelectionPopup,
+        MenuTopicTreeItem,
+        MenuSection,
+    },
     props: {
         compact: {
             type: Boolean,
@@ -50,6 +62,7 @@ export default {
     },
     data() {
         return {
+            showLayerInfoFor: null,
             showTopicSelectionPopup: false,
         }
     },
@@ -72,19 +85,21 @@ export default {
         setShowTopicSelectionPopup() {
             this.showTopicSelectionPopup = true
         },
-        onClickOnLayerTopicItem(layerId) {
+        selectTopic(topic) {
+            this.changeTopic(topic)
+            this.showTopicSelectionPopup = false
+        },
+        onClickTopicItem(layerId) {
             const layer = this.getActiveLayerById(layerId)
             if (layer) {
                 this.toggleLayerVisibility(layerId)
             } else {
-                this.addLayer(layerId).then(() =>
-                    this.setLayerVisibility({ layerId, visible: true })
-                )
+                this.addLayer(layerId)
+                this.setLayerVisibility({ layerId, visible: true })
             }
         },
-        selectTopic(topic) {
-            this.changeTopic(topic)
-            this.showTopicSelectionPopup = false
+        onClickLayerInfo(layerId) {
+            this.showLayerInfoFor = layerId
         },
     },
 }

--- a/src/modules/menu/components/topics/MenuTopicTreeItem.vue
+++ b/src/modules/menu/components/topics/MenuTopicTreeItem.vue
@@ -7,7 +7,11 @@
         ]"
         data-cy="topic-tree-item"
     >
-        <div class="menu-topic-item-title" :data-cy="`topic-tree-item-${item.id}`" @click="onClick">
+        <div
+            class="menu-topic-item-title"
+            :data-cy="`topic-tree-item-${item.id}`"
+            @click="onItemClick"
+        >
             <ButtonWithIcon
                 :button-font-awesome-icon="showHideIcon"
                 :class="{
@@ -18,9 +22,21 @@
                 :square="isTheme"
             />
             <span class="menu-topic-item-name">{{ item.name }}</span>
+            <ButtonWithIcon
+                v-if="isLayer"
+                data-cy="topic-tree-item-info"
+                :button-font-awesome-icon="['fas', 'info-circle']"
+                :large="!compact"
+                transparent
+                @click.stop="onInfoClick"
+            />
         </div>
         <CollapseTransition :duration="200">
-            <ul v-if="showChildren" class="menu-topic-item-children" :class="`ps-${2 + 2 * depth}`">
+            <ul
+                v-show="showChildren"
+                class="menu-topic-item-children"
+                :class="`ps-${2 + 2 * depth}`"
+            >
                 <MenuTopicTreeItem
                     v-for="child in item.children"
                     :key="`${child.id}-${child.name}`"
@@ -28,7 +44,8 @@
                     :active-layers="activeLayers"
                     :depth="depth + 1"
                     :compact="compact"
-                    @click-on-layer-topic-item="(layerId) => bubbleEventToParent(layerId)"
+                    @click-on-topic-item="bubbleToggleItemEvent"
+                    @click-on-layer-info="bubbleLayerInfoEvent"
                 />
             </ul>
         </CollapseTransition>
@@ -49,8 +66,8 @@ import ButtonWithIcon from '@/utils/ButtonWithIcon.vue'
 export default {
     name: 'MenuTopicTreeItem',
     components: {
-        CollapseTransition,
         ButtonWithIcon,
+        CollapseTransition,
     },
     props: {
         item: {
@@ -70,7 +87,7 @@ export default {
             default: 0,
         },
     },
-    emits: ['clickOnLayerTopicItem'],
+    emits: ['clickOnTopicItem', 'clickOnLayerInfo'],
     data() {
         return {
             showChildren: false,
@@ -92,6 +109,9 @@ export default {
                 }
             }
         },
+        isLayer() {
+            return this.item.type === topicTypes.LAYER
+        },
         isActive() {
             return (
                 this.item.type === topicTypes.LAYER &&
@@ -111,12 +131,15 @@ export default {
         },
     },
     methods: {
-        onClick() {
+        onItemClick() {
             if (this.item.type === topicTypes.THEME) {
                 this.showChildren = !this.showChildren
             } else {
-                this.$emit('clickOnLayerTopicItem', this.item.layerId)
+                this.$emit('clickOnTopicItem', this.item.layerId)
             }
+        },
+        onInfoClick() {
+            this.$emit('clickOnLayerInfo', this.item.layerId)
         },
         /**
          * As we can have recursive component (see template), we have to bubble up user interaction
@@ -125,8 +148,11 @@ export default {
          *
          * @param {String} layerId The ID of the layer that has been clicked in the topic tree
          */
-        bubbleEventToParent: function (layerId) {
-            this.$emit('clickOnLayerTopicItem', layerId)
+        bubbleToggleItemEvent(layerId) {
+            this.$emit('clickOnTopicItem', layerId)
+        },
+        bubbleLayerInfoEvent(layerId) {
+            this.$emit('clickOnLayerInfo', layerId)
         },
     },
 }

--- a/tests/e2e/specs/topics.spec.js
+++ b/tests/e2e/specs/topics.spec.js
@@ -205,7 +205,7 @@ describe('Topics', () => {
                     })
                     it('does not open the first elements of the tree by default', () => {
                         cy.get('[data-cy="topic-tree-item-2"]').should('be.visible')
-                        cy.get('[data-cy="topic-tree-item-3"]').should('not.exist')
+                        cy.get('[data-cy="topic-tree-item-3"]').should('not.be.visible')
                     })
                     it("shows a topic tree item's children when we click on it", () => {
                         cy.get('[data-cy="topic-tree-item-2"]').click()
@@ -221,6 +221,20 @@ describe('Topics', () => {
                             const [firstLayer] = activeLayers
                             expect(firstLayer.getID()).to.eq('test.wmts.layer')
                         })
+                    })
+                    it('opens the layer legend popup when clicking the info button', () => {
+                        const expectedContent = 'Test'
+                        cy.intercept(
+                            `**/rest/services/all/MapServer/*/legend**`,
+                            `<div>${expectedContent}</div>`
+                        ).as('legend')
+
+                        cy.get('[data-cy="topic-tree-item-2"]').click()
+                        cy.get('[data-cy="topic-tree-item-3"]').click()
+                        cy.get('[data-cy="topic-tree-item-info"]').first().click()
+                        cy.get('[data-cy="layer-legend-popup"]')
+                            .should('be.visible')
+                            .contains(expectedContent)
                     })
                 })
             }


### PR DESCRIPTION
As with the info-button for the selected layers (settings) and the
search results we now also have an info-button for the available layers.

Plus, the usual minor refactoring.
This time function assignments, async/await, and some renaming.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-2268-layer-info-button/index.html)