### PR TITLE
BGDIINF_SB-2275: Changed QR code from toggle to link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
                 "@babel/eslint-plugin": "^7.16.5",
                 "@cypress/vue": "next",
                 "@cypress/webpack-preprocessor": "^5.11.0",
-                "@nuintun/qrcode": "^3.1.1",
                 "@vue/cli-plugin-babel": "next",
                 "@vue/cli-plugin-e2e-cypress": "next",
                 "@vue/cli-plugin-eslint": "next",
@@ -50,7 +49,7 @@
                 "@vue/cli-plugin-unit-mocha": "next",
                 "@vue/cli-plugin-vuex": "next",
                 "@vue/cli-service": "next",
-                "@vue/compiler-sfc": "*",
+                "@vue/compiler-sfc": "latest",
                 "@vue/test-utils": "next",
                 "aws-sdk": "^2.1070.0",
                 "caniuse-lite": "^1.0.30001309",
@@ -2246,15 +2245,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/@nuintun/qrcode": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@nuintun/qrcode/-/qrcode-3.1.1.tgz",
-            "integrity": "sha512-wIZHSut0P7208M0LvoljEsxjYdrpkGuOwNUKAdZaK7sxlnv07G4adondqbD0tpRTOFNSYAjhomybCmzeDaGhCw==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^2.3.1"
             }
         },
         "node_modules/@petamoriken/float16": {
@@ -20513,15 +20503,6 @@
             "requires": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
-            }
-        },
-        "@nuintun/qrcode": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@nuintun/qrcode/-/qrcode-3.1.1.tgz",
-            "integrity": "sha512-wIZHSut0P7208M0LvoljEsxjYdrpkGuOwNUKAdZaK7sxlnv07G4adondqbD0tpRTOFNSYAjhomybCmzeDaGhCw==",
-            "dev": true,
-            "requires": {
-                "tslib": "^2.3.1"
             }
         },
         "@petamoriken/float16": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
         "@babel/eslint-plugin": "^7.16.5",
         "@cypress/vue": "next",
         "@cypress/webpack-preprocessor": "^5.11.0",
-        "@nuintun/qrcode": "^3.1.1",
         "@vue/cli-plugin-babel": "next",
         "@vue/cli-plugin-e2e-cypress": "next",
         "@vue/cli-plugin-eslint": "next",

--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -7,15 +7,7 @@
         data-cy="location-popup"
         @close="clearClick"
     >
-        <template #extra-buttons>
-            <ButtonWithIcon
-                :button-font-awesome-icon="['fas', 'qrcode']"
-                data-cy="location-popup-toggle"
-                @click="toggleQrCode"
-            />
-        </template>
-
-        <div v-show="!showQrCode" class="coordinates-list text-start">
+        <div class="coordinates-list text-start">
             <div>
                 <a :href="$t('contextpopup_lv95_url')" target="_blank">CH1903+ / LV95</a>
             </div>
@@ -77,8 +69,12 @@
                 </a>
             </div>
         </div>
-        <div v-show="showQrCode" class="qrcode-container">
-            <img v-if="qrCodeImageSrc" :src="qrCodeImageSrc" data-cy="location-popup-qr-code" />
+
+        <div class="qrcode-container">
+            <a :href="qrCodeUrl" target="_blank" data-cy="location-popup-qrcode">
+                <FontAwesomeIcon :icon="['fas', 'qrcode']" />
+                QR-Code anzeigen
+            </a>
         </div>
     </OpenLayersPopover>
 </template>
@@ -94,21 +90,20 @@ import { requestHeight } from '@/api/height.api'
 import { generateQrCode } from '@/api/qrcode.api'
 import { ClickType } from '@/modules/map/store/map.store'
 import OpenLayersPopover from '@/modules/map/components/openlayers/OpenLayersPopover.vue'
-import ButtonWithIcon from '@/utils/ButtonWithIcon.vue'
 import { printHumanReadableCoordinates, CoordinateSystems } from '@/utils/coordinateUtils'
 import { round } from '@/utils/numberUtils'
 import stringifyQuery from '@/router/stringifyQuery'
+import { API_SERVICES_BASE_URL } from '@/config'
 
 /** Right click pop up which shows the coordinates of the position under the cursor. */
 export default {
-    components: { OpenLayersPopover, ButtonWithIcon },
+    components: { OpenLayersPopover },
     inject: ['getMap'],
     data() {
         return {
             clickWhat3Words: null,
             height: null,
             qrCodeImageSrc: null,
-            showQrCode: false,
         }
     },
     computed: {
@@ -169,6 +164,10 @@ export default {
             }
             return `${location.origin}/#/map?${stringifyQuery(query)}`
         },
+        qrCodeUrl() {
+            const url = encodeURIComponent(this.shareLinkUrl)
+            return `${API_SERVICES_BASE_URL}qrcode/generate?url=${url}`
+        },
     },
     watch: {
         clickCoordinates(newClickCoordinates) {
@@ -213,9 +212,6 @@ export default {
         ...mapActions(['clearClick']),
         onClose() {
             this.clearClick()
-        },
-        toggleQrCode() {
-            this.showQrCode = !this.showQrCode
         },
         reprojectClickCoordinates(targetEpsg) {
             return proj4('EPSG:3857', targetEpsg, this.clickCoordinates)


### PR DESCRIPTION
The current solution with the toggle in the modal title-bar was
a bit hard to find.

This removes the toggle and instead adds a link that opens the
QR code in a new window.

The link to show the QR code is not yet translated. I will amend this commit when the translations are confirmed and included.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-2275-qrcode-as-link/index.html)