### PR TITLE
BGDIINF_SB-2266: Added dynamic focus outlines

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -60,10 +60,10 @@ export default {
 // to the output CSS as many time as this file is imported
 @import 'node_modules/bootstrap/scss/bootstrap';
 #main-component {
-    font-family: Avenir, Helvetica, Arial, sans-serif;
+    font-family: $frutiger;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    color: #2c3e50;
+    color: $coal;
 }
 :focus {
     outline-style: none;

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,10 @@
 <template>
-    <div id="main-component">
+    <div
+        id="main-component"
+        :class="{ outlines: showOutlines }"
+        @keydown="setOutlines(true)"
+        @pointerdown="setOutlines(false)"
+    >
         <router-view />
     </div>
 </template>
@@ -14,6 +19,11 @@ import { mapActions, mapState } from 'vuex'
  */
 export default {
     name: 'App',
+    data() {
+        return {
+            showOutlines: false,
+        }
+    },
     computed: {
         ...mapState({
             currentUiMode: (state) => state.ui.mode,
@@ -35,6 +45,9 @@ export default {
                 height: window.innerHeight,
             })
         },
+        setOutlines(state) {
+            this.showOutlines = state
+        },
     },
 }
 </script>
@@ -51,5 +64,12 @@ export default {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     color: #2c3e50;
+}
+:focus {
+    outline-style: none;
+    .outlines & {
+        outline-offset: 1px;
+        outline: $focus-outline;
+    }
 }
 </style>

--- a/src/modules/menu/components/header/SwissFlag.vue
+++ b/src/modules/menu/components/header/SwissFlag.vue
@@ -26,12 +26,6 @@ export default {
 @import 'src/scss/webmapviewer-bootstrap-theme';
 .swiss-flag {
     height: 34px;
-    :first-child {
-        fill: $red;
-    }
-    :last-child {
-        fill: $white;
-    }
     &.dev-site {
         filter: hue-rotate(225deg);
     }

--- a/src/scss/variables-admin.scss
+++ b/src/scss/variables-admin.scss
@@ -2,8 +2,9 @@
  * admin-variables.scss
  * Variables set for our project
  *
- * Author: Yann Gouffon, yann@antistatique.net
- * Date:   2014-04-30 09:38:36
+ * Author:  Yann Gouffon, yann@antistatique.net
+ * Website: https://swiss.github.io/styleguide
+ * Date:    2014-04-30 09:38:36
  *
  * Copyright 2014 Federal Chancellery of Switzerland
  * Licensed under MIT
@@ -14,8 +15,7 @@
 //=============================================================================
 
 $venetian-red:                               #dc0018;
-// We currently have a different $red. That will be updated in another commit.
-// $red:                                        #f7001d;
+$red:                                        #f7001d;
 $mocassin:                                   #fffab2;
 $cerulean:                                   #006699;
 $pattens-blue:                               #d8e8ef;

--- a/src/scss/variables-admin.scss
+++ b/src/scss/variables-admin.scss
@@ -1,0 +1,49 @@
+/* ==========================================================
+ * admin-variables.scss
+ * Variables set for our project
+ *
+ * Author: Yann Gouffon, yann@antistatique.net
+ * Date:   2014-04-30 09:38:36
+ *
+ * Copyright 2014 Federal Chancellery of Switzerland
+ * Licensed under MIT
+ =========================================================== */
+
+//=============================================================================
+// COLORS
+//=============================================================================
+
+$venetian-red:                               #dc0018;
+// We currently have a different $red. That will be updated in another commit.
+// $red:                                        #f7001d;
+$mocassin:                                   #fffab2;
+$cerulean:                                   #006699;
+$pattens-blue:                               #d8e8ef;
+$malibu:                                     #66afe9;
+$solitude:                                   #e7edef;
+$clear-day:                                  #f2f7f9;
+
+$black:                                      #000000;
+$night-rider:                                #333333; // gray 80%;
+$coal:                                       #454545; // gray 73%;
+$empress:                                    #757575; // gray 54%;
+$silver:                                     #cccccc; // gray 20%;
+$light-grey:                                 #d5d5d5; // gray 16%;
+$gainsboro:                                  #e5e5e5; // gray 10%;
+$smoke:                                      #f5f5f5; // gray 4%;
+$white:                                      #ffffff;
+
+$sherpa-blue:                                #03344d;
+$fire-engine-red:                            #bb1122;
+$cadillac:                                   #884488;
+
+// TYPOGRAPHY
+//=============================================================================
+
+//** Fonts variables
+$frutiger:    'Frutiger Neue', Helvetica, Arial, sans-serif;
+$admin-icons: 'Admin Icons';
+
+// MISC
+//=============================================================================
+$focus-outline: 3px solid $coal;

--- a/src/scss/webmapviewer-bootstrap-theme.scss
+++ b/src/scss/webmapviewer-bootstrap-theme.scss
@@ -1,5 +1,3 @@
-$red: #dc3545 !default;
-$primary: $red;
 
 @import 'src/scss/variables';
 @import 'src/scss/variables-admin';
@@ -8,6 +6,7 @@ $component-active-bg: $malibu;
 // https://stackoverflow.com/a/49033912/4840446
 $input-btn-focus-box-shadow: none;
 $input-btn-focus-width: 0;
+$primary: $venetian-red;
 
 @import 'node_modules/bootstrap/scss/functions';
 @import 'node_modules/bootstrap/scss/variables';

--- a/src/scss/webmapviewer-bootstrap-theme.scss
+++ b/src/scss/webmapviewer-bootstrap-theme.scss
@@ -2,6 +2,13 @@ $red: #dc3545 !default;
 $primary: $red;
 
 @import 'src/scss/variables';
+@import 'src/scss/variables-admin';
+
+$component-active-bg: $malibu;
+// https://stackoverflow.com/a/49033912/4840446
+$input-btn-focus-box-shadow: none;
+$input-btn-focus-width: 0;
+
 @import 'node_modules/bootstrap/scss/functions';
 @import 'node_modules/bootstrap/scss/variables';
 @import 'node_modules/bootstrap/scss/mixins';

--- a/src/utils/ModalWithBackdrop.vue
+++ b/src/utils/ModalWithBackdrop.vue
@@ -1,5 +1,6 @@
 <template>
-    <teleport to="body">
+    <teleport to="#main-component">
+        <!-- Must teleport inside main-component in order for dynamic outlines to work. -->
         <BlackBackdrop front @click="onClose(false)" />
         <div class="modal-popup">
             <div class="card">


### PR DESCRIPTION
Outlines, while useful, can be rather ugly. That's why we decided
we want to remove them where possible.

This change introduces the dynamic outlines from the Swiss Style
Guide (based on outline.js) that only show when using the keyboard.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-2266-dynamic-outlines/index.html)