### PR TITLE
BGDIINF_SB-1388: Added preview for search results

### DIFF
--- a/src/modules/map/store/map.store.js
+++ b/src/modules/map/store/map.store.js
@@ -97,11 +97,14 @@ export default {
          * @param {Number[]} coordinates Dropped pin location expressed in EPSG:3857
          */
         setPinnedLocation: ({ commit }, coordinates) => {
-            if (coordinates && Array.isArray(coordinates) && coordinates.length === 2) {
+            if (Array.isArray(coordinates) && coordinates.length === 2) {
                 commit('setPinnedLocation', coordinates)
             } else {
                 commit('setPinnedLocation', null)
             }
+        },
+        clearPinnedLocation({ commit }) {
+            commit('setPinnedLocation', null)
         },
         setDisplayedProjectionWithId({ commit }, projectionId) {
             if (projectionId && CoordinateSystems[projectionId]) {

--- a/src/modules/menu/components/search/SearchResultCategory.vue
+++ b/src/modules/menu/components/search/SearchResultCategory.vue
@@ -14,6 +14,7 @@
                 :index="index"
                 :entry="entry"
                 @show-layer-legend-popup="showLayerLegendPopup"
+                @preview="bubblePreviewEvent"
             />
         </ul>
 
@@ -49,6 +50,7 @@ export default {
             default: false,
         },
     },
+    emits: ['preview'],
     data() {
         return {
             showLayerLegendForId: null,
@@ -60,6 +62,9 @@ export default {
         },
         closeLayerLegendPopup() {
             this.showLayerLegendForId = null
+        },
+        bubblePreviewEvent(data) {
+            this.$emit('preview', data)
         },
     },
 }

--- a/src/modules/menu/components/search/SearchResultCategory.vue
+++ b/src/modules/menu/components/search/SearchResultCategory.vue
@@ -14,7 +14,8 @@
                 :index="index"
                 :entry="entry"
                 @show-layer-legend-popup="showLayerLegendPopup"
-                @preview="bubblePreviewEvent"
+                @preview-start="bubbleEvent('previewStart', $event)"
+                @preview-stop="bubbleEvent('previewStop', $event)"
             />
         </ul>
 
@@ -63,8 +64,8 @@ export default {
         closeLayerLegendPopup() {
             this.showLayerLegendForId = null
         },
-        bubblePreviewEvent(data) {
-            this.$emit('preview', data)
+        bubbleEvent(type, payload) {
+            this.$emit(type, payload)
         },
     },
 }

--- a/src/modules/menu/components/search/SearchResultList.vue
+++ b/src/modules/menu/components/search/SearchResultList.vue
@@ -11,18 +11,20 @@
             :half-size="results.locationResults.length > 0"
             :entries="results.locationResults"
             data-cy="search-results-locations"
+            @preview="setPinnedLocation"
         />
         <SearchResultCategory
             :title="$t('layers_results_header')"
             :half-size="results.layerResults.length > 0"
             :entries="results.layerResults"
             data-cy="search-results-layers"
+            @preview="setPreviewLayer"
         />
     </div>
 </template>
 
 <script>
-import { mapState } from 'vuex'
+import { mapActions, mapState } from 'vuex'
 import SearchResultCategory from './SearchResultCategory.vue'
 
 /** Component showing all results from the search, divided in two groups (categories) : layers and locations */
@@ -34,6 +36,9 @@ export default {
             results: (state) => state.search.results,
             showResults: (state) => state.search.show,
         }),
+    },
+    methods: {
+        ...mapActions(['setPreviewLayer', 'setPinnedLocation']),
     },
 }
 </script>

--- a/src/modules/menu/components/search/SearchResultList.vue
+++ b/src/modules/menu/components/search/SearchResultList.vue
@@ -11,14 +11,16 @@
             :half-size="results.locationResults.length > 0"
             :entries="results.locationResults"
             data-cy="search-results-locations"
-            @preview="setPinnedLocation"
+            @preview-start="setPinnedLocation"
+            @preview-stop="clearPinnedLocation"
         />
         <SearchResultCategory
             :title="$t('layers_results_header')"
             :half-size="results.layerResults.length > 0"
             :entries="results.layerResults"
             data-cy="search-results-layers"
-            @preview="setPreviewLayer"
+            @preview-start="setPreviewLayer"
+            @preview-stop="clearPreviewLayer"
         />
     </div>
 </template>
@@ -38,7 +40,12 @@ export default {
         }),
     },
     methods: {
-        ...mapActions(['setPreviewLayer', 'setPinnedLocation']),
+        ...mapActions([
+            'setPinnedLocation',
+            'clearPinnedLocation',
+            'setPreviewLayer',
+            'clearPreviewLayer',
+        ]),
     },
 }
 </script>

--- a/src/modules/menu/components/search/SearchResultListEntry.vue
+++ b/src/modules/menu/components/search/SearchResultListEntry.vue
@@ -9,8 +9,8 @@
         @keydown.home.prevent="goToFirst"
         @keydown.end.prevent="goToLast"
         @keypress.enter.prevent="selectItem"
-        @mouseenter="previewResult(true)"
-        @mouseleave="previewResult(false)"
+        @mouseenter="startResultPreview"
+        @mouseleave="stopResultPreview"
     >
         <!-- eslint-disable vue/no-v-html-->
         <div class="search-category-entry-main p-2" @click="selectItem" v-html="entry.title"></div>
@@ -44,7 +44,7 @@ export default {
             required: true,
         },
     },
-    emits: ['showLayerLegendPopup', 'preview'],
+    emits: ['showLayerLegendPopup', 'previewStart', 'previewStop'],
     computed: {
         resultType() {
             return this.entry.resultType.toLowerCase()
@@ -77,12 +77,15 @@ export default {
                 this.$refs.item.tabIndex = '-1'
             }
         },
-        previewResult(show) {
+        startResultPreview() {
             if (this.resultType === 'layer') {
-                this.$emit('preview', show ? this.entry.layerId : null)
+                this.$emit('previewStart', this.entry.layerId)
             } else {
-                this.$emit('preview', show ? this.entry.coordinates : null)
+                this.$emit('previewStart', this.entry.coordinates)
             }
+        },
+        stopResultPreview() {
+            this.$emit('previewStop')
         },
     },
 }

--- a/src/modules/menu/components/search/SearchResultListEntry.vue
+++ b/src/modules/menu/components/search/SearchResultListEntry.vue
@@ -9,6 +9,8 @@
         @keydown.home.prevent="goToFirst"
         @keydown.end.prevent="goToLast"
         @keypress.enter.prevent="selectItem"
+        @mouseenter="previewResult(true)"
+        @mouseleave="previewResult(false)"
     >
         <!-- eslint-disable vue/no-v-html-->
         <div class="search-category-entry-main p-2" @click="selectItem" v-html="entry.title"></div>
@@ -42,7 +44,7 @@ export default {
             required: true,
         },
     },
-    emits: ['showLayerLegendPopup'],
+    emits: ['showLayerLegendPopup', 'preview'],
     computed: {
         resultType() {
             return this.entry.resultType.toLowerCase()
@@ -73,6 +75,13 @@ export default {
                 target.tabIndex = '0'
                 target.focus()
                 this.$refs.item.tabIndex = '-1'
+            }
+        },
+        previewResult(show) {
+            if (this.resultType === 'layer') {
+                this.$emit('preview', show ? this.entry.layerId : null)
+            } else {
+                this.$emit('preview', show ? this.entry.coordinates : null)
             }
         },
     },

--- a/src/modules/menu/components/topics/MenuTopicSection.vue
+++ b/src/modules/menu/components/topics/MenuTopicSection.vue
@@ -29,7 +29,7 @@
                 :compact="compact"
                 @click-on-topic-item="onClickTopicItem"
                 @click-on-layer-info="onClickLayerInfo"
-                @preview-layer="onPreviewLayer"
+                @preview="setPreviewLayer"
             />
         </ul>
         <LayerLegendPopup
@@ -87,8 +87,7 @@ export default {
             'toggleLayerVisibility',
             'setLayerVisibility',
             'changeTopic',
-            'showLayerPreview',
-            'hideLayerPreview',
+            'setPreviewLayer',
         ]),
         setShowTopicSelectionPopup() {
             this.showTopicSelectionPopup = true
@@ -108,13 +107,6 @@ export default {
         },
         onClickLayerInfo(layerId) {
             this.showLayerInfoFor = layerId
-        },
-        onPreviewLayer(layerId) {
-            if (layerId) {
-                this.showLayerPreview(layerId)
-            } else {
-                this.hideLayerPreview()
-            }
         },
     },
 }

--- a/src/modules/menu/components/topics/MenuTopicSection.vue
+++ b/src/modules/menu/components/topics/MenuTopicSection.vue
@@ -29,7 +29,8 @@
                 :compact="compact"
                 @click-on-topic-item="onClickTopicItem"
                 @click-on-layer-info="onClickLayerInfo"
-                @preview="setPreviewLayer"
+                @preview-start="setPreviewLayer"
+                @preview-stop="clearPreviewLayer"
             />
         </ul>
         <LayerLegendPopup
@@ -88,6 +89,7 @@ export default {
             'setLayerVisibility',
             'changeTopic',
             'setPreviewLayer',
+            'clearPreviewLayer',
         ]),
         setShowTopicSelectionPopup() {
             this.showTopicSelectionPopup = true

--- a/src/modules/menu/components/topics/MenuTopicTreeItem.vue
+++ b/src/modules/menu/components/topics/MenuTopicTreeItem.vue
@@ -11,8 +11,8 @@
             class="menu-topic-item-title"
             :data-cy="`topic-tree-item-${item.id}`"
             @click="onItemClick"
-            @mouseenter="previewLayer(true)"
-            @mouseleave="previewLayer(false)"
+            @mouseenter="startResultPreview"
+            @mouseleave="stopResultPreview"
         >
             <ButtonWithIcon
                 :button-font-awesome-icon="showHideIcon"
@@ -46,9 +46,10 @@
                     :active-layers="activeLayers"
                     :depth="depth + 1"
                     :compact="compact"
-                    @click-on-topic-item="bubbleToggleItemEvent"
-                    @click-on-layer-info="bubbleLayerInfoEvent"
-                    @preview="bubblePreviewEvent"
+                    @click-on-topic-item="bubbleEvent('clickOnTopicItem', $event)"
+                    @click-on-layer-info="bubbleEvent('clickOnLayerInfo', $event)"
+                    @preview-start="bubbleEvent('previewStart', $event)"
+                    @preview-stop="bubbleEvent('previewStop', $event)"
                 />
             </ul>
         </CollapseTransition>
@@ -90,7 +91,7 @@ export default {
             default: 0,
         },
     },
-    emits: ['clickOnTopicItem', 'clickOnLayerInfo', 'preview'],
+    emits: ['clickOnTopicItem', 'clickOnLayerInfo', 'previewStart', 'previewStop'],
     data() {
         return {
             showChildren: false,
@@ -117,7 +118,7 @@ export default {
         },
         isActive() {
             return (
-                this.item.type === topicTypes.LAYER &&
+                this.isLayer &&
                 this.activeLayers.find((layer) => layer.getID() === this.item.layerId)
             )
         },
@@ -144,26 +145,23 @@ export default {
         onInfoClick() {
             this.$emit('clickOnLayerInfo', this.item.layerId)
         },
-        previewLayer(show) {
+        startResultPreview() {
             if (this.isLayer) {
-                this.$emit('preview', show ? this.item.layerId : null)
+                this.$emit('previewStart', this.item.layerId)
+            }
+        },
+        stopResultPreview() {
+            if (this.isLayer) {
+                this.$emit('previewStop')
             }
         },
         /**
          * As we can have recursive component (see template), we have to bubble up user interaction
          * events, otherwise the event get stuck mid course and never reaches the parent that can
          * interact with the store
-         *
-         * @param {String} layerId The ID of the layer that has been clicked in the topic tree
          */
-        bubbleToggleItemEvent(layerId) {
-            this.$emit('clickOnTopicItem', layerId)
-        },
-        bubbleLayerInfoEvent(layerId) {
-            this.$emit('clickOnLayerInfo', layerId)
-        },
-        bubblePreviewEvent(layerId) {
-            this.$emit('preview', layerId)
+        bubbleEvent(type, payload) {
+            this.$emit(type, payload)
         },
     },
 }

--- a/src/modules/menu/components/topics/MenuTopicTreeItem.vue
+++ b/src/modules/menu/components/topics/MenuTopicTreeItem.vue
@@ -48,7 +48,7 @@
                     :compact="compact"
                     @click-on-topic-item="bubbleToggleItemEvent"
                     @click-on-layer-info="bubbleLayerInfoEvent"
-                    @preview-layer="bubblePreviewEvent"
+                    @preview="bubblePreviewEvent"
                 />
             </ul>
         </CollapseTransition>
@@ -90,7 +90,7 @@ export default {
             default: 0,
         },
     },
-    emits: ['clickOnTopicItem', 'clickOnLayerInfo', 'previewLayer'],
+    emits: ['clickOnTopicItem', 'clickOnLayerInfo', 'preview'],
     data() {
         return {
             showChildren: false,
@@ -145,8 +145,8 @@ export default {
             this.$emit('clickOnLayerInfo', this.item.layerId)
         },
         previewLayer(show) {
-            if (this.item.type === topicTypes.LAYER) {
-                this.$emit('previewLayer', show ? this.item.layerId : null)
+            if (this.isLayer) {
+                this.$emit('preview', show ? this.item.layerId : null)
             }
         },
         /**
@@ -163,7 +163,7 @@ export default {
             this.$emit('clickOnLayerInfo', layerId)
         },
         bubblePreviewEvent(layerId) {
-            this.$emit('previewLayer', layerId)
+            this.$emit('preview', layerId)
         },
     },
 }

--- a/src/modules/menu/store/search.store.js
+++ b/src/modules/menu/store/search.store.js
@@ -70,7 +70,7 @@ const actions = {
                 })
             }
         } else if (query.length === 0) {
-            dispatch('setPinnedLocation', null)
+            dispatch('clearPinnedLocation')
         }
     },
     setSearchResults: ({ commit }, results) => commit('setSearchResults', results),

--- a/src/modules/store/modules/layers.store.js
+++ b/src/modules/store/modules/layers.store.js
@@ -39,10 +39,10 @@ const getters = {
      * @param state
      * @returns {AbstractLayer[]} All layers that are currently visible on the map
      */
-    visibleLayers: (state) =>
-        [...state.activeLayers.filter((layer) => layer.visible), state.previewLayer].filter(
-            (layer) => layer !== null
-        ),
+    visibleLayers: (state) => {
+        const activeVisible = state.activeLayers.filter((layer) => layer.visible)
+        return state.previewLayer === null ? activeVisible : [...activeVisible, state.previewLayer]
+    },
     /**
      * All layers in the config that have the flag `background` to `true` (that can be shown as a
      * background layer).
@@ -221,18 +221,19 @@ const actions = {
             }
         }
     },
-    showLayerPreview({ commit, getters }, layerId) {
-        const layer = getters.getLayerConfigById(layerId)
-        if (layer) {
-            const cloned = layer.clone()
-            cloned.visible = true
-            commit('setPreviewLayer', cloned)
+    setPreviewLayer({ commit, getters }, layerId) {
+        if (!layerId) {
+            commit('setPreviewLayer', null)
         } else {
-            log.error(`Layer "${layerId} not found in configs.`)
+            const layer = getters.getLayerConfigById(layerId)
+            if (layer) {
+                const cloned = layer.clone()
+                cloned.visible = true
+                commit('setPreviewLayer', cloned)
+            } else {
+                log.error(`Layer "${layerId} not found in configs.`)
+            }
         }
-    },
-    hideLayerPreview({ commit }) {
-        commit('setPreviewLayer', null)
     },
 }
 

--- a/src/modules/store/modules/layers.store.js
+++ b/src/modules/store/modules/layers.store.js
@@ -40,8 +40,11 @@ const getters = {
      * @returns {AbstractLayer[]} All layers that are currently visible on the map
      */
     visibleLayers: (state) => {
-        const activeVisible = state.activeLayers.filter((layer) => layer.visible)
-        return state.previewLayer === null ? activeVisible : [...activeVisible, state.previewLayer]
+        const visibleLayers = state.activeLayers.filter((layer) => layer.visible)
+        if (state.previewLayer !== null) {
+            visibleLayers.push(state.previewLayer)
+        }
+        return visibleLayers
     },
     /**
      * All layers in the config that have the flag `background` to `true` (that can be shown as a
@@ -222,18 +225,17 @@ const actions = {
         }
     },
     setPreviewLayer({ commit, getters }, layerId) {
-        if (!layerId) {
-            commit('setPreviewLayer', null)
+        const layer = getters.getLayerConfigById(layerId)
+        if (layer) {
+            const cloned = layer.clone()
+            cloned.visible = true
+            commit('setPreviewLayer', cloned)
         } else {
-            const layer = getters.getLayerConfigById(layerId)
-            if (layer) {
-                const cloned = layer.clone()
-                cloned.visible = true
-                commit('setPreviewLayer', cloned)
-            } else {
-                log.error(`Layer "${layerId} not found in configs.`)
-            }
+            log.error(`Layer "${layerId} not found in configs.`)
         }
+    },
+    clearPreviewLayer({ commit }) {
+        commit('setPreviewLayer', null)
     },
 }
 

--- a/tests/e2e/specs/topics.spec.js
+++ b/tests/e2e/specs/topics.spec.js
@@ -236,6 +236,25 @@ describe('Topics', () => {
                             .should('be.visible')
                             .contains(expectedContent)
                     })
+                    it('previews the layer on hover', () => {
+                        const expectedLayerId = 'test.wmts.layer'
+                        const layerSelector = `[data-cy="topic-tree-item-${expectedLayerId}"]`
+
+                        cy.get('[data-cy="topic-tree-item-2"]').click()
+                        cy.get('[data-cy="topic-tree-item-3"]').click()
+
+                        cy.get(layerSelector).trigger('mouseenter')
+                        cy.readStoreValue('getters.visibleLayers').then((visibleLayers) => {
+                            const visibleIds = visibleLayers.map((layer) => layer.getID())
+                            expect(visibleIds).to.contain(expectedLayerId)
+                        })
+
+                        cy.get(layerSelector).trigger('mouseleave')
+                        cy.readStoreValue('getters.visibleLayers').then((visibleLayers) => {
+                            const visibleIds = visibleLayers.map((layer) => layer.getID())
+                            expect(visibleIds).not.to.contain(expectedLayerId)
+                        })
+                    })
                 })
             }
         )


### PR DESCRIPTION
In line with mf-geoadmin3 this adds a preview on hover to the search
results. The layers use the same functionality as the topic list and
the locations use the pinnedLocation that was already present.

This also includes some refactoring of the layer preview code and
adds the e2e tests for both the topic list and search results.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-1388-search-layer-preview/index.html)