### PR TITLE
BGDIINF_SB-2263: Added trigger to open/close menu

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,6 +11,7 @@
 
 <script>
 import { mapActions } from 'vuex'
+import debounce from '@/utils/debounce'
 
 /**
  * Main component of the App.
@@ -27,10 +28,11 @@ export default {
     mounted() {
         // reading size
         this.setScreenSizeFromWindowSize()
-        window.addEventListener('resize', this.setScreenSizeFromWindowSize)
+        this.debouncedOnResize = debounce(this.setScreenSizeFromWindowSize, 300)
+        window.addEventListener('resize', this.debouncedOnResize, { passive: true })
     },
     unmounted() {
-        window.removeEventListener('resize', this.setScreenSizeFromWindowSize)
+        window.removeEventListener('resize', this.debouncedOnResize)
     },
     methods: {
         ...mapActions(['setSize']),

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script>
-import { mapActions, mapState } from 'vuex'
+import { mapActions } from 'vuex'
 
 /**
  * Main component of the App.
@@ -24,11 +24,6 @@ export default {
             showOutlines: false,
         }
     },
-    computed: {
-        ...mapState({
-            currentUiMode: (state) => state.ui.mode,
-        }),
-    },
     mounted() {
         // reading size
         this.setScreenSizeFromWindowSize()
@@ -38,7 +33,7 @@ export default {
         window.removeEventListener('resize', this.setScreenSizeFromWindowSize)
     },
     methods: {
-        ...mapActions(['setSize', 'setUiMode']),
+        ...mapActions(['setSize']),
         setScreenSizeFromWindowSize() {
             this.setSize({
                 width: window.innerWidth,

--- a/src/config.js
+++ b/src/config.js
@@ -165,14 +165,23 @@ export const TILEGRID_RESOLUTIONS = [
 export const MAP_CENTER = [915602.81, 5911929.47]
 
 /**
- * Threshold to know when the side menu should switch to the mobile version (when bellow threshold)
+ * Horizontal threshold for the phone view. (max-width) This will change the menu and also some interactions.
  *
- * Height value is here to make sure that a landscape mobile device doesn't switch to the
- * desktop/tablet layout.
+ * The value is taken from the "sm" breakpoint from Bootstrap.
  *
- * @type {{ width: number; height: number }}
+ * @type {Number}
  */
-export const screenThresholdToShowTheSideMenu = {
-    width: 576, // sm breakpoint in bootstrap
-    height: 500,
-}
+export const BREAKPOINT_PHONE_WIDTH = 576
+/**
+ * Horizontal threshold for the phone view. (max-height) The height is needed to catch landscape
+ * view on mobile.
+ *
+ * @type {Number}
+ */
+export const BREAKPOINT_PHONE_HEIGHT = 500
+/**
+ * Horizontal threshold for the tablet view. (max-width)
+ *
+ * @type {Number}
+ */
+export const BREAKPOINT_TABLET = 768

--- a/src/modules/infobox/InfoboxModule.vue
+++ b/src/modules/infobox/InfoboxModule.vue
@@ -32,10 +32,7 @@ export default {
     },
     computed: {
         ...mapState({
-            uiMode: (state) => state.ui.mode,
             selectedFeatures: (state) => state.feature.selectedFeatures,
-            screenHeight: (state) => state.ui.height,
-            isFooterVisible: (state) => !state.ui.fullscreenMode,
             tooltipInFooter: (state) => !state.ui.floatingTooltip,
         }),
     },

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -136,8 +136,6 @@ export default {
             geolocationPosition: (state) => state.geolocation.position,
             geolocationAccuracy: (state) => state.geolocation.accuracy,
             crossHair: (state) => state.position.crossHair,
-            uiMode: (state) => state.ui.mode,
-            isFooterVisible: (state) => !state.ui.fullscreenMode,
             isFeatureTooltipInFooter: (state) => !state.ui.floatingTooltip,
         }),
         ...mapGetters([

--- a/src/modules/menu/MenuModule.vue
+++ b/src/modules/menu/MenuModule.vue
@@ -32,21 +32,20 @@
                 class="menu-tray"
                 :class="{
                     'desktop-mode': shouldMenuTrayAlwaysBeVisible,
-                    'desktop-menu-closed': shouldMenuTrayAlwaysBeVisible && closeMenuDesktopMode,
+                    'desktop-menu-closed': shouldMenuTrayAlwaysBeVisible && !menuDesktopOpen,
                 }"
+                data-cy="menu-tray"
             >
                 <MenuTray class="menu-tray-content" :compact="shouldMenuTrayAlwaysBeVisible" />
                 <ButtonWithIcon
                     v-if="shouldMenuTrayAlwaysBeVisible"
                     class="m-auto"
-                    :button-font-awesome-icon="[
-                        'fas',
-                        closeMenuDesktopMode ? 'caret-down' : 'caret-up',
-                    ]"
-                    :button-title="$t(closeMenuDesktopMode ? 'open_menu' : 'close_menu')"
+                    data-cy="menu-button"
+                    :button-font-awesome-icon="['fas', menuDesktopOpen ? 'caret-up' : 'caret-down']"
+                    :button-title="$t(menuDesktopOpen ? 'close_menu' : 'open_menu')"
                     icons-before-text
                     dark
-                    @click="closeMenuDesktopMode = !closeMenuDesktopMode"
+                    @click="toggleMenuDesktopOpen"
                 >
                 </ButtonWithIcon>
             </div>
@@ -74,11 +73,6 @@ export default {
         ButtonWithIcon,
         MenuTray,
     },
-    data() {
-        return {
-            closeMenuDesktopMode: false,
-        }
-    },
     computed: {
         ...mapState({
             showLoadingBar: (state) => state.ui.showLoadingBar,
@@ -90,6 +84,7 @@ export default {
             isCurrentlyDrawing: (state) => state.ui.showDrawingOverlay,
             isGeolocationActive: (state) => state.geolocation.active,
             isGeolocationDenied: (state) => state.geolocation.denied,
+            menuDesktopOpen: (state) => state.ui.menuDesktopOpen,
         }),
         shouldMenuTrayAlwaysBeVisible() {
             return this.currentUiMode === UIModes.MENU_ALWAYS_OPEN
@@ -110,7 +105,13 @@ export default {
         },
     },
     methods: {
-        ...mapActions(['toggleGeolocation', 'increaseZoom', 'decreaseZoom', 'toggleMenuTray']),
+        ...mapActions([
+            'toggleGeolocation',
+            'increaseZoom',
+            'decreaseZoom',
+            'toggleMenuTray',
+            'toggleMenuDesktopOpen',
+        ]),
     },
 }
 </script>

--- a/src/modules/store/modules/ui.store.js
+++ b/src/modules/store/modules/ui.store.js
@@ -1,3 +1,5 @@
+import { BREAKPOINT_TABLET } from '@/config'
+
 /**
  * Describes the different mode the UI can have. Either desktop (menu is always shown, info box is a
  * side tray) or touch (menu has to be opened with a button, info box is a swipeable element)
@@ -75,6 +77,12 @@ export default {
          * @type Boolean
          */
         floatingTooltip: true,
+        /**
+         * Flag telling if the menu in desktop mode (MENU_ALWAYS_OPEN) is open.
+         *
+         * @type Boolean
+         */
+        menuDesktopOpen: window.innerWidth > BREAKPOINT_TABLET,
     },
     getters: {
         screenDensity(state) {
@@ -111,6 +119,9 @@ export default {
                 commit('setUiMode', mode)
             }
         },
+        toggleMenuDesktopOpen({ commit, state }) {
+            commit('setMenuDesktopOpen', !state.menuDesktopOpen)
+        },
     },
     mutations: {
         setSize(state, { height, width }) {
@@ -134,6 +145,9 @@ export default {
         },
         setUiMode(state, mode) {
             state.mode = mode
+        },
+        setMenuDesktopOpen(state, flagValue) {
+            state.menuDesktopOpen = flagValue
         },
     },
 }

--- a/src/modules/store/plugins/screen-size-management.plugin.js
+++ b/src/modules/store/plugins/screen-size-management.plugin.js
@@ -33,11 +33,15 @@ const screenSizeManagementPlugin = (store) => {
                 }
             }
 
+            // Check if the viewport width passes the configured tablet threshold.
             if (state.ui.width > BREAKPOINT_TABLET && lastWidth <= BREAKPOINT_TABLET) {
+                // Open the menu if the viewport passes to desktop size.
                 store.commit('setMenuDesktopOpen', true)
             } else if (state.ui.width <= BREAKPOINT_TABLET && lastWidth > BREAKPOINT_TABLET) {
+                // Close the menu if the viewport passes to tablet size.
                 store.commit('setMenuDesktopOpen', false)
             }
+            // Update the last width for the next check.
             lastWidth = state.ui.width
         }
     })

--- a/src/modules/store/plugins/screen-size-management.plugin.js
+++ b/src/modules/store/plugins/screen-size-management.plugin.js
@@ -1,15 +1,17 @@
 import { UIModes } from '@/modules/store/modules/ui.store'
-import { screenThresholdToShowTheSideMenu } from '@/config'
+import { BREAKPOINT_PHONE_WIDTH, BREAKPOINT_PHONE_HEIGHT, BREAKPOINT_TABLET } from '@/config'
 
 /** @param store */
 const screenSizeManagementPlugin = (store) => {
+    let lastWidth = window.innerWidth
+
     store.subscribe((mutation, state) => {
         if (mutation.type === 'setSize') {
             // listening to screen size change to decide if we should switch UI mode too
             let wantedUiMode
             if (
-                state.ui.width >= screenThresholdToShowTheSideMenu.width &&
-                state.ui.height > screenThresholdToShowTheSideMenu.height
+                state.ui.width >= BREAKPOINT_PHONE_WIDTH &&
+                state.ui.height > BREAKPOINT_PHONE_HEIGHT
             ) {
                 wantedUiMode = UIModes.MENU_ALWAYS_OPEN
             } else {
@@ -30,6 +32,13 @@ const screenSizeManagementPlugin = (store) => {
                     store.dispatch('toggleFloatingTooltip')
                 }
             }
+
+            if (state.ui.width > BREAKPOINT_TABLET && lastWidth <= BREAKPOINT_TABLET) {
+                store.commit('setMenuDesktopOpen', true)
+            } else if (state.ui.width <= BREAKPOINT_TABLET && lastWidth > BREAKPOINT_TABLET) {
+                store.commit('setMenuDesktopOpen', false)
+            }
+            lastWidth = state.ui.width
         }
     })
 }

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,0 +1,9 @@
+export default function debounce(target, delay) {
+    let timeout
+    return function () {
+        clearTimeout(timeout)
+        timeout = setTimeout(() => {
+            target.apply(this, arguments)
+        }, delay)
+    }
+}

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,8 +1,17 @@
+/**
+ * Debounce function to delay execution if called repeatedly.
+ *
+ * @param {Function} target The actual function to execute.
+ * @param {Number} delay The time to wait for another call.
+ * @returns The function that can be called repeatedly.
+ */
 export default function debounce(target, delay) {
     let timeout
     return function () {
         clearTimeout(timeout)
         timeout = setTimeout(() => {
+            // Call the target function the way the debounced function was called.
+            // Passing `this` isn't necessary with arrow-functions but it doesn't hurt.
             target.apply(this, arguments)
         }, delay)
     }

--- a/tests/e2e/specs/drawing/delete.spec.js
+++ b/tests/e2e/specs/drawing/delete.spec.js
@@ -6,10 +6,10 @@ const chooseExportFormatButton = '[data-cy="drawing-toolbox-choose-export-format
 const shareButton = '[data-cy="drawing-toolbox-share-button"]'
 
 describe('Delete action in the drawing module', () => {
-    forEachTestViewport((viewport, isMobileViewport) => {
+    forEachTestViewport((viewport, isMobileViewport, isTabletViewport) => {
         it(`viewport: ${viewport} - deletes the drawing when confirming the delete modal`, () => {
             cy.viewport(viewport)
-            cy.goToDrawing(isMobileViewport)
+            cy.goToDrawing(isMobileViewport || isTabletViewport)
             cy.drawGeoms()
             cy.get(deleteButton).click()
             cy.get('[data-cy="modal-confirm-button"]').click()

--- a/tests/e2e/specs/drawing/drawing-layer.spec.js
+++ b/tests/e2e/specs/drawing/drawing-layer.spec.js
@@ -3,10 +3,10 @@
 import { forEachTestViewport } from '../../support'
 
 describe('A drawing layer is added at the end of the drawing session', () => {
-    forEachTestViewport((viewport, isMobileViewport) => {
+    forEachTestViewport((viewport, isMobileViewport, isTabletViewport) => {
         it(`viewport: ${viewport} - creates a layers in the layer stack that contains the drawing`, () => {
             cy.viewport(viewport)
-            cy.goToDrawing(isMobileViewport)
+            cy.goToDrawing(isMobileViewport || isTabletViewport)
             cy.drawGeoms()
             cy.get('[data-cy="drawing-toolbox-close-button"]').click()
             cy.readStoreValue('state.layers.activeLayers').then((layers) => {

--- a/tests/e2e/specs/drawing/export.spec.js
+++ b/tests/e2e/specs/drawing/export.spec.js
@@ -40,7 +40,7 @@ const checkGpxFile = (content) => {
 }
 
 describe('Drawing toolbox actions', () => {
-    forEachTestViewport((viewport, isMobileViewport, isTablet, dimensions) => {
+    forEachTestViewport((viewport, isMobileViewport, isTabletViewport, dimensions) => {
         context(
             `viewport: ${viewport}`,
             {
@@ -50,7 +50,7 @@ describe('Drawing toolbox actions', () => {
             () => {
                 beforeEach(() => {
                     cy.task('deleteFolder', downloadsFolder)
-                    cy.goToDrawing(isMobileViewport)
+                    cy.goToDrawing(isMobileViewport || isTabletViewport)
                     cy.drawGeoms()
                 })
                 context('Export KML', () => {

--- a/tests/e2e/specs/drawing/kml.spec.js
+++ b/tests/e2e/specs/drawing/kml.spec.js
@@ -12,7 +12,7 @@ describe('Drawing saving KML', () => {
             },
             () => {
                 beforeEach(() => {
-                    cy.goToDrawing(isMobileViewport)
+                    cy.goToDrawing(isMobileViewport || isTabletViewport)
                 })
 
                 it('saves a KML on draw end', () => {

--- a/tests/e2e/specs/drawing/line-polygon.spec.js
+++ b/tests/e2e/specs/drawing/line-polygon.spec.js
@@ -7,7 +7,7 @@ const drawingStyleLinePopup = '[data-cy="drawing-style-line-popup"]'
 const drawingDeleteLastPointButton = '[data-cy="drawing-delete-last-point-button"]'
 
 describe('Line/Polygon tool', () => {
-    forEachTestViewport((viewport, isMobileViewport, isTablet, dimensions) => {
+    forEachTestViewport((viewport, isMobileViewport, isTabletViewport, dimensions) => {
         context(
             `viewport: ${viewport}`,
             {
@@ -16,7 +16,7 @@ describe('Line/Polygon tool', () => {
             },
             () => {
                 beforeEach(() => {
-                    cy.goToDrawing(isMobileViewport)
+                    cy.goToDrawing(isMobileViewport || isTabletViewport)
 
                     cy.clickDrawingTool('line')
                     cy.get(olSelector).click(100, 200)

--- a/tests/e2e/specs/drawing/marker-text.spec.js
+++ b/tests/e2e/specs/drawing/marker-text.spec.js
@@ -18,7 +18,6 @@ const drawingStyleColorBox = '[data-cy="drawing-style-color-select-box"]'
 const drawingStyleSizeSelector = '[data-cy="drawing-style-size-selector"]'
 
 const createAPoint = (kind, x = 0, y = 0, xx = MAP_CENTER[0], yy = MAP_CENTER[1]) => {
-    cy.goToDrawing()
     cy.clickDrawingTool(kind)
     cy.readWindowValue('map').then((map) => {
         // Create a point, a geojson will appear in the store
@@ -60,7 +59,7 @@ const changeIconSize = (size) => {
 }
 
 describe('Drawing marker/points', () => {
-    forEachTestViewport((viewport, isMobileViewport, isTablet, dimensions) => {
+    forEachTestViewport((viewport, isMobileViewport, isTabletViewport, dimensions) => {
         // TODO : test layout for mobile
         if (!isMobileViewport) {
             context(
@@ -74,7 +73,7 @@ describe('Drawing marker/points', () => {
                         cy.intercept(`**/api/icons/sets/default/icons/**${GREEN.rgbString}.png`, {
                             fixture: 'service-icons/placeholder.png',
                         }).as('icon-default-green')
-                        cy.goToDrawing(isMobileViewport)
+                        cy.goToDrawing(isMobileViewport || isTabletViewport)
                     })
                     // see : https://jira.swisstopo.ch/browse/BGDIINF_SB-2182
                     // it('Re-requests all icons from an icon sets with the new color whenever the color changed', () => {

--- a/tests/e2e/specs/header.spec.js
+++ b/tests/e2e/specs/header.spec.js
@@ -45,16 +45,38 @@ describe('Test functions for the header / search bar', () => {
                     })
                 }
 
+                if (isTabletViewport) {
+                    context('Menu on tablet', () => {
+                        it('should start closed', () => {
+                            cy.get('[data-cy="menu-tray"]').should(
+                                'have.class',
+                                'desktop-menu-closed'
+                            )
+                        })
+                    })
+                }
+
+                if (!isMobileViewport && !isTabletViewport) {
+                    context('Menu on Desktop', () => {
+                        it('should start open', () => {
+                            cy.get('[data-cy="menu-tray"]').should(
+                                'not.have.class',
+                                'desktop-menu-closed'
+                            )
+                        })
+                    })
+                }
+
                 context('Settings Menu Section', () => {
                     it('does not show the settings sections on opening the menu', () => {
-                        if (isMobileViewport) {
+                        if (isMobileViewport || isTabletViewport) {
                             cy.get(menuButtonSelector).click()
                         }
                         cy.get(menuSettingsContentSelector).should('be.hidden')
                     })
 
                     it('shows the settings on clicking on the settings section', () => {
-                        if (isMobileViewport) {
+                        if (isMobileViewport || isTabletViewport) {
                             cy.get(menuButtonSelector).click()
                         }
                         cy.get(menuSettingsSectionSelector).click()
@@ -62,7 +84,7 @@ describe('Test functions for the header / search bar', () => {
                     })
 
                     it('hides the settings section if clicked again', () => {
-                        if (isMobileViewport) {
+                        if (isMobileViewport || isTabletViewport) {
                             cy.get(menuButtonSelector).click()
                         }
                         cy.get(menuSettingsSectionSelector).click().click()
@@ -91,7 +113,7 @@ describe('Test functions for the header / search bar', () => {
                         })
                     }
                     const selectTopicStandardAndAddLayerFromTopicTree = () => {
-                        if (isMobileViewport) {
+                        if (isMobileViewport || isTabletViewport) {
                             cy.get(menuButtonSelector).click()
                         }
                         cy.get('[data-cy="change-topic-button"]').click()

--- a/tests/e2e/specs/layers.spec.js
+++ b/tests/e2e/specs/layers.spec.js
@@ -44,7 +44,7 @@ describe('Test of layer handling', () => {
             },
             () => {
                 const clickOnMenuButtonIfMobile = () => {
-                    if (isMobile) {
+                    if (isMobile || isTablet) {
                         // clicking on the menu button
                         cy.get('[data-cy="menu-button"]').click()
                     }

--- a/tests/e2e/specs/topics.spec.js
+++ b/tests/e2e/specs/topics.spec.js
@@ -12,10 +12,13 @@ describe('Topics', () => {
                 // mimic the output of `/rest/services` endpoint
                 let mockupTopics = {}
                 const selectTopicWithId = (topicId) => {
-                    if (isMobileViewport) {
-                        cy.readStoreValue('state.ui.showMenuTray').then((showMenuTray) => {
+                    if (isMobileViewport || isTabletViewport) {
+                        cy.readStoreValue('state.ui').then((ui) => {
                             // only click on the menu button if the menu is not opened yet
-                            if (!showMenuTray) {
+                            if (
+                                (isMobileViewport && !ui.showMenuTray) ||
+                                (isTabletViewport && !ui.menuDesktopOpen)
+                            ) {
                                 cy.get('[data-cy="menu-button"]').click()
                             }
                         })
@@ -197,7 +200,7 @@ describe('Topics', () => {
                 context('Layer selection in the topic tree', () => {
                     beforeEach(() => {
                         cy.goToMapView()
-                        if (isMobileViewport) {
+                        if (isMobileViewport || isTabletViewport) {
                             cy.get('[data-cy="menu-button"]').click()
                         }
                         cy.get('[data-cy="menu-topic-section"]').click()

--- a/tests/e2e/support/drawing.js
+++ b/tests/e2e/support/drawing.js
@@ -52,13 +52,13 @@ Cypress.on('uncaught:exception', () => {
     return false
 })
 
-Cypress.Commands.add('goToDrawing', (isMobileViewport = false) => {
+Cypress.Commands.add('goToDrawing', (menuIsClosed = false) => {
     addIconFixtureAndIntercept()
     addIconSetsFixtureAndIntercept()
     addDefaultIconsFixtureAndIntercept()
     addSecondIconsFixtureAndIntercept()
     cy.goToMapView()
-    if (isMobileViewport) {
+    if (menuIsClosed) {
         cy.get('[data-cy="menu-button"]').click()
     }
     cy.get('[data-cy="menu-tray-drawing-section"]').click()


### PR DESCRIPTION
To show more of the map we close the menu on smaller viewports.

It opens the menu (desktop mode) when window gets bigger than 768px
and closes the menu when the window gets smaller than 768px.

[Test link](https://web-mapviewer.dev.bgdi.ch/feature-jira-bgdiinf_sb-2263-uimodes-tablet/index.html)