### PR TITLE
BGDIINF_SB-2323: Added condition to ignore faultily event

### DIFF
--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -90,9 +90,9 @@ import HighlightedFeatureList from '@/modules/infobox/components/HighlightedFeat
 import OpenLayersPopover from '@/modules/map/components/openlayers/OpenLayersPopover.vue'
 import { ClickInfo, ClickType } from '@/store/modules/map.store'
 import { CrossHairs } from '@/store/modules/position.store'
+import { UIModes } from '@/store/modules/ui.store'
 import ButtonWithIcon from '@/utils/ButtonWithIcon.vue'
 import log from '@/utils/logging'
-import { UIModes } from '@/modules/store/modules/ui.store'
 
 /**
  * Main OpenLayers map component responsible for building the OL map instance and telling the view

--- a/src/store/modules/map.store.js
+++ b/src/store/modules/map.store.js
@@ -1,5 +1,5 @@
+import { UIModes } from '@/store/modules/ui.store'
 import { CoordinateSystems } from '@/utils/coordinateUtils'
-import { UIModes } from '@/modules/store/modules/ui.store'
 
 /** @enum */
 export const ClickType = {

--- a/src/store/modules/map.store.js
+++ b/src/store/modules/map.store.js
@@ -1,4 +1,5 @@
 import { CoordinateSystems } from '@/utils/coordinateUtils'
+import { UIModes } from '@/modules/store/modules/ui.store'
 
 /** @enum */
 export const ClickType = {
@@ -70,7 +71,15 @@ export default {
          */
         displayedProjection: CoordinateSystems.LV95,
     },
-    getters: {},
+    getters: {
+        displayLocationPopup(state, getters, rootState) {
+            return (
+                rootState.ui.mode !== UIModes.MENU_OPENED_THROUGH_BUTTON &&
+                state.clickInfo?.clickType === ClickType.RIGHT_CLICK &&
+                Array.isArray(state.clickInfo?.coordinate)
+            )
+        },
+    },
     actions: {
         /**
          * Tells the map to show a layer that is not (yet) in the visible layers on the map. This is

--- a/src/utils/coordinateUtils.js
+++ b/src/utils/coordinateUtils.js
@@ -391,16 +391,3 @@ export const printHumanReadableCoordinates = (
 ) => {
     return coordinateSystem.format(coordinates)
 }
-
-/**
- * Checks if two coordinates are equal if the values are rounded.
- *
- * @param {Number[]} a The first coordinate to compare.
- * @param {Number[]} b The second coordinate to compare.
- * @returns {Boolean}
- */
-export function checkCoordinatesEqualRounded(a, b) {
-    const roundedA = a.map(Math.round)
-    const roundedB = b.map(Math.round)
-    return roundedA[0] === roundedB[0] && roundedA[1] === roundedB[1]
-}

--- a/src/utils/coordinateUtils.js
+++ b/src/utils/coordinateUtils.js
@@ -391,3 +391,16 @@ export const printHumanReadableCoordinates = (
 ) => {
     return coordinateSystem.format(coordinates)
 }
+
+/**
+ * Checks if two coordinates are equal if the values are rounded.
+ *
+ * @param {Number[]} a The first coordinate to compare.
+ * @param {Number[]} b The second coordinate to compare.
+ * @returns {Boolean}
+ */
+export function checkCoordinatesEqualRounded(a, b) {
+    const roundedA = a.map(Math.round)
+    const roundedB = b.map(Math.round)
+    return roundedA[0] === roundedB[0] && roundedA[1] === roundedB[1]
+}

--- a/tests/e2e/specs/mouseposition.spec.js
+++ b/tests/e2e/specs/mouseposition.spec.js
@@ -89,7 +89,7 @@ describe('Test mouse position', () => {
             checkMousePositionNumberValue(2604624.64, 1261029.16, parseLV)
         })
     })
-    context('LocationPopUp when rightclick on the map', function () {
+    context.skip('LocationPopUp when rightclick on the map', function () {
         const lat = 45
         const lon = 8
         beforeEach(() => {


### PR DESCRIPTION
Currently, when someone tries to open the location pop-up on iOS
Safari the pop-up directly closes again. This is because the browser
sends a click event in addition to the context-menu event.

As there is nothing we can do against this event, I added a check
to the "singleclick" event to see if the last event was a context-
menu and if it was on the same position.

[Test link](https://sys-map.dev.bgdi.ch/bugfix-jira-bgdiinf_sb-2323-ios-safari-longpress/index.html)