### PR TITLE
Fixed drawing tooltip and tolerances

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -185,3 +185,10 @@ export const BREAKPOINT_PHONE_HEIGHT = 500
  * @type {Number}
  */
 export const BREAKPOINT_TABLET = 768
+
+/**
+ * The tolerance in pixel when testing if the cursor is over an element in drawing mode.
+ *
+ * @type {Number}
+ */
+export const DRAWING_HIT_TOLERANCE = 6

--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -15,6 +15,7 @@
             v-if="show"
             :current-drawing-mode="currentDrawingMode"
             :selected-features="selectedFeatures"
+            :currently-sketched-feature="currentlySketchedFeature"
         />
         <teleport v-if="readyForTeleport" to="#map-footer-middle">
             <ProfilePopup
@@ -45,21 +46,25 @@
             v-if="show && isDrawingModeMarker"
             ref="markerInteraction"
             :available-icon-sets="availableIconSets"
+            @draw-start="onDrawStart"
             @draw-end="onDrawEnd"
         />
         <DrawingTextInteraction
             v-if="show && isDrawingModeAnnotation"
             ref="textInteraction"
+            @draw-start="onDrawStart"
             @draw-end="onDrawEnd"
         />
         <DrawingLineInteraction
             v-if="show && isDrawingModeLine"
             ref="lineInteraction"
+            @draw-start="onDrawStart"
             @draw-end="onDrawEnd"
         />
         <DrawingMeasureInteraction
             v-if="show && isDrawingModeMeasure"
             ref="measureInteraction"
+            @draw-start="onDrawStart"
             @draw-end="onDrawEnd"
         />
     </div>
@@ -109,6 +114,7 @@ export default {
         return {
             drawingModes: Object.values(DrawingModes),
             isDrawingEmpty: true,
+            currentlySketchedFeature: null,
             /** Delay teleport until view is rendered. Updated in mounted-hook. */
             readyForTeleport: false,
         }
@@ -255,7 +261,11 @@ export default {
                 this.triggerKMLUpdate()
             }
         },
+        onDrawStart(feature) {
+            this.currentlySketchedFeature = feature
+        },
         onDrawEnd(feature) {
+            this.currentlySketchedFeature = null
             this.$refs.selectInteraction.selectFeature(feature)
             // de-selecting the current tool (drawing mode)
             this.setDrawingMode(null)
@@ -362,7 +372,7 @@ export default {
 </script>
 
 <style lang="scss">
-/* Unscoped style as what is described below will not be wrapped 
+/* Unscoped style as what is described below will not be wrapped
 in this component but added straight the the OpenLayers map */
 .tooltip-measure,
 .draw-measure-tmp,

--- a/src/modules/drawing/components/DrawingModifyInteraction.vue
+++ b/src/modules/drawing/components/DrawingModifyInteraction.vue
@@ -43,6 +43,7 @@ export default {
             deleteCondition: (event) => noModifierKeys(event) && singleClick(event),
             // This enables click on the shape of features (instead of pixel tolerance from their coordinates)
             hitDetection: true,
+            pixelTolerance: 8,
         })
         this.modifyInteraction.on('modifystart', this.onModifyStart)
         this.modifyInteraction.on('modifyend', this.onModifyEnd)

--- a/src/modules/drawing/components/DrawingModifyInteraction.vue
+++ b/src/modules/drawing/components/DrawingModifyInteraction.vue
@@ -7,6 +7,7 @@ import { extractOpenLayersFeatureCoordinates } from '@/modules/drawing/lib/drawi
 import { editingFeatureStyleFunction } from '@/modules/drawing/lib/style'
 import { noModifierKeys, singleClick } from 'ol/events/condition'
 import ModifyInteraction from 'ol/interaction/Modify'
+import { DRAWING_HIT_TOLERANCE } from '@/config'
 
 const cursorGrabbingClass = 'cursor-grabbing'
 
@@ -43,7 +44,9 @@ export default {
             deleteCondition: (event) => noModifierKeys(event) && singleClick(event),
             // This enables click on the shape of features (instead of pixel tolerance from their coordinates)
             hitDetection: true,
-            pixelTolerance: 8,
+            // This seems to be calculated differently than the hitTolerance properties of SelectInteraction
+            // and forEachFeatureAtPixel. That's why we have to manually correct the value here.
+            pixelTolerance: DRAWING_HIT_TOLERANCE + 2,
         })
         this.modifyInteraction.on('modifystart', this.onModifyStart)
         this.modifyInteraction.on('modifyend', this.onModifyEnd)

--- a/src/modules/drawing/components/DrawingSelectInteraction.vue
+++ b/src/modules/drawing/components/DrawingSelectInteraction.vue
@@ -90,7 +90,7 @@ export default {
             layers: [this.getDrawingLayer()],
             // As we've seen with the old viewer, some small features were hard
             // to select. We will try to add a bigger hit tolerance to mitigate that.
-            hitTolerance: 3,
+            hitTolerance: 6,
         })
     },
     mounted() {

--- a/src/modules/drawing/components/DrawingSelectInteraction.vue
+++ b/src/modules/drawing/components/DrawingSelectInteraction.vue
@@ -7,6 +7,7 @@ import { EditableFeature } from '@/api/features.api'
 import { extractOpenLayersFeatureCoordinates } from '@/modules/drawing/lib/drawingUtils'
 import { editingFeatureStyleFunction } from '@/modules/drawing/lib/style'
 import SelectInteraction from 'ol/interaction/Select'
+import { DRAWING_HIT_TOLERANCE } from '@/config'
 
 /**
  * Manages the selection of features on the drawing layer. Shares also which features are selected
@@ -90,7 +91,7 @@ export default {
             layers: [this.getDrawingLayer()],
             // As we've seen with the old viewer, some small features were hard
             // to select. We will try to add a bigger hit tolerance to mitigate that.
-            hitTolerance: 6,
+            hitTolerance: DRAWING_HIT_TOLERANCE,
         })
     },
     mounted() {

--- a/src/modules/drawing/lib/drawingUtils.js
+++ b/src/modules/drawing/lib/drawingUtils.js
@@ -154,3 +154,43 @@ export function extractOpenLayersFeatureCoordinates(feature) {
     }
     return coordinates
 }
+
+/**
+ * Checks if point is at target within tolerance.
+ *
+ * @param {Number[]} point The point in question.
+ * @param {Number[]} target The target to check against.
+ * @param {Number} [tolerance=0] Distance from target that still counts. Default is `0`
+ * @returns {Boolean} If the point is close enough to the target.
+ */
+export function pointWithinTolerance(point, target, tolerance = 0) {
+    return (
+        point[0] >= target[0] - tolerance &&
+        point[0] <= target[0] + tolerance &&
+        point[1] >= target[1] - tolerance &&
+        point[1] <= target[1] + tolerance
+    )
+}
+
+/**
+ * Extracts and normalizes coordinates from LineStrings and Polygons.
+ *
+ * @param {ol.Feature} feature The feature to extract from.
+ * @returns {Number[][]} An array of coordinates.
+ */
+export function getVertexCoordinates(feature) {
+    let normalized = []
+    const geometry = feature?.getGeometry()
+
+    if (geometry) {
+        const coordinates = geometry.getCoordinates()
+
+        if (geometry instanceof LineString) {
+            normalized = coordinates
+        } else if (geometry instanceof Polygon) {
+            normalized = coordinates[0]
+        }
+    }
+
+    return normalized
+}

--- a/src/modules/drawing/lib/drawingUtils.js
+++ b/src/modules/drawing/lib/drawingUtils.js
@@ -164,6 +164,10 @@ export function extractOpenLayersFeatureCoordinates(feature) {
  * @returns {Boolean} If the point is close enough to the target.
  */
 export function pointWithinTolerance(point, target, tolerance = 0) {
+    if (!point || !target) {
+        return false
+    }
+
     return (
         point[0] >= target[0] - tolerance &&
         point[0] <= target[0] + tolerance &&


### PR DESCRIPTION
This fixes the drawing tooltip (especially for lines/polygons) and
updates the tolerances of the different interactions so that they
match visually. At least as good as it gets.

[Test link](https://web-mapviewer.dev.bgdi.ch/develop-refactor-drawing-cursor/index.html)