### PR TITLE
BGDIINF_SB-2360: Updated width and added auto-pan

### DIFF
--- a/src/modules/infobox/components/SelectedFeatureList.vue
+++ b/src/modules/infobox/components/SelectedFeatureList.vue
@@ -95,9 +95,6 @@ export default {
 
 <style lang="scss">
 @import 'src/scss/media-query.mixin';
-.tooltip-feature {
-    overflow: hidden;
-}
 .htmlpopup-container {
     width: 100%;
     font-size: 11px;

--- a/src/modules/map/components/openlayers/OpenLayersPopover.vue
+++ b/src/modules/map/components/openlayers/OpenLayersPopover.vue
@@ -62,6 +62,7 @@ export default {
             offset: [0, 15],
             positioning: OverlayPositioning.TOP_CENTER,
             className: 'map-popover-overlay',
+            autoPan: { margin: 0 },
         })
     },
     mounted() {
@@ -88,7 +89,6 @@ export default {
 .map-popover {
     .card-body {
         width: $overlay-width;
-        min-width: 300px;
         max-width: 100%;
         max-height: 350px;
         overflow-y: auto;

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -16,7 +16,7 @@ $zindex-modal: $zindex-backdrop-front + 1;
 
 $header-height: 3rem;
 $footer-height: 1.5rem;
-$overlay-width: 400px;
+$overlay-width: 360px;
 
 $screen-padding-for-ui-elements: 0.5rem;
 

--- a/tests/e2e/specs/drawing/line-polygon.spec.js
+++ b/tests/e2e/specs/drawing/line-polygon.spec.js
@@ -34,7 +34,7 @@ describe('Line/Polygon tool', () => {
                         )
                     )
                 })
-                it('changes color of line/ polygon', () => {
+                it('changes color of line/polygon', () => {
                     cy.get(olSelector).click(150, 230)
                     cy.get(olSelector).click(100, 200)
                     cy.readDrawingFeatures('Polygon')


### PR DESCRIPTION
To fix this test I reduced the overlay width and more importantly
added an auto-pan option to the overlay to make sure it is positioned
properly.

[Test link](https://web-mapviewer.dev.bgdi.ch/bugfix-jira-bgdiinf_sb-2360-e2e-line-polygon/index.html)