### PR TITLE
BGDIINF_SB-2264: footer link adapted color and added link to CMS

### DIFF
--- a/src/modules/map/components/footer/MapFooterAppCopyright.vue
+++ b/src/modules/map/components/footer/MapFooterAppCopyright.vue
@@ -22,3 +22,15 @@ export default {
     },
 }
 </script>
+
+<style lang="scss" scoped>
+@import 'src/scss/variables-admin';
+a {
+    color: $black;
+    text-decoration: initial;
+}
+a:hover,
+a:focus {
+    text-decoration: underline;
+}
+</style>

--- a/src/modules/map/components/footer/MapFooterAppCopyright.vue
+++ b/src/modules/map/components/footer/MapFooterAppCopyright.vue
@@ -1,14 +1,23 @@
 <template>
-    <a :href="link" target="_blank">
-        {{ $t('copyright_label') }}
+    <a v-for="(link, index) in links" :key="index" :href="link.url" target="_blank">
+        {{ $t(link.label) }}
     </a>
 </template>
 
 <script>
 export default {
     computed: {
-        link() {
-            return `https://www.geo.admin.ch/${this.$i18n.locale}/about-swiss-geoportal/impressum.html#copyright`
+        links() {
+            return [
+                {
+                    label: 'ech_service_link_label',
+                    url: `https://www.geo.admin.ch/${this.$i18n.locale}/home.html`,
+                },
+                {
+                    label: 'copyright_label',
+                    url: `https://www.geo.admin.ch/${this.$i18n.locale}/about-swiss-geoportal/impressum.html#copyright`,
+                },
+            ]
         },
     },
 }


### PR DESCRIPTION
Painted the links as they are on map.geo.admin.ch in the footer (no underlining, black, but underlining when hover).

Added a link to the CMS (geo.admin.ch) as on mf-geoadmin3

[Test link](https://sys-map.dev.bgdi.ch/feat-2264-footer-link-adapt-color/index.html)