### PR TITLE
Use a relative base path while building

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ import vue from '@vitejs/plugin-vue'
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
     return {
-        base: '/',
+        base: './',
         plugins: [vue()],
         resolve: {
             alias: {


### PR DESCRIPTION
So that Vite build will output code that can be placed anywhere in a bucket (even in a branch folder) and still function properly. Otherwise a base of `/` is used and then only the root of the bucket is a valid place to deploy the code.

[Test link](https://sys-map.dev.bgdi.ch/feat-use-relative-path-with-vite/index.html)