### PR TITLE
Feat 2396 plot title should have two links

### DIFF
--- a/src/modules/drawing/components/ProfilePopupPlot.vue
+++ b/src/modules/drawing/components/ProfilePopupPlot.vue
@@ -78,13 +78,22 @@ export default {
                 height: 0,
                 xLabel: 'profile_x_label',
                 yLabel: 'profile_y_label',
-                sourceLink: {
-                    label: 'swissALTI3D/DHM25', //* profile_source_link_label *//
-                    url:
-                        this.$i18n.locale == 'rm' //* Linked site is not translated in Rm *//
-                            ? `https://www.swisstopo.admin.ch/de/geodata/height/dhm25.html`
-                            : `https://www.swisstopo.admin.ch/${this.$i18n.locale}/geodata/height/dhm25.html`,
-                },
+                sourceLinks: [
+                    {
+                        label: 'swissALTI3D',
+                        url:
+                            this.$i18n.locale == 'rm' //* Linked site is not translated in Rm *//
+                                ? `https://www.swisstopo.admin.ch/de/geodata/height/alti3d.html`
+                                : `https://www.swisstopo.admin.ch/${this.$i18n.locale}/geodata/height/alti3d.html`,
+                    },
+                    {
+                        label: 'DHM25',
+                        url:
+                            this.$i18n.locale == 'rm' //* Linked site is not translated in Rm *//
+                                ? `https://www.swisstopo.admin.ch/de/geodata/height/dhm25.html`
+                                : `https://www.swisstopo.admin.ch/${this.$i18n.locale}/geodata/height/dhm25.html`,
+                    },
+                ],
             },
             profileInfo: null,
         }

--- a/src/modules/drawing/lib/ProfileChart.js
+++ b/src/modules/drawing/lib/ProfileChart.js
@@ -228,18 +228,29 @@ export default class ProfileChart {
             .attr('d', area)
             .attr('data-cy', 'profile-popup-area')
 
-        this.group
-            .append('a')
-            .attr('xlink:href', this.options.sourceLink.url)
-            .attr('target', '_blank')
-            .attr('class', 'profile-source-link')
+        this.profileSourceText = this.group
             .append('text')
             .attr('class', 'profile-source-link')
             .attr('text-anchor', 'end')
             .attr('x', this.width)
             .attr('y', -this.sourceFontMargin)
             .attr('font-size', this.sourceFontSize)
-            .text(this.options.sourceLink.label)
+
+        this.profileSourceText
+            .append('a')
+            .attr('href', this.options.sourceLinks[0].url)
+            .attr('target', '_blank')
+            .append('tspan')
+            .text(this.options.sourceLinks[0].label)
+
+        this.profileSourceText.append('tspan').text(' / ')
+
+        this.profileSourceText
+            .append('a')
+            .attr('href', this.options.sourceLinks[1].url)
+            .attr('target', '_blank')
+            .append('tspan')
+            .text(this.options.sourceLinks[1].label)
 
         this.group
             .append('text')


### PR DESCRIPTION
The source link of the plot was split into two links: swissalti3d and dhm25

[Test link](https://sys-map.dev.bgdi.ch/feat-2396-plot-title-should-have-two-links/index.html)