### PR TITLE
BGDIINF_SB-2403: Fixed wrong calculation of maxheight in TooltipBox for the ProfilePopupPlot

### DIFF
--- a/src/modules/infobox/components/FeatureProfile.vue
+++ b/src/modules/infobox/components/FeatureProfile.vue
@@ -101,7 +101,17 @@ export default {
                     },
                 ],
             },
-            profileInfo: null,
+            // Not simply a null property, since it should already be added to the dom from the
+            // beginning for correct height calculations in TooltipBox.vue setMaxHeight()
+            profileInfo: {
+                elevationDiff: 0,
+                totalElevationDiff: 0,
+                elevationPoints: 0,
+                distance: 0,
+                slopeDistance: 0,
+                hikingTime: 0,
+                unitX: 0,
+            },
         }
     },
     computed: {
@@ -116,9 +126,6 @@ export default {
             )
         },
         profileInformation() {
-            if (!this.profileInfo) {
-                return []
-            }
             return [
                 {
                     title: 'profile_elevation_difference',


### PR DESCRIPTION
profileInfo in ProfilePopupPlot.vue in now not anymore a null object,
but an object with "0" properties, so that its corresponding dom
elements are already drawn when the component is created

[Test link](https://sys-map.dev.bgdi.ch/feat-2403-maxheight-of-tooltipbox-wrongly-calculated/index.html)