### PR TITLE
BGDIINF_SB-2405: Added the profilechart axis labels and added translation in the tooltip

### DIFF
--- a/src/modules/drawing/lib/ProfileChart.js
+++ b/src/modules/drawing/lib/ProfileChart.js
@@ -249,14 +249,15 @@ export default class ProfileChart {
 
         this.group
             .append('text')
-            .attr('class', 'profile-label ga-profile-label-x')
+            .attr('class', 'profile-label profile-label-x')
+            .attr('x', this.width / 2)
             .attr('y', this.height + this.options.margin.bottom - 5)
             .style('text-anchor', 'middle')
             .attr('font-size', '0.80em')
 
         this.group
             .append('text')
-            .attr('class', 'profile-label ga-profile-label-y')
+            .attr('class', 'profile-label profile-label-y')
             .attr('transform', 'rotate(-90)')
             .attr('y', 0 - this.options.margin.left)
             .attr('x', -this.height / 2)
@@ -279,12 +280,9 @@ export default class ProfileChart {
 
     updateLabels() {
         this.group
-            .select('text.ga-profile-label-x')
-            .attr('x', this.width / 2)
+            .select('text.profile-label-x')
             .text(`${i18n.global.t(this.options.xLabel)} [${this.unitX}]`)
-        this.group
-            .select('text.ga-profile-label-y')
-            .text(`${i18n.global.t(this.options.yLabel)} [m]`)
+        this.group.select('text.profile-label-y').text(`${i18n.global.t(this.options.yLabel)} [m]`)
     }
 
     getProfileInfo() {
@@ -317,7 +315,6 @@ export default class ProfileChart {
                 .duration(transitionTime)
                 .attr('x', this.width / 2)
                 .attr('y', this.height + this.options.margin.bottom - 5)
-                .style('text-anchor', 'middle')
             this.group
                 .select('text.profile-source-link')
                 .transition()

--- a/src/modules/drawing/lib/ProfileChart.js
+++ b/src/modules/drawing/lib/ProfileChart.js
@@ -41,7 +41,7 @@ export default class ProfileChart {
             const coords = []
             const maxX = data[data.length - 1].dist
             const denom = maxX >= 10000 ? 1000 : 1
-            this.unitX = maxX >= 10000 ? ' km' : ' m'
+            this.unitX = maxX >= 10000 ? 'km' : 'm'
             data.forEach((datum) => {
                 coords.push([datum.easting, datum.northing])
                 datum.domainDist = datum.dist / denom
@@ -250,19 +250,19 @@ export default class ProfileChart {
         this.group
             .append('text')
             .attr('class', 'profile-label ga-profile-label-x')
-            .attr('x', this.width / 2)
             .attr('y', this.height + this.options.margin.bottom - 5)
             .style('text-anchor', 'middle')
-            .attr('font-size', '0.95em')
+            .attr('font-size', '0.80em')
 
         this.group
             .append('text')
             .attr('class', 'profile-label ga-profile-label-y')
             .attr('transform', 'rotate(-90)')
             .attr('y', 0 - this.options.margin.left)
-            .attr('x', 0 - this.height / 2 - 30)
-            .attr('dy', '1em')
-            .attr('font-size', '0.95em')
+            .attr('x', -this.height / 2)
+            .attr('dy', '0.85em')
+            .style('text-anchor', 'middle')
+            .attr('font-size', '0.80em')
 
         this.glass = this.group
             .append('rect')
@@ -279,9 +279,12 @@ export default class ProfileChart {
 
     updateLabels() {
         this.group
-            .select('text.profile-label-x')
+            .select('text.ga-profile-label-x')
+            .attr('x', this.width / 2)
             .text(`${i18n.global.t(this.options.xLabel)} [${this.unitX}]`)
-        this.group.select('text.profile-label-y').text(`${i18n.global.t(this.options.yLabel)} [m]`)
+        this.group
+            .select('text.ga-profile-label-y')
+            .text(`${i18n.global.t(this.options.yLabel)} [m]`)
     }
 
     getProfileInfo() {

--- a/src/modules/infobox/components/FeatureProfile.vue
+++ b/src/modules/infobox/components/FeatureProfile.vue
@@ -15,11 +15,11 @@
         >
             <div class="profile-tooltip-inner p-2">
                 <div>
-                    <strong>Distance: </strong>
+                    <strong>{{ $t(options.xLabel) }}: </strong>
                     <span class="distance"></span>
                 </div>
                 <div>
-                    <strong>Elevation: </strong>
+                    <strong>{{ $t(options.yLabel) }}: </strong>
                     <span class="elevation"></span>
                 </div>
             </div>
@@ -79,7 +79,7 @@ export default {
         return {
             showTooltip: false,
             options: {
-                margin: { left: 35, right: 15, bottom: 25, top: 15 },
+                margin: { left: 55, right: 15, bottom: 35, top: 15 },
                 width: 0,
                 height: 0,
                 xLabel: 'profile_x_label',
@@ -280,7 +280,8 @@ export default {
                     this.$refs.profilePopupContent.getBoundingClientRect().y -
                     this.$refs.profileTooltipAnchor.getBoundingClientRect().y +
                     'px'
-                toltipEl.querySelector('.distance').innerText = `${xCoord.toFixed(2)}${
+
+                toltipEl.querySelector('.distance').innerText = `${xCoord.toFixed(2)} ${
                     this.profileInfo.unitX
                 }`
                 toltipEl.querySelector('.elevation').innerText = `${yCoord.toFixed(2)} m`


### PR DESCRIPTION
replaces https://github.com/geoadmin/web-mapviewer/pull/218 (rebased on `develop`)

[Test link](https://sys-map.dev.bgdi.ch/feat-bgdiinf_sb-2405-x-y-axis-profile/index.html)