### PR TITLE
BGDIINF_SB-2420: icons api origin header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # web-mapviewer
 
-| Branch  | Status                                                                                                                                                                                                                                                                                                                      | Deployed version                   |
-| ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| develop | ![Build Status](https://codebuild.eu-central-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiNml3WEJ4dGpETUExUGswQmxnOXdLczNNOFJUMG05dW9GUk5EYWEzL2Nmek1EbFAvYlpNS2FWRkxzTGtxaFpKeWJKallVTmIyOHhrTWZqRnlyUUU3Uk5RPSIsIml2UGFyYW1ldGVyU3BlYyI6IllNU05Qdi9zcUtMSzF4OGciLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=develop) | https://sys-map.dev.bgdi.ch/       |
+| Branch  | Status                                                                                                                                                                                                                                                                                                                      | Deployed version             |
+| ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| develop | ![Build Status](https://codebuild.eu-central-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiNml3WEJ4dGpETUExUGswQmxnOXdLczNNOFJUMG05dW9GUk5EYWEzL2Nmek1EbFAvYlpNS2FWRkxzTGtxaFpKeWJKallVTmIyOHhrTWZqRnlyUUU3Uk5RPSIsIml2UGFyYW1ldGVyU3BlYyI6IllNU05Qdi9zcUtMSzF4OGciLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=develop) | https://sys-map.dev.bgdi.ch/ |
 | master  | ![Build Status](https://codebuild.eu-central-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiNml3WEJ4dGpETUExUGswQmxnOXdLczNNOFJUMG05dW9GUk5EYWEzL2Nmek1EbFAvYlpNS2FWRkxzTGtxaFpKeWJKallVTmIyOHhrTWZqRnlyUUU3Uk5RPSIsIml2UGFyYW1ldGVyU3BlYyI6IllNU05Qdi9zcUtMSzF4OGciLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)  | https://sys-map.int.bgdi.ch/ |
 
 The next generation map viewer application of geo.admin.ch: Digital data can be viewed, printed out, ordered and supplied by means of web-mapviewer. The required data is available in the form of digital maps and imagery, vector data and also as online services.
@@ -158,7 +158,7 @@ All script commands starting a webserver or using one (`serve` and all things re
 
 The CI uses this file to ensure it will not stumble upon a minor version of a library that breaks the app. So this file needs to be versioned, and kept up to date (each time a new library or version of a library is added to `package.json`, `npm install` will update `package-lock.json` accordingly).
 
-The CI will use `npm ci`, which act like `npm install` but it ignores the file `package.json` and loads all libraries versions found in `pakcage-lock.json` (which are not volatile, e.g. `^1.0.0` or `~1.0.0.`, but fixed).
+The CI will use `npm ci`, which act like `npm install` but it ignores the file `package.json` and loads all libraries versions found in `package-lock.json` (which are not volatile, e.g. `^1.0.0` or `~1.0.0.`, but fixed).
 
 ### What does the deploy script do?
 

--- a/src/api/icon.api.js
+++ b/src/api/icon.api.js
@@ -149,27 +149,23 @@ export class Icon {
  * @returns {Promise<IconSet[]>}
  */
 export async function loadAllIconSetsFromBackend() {
-    const rawSets = (
-        await axios.get(`${API_SERVICES_BASE_URL}icons/sets`, {
-            headers: {
-                'Access-Control-Allow-Origin': '*',
-                'Access-Control-Allow-Headers': '*',
-                'Access-Control-Allow-Credentials': 'true',
-            },
-        })
-    ).data.items
     const sets = []
-    for (const rawSet of rawSets) {
-        const iconSet = new IconSet(
-            rawSet.name,
-            rawSet.colorable,
-            rawSet.icons_url,
-            rawSet.template_url
-        )
-        // retrieving all icons for this icon set
-        await loadIconsForIconSet(iconSet)
+    try {
+        const rawSets = (await axios.get(`${API_SERVICES_BASE_URL}icons/sets`)).data.items
+        for (const rawSet of rawSets) {
+            const iconSet = new IconSet(
+                rawSet.name,
+                rawSet.colorable,
+                rawSet.icons_url,
+                rawSet.template_url
+            )
+            // retrieving all icons for this icon set
+            await loadIconsForIconSet(iconSet)
 
-        sets.push(iconSet)
+            sets.push(iconSet)
+        }
+    } catch (error) {
+        log.error(`Failed to retrieve icons sets: ${error}`)
     }
     return sets
 }
@@ -182,13 +178,7 @@ export async function loadAllIconSetsFromBackend() {
  */
 function loadIconsForIconSet(iconSet) {
     return axios
-        .get(iconSet.iconsURL, {
-            headers: {
-                'Access-Control-Allow-Origin': '*',
-                'Access-Control-Allow-Headers': '*',
-                'Access-Control-Allow-Credentials': 'true',
-            },
-        })
+        .get(iconSet.iconsURL)
         .then((rawIcons) => {
             iconSet.icons = rawIcons.data.items.map(
                 (rawIcon) =>

--- a/src/api/qrcode.api.js
+++ b/src/api/qrcode.api.js
@@ -23,11 +23,6 @@ export const generateQrCode = (url) => {
                     url: url,
                 },
                 responseType: 'arraybuffer',
-                headers: {
-                    'Access-Control-Allow-Origin': '*',
-                    'Access-Control-Allow-Headers': '*',
-                    'Access-Control-Allow-Credentials': 'true',
-                },
             })
             .then((image) => {
                 resolve(


### PR DESCRIPTION
Unfortunately the `Origin` header cannot be set by the application (Some browser like Chrome doesn't allow it) and this header is omitted on same origin use case. Therefore we need to change the backend, see https://github.com/geoadmin/service-icons/pull/56.

Did anyway some clean up here.

[Test link](https://sys-map.dev.bgdi.ch/bug-bgdiinf_sb-2420-icons-cors/index.html)