### PR TITLE
Bugfix 2410 drawing should be editable when reopened

### DIFF
--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -81,7 +81,7 @@ import KML from 'ol/format/KML'
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
 import { mapActions, mapState } from 'vuex'
-import MeasureManager from '@/modules/drawing/lib/MeasureManager'
+import MeasureManager from '@/utils/MeasureManager'
 
 export default {
     components: {

--- a/src/modules/drawing/components/drawingInteraction.mixin.js
+++ b/src/modules/drawing/components/drawingInteraction.mixin.js
@@ -23,6 +23,7 @@ import { getUid } from 'ol/util'
  *
  * - `onDrawStart` (function): called after the drawing has started with the feature being drawn as argument
  * - `onDrawEnd` (function): called after the drawing is done with the drawn feature as argument
+ * - `onDrawAbort` (function): called when the drawing is aborted with the aborted feature as argument
  * - `editingStyle` (function): style function used while drawing, if none given
  *   {@link editingFeatureStyleFunction} will be used
  * - `featureStyle` (function): style applied to the feature as soon as it is done being drawn, will
@@ -51,6 +52,7 @@ const drawingInteractionMixin = {
             this.interaction.getOverlay().getSource().on('addfeature', this.onAddFeature)
             this.interaction.on('drawstart', this._onDrawStart)
             this.interaction.on('drawend', this._onDrawEnd)
+            this.interaction.on('drawabort', this._onDrawAbort)
 
             this.getMap().addInteraction(this.interaction)
         },
@@ -61,6 +63,7 @@ const drawingInteractionMixin = {
 
             this.interaction.un('drawend', this._onDrawEnd)
             this.interaction.un('drawstart', this._onDrawStart)
+            this.interaction.un('drawabort', this._onDrawAbort)
             this.interaction.getOverlay().getSource().un('addfeature', this.onAddFeature)
         },
         onAddFeature(event) {
@@ -111,6 +114,12 @@ const drawingInteractionMixin = {
             // see https://openlayers.org/en/latest/apidoc/module-ol_interaction_Draw-Draw.html#finishDrawing
             this.interaction.finishDrawing()
             this.$emit('drawEnd', feature)
+        },
+        _onDrawAbort(event) {
+            // if optional onDrawAbort is defined, we call it
+            if (this.onDrawAbort) {
+                this.onDrawAbort(event.feature)
+            }
         },
         removeLastPoint() {
             this.interaction.removeLastPoint()

--- a/src/modules/drawing/lib/MeasureManager.js
+++ b/src/modules/drawing/lib/MeasureManager.js
@@ -9,6 +9,7 @@ import {
 } from '@/modules/drawing/lib/drawingUtils'
 import { LineString, Polygon } from 'ol/geom'
 import { Collection } from 'ol'
+import { DrawingModes } from '@/store/modules/drawing.store'
 
 export default class MeasureManager {
     constructor(map, layer) {
@@ -170,7 +171,7 @@ export default class MeasureManager {
             .getSource()
             .getFeatures()
             .forEach((feature) => {
-                if (feature.get('type') === 'MEASURE') {
+                if (feature.get('drawingMode') === DrawingModes.MEASURE) {
                     if (visible) {
                         this.addOverlays(feature)
                     } else {

--- a/src/modules/infobox/components/styling/FeatureStyleEdit.vue
+++ b/src/modules/infobox/components/styling/FeatureStyleEdit.vue
@@ -82,6 +82,7 @@
                 </PopoverButton>
 
                 <ButtonWithIcon
+                    data-cy="drawing-style-delete-button"
                     :button-font-awesome-icon="['far', 'trash-alt']"
                     @click="onDelete"
                 ></ButtonWithIcon>

--- a/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
@@ -11,10 +11,13 @@ import KML from 'ol/format/KML'
 import addLayerToMapMixin from './utils/addLayerToMap-mixins'
 import { featureStyleFunction } from '@/modules/drawing/lib/style'
 import { deserializeAnchor } from '@/utils/featureAnchor'
+import MeasureManager from '@/utils/MeasureManager'
+import { DrawingModes } from '@/store/modules/drawing.store'
 
 /** Renders a KML file on the map */
 export default {
     mixins: [addLayerToMapMixin],
+    inject: ['getMap'],
     props: {
         layerId: {
             type: String,
@@ -53,12 +56,16 @@ export default {
                 format: new KML(),
             }),
         })
+        this.measureManager = new MeasureManager(this.getMap(), this.layer)
         this.layer.getSource().on('addfeature', (event) => {
             const f = event.feature
             // The following deserialization is a hack. See @module comment in file.
             deserializeAnchor(f)
             f.set('type', f.get('type').toUpperCase())
             f.setStyle((feature) => featureStyleFunction(feature))
+            if (f.get('drawingMode') === DrawingModes.MEASURE) {
+                this.measureManager.addOverlays(f)
+            }
         })
     },
 }

--- a/src/store/modules/drawing.store.js
+++ b/src/store/modules/drawing.store.js
@@ -37,7 +37,7 @@ export default {
          */
         mode: null,
         /**
-         * Ids of stored KML file
+         * Ids of stored KML file. Format is: {adminId, fileId}
          *
          * @type {DrawingKmlIds | null}
          */
@@ -90,8 +90,11 @@ export default {
             dispatch('clearAllSelectedFeatures')
             commit('deleteDrawingFeature', featureId)
         },
-        clearFeatureIds({ commit }) {
-            commit('clearFeatureIds')
+        clearDrawingFeatures({ commit }) {
+            commit('setDrawingFeatures', [])
+        },
+        setDrawingFeatures({ commit }, featureIds) {
+            commit('setDrawingFeatures', featureIds)
         },
     },
     mutations: {
@@ -101,6 +104,6 @@ export default {
         addDrawingFeature: (state, featureId) => state.featureIds.push(featureId),
         deleteDrawingFeature: (state, featureId) =>
             (state.featureIds = state.featureIds.filter((featId) => featId !== featureId)),
-        clearFeatureIds: (state) => (state.featureIds = []),
+        setDrawingFeatures: (state, featureIds) => (state.featureIds = featureIds),
     },
 }

--- a/src/utils/MeasureManager.js
+++ b/src/utils/MeasureManager.js
@@ -1,9 +1,3 @@
-/**
- * Handels the overlays that are shown on top of a each measure drawing
- *
- * It is used in the Drawing module as well as in the map KMLLayer, as the drawing is displayed with
- * a KML Layer when outside of the drawing mode.
- */
 import Overlay from 'ol/Overlay'
 import {
     canShowAzimuthCircle,
@@ -17,6 +11,12 @@ import { LineString, Polygon } from 'ol/geom'
 import { Collection } from 'ol'
 import { DrawingModes } from '@/store/modules/drawing.store'
 
+/**
+ * Handels the overlays that are shown on top of a each measure drawing
+ *
+ * It is used in the Drawing module as well as in the map KMLLayer, as the drawing is displayed with
+ * a KML Layer when outside of the drawing mode.
+ */
 export default class MeasureManager {
     constructor(map, layer) {
         this.map = map

--- a/src/utils/MeasureManager.js
+++ b/src/utils/MeasureManager.js
@@ -1,3 +1,9 @@
+/**
+ * Handels the overlays that are shown on top of a each measure drawing
+ *
+ * It is used in the Drawing module as well as in the map KMLLayer, as the drawing is displayed with
+ * a KML Layer when outside of the drawing mode.
+ */
 import Overlay from 'ol/Overlay'
 import {
     canShowAzimuthCircle,
@@ -169,8 +175,8 @@ export default class MeasureManager {
     toggleOverlays(visible) {
         this.layer
             .getSource()
-            .getFeatures()
-            .forEach((feature) => {
+            ?.getFeatures()
+            ?.forEach((feature) => {
                 if (feature.get('drawingMode') === DrawingModes.MEASURE) {
                     if (visible) {
                         this.addOverlays(feature)

--- a/tests/e2e-cypress/fixtures/service-kml/lonelyMarker.kml
+++ b/tests/e2e-cypress/fixtures/service-kml/lonelyMarker.kml
@@ -1,0 +1,40 @@
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd">
+    <Document>
+        <name>Dessin</name>
+        <Placemark id="138">
+            <description></description>
+            <Style />
+            <ExtendedData>
+                <Data name="anchor" />
+                <Data name="anchorString">
+                    <value>[0.5,0.875]</value>
+                </Data>
+                <Data name="color">
+                    <value>#ff0000</value>
+                </Data>
+                <Data name="drawingMode">
+                    <value>MARKER</value>
+                </Data>
+                <Data name="font">
+                    <value>normal 24px Helvetica</value>
+                </Data>
+                <Data name="icon" />
+                <Data name="iconUrl">
+                    <value>https://sys-map.dev.bgdi.ch/api/icons/sets/default/icons/001-marker@1x-255,0,0.png</value>
+                </Data>
+                <Data name="text">
+                    <value>A not interesting comment</value>
+                </Data>
+                <Data name="textScale">
+                    <value>1.5</value>
+                </Data>
+                <Data name="type">
+                    <value>point</value>
+                </Data>
+            </ExtendedData>
+            <Point>
+                <coordinates>7.743,47.097</coordinates>
+            </Point>
+        </Placemark>
+    </Document>
+</kml>

--- a/tests/e2e-cypress/integration/drawing/measureOverlays.cy.js
+++ b/tests/e2e-cypress/integration/drawing/measureOverlays.cy.js
@@ -1,0 +1,38 @@
+import { EditableFeatureTypes } from '@/api/features.api'
+import { Collection } from 'ol'
+
+const olSelector = '.ol-viewport'
+
+const latitude = 47.097
+const longitude = 7.743
+const zoom = 9.5
+
+describe('Measure Overlays handling', () => {
+    it('draw measure, abort, and check that there are no overlays left', () => {
+        //Open drawing mode
+        cy.goToDrawing('fr', { lat: latitude, lon: longitude, z: zoom }, true)
+        cy.readWindowValue('map').then((map) => {
+            const nbOverlaysAtBeginning = map.getOverlays().getLength()
+            cy.readWindowValue('drawingLayer')
+                .then((layer) => layer.getSource().getFeatures())
+                .should('have.length', 0)
+            //Start drawing a measure
+            cy.clickDrawingTool(EditableFeatureTypes.MEASURE)
+            cy.get(olSelector).click('left')
+            cy.get(olSelector).click('center')
+            //Overlays should be visible
+            cy.readWindowValue('map')
+                .then((map) => map.getOverlays().getLength())
+                .should('be.greaterThan', nbOverlaysAtBeginning)
+            //Cancel drawing
+            cy.clickDrawingTool(EditableFeatureTypes.MEASURE, true)
+            //Overlays should have disappeared
+            cy.readWindowValue('map')
+                .then((map) => map.getOverlays().getLength())
+                .should('be.at.most', nbOverlaysAtBeginning)
+            cy.readWindowValue('drawingLayer')
+                .then((layer) => layer.getSource().getFeatures())
+                .should('have.length', 0)
+        })
+    })
+})

--- a/tests/e2e-cypress/support/drawing.js
+++ b/tests/e2e-cypress/support/drawing.js
@@ -1,4 +1,4 @@
-import { EditableFeatureTypes } from "@/api/features.api";
+import { EditableFeatureTypes } from '@/api/features.api'
 import { BREAKPOINT_PHONE_WIDTH } from '@/config'
 import pako from 'pako'
 import { parseInterception } from './multipart'
@@ -57,12 +57,12 @@ Cypress.on('uncaught:exception', () => {
     return false
 })
 
-Cypress.Commands.add('goToDrawing', () => {
+Cypress.Commands.add('goToDrawing', (...args) => {
     addIconFixtureAndIntercept()
     addIconSetsFixtureAndIntercept()
     addDefaultIconsFixtureAndIntercept()
     addSecondIconsFixtureAndIntercept()
-    cy.goToMapView()
+    cy.goToMapView(...args)
     const viewportWidth = Cypress.config('viewportWidth')
     if (viewportWidth && viewportWidth < BREAKPOINT_PHONE_WIDTH) {
         cy.get('[data-cy="menu-button"]').click()
@@ -72,10 +72,14 @@ Cypress.Commands.add('goToDrawing', () => {
     cy.waitUntilState((state) => state.drawing.iconSets.length > 0)
 })
 
-Cypress.Commands.add('clickDrawingTool', (name) => {
+Cypress.Commands.add('clickDrawingTool', (name, unselect = false) => {
     expect(Object.values(EditableFeatureTypes)).to.include(name)
     cy.get(`[data-cy="drawing-toolbox-mode-button-${name}`).click()
-    cy.readStoreValue('state.drawing.mode').should('eq', name)
+    if (unselect) {
+        cy.readStoreValue('state.drawing.mode').should('eq', null)
+    } else {
+        cy.readStoreValue('state.drawing.mode').should('eq', name)
+    }
 })
 
 Cypress.Commands.add('readDrawingFeatures', (type, callback) => {


### PR DESCRIPTION
The bug was due to a call to the measure manager in the drawing module, in which it was undefined. Tof fix it, the measure manager was moved to the Drawing Layer, so that it can also be called when adding a saved KML Layer. It was also added in the map KML Layer.

[Test link](https://sys-map.dev.bgdi.ch/bugfix-2410-drawing-should-be-editable-when-reopened/index.html)