### PR TITLE
Focus on search bar at app startup

### DIFF
--- a/src/modules/menu/components/search/SearchBar.vue
+++ b/src/modules/menu/components/search/SearchBar.vue
@@ -46,6 +46,9 @@ export default {
             resultsShown: (state) => state.search.show,
         }),
     },
+    mounted() {
+        this.$refs.search.focus()
+    },
     methods: {
         ...mapActions(['setSearchQuery', 'showSearchResults', 'hideSearchResults']),
         updateSearchQuery(event) {


### PR DESCRIPTION
Now focuses on search bar at app startup

[Test link](https://sys-map.dev.bgdi.ch/feat-2435-focus-on-search-bar-at-startup/index.html)