### PR TITLE
Feature: BGDIINF_SB-2431: close share menu on map movement

### DIFF
--- a/src/modules/menu/components/menu/MenuSection.vue
+++ b/src/modules/menu/components/menu/MenuSection.vue
@@ -11,6 +11,7 @@
             data-cy="menu-section-header"
             data-toggle="collapse"
             @click="toggleShowBody"
+
         >
             <span class="menu-section-title">
                 <button class="btn menu-section-title-icon" type="button">
@@ -55,7 +56,7 @@ export default {
             default: false,
         },
     },
-    emits: ['showBody'],
+    emits: ['showBody', 'click:header'],
     data() {
         return {
             showBody: this.showContent,
@@ -85,6 +86,7 @@ export default {
             if (this.showBody) {
                 this.$emit('showBody')
             }
+            this.$emit('click:header')
         },
     },
 }

--- a/src/modules/menu/components/share/MenuShareSection.vue
+++ b/src/modules/menu/components/share/MenuShareSection.vue
@@ -4,7 +4,7 @@
         :show-content="isSectionShown"
         data-cy="menu-share-section"
         secondary
-        @click="toggleShareMenu"
+        @click:header="toggleShareMenu"
     >
         <FontAwesomeIcon v-if="!shortLink" icon="spinner" spin size="2x" class="p-2" />
         <div v-if="shortLink" class="p-2">

--- a/src/modules/menu/components/share/MenuShareSection.vue
+++ b/src/modules/menu/components/share/MenuShareSection.vue
@@ -1,9 +1,10 @@
 <template>
     <MenuSection
         :title="$t('share')"
+        :show-content="isSectionShown"
         data-cy="menu-share-section"
         secondary
-        @click="toggleShortLinkUpdate"
+        @click="toggleShareMenu"
     >
         <FontAwesomeIcon v-if="!shortLink" icon="spinner" spin size="2x" class="p-2" />
         <div v-if="shortLink" class="p-2">
@@ -29,32 +30,25 @@ export default {
         MenuShareSocialNetworks,
         MenuSection,
     },
-    data() {
-        return {
-            /** Keeping track of the visibility of the share section */
-            isSectionShown: false,
-        }
-    },
     computed: {
         ...mapState({
             shortLink: (state) => state.share.shortLink,
+            isSectionShown: (state) => state.share.isMenuSectionShown,
         }),
     },
     methods: {
-        ...mapActions(['generateShortLink', 'setKeepUpdatingShortLink']),
-        generateShortLinkIfMNeeded() {
-            if (!this.shortLink) {
+        ...mapActions(['generateShortLink',' clearShortLink', 'toggleShareMenuSection']),
+        toggleShareMenu() {
+            this.toggleShareMenuSection()
+            if (!this.shortLink){
                 this.generateShortLink()
             }
-        },
-        toggleShortLinkUpdate() {
-            this.isSectionShown = !this.isSectionShown
-            // first time here, shortLink is not yet defined
-            if (this.isSectionShown && !this.shortLink) {
-                this.generateShortLink()
+            else {
+                this.clearShortLink()
             }
-            this.setKeepUpdatingShortLink(this.isSectionShown)
+
         },
+
     },
 }
 </script>

--- a/src/modules/menu/components/share/MenuShareShortLinkInput.vue
+++ b/src/modules/menu/components/share/MenuShareShortLinkInput.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="shortLink" class="p-1">
+    <div v-if="shortLink" data-cy="share-menu-opened" class="p-1">
         <label v-if="withText">{{ $t('share_link') }}: </label>
         <div class="input-group input-group-sm">
             <input

--- a/src/router/storeSync/storeSync.routerPlugin.js
+++ b/src/router/storeSync/storeSync.routerPlugin.js
@@ -65,9 +65,10 @@ function storeMutationWatcher(store, mutation, router) {
                     routeChangeIsTriggeredByThisModule = false
                 })
             // if the short linked version of the URL is already defined,
-            // and the menu opened, we must refresh it as the URL has just changed
-            if (store.getters.showMenu && store.state.share.keepUpdatingShortLink) {
-                store.dispatch('generateShortLink')
+            // and the share menu opened, we must close the share menu and
+            // reset the shortlink
+            if (store.state.share.shortLink) {
+                store.dispatch('closeShareMenuAndRemoveShortlink')
             }
         }
     }

--- a/src/store/modules/share.store.js
+++ b/src/store/modules/share.store.js
@@ -1,5 +1,4 @@
 import { getShortLink } from '@/api/shortlink.api'
-
 export default {
     state: {
         /**
@@ -11,13 +10,13 @@ export default {
          */
         shortLink: null,
         /**
-         * Flag telling if the short link should be updated anytime the URL changes.
+         * The state of the shortlink share menu section. As we need to be able to change this
+         * whenever the user moves the map, and it should only be done within mutations.
          *
-         * This will be true when the share section of the menu is shown so that the short link is
-         * always in sync with the app state. But as soon as the share section in the menu is closed
-         * we can stop updating the link (otherwise we create a lot of unwanted/unused short links)
+         *
+         * @type Boolean
          */
-        keepUpdatingShortLink: false,
+        isMenuSectionShown: false,
     },
     getters: {},
     actions: {
@@ -27,16 +26,24 @@ export default {
                 commit('setShortLink', shortLink)
             }
         },
-        setKeepUpdatingShortLink({ commit }, flagValue) {
-            commit('setKeepUpdatingShortLink', flagValue)
+        closeShareMenuAndRemoveShortlink({ commit }) {
+            commit('setIsMenuSectionShown', false)
+            commit('setShortLink', null)
+
         },
+        toggleShareMenuSection({ commit, state }) {
+            commit('setIsMenuSectionShown', !state.isMenuSectionShown)
+        },
+        clearShortLink({ commit }) {
+            commit('setShortLink', null)
+        }
     },
     mutations: {
         setShortLink(state, shortLink) {
             state.shortLink = shortLink
         },
-        setKeepUpdatingShortLink(state, flagValue) {
-            state.keepUpdatingShortLink = flagValue
-        },
+        setIsMenuSectionShown(state, flag) {
+            state.isMenuSectionShown = flag
+        }
     },
 }

--- a/tests/e2e-cypress/integration/shareShortLink.cy.js
+++ b/tests/e2e-cypress/integration/shareShortLink.cy.js
@@ -19,21 +19,20 @@ describe('Testing the share menu', () => {
             cy.wait('@shortLink')
             cy.readStoreValue('state.share.shortLink').should('eq', dummyShortLink)
         })
-        it('Updates the short link as soon as the state of the map (the URL) has changed', () => {
+        it('deletes the short link and close the menu as soon as the state of the map (the URL) has changed', () => {
             cy.get('[data-cy="menu-share-section"]').click()
             // a short link should be generated as it is our first time opening this section
             cy.wait('@shortLink')
-            // overriding the response of the service with a different URL
-            const updatedDummyShortLink = 'https://updated.dummy.link'
-            cy.intercept('https://s.geo.admin.ch**', {
-                body: { shorturl: updatedDummyShortLink },
-            }).as('updateShortLink')
-            // closing the menu
+            // We close the menu to still be able too click on the zoom button
             cy.get('[data-cy="menu-button"]').click()
             // zoom in the map in order to change the URL
             cy.get('[data-cy="zoom-in"]').click()
-            cy.wait('@updateShortLink')
-            cy.readStoreValue('state.share.shortLink').should('eq', updatedDummyShortLink)
+            // checking that the shortLink value doesn't exist anymore
+            cy.readStoreValue('state.share.shortLink').should('eq', null)
+            // opening the general menu again
+            cy.get('[data-cy="menu-button"]').click
+            // checking that the share menu has been closed
+            cy.get('[data-cy="share-menu-opened"]').should('not.exist')
         })
     })
     context('Social networks', () => {


### PR DESCRIPTION
Issue : the short link generation call was made every time there was a change in the url, causing a lot of unnecessary calls to the underlying service, beginning the first time a short link was generated and never stopping afterwards.
Fix : Whenever there is a change, if there is an existing short link, this will reset its state to null and close the share menu should it be open. Meaning the only calls made to the shortLink service should be for links people actually want to share.

[Test link](https://sys-map.dev.bgdi.ch/feat-bgdiinf_sb-2431-close-share-menu-on-map-movement/index.html)