### PR TITLE
Feat 2271 limit menu height

### DIFF
--- a/src/modules/map/components/footer/MapFooter.vue
+++ b/src/modules/map/components/footer/MapFooter.vue
@@ -72,8 +72,6 @@ $flex-gap: 1em;
     left: 0;
     bottom: 0;
     right: 0;
-    z-index: $zindex-menu + 1;
-
     transition: transform $transition-duration;
     pointer-events: none;
 
@@ -85,6 +83,8 @@ $flex-gap: 1em;
     }
 
     &-top {
+        position: relative;
+        z-index: $zindex-footer;
         display: flex;
         align-items: flex-end;
         flex-direction: row;
@@ -108,10 +108,14 @@ $flex-gap: 1em;
     }
 
     &-middle {
+        position: relative;
+        z-index: $zindex-footer-infobox;
         background-color: $white;
     }
 
     &-bottom {
+        position: relative;
+        z-index: $zindex-footer;
         width: 100%;
         padding: 0.6em;
         background-color: rgba($white, 0.9);

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -1,8 +1,6 @@
 <template>
     <!-- preventing right click (or long left click) to trigger the contextual menu of the browser-->
     <div id="ol-map" ref="map" @contextmenu="onContextMenu">
-        <!-- So that external modules can have access to the map instance through the provided 'getMap' -->
-        <slot />
         <!-- Adding background layer -->
         <OpenLayersInternalLayer
             v-if="currentBackgroundLayer"
@@ -68,6 +66,8 @@
             :z-index="zIndexAccuracyCircle + 1"
         />
     </div>
+    <!-- So that external modules can have access to the map instance through the provided 'getMap' -->
+    <slot />
 </template>
 
 <script>
@@ -432,5 +432,7 @@ export default {
 #ol-map {
     width: 100%;
     height: 100%;
+    position: relative; // Element must be positioned to set a z-index
+    z-index: $zindex-map;
 }
 </style>

--- a/src/modules/menu/MenuModule.vue
+++ b/src/modules/menu/MenuModule.vue
@@ -20,30 +20,41 @@
             <ZoomButtons @zoom-in="increaseZoom" @zoom-out="decreaseZoom" />
             <CompassButton />
         </div>
-        <transition name="slide-up">
-            <div
-                v-show="showMenu"
-                class="menu-tray"
-                :class="{
-                    'desktop-mode': shouldMenuTrayAlwaysBeVisible,
-                    'desktop-menu-closed': shouldMenuTrayAlwaysBeVisible && !menuDesktopOpen,
-                }"
-                data-cy="menu-tray"
-            >
-                <MenuTray class="menu-tray-content" :compact="shouldMenuTrayAlwaysBeVisible" />
-                <ButtonWithIcon
-                    v-if="shouldMenuTrayAlwaysBeVisible"
-                    class="button-open-close-desktop-menu m-auto"
-                    data-cy="menu-button"
-                    :button-font-awesome-icon="['fas', menuDesktopOpen ? 'caret-up' : 'caret-down']"
-                    :button-title="$t(menuDesktopOpen ? 'close_menu' : 'open_menu')"
-                    icons-before-text
-                    dark
-                    @click="toggleMenuDesktopOpen"
+        <div
+            class="menu-tray-container"
+            :class="{
+                'desktop-mode': shouldMenuTrayAlwaysBeVisible,
+            }"
+        >
+            <transition name="slide-up">
+                <div
+                    v-show="showMenu"
+                    class="menu-tray"
+                    :class="{
+                        'desktop-mode': shouldMenuTrayAlwaysBeVisible,
+                        'desktop-menu-closed': shouldMenuTrayAlwaysBeVisible && !menuDesktopOpen,
+                    }"
+                    data-cy="menu-tray"
                 >
-                </ButtonWithIcon>
-            </div>
-        </transition>
+                    <MenuTray class="menu-tray-content" :compact="shouldMenuTrayAlwaysBeVisible" />
+                    <ButtonWithIcon
+                        v-if="shouldMenuTrayAlwaysBeVisible"
+                        class="m-auto button-open-close-desktop-menu"
+                        data-cy="menu-button"
+                        style="{ flex: 'none', max-height: '100%' + 'px' }"
+                        :button-font-awesome-icon="[
+                            'fas',
+                            menuDesktopOpen ? 'caret-up' : 'caret-down',
+                        ]"
+                        :button-title="$t(menuDesktopOpen ? 'close_menu' : 'open_menu')"
+                        icons-before-text
+                        dark
+                        @click="toggleMenuDesktopOpen"
+                    >
+                    </ButtonWithIcon>
+                </div>
+            </transition>
+        </div>
     </div>
 </template>
 
@@ -136,19 +147,34 @@ $animation-time: 0.5s;
         position: relative;
         margin: $screen-padding-for-ui-elements;
     }
-    .menu-tray {
+    .menu-tray-container {
+        pointer-events: none;
         position: absolute;
-        z-index: $zindex-menu-tray;
         top: $header-height;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        &.desktop-mode {
+            bottom: 70px;
+        }
+    }
+    .menu-tray {
+        /* Don't activate pointer events right here, as this box is still a bit larger than the
+        actual menu in desktop mode (includes right and left of close button) */
+        position: absolute;
+        display: grid;
+        // The menu takes the whole available width, the open close button only as much as needed
+        grid-template-rows: 1fr auto;
+        z-index: $zindex-menu-tray;
+        top: 0;
         left: 0;
         width: 100%;
         max-width: 100%;
-        max-height: calc(100% - #{$header-height});
-        overflow-y: auto;
+        max-height: 100%;
         transition: $animation-time;
-        $openCloseButtonHeight: 38px;
-        .button-open-close-desktop-menu {
-            height: $openCloseButtonHeight;
+
+        .menu-tray-content {
+            pointer-events: all;
         }
         &.desktop-mode {
             .menu-tray-content {
@@ -156,17 +182,22 @@ $animation-time: 0.5s;
             }
             max-width: 22rem;
         }
+        $openCloseButtonHeight: 2.5rem;
         &.desktop-menu-closed {
             .menu-tray-content {
                 opacity: 0;
             }
             transform: translate(0px, calc(-100% + #{$openCloseButtonHeight}));
         }
+        .button-open-close-desktop-menu {
+            pointer-events: all;
+            height: $openCloseButtonHeight;
+        }
     }
 }
 @include respond-above(lg) {
     .menu {
-        .menu-tray {
+        .menu-tray-container {
             top: 2 * $header-height;
         }
     }

--- a/src/modules/menu/MenuModule.vue
+++ b/src/modules/menu/MenuModule.vue
@@ -137,7 +137,6 @@ $animation-time: 0.5s;
         background: rgba($white, 0.9);
         box-shadow: 6px 6px 12px rgb(0 0 0 / 18%);
         position: relative;
-        z-index: $zindex-menu;
         .header-content {
             transition: height $animation-time;
         }

--- a/src/modules/menu/components/BlackBackdrop.vue
+++ b/src/modules/menu/components/BlackBackdrop.vue
@@ -1,17 +1,8 @@
 <template>
-    <div class="app-backdrop" :class="{ front }" data-cy="black-backdrop"></div>
+    <div class="app-backdrop" data-cy="black-backdrop"></div>
 </template>
 
-<script>
-export default {
-    props: {
-        front: {
-            type: Boolean,
-            default: false,
-        },
-    },
-}
-</script>
+<script></script>
 
 <style lang="scss" scoped>
 @import 'src/scss/variables';
@@ -23,9 +14,6 @@ export default {
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.5);
-    z-index: $zindex-backdrop-default;
-    &.front {
-        z-index: $zindex-backdrop-front;
-    }
+    z-index: -1000; //Display behind the current stacking context
 }
 </style>

--- a/src/modules/menu/components/header/HeaderWithSearch.vue
+++ b/src/modules/menu/components/header/HeaderWithSearch.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="header">
-        <HeaderLoadingBar v-if="showLoadingBar" />
+        <LoadingBar v-if="showLoadingBar" />
         <div class="header-content align-items-center p-1 d-flex justify-content-between">
             <div class="justify-content-start d-flex">
                 <SwissFlag
@@ -34,7 +34,7 @@
 <script>
 import { DEV_SITE_WARNING } from '@/config'
 
-import HeaderLoadingBar from '@/modules/menu/components/header/HeaderLoadingBar.vue'
+import LoadingBar from '@/utils/LoadingBar.vue'
 import HeaderMenuButton from '@/modules/menu/components/header/HeaderMenuButton.vue'
 import HeaderSwissConfederationText from '@/modules/menu/components/header/HeaderSwissConfederationText.vue'
 import SwissFlag from '@/modules/menu/components/header/SwissFlag.vue'
@@ -48,7 +48,7 @@ export default {
         HeaderMenuButton,
         HeaderSwissConfederationText,
         SwissFlag,
-        HeaderLoadingBar,
+        LoadingBar,
     },
     data() {
         return {
@@ -85,7 +85,7 @@ export default {
     background: rgba(255, 255, 255, 0.9);
     box-shadow: 6px 6px 12px rgb(0 0 0 / 18%);
     position: relative;
-    z-index: $zindex-menu;
+    z-index: $zindex-menu-header;
     .header-content {
         height: $header-height;
     }

--- a/src/modules/menu/components/menu/MenuSection.vue
+++ b/src/modules/menu/components/menu/MenuSection.vue
@@ -22,7 +22,12 @@
             <slot name="extra-button" />
         </div>
         <CollapseTransition :duration="200">
-            <div v-show="showBody" ref="sectionBody" class="menu-section-body">
+            <div
+                v-show="showBody"
+                ref="sectionBody"
+                class="menu-section-body"
+                data-cy="menu-section-body"
+            >
                 <slot />
             </div>
         </CollapseTransition>
@@ -103,6 +108,7 @@ export default {
 $section-border: 1px;
 
 .menu-section-header {
+    display: flex;
     flex: none;
     overflow: visible;
     padding: 0.5rem 1rem;

--- a/src/modules/menu/components/menu/MenuSection.vue
+++ b/src/modules/menu/components/menu/MenuSection.vue
@@ -32,12 +32,17 @@
 <script>
 // importing directly the vue component, see https://github.com/ivanvermeyen/vue-collapse-transition/issues/5
 import CollapseTransition from '@ivanv/vue-collapse-transition/src/CollapseTransition.vue'
-
 export default {
     components: {
         CollapseTransition,
     },
     props: {
+        // String that uniquely identifies this section
+        id: {
+            type: String,
+            required: true,
+        },
+        // Translated name of this section
         title: {
             type: String,
             required: true,
@@ -55,7 +60,8 @@ export default {
             default: false,
         },
     },
-    emits: ['showBody', 'click:header'],
+    expose: ['close'],
+    emits: ['openMenuSection', 'click:header'],
     data() {
         return {
             showBody: this.showContent,
@@ -79,10 +85,13 @@ export default {
             if (!this.alwaysKeepClosed) {
                 this.showBody = !this.showBody
             }
-            if (this.showBody) {
-                this.$emit('showBody')
-            }
             this.$emit('click:header')
+            if (this.showBody) {
+                this.$emit('openMenuSection', this.id)
+            }
+        },
+        close() {
+            this.showBody = false
         },
     },
 }

--- a/src/modules/menu/components/menu/MenuSection.vue
+++ b/src/modules/menu/components/menu/MenuSection.vue
@@ -11,7 +11,6 @@
             data-cy="menu-section-header"
             data-toggle="collapse"
             @click="toggleShowBody"
-
         >
             <span class="menu-section-title">
                 <button class="btn menu-section-title-icon" type="button">
@@ -69,9 +68,6 @@ export default {
             }
             return 'caret-right'
         },
-        computedBodyHeight() {
-            return this.$refs.sectionBody && this.$refs.sectionBody.clientHeight
-        },
     },
     watch: {
         showContent(showContent) {
@@ -95,13 +91,14 @@ export default {
 <style lang="scss" scoped>
 @import 'src/scss/webmapviewer-bootstrap-theme';
 
-.menu-section {
-    border: 0;
-}
+$section-border: 1px;
+
 .menu-section-header {
-    display: flex;
+    flex: none;
+    overflow: visible;
     padding: 0.5rem 1rem;
-    border-bottom: 1px solid $gray-400;
+    line-height: 1.5;
+    border-top: $section-border solid $gray-400;
     background-color: $light;
     cursor: pointer;
     .menu-section-secondary & {
@@ -110,6 +107,7 @@ export default {
         border-color: $gray-400;
     }
     .menu-section-open & {
+        border-bottom: $section-border solid $gray-400;
         background-color: $white;
     }
 }
@@ -133,7 +131,19 @@ export default {
     }
 }
 .menu-section-body {
-    padding: 0;
+    background-color: $white;
+    overflow: auto;
+    flex: initial;
+}
+
+.menu-section {
+    overflow: hidden;
+    display: flex; // so that the scrollable section can take the full space except for the header.
+    flex-direction: column;
+    border: 0;
+}
+
+.menu-section-open {
     background-color: $white;
 }
 </style>

--- a/src/modules/menu/components/menu/MenuTray.vue
+++ b/src/modules/menu/components/menu/MenuTray.vue
@@ -1,5 +1,5 @@
 <template>
-    <div data-cy="menu-tray" :class="{ 'menu-tray-compact': compact }">
+    <div data-cy="menu-tray" :class="[{ 'menu-tray-compact': compact }, 'menu-tray-inner']">
         <MenuSection
             :title="$t('settings')"
             :show-content="false"
@@ -66,6 +66,16 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.menu-tray-inner {
+    display: grid;
+    /* One entry for each menu section.
+    - "min-content" means the menu section is non-scrollable (intrinsic size i.e. based solely on content)
+    - "auto" means the menu section is scrollable (size based on content and the container) */
+    grid-template-rows: min-content min-content min-content auto auto;
+    overflow: hidden;
+}
+
+// UI is compact if in desktop mode
 .menu-tray-compact {
     font-size: 0.825rem;
 }

--- a/src/modules/menu/components/menu/MenuTray.vue
+++ b/src/modules/menu/components/menu/MenuTray.vue
@@ -1,5 +1,5 @@
 <template>
-    <div data-cy="menu-tray" :class="[{ 'menu-tray-compact': compact }, 'menu-tray-inner']">
+    <div data-cy="menu-tray-inner" :class="[{ 'menu-tray-compact': compact }, 'menu-tray-inner']">
         <MenuSection
             id="settingsSection"
             ref="settingsSection"

--- a/src/modules/menu/components/menu/MenuTray.vue
+++ b/src/modules/menu/components/menu/MenuTray.vue
@@ -1,27 +1,43 @@
 <template>
     <div data-cy="menu-tray" :class="[{ 'menu-tray-compact': compact }, 'menu-tray-inner']">
         <MenuSection
+            id="settingsSection"
+            ref="settingsSection"
             :title="$t('settings')"
             :show-content="false"
             secondary
             data-cy="menu-settings-section"
+            @open-menu-section="onOpenMenuSection"
         >
             <MenuSettings :current-ui-mode="currentUiMode" @change-ui-mode="setUiMode" />
         </MenuSection>
-        <MenuShareSection />
+        <MenuShareSection
+            id="shareSection"
+            ref="shareSection"
+            @open-menu-section="onOpenMenuSection"
+        />
         <!-- Drawing section is a glorified button, we always keep it closed and listen to click events -->
         <MenuSection
+            id="drawSection"
             :title="$t('draw_panel_title')"
             :always-keep-closed="true"
             secondary
             data-cy="menu-tray-drawing-section"
             @click="toggleDrawingOverlay"
         />
-        <MenuTopicSection :compact="compact" />
+        <MenuTopicSection
+            id="topicsSection"
+            ref="topicsSection"
+            :compact="compact"
+            @open-menu-section="onOpenMenuSection"
+        />
         <MenuSection
+            id="activeLayersSection"
+            ref="activeLayersSection"
             :title="$t('layers_displayed')"
             :show-content="showLayerList"
             data-cy="menu-active-layers"
+            @open-menu-section="onOpenMenuSection"
         >
             <MenuActiveLayersList :compact="compact" />
         </MenuSection>
@@ -50,6 +66,14 @@ export default {
             default: false,
         },
     },
+    data() {
+        return {
+            /* Please note that if the following 2 arrays are updated, "grid-template-rows" in
+            the css section must also be updated. */
+            scrollableMenuSections: ['topicsSection', 'activeLayersSection'],
+            nonScrollableMenuSections: ['settingsSection', 'shareSection'],
+        }
+    },
     computed: {
         ...mapState({
             activeLayers: (state) => state.layers.activeLayers,
@@ -61,6 +85,13 @@ export default {
     },
     methods: {
         ...mapActions(['toggleDrawingOverlay', 'setUiMode']),
+        onOpenMenuSection(id) {
+            let toClose = this.nonScrollableMenuSections.filter((section) => section !== id)
+            if (this.nonScrollableMenuSections.includes(id)) {
+                toClose = toClose.concat(this.scrollableMenuSections)
+            }
+            toClose.forEach((section) => this.$refs[section].close())
+        },
     },
 }
 </script>

--- a/src/modules/menu/components/search/SearchBar.vue
+++ b/src/modules/menu/components/search/SearchBar.vue
@@ -104,8 +104,4 @@ export default {
         padding-right: 2.5rem;
     }
 }
-#clear-search-button {
-    margin-left: -40px;
-    z-index: $zindex-map + 1;
-}
 </style>

--- a/src/modules/menu/components/share/MenuShareSection.vue
+++ b/src/modules/menu/components/share/MenuShareSection.vue
@@ -5,6 +5,7 @@
         data-cy="menu-share-section"
         secondary
         @click:header="toggleShareMenu"
+        @open-menu-section="(id) => $emit('openMenuSection', id)"
     >
         <FontAwesomeIcon v-if="!shortLink" icon="spinner" spin size="2x" class="p-2" />
         <div v-if="shortLink" class="p-2">
@@ -30,6 +31,8 @@ export default {
         MenuShareSocialNetworks,
         MenuSection,
     },
+    emits: ['openMenuSection'],
+    expose: ['close'],
     computed: {
         ...mapState({
             shortLink: (state) => state.share.shortLink,
@@ -37,18 +40,23 @@ export default {
         }),
     },
     methods: {
-        ...mapActions(['generateShortLink',' clearShortLink', 'toggleShareMenuSection']),
+        ...mapActions([
+            'generateShortLink',
+            'clearShortLink',
+            'toggleShareMenuSection',
+            'closeShareMenuAndRemoveShortlink',
+        ]),
         toggleShareMenu() {
             this.toggleShareMenuSection()
-            if (!this.shortLink){
+            if (!this.shortLink) {
                 this.generateShortLink()
-            }
-            else {
+            } else {
                 this.clearShortLink()
             }
-
         },
-
+        close() {
+            this.closeShareMenuAndRemoveShortlink()
+        },
     },
 }
 </script>

--- a/src/modules/menu/components/topics/MenuTopicSection.vue
+++ b/src/modules/menu/components/topics/MenuTopicSection.vue
@@ -119,7 +119,6 @@ export default {
 
 .menu-topic-list {
     @extend .menu-list;
-    max-height: 50vh;
     overflow-y: auto;
 }
 .menu-topic-switch {

--- a/src/modules/menu/components/topics/MenuTopicSection.vue
+++ b/src/modules/menu/components/topics/MenuTopicSection.vue
@@ -1,9 +1,11 @@
 <template>
     <MenuSection
         v-if="currentTopic"
+        ref="menuTopicSection"
         :title="$t(currentTopic.id)"
         :show-content="showTopicTree"
         data-cy="menu-topic-section"
+        @open-menu-section="(id) => $emit('openMenuSection', id)"
     >
         <template #extra-button>
             <button
@@ -62,6 +64,8 @@ export default {
             default: false,
         },
     },
+    emits: ['openMenuSection'],
+    expose: ['close'],
     data() {
         return {
             showLayerInfoFor: null,
@@ -109,6 +113,9 @@ export default {
         },
         onClickLayerInfo(layerId) {
             this.showLayerInfoFor = layerId
+        },
+        close() {
+            this.$refs.menuTopicSection.close()
         },
     },
 }

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -1,20 +1,27 @@
 
+/* Z Indices are not an absolute value. Different css attributes (most importantly the z-index
+attribute) can trigger the generation of a new stacking context. An element cannot break out of its
+stacking context, independently of the value of its z-index. Inatall an extension like
+"https://github.com/andreadev-it/stacking-contexts-inspector" to see the stacking contexts in the
+browser dev tools. */
+
+// Main stacking context
 $zindex-map: 1;
-$zindex-toolbox: $zindex-map + 1;
-$zindex-copyrights: $zindex-toolbox + 1;
-$zindex-swipable-element: $zindex-copyrights + 1;
-$zindex-footer: $zindex-swipable-element + 1;
-$zindex-backdrop-default: 200;
-// the menu is above the map backdrop (but the menu tray is one step behind the rest of the menu so that it can slip behind when closed)
-$zindex-menu-tray: $zindex-backdrop-default + 1;
-$zindex-menu: $zindex-menu-tray + 1;
-// in order to have the header slip behind the drawing toolbox when the hiding animation occurs
-$zindex-drawing-toolbox: $zindex-menu + 1;
-$zindex-backdrop-front: 300;
-// so that the modal is above the menu (and its backdrop)
-$zindex-modal: $zindex-backdrop-front + 1;
-$zindex-loading-screen: 400;
-$zindex-loading-bar: $zindex-loading-screen + 1;
+$zindex-footer: $zindex-map + 1; // The menu should be displayed above the footer in phone mode
+$zindex-menu: $zindex-footer + 1;
+$zindex-footer-infobox: $zindex-menu + 1; //Is part of the footer, but should be displayed above other menu items
+$zindex-swipable-element: $zindex-menu + 1; //Not used for the moment, please check the value before using it.
+
+// Modules teleported to the main stacking context (so that they can be on top of all other elements)
+$zindex-modal: 100;
+$zindex-loading-screen: 101;
+
+// Menu stacking context
+$zindex-menu-tray: 1; // one step behind the header so that it can slip behind when closed, but above the toolbox buttons
+$zindex-menu-header: 2;
+/* in order to have the header slip behind the drawing toolbox when the hiding animation
+occurs (teleported in the menu context)*/
+$zindex-drawing-toolbox: 3;
 
 $header-height: 3rem;
 $footer-height: 1.5rem;

--- a/src/utils/LoadingBar.vue
+++ b/src/utils/LoadingBar.vue
@@ -16,7 +16,7 @@ $loading-bar-animation-duration: 2s;
 
 .header-loading-bar {
     @import 'src/scss/variables';
-    z-index: $zindex-loading-bar;
+    z-index: 1000; //Always on top of current stacking context
     box-sizing: content-box;
     height: 2px;
     position: fixed;

--- a/src/utils/LoadingScreen.vue
+++ b/src/utils/LoadingScreen.vue
@@ -1,15 +1,19 @@
 <template>
-    <HeaderLoadingBar />
-    <div class="loading-glass">
-        <font-awesome-icon class="loading-glass-spinner" :icon="['fas', 'spinner']" spin />
-    </div>
+    <!-- To be sure it is always on the main stacking context so that it can be on top of everything
+    else -->
+    <teleport to="#main-component">
+        <LoadingBar />
+        <div class="loading-glass">
+            <font-awesome-icon class="loading-glass-spinner" :icon="['fas', 'spinner']" spin />
+        </div>
+    </teleport>
 </template>
 
 <script>
-import HeaderLoadingBar from '@/modules/menu/components/header/HeaderLoadingBar.vue'
+import LoadingBar from '@/utils/LoadingBar.vue'
 export default {
     components: {
-        HeaderLoadingBar,
+        LoadingBar,
     },
 }
 </script>

--- a/src/utils/ModalWithBackdrop.vue
+++ b/src/utils/ModalWithBackdrop.vue
@@ -1,8 +1,9 @@
 <template>
     <teleport to="#main-component">
-        <!-- Must teleport inside main-component in order for dynamic outlines to work. -->
-        <BlackBackdrop front @click="onClose(false)" />
+        <!-- Must teleport inside main-component in order for dynamic outlines to work and to be
+        sure that it is always on top of the reset. -->
         <div class="modal-popup" :class="{ 'modal-popup-fluid': fluid }">
+            <BlackBackdrop @click="onClose(false)" />
             <div class="card">
                 <div class="card-header d-flex align-middle">
                     <span v-if="title" class="flex-grow-1 text-start">{{ title }}</span>

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -38,7 +38,6 @@ export default {
 @import 'src/scss/variables.scss';
 #map-view {
     position: absolute;
-    z-index: $zindex-map;
     width: 100%;
     height: 100%;
 }

--- a/tests/e2e-cypress/integration/layers.cy.js
+++ b/tests/e2e-cypress/integration/layers.cy.js
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 
-import { BREAKPOINT_TABLET } from "@/config";
-import { randomIntBetween } from "@/utils/numberUtils";
+import { BREAKPOINT_TABLET } from '@/config'
+import { randomIntBetween } from '@/utils/numberUtils'
 
 /**
  * Returns a timestamp from the layer's config that is different from the default behaviour
@@ -256,13 +256,11 @@ describe('Test of layer handling', () => {
                 const timedLayerMetadata = layers[timedLayerId]
                 const defaultTimestamp = timedLayerMetadata.timeBehaviour
                 timedLayerMetadata.timestamps.forEach((timestamp) => {
-                    cy.get(`[data-cy="time-select-${timestamp}"]`)
-                        .should('be.visible')
-                        .then((timestampButton) => {
-                            if (timestamp === defaultTimestamp) {
-                                expect(timestampButton).to.have.class('btn-danger')
-                            }
-                        })
+                    cy.get(`[data-cy="time-select-${timestamp}"]`).then((timestampButton) => {
+                        if (timestamp === defaultTimestamp) {
+                            expect(timestampButton).to.have.class('btn-danger')
+                        }
+                    })
                 })
             })
         })
@@ -272,7 +270,8 @@ describe('Test of layer handling', () => {
             cy.fixture('layers.fixture.json').then((layersMetadata) => {
                 const timedLayerMetadata = layersMetadata[timedLayerId]
                 const randomTimestamp = getRandomTimestampFromSeries(timedLayerMetadata)
-                cy.get(`[data-cy="time-select-${randomTimestamp}"]`).click()
+                // "force" is needed, as else there is a false positive "button hidden"
+                cy.get(`[data-cy="time-select-${randomTimestamp}"]`).click({ force: true })
                 cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
                     expect(activeLayers).to.be.an('Array').length(visibleLayerIds.length)
                     activeLayers.forEach((layer) => {
@@ -402,6 +401,11 @@ describe('Test of layer handling', () => {
 
             cy.goToMapView(langBefore, {
                 layers: visibleLayerIds.map((layer) => `${layer},f,0.1`).join(';'),
+            })
+
+            // Wait until the active layers are ready.
+            cy.waitUntilState((state) => {
+                return state.layers.activeLayers.some((layer) => layer.lang === langBefore)
             })
 
             // CHECK before

--- a/tests/e2e-cypress/integration/menuTray.cy.js
+++ b/tests/e2e-cypress/integration/menuTray.cy.js
@@ -1,4 +1,3 @@
-import { getDefaultFixturesAndIntercepts } from 'tests/e2e-cypress/support/commands'
 import { BREAKPOINT_PHONE_WIDTH, BREAKPOINT_TABLET } from '@/config'
 import { UIModes } from '@/store/modules/ui.store'
 
@@ -52,58 +51,58 @@ function addFakeWMTSLayer(layers, id) {
 
 function getFixturesAndIntercepts(nbLayers, nbSelectedLayers) {
     const topicId = 'ech'
-    let fixAndInt = getDefaultFixturesAndIntercepts()
-    fixAndInt.addCatalogFixtureAndIntercept = () => {
-        let layersCatalogEntries = []
-        for (let i = 2; i < nbLayers + 2; i++) {
-            layersCatalogEntries = layersCatalogEntries.concat(getFakeWMTSLayerCatalogEntry(i))
-        }
-        const catalog = {
-            results: {
-                root: {
-                    category: 'root',
-                    staging: 'prod',
-                    id: 1,
-                    children: layersCatalogEntries,
-                },
-            },
-        }
-        // intercepting further topic metadata retrieval. Each topic has its own topic tree
-        cy.intercept(`**/rest/services/${topicId}/CatalogServer?lang=**`, {
-            body: catalog,
-        }).as(`topic-${topicId}`)
-    }
-    fixAndInt.addLayerFixtureAndIntercept = () => {
-        let layers = {}
-        for (let i = 2; i < nbLayers + 2; i++) {
-            addFakeWMTSLayer(layers, i)
-        }
-        cy.intercept('**/rest/services/all/MapServer/layersConfig**', {
-            body: layers,
-        }).as('layers')
-    }
-    fixAndInt.addTopicFixtureAndIntercept = () => {
-        let activatedLayers = []
-        for (let i = 2; i < nbSelectedLayers + 2; i++) {
-            activatedLayers.push('test.wmts.layer.' + i)
-        }
-        cy.intercept('**/rest/services', {
-            body: {
-                topics: [
-                    {
-                        activatedLayers,
-                        backgroundLayers: ['test.background.layer', 'test.background.layer2'],
-                        defaultBackground: 'test.background.layer2',
-                        groupId: 1,
-                        id: topicId,
-                        plConfig: null,
-                        selectedLayers: [],
+    return {
+        addCatalogFixtureAndIntercept: () => {
+            let layersCatalogEntries = []
+            for (let i = 2; i < nbLayers + 2; i++) {
+                layersCatalogEntries = layersCatalogEntries.concat(getFakeWMTSLayerCatalogEntry(i))
+            }
+            const catalog = {
+                results: {
+                    root: {
+                        category: 'root',
+                        staging: 'prod',
+                        id: 1,
+                        children: layersCatalogEntries,
                     },
-                ],
-            },
-        }).as('topics')
+                },
+            }
+            // intercepting further topic metadata retrieval. Each topic has its own topic tree
+            cy.intercept(`**/rest/services/${topicId}/CatalogServer?lang=**`, {
+                body: catalog,
+            }).as(`topic-${topicId}`)
+        },
+        addLayerFixtureAndIntercept: () => {
+            let layers = {}
+            for (let i = 2; i < nbLayers + 2; i++) {
+                addFakeWMTSLayer(layers, i)
+            }
+            cy.intercept('**/rest/services/all/MapServer/layersConfig**', {
+                body: layers,
+            }).as('layers')
+        },
+        addTopicFixtureAndIntercept: () => {
+            let activatedLayers = []
+            for (let i = 2; i < nbSelectedLayers + 2; i++) {
+                activatedLayers.push('test.wmts.layer.' + i)
+            }
+            cy.intercept('**/rest/services', {
+                body: {
+                    topics: [
+                        {
+                            activatedLayers,
+                            backgroundLayers: ['test.background.layer', 'test.background.layer2'],
+                            defaultBackground: 'test.background.layer2',
+                            groupId: 1,
+                            id: topicId,
+                            plConfig: null,
+                            selectedLayers: [],
+                        },
+                    ],
+                },
+            }).as('topics')
+        },
     }
-    return fixAndInt
 }
 
 /**

--- a/tests/e2e-cypress/integration/menuTray.cy.js
+++ b/tests/e2e-cypress/integration/menuTray.cy.js
@@ -1,0 +1,267 @@
+import { getDefaultFixturesAndIntercepts } from 'tests/e2e-cypress/support/commands'
+import { BREAKPOINT_PHONE_WIDTH, BREAKPOINT_TABLET } from '@/config'
+import { UIModes } from '@/store/modules/ui.store'
+
+const width = Cypress.config('viewportWidth')
+const height = Cypress.config('viewportHeight')
+const isTabletViewport = width > BREAKPOINT_PHONE_WIDTH && width <= BREAKPOINT_TABLET
+
+const menuTraySelector = '[data-cy="menu-tray"]'
+const menuTopicSectionSelector = '[data-cy="menu-topic-section"]'
+const menuTopicHeaderSelector = menuTopicSectionSelector + ' > [data-cy="menu-section-header"]'
+const menuActiveLayersSectionSelector = '[data-cy="menu-active-layers"]'
+const menuActiveLayersHeaderSelector =
+    menuActiveLayersSectionSelector + ' > [data-cy="menu-section-header"]'
+const menuSettingsHeaderSelector =
+    '[data-cy="menu-settings-section"] > [data-cy="menu-section-header"]'
+const menuShareHeaderSelector = '[data-cy="menu-share-section"] > [data-cy="menu-section-header"]'
+
+function getFakeWMTSLayerCatalogEntry(id) {
+    return {
+        category: 'layer',
+        id: id,
+        label: `Fake WMTS layer ${id}`,
+        layerBodId: 'test.wmts.layer.' + id,
+        staging: 'prod',
+    }
+}
+
+function addFakeWMTSLayer(layers, id) {
+    const layerName = 'test.wmts.layer.' + id
+    layers[layerName] = {
+        opacity: 1.0,
+        attribution: 'attribution.test.wmts.layer',
+        background: false,
+        searchable: true,
+        format: 'png',
+        queryableAttributes: ['id', 'name'],
+        topics: 'ech,test-topic-standard,test-topic-with-active-and-visible-layers',
+        attributionUrl: 'https://api3.geo.admin.ch/',
+        tooltip: true,
+        timeEnabled: false,
+        highlightable: true,
+        chargeable: false,
+        timestamps: ['current'],
+        hasLegend: true,
+        label: 'WMTS test layer ' + id,
+        type: 'wmts',
+        serverLayerName: 'test.wmts.layer.' + id,
+    }
+    return layers
+}
+
+function getFixturesAndIntercepts(nbLayers, nbSelectedLayers) {
+    const topicId = 'ech'
+    let fixAndInt = getDefaultFixturesAndIntercepts()
+    fixAndInt.addCatalogFixtureAndIntercept = () => {
+        let layersCatalogEntries = []
+        for (let i = 2; i < nbLayers + 2; i++) {
+            layersCatalogEntries = layersCatalogEntries.concat(getFakeWMTSLayerCatalogEntry(i))
+        }
+        const catalog = {
+            results: {
+                root: {
+                    category: 'root',
+                    staging: 'prod',
+                    id: 1,
+                    children: layersCatalogEntries,
+                },
+            },
+        }
+        // intercepting further topic metadata retrieval. Each topic has its own topic tree
+        cy.intercept(`**/rest/services/${topicId}/CatalogServer?lang=**`, {
+            body: catalog,
+        }).as(`topic-${topicId}`)
+    }
+    fixAndInt.addLayerFixtureAndIntercept = () => {
+        let layers = {}
+        for (let i = 2; i < nbLayers + 2; i++) {
+            addFakeWMTSLayer(layers, i)
+        }
+        cy.intercept('**/rest/services/all/MapServer/layersConfig**', {
+            body: layers,
+        }).as('layers')
+    }
+    fixAndInt.addTopicFixtureAndIntercept = () => {
+        let activatedLayers = []
+        for (let i = 2; i < nbSelectedLayers + 2; i++) {
+            activatedLayers.push('test.wmts.layer.' + i)
+        }
+        cy.intercept('**/rest/services', {
+            body: {
+                topics: [
+                    {
+                        activatedLayers,
+                        backgroundLayers: ['test.background.layer', 'test.background.layer2'],
+                        defaultBackground: 'test.background.layer2',
+                        groupId: 1,
+                        id: topicId,
+                        plConfig: null,
+                        selectedLayers: [],
+                    },
+                ],
+            },
+        }).as('topics')
+    }
+    return fixAndInt
+}
+
+/**
+ * Check that the menu is less or equal than its maximal allowed size
+ *
+ * @param {any} shouldHaveMaxSize Wheather or not the menu should have attained its maximal size
+ */
+function measureMenu(shouldHaveMaxSize) {
+    cy.get(menuTraySelector)
+        .then((elems) => elems[0].getBoundingClientRect().bottom)
+        .as('menuTrayBottom')
+
+    cy.get('@expectedMenuTrayBottom').then((expectedMenuTrayBottom) => {
+        if (shouldHaveMaxSize) {
+            cy.get('@menuTrayBottom').should('be.equal', expectedMenuTrayBottom)
+        } else {
+            cy.get('@menuTrayBottom').should('be.lt', expectedMenuTrayBottom)
+        }
+    })
+}
+
+/**
+ * Initializes the app with the specified amount of menu items, then initialize the test
+ *
+ * @param {any} nbLayers Number of menu items in the topics list
+ * @param {any} nbSelectedLayers Number of menu items in the active layers list
+ */
+function init(nbLayers, nbSelectedLayers) {
+    cy.goToMapView({ fixturesAndIntercepts: getFixturesAndIntercepts(nbLayers, nbSelectedLayers) })
+    cy.readStoreValue('state.ui.mode')
+        .as('uiMode')
+        .then((uiMode) => {
+            if (uiMode === UIModes.MENU_OPENED_THROUGH_BUTTON) {
+                cy.get('[data-cy="menu-button"]').click()
+                cy.wrap(height).as('expectedMenuTrayBottom')
+            } else if (isTabletViewport) {
+                cy.get('[data-cy="menu-button"]').click()
+                cy.wrap(height - 70).as('expectedMenuTrayBottom')
+            } else {
+                cy.wrap(height - 70).as('expectedMenuTrayBottom')
+            }
+            cy.get(menuTopicHeaderSelector).click()
+            /*Wait for all animations to finish (animations last 0.2s) */
+            cy.wait(200)
+        })
+}
+
+/**
+ * Check that only the specified sections are open.
+ *
+ * @param {[String]} openSections An array listening all open sections
+ */
+function checkOpenSections(openSections) {
+    const sections = [
+        { name: 'topics', selector: '[data-cy="menu-topic-tree"]' },
+        { name: 'activeLayers', selector: '[data-cy="menu-section-active-layers"]' },
+        { name: 'settings', selector: '[data-cy="menu-settings-content"]' },
+        {
+            name: 'share',
+            selector: '[data-cy="menu-share-section"] > [data-cy="menu-section-body"]',
+        },
+    ]
+    sections
+        .filter((section) => openSections.includes(section.name))
+        .forEach((section) => {
+            cy.get(section.selector).should('be.visible')
+        })
+    sections
+        .filter((section) => !openSections.includes(section.name))
+        .forEach((section) => cy.get(section.selector).should('be.hidden'))
+}
+
+/**
+ * Check whether or not scrollbars are visible
+ *
+ * @param {any} topicsScrollable Should the scrollbar of the topcis section be visible?
+ * @param {any} activeLayersScrollable Should the scrollbar of the active layers section be visible?
+ */
+function checkScrollbarVisibility(topicsScrollable, activeLayersScrollable) {
+    let topicSectionOriginalHeight
+    cy.get('[data-cy="menu-topic-tree"]')
+        .then((elems) => {
+            topicSectionOriginalHeight = elems[0].clientHeight
+            return elems
+        })
+        .parents('[data-cy="menu-section-body"]')
+        .should((elems) => {
+            const clientHeight = elems[0].clientHeight
+            if (topicsScrollable) {
+                expect(clientHeight).to.be.lt(topicSectionOriginalHeight)
+            } else {
+                expect(clientHeight).to.be.eq(topicSectionOriginalHeight)
+            }
+        })
+    let activeSectionOriginalHeight
+    cy.get('[data-cy="menu-section-active-layers"]')
+        .then((elems) => {
+            activeSectionOriginalHeight = elems[0].clientHeight
+            return elems
+        })
+        .parents('[data-cy="menu-section-body"]')
+        .should((elems) => {
+            const clientHeight = elems[0].clientHeight
+            if (activeLayersScrollable) {
+                expect(clientHeight).to.be.lt(activeSectionOriginalHeight)
+            } else {
+                expect(clientHeight).to.be.eq(activeSectionOriginalHeight)
+            }
+        })
+}
+
+describe('Test menu tray ui', () => {
+    it('check correct sizing of menu and autoclosing of menu sections', function () {
+        init(30, 30)
+        checkOpenSections(['topics', 'activeLayers'])
+        measureMenu(true)
+        checkScrollbarVisibility(true, true)
+
+        cy.get(menuActiveLayersHeaderSelector).click()
+        cy.wait(200)
+        checkOpenSections(['topics'])
+        measureMenu(true)
+
+        cy.get(menuTopicHeaderSelector).click()
+        cy.wait(200)
+        checkOpenSections([])
+        measureMenu(false)
+
+        cy.get(menuActiveLayersHeaderSelector).click()
+        cy.wait(200)
+        checkOpenSections(['activeLayers'])
+        measureMenu(true)
+
+        cy.get(menuSettingsHeaderSelector).click()
+        cy.wait(200)
+        checkOpenSections(['settings'])
+        measureMenu(false)
+
+        cy.get(menuShareHeaderSelector).click()
+        cy.wait(200)
+        checkOpenSections(['share'])
+        measureMenu(false)
+
+        cy.get(menuTopicHeaderSelector).click()
+        cy.wait(200)
+        checkOpenSections(['topics'])
+        measureMenu(true)
+    })
+    it('Each open menu section has a minimal height, even if there is a high discrepancy between their original heights', () => {
+        init(30, 2)
+        checkOpenSections(['topics', 'activeLayers'])
+        measureMenu(true)
+        checkScrollbarVisibility(true, false)
+    })
+    it('no scrolling if menus are small enough', () => {
+        init(3, 2)
+        checkOpenSections(['topics', 'activeLayers'])
+        measureMenu(false)
+        checkScrollbarVisibility(false, false)
+    })
+})

--- a/tests/e2e-cypress/support/commands.js
+++ b/tests/e2e-cypress/support/commands.js
@@ -103,7 +103,8 @@ export function getDefaultFixturesAndIntercepts() {
  * @param {Object} otherParams URL parameters except the language
  * @param {Boolean} withHash Wheather or not to use the new URL format (that has a hash)
  * @param {Object} geolocationMockupOptions Latitude and Longitude of facked geolocation
- * @param {Object} fixturesAndIntercepts Contains functions that add interceptions to the backend
+ * @param {Object} fixturesAndIntercepts Contains functions that overwrite the default interceptions
+ *   to the backend.
  */
 Cypress.Commands.add(
     'goToMapView',
@@ -112,7 +113,7 @@ Cypress.Commands.add(
         otherParams = {},
         withHash = false,
         geolocationMockupOptions = { latitude: 47, longitude: 7 },
-        fixturesAndIntercepts = getDefaultFixturesAndIntercepts()
+        fixturesAndIntercepts = {}
     ) => {
         // If parameters have been passed inside a wrapper object, unwrap the object
         if (typeof lang === 'object' && !(lang instanceof String)) {
@@ -125,13 +126,17 @@ Cypress.Commands.add(
                 params.fixturesAndIntercepts
             )
         }
-        fixturesAndIntercepts.addLayerTileFixture()
-        fixturesAndIntercepts.addFileAPIFixtureAndIntercept()
-        fixturesAndIntercepts.addLayerFixtureAndIntercept()
-        fixturesAndIntercepts.addTopicFixtureAndIntercept()
-        fixturesAndIntercepts.addCatalogFixtureAndIntercept()
-        fixturesAndIntercepts.addWhat3WordFixtureAndIntercept()
-        fixturesAndIntercepts.addHeightFixtureAndIntercept()
+        // Intercepts passed as parameters to "fixturesAndIntercepts" will overwrite the correspondent
+        // default intercept.
+        const defIntercepts = getDefaultFixturesAndIntercepts()
+        const intercepts = fixturesAndIntercepts
+        for (const intercept in defIntercepts) {
+            if (intercept in intercepts) {
+                intercepts[intercept]()
+            } else {
+                defIntercepts[intercept]()
+            }
+        }
         let flattenedOtherParams = ''
         Object.keys(otherParams).forEach((key) => {
             flattenedOtherParams += `&${key}=${otherParams[key]}`

--- a/tests/e2e-cypress/support/commands.js
+++ b/tests/e2e-cypress/support/commands.js
@@ -83,22 +83,55 @@ const addWhat3WordFixtureAndIntercept = () => {
     }).as('coordinates-for-w3w')
 }
 
-// Adds a command that visit the main view and wait for the map to be shown (for the app to be ready)
+export function getDefaultFixturesAndIntercepts() {
+    return {
+        addLayerTileFixture,
+        addFileAPIFixtureAndIntercept,
+        addLayerFixtureAndIntercept,
+        addTopicFixtureAndIntercept,
+        addCatalogFixtureAndIntercept,
+        addHeightFixtureAndIntercept,
+        addWhat3WordFixtureAndIntercept,
+    }
+}
+
+/**
+ * Command that visits the main view and waits for the map to be shown (for the app to be ready) All
+ * parameters are optional. They can either be passed in order or inside a wrapper object.
+ *
+ * @param {String} lang Language of the app
+ * @param {Object} otherParams URL parameters except the language
+ * @param {Boolean} withHash Wheather or not to use the new URL format (that has a hash)
+ * @param {Object} geolocationMockupOptions Latitude and Longitude of facked geolocation
+ * @param {Object} fixturesAndIntercepts Contains functions that add interceptions to the backend
+ */
 Cypress.Commands.add(
     'goToMapView',
     (
         lang = 'en',
         otherParams = {},
         withHash = false,
-        geolocationMockupOptions = { latitude: 47, longitude: 7 }
+        geolocationMockupOptions = { latitude: 47, longitude: 7 },
+        fixturesAndIntercepts = getDefaultFixturesAndIntercepts()
     ) => {
-        addLayerTileFixture()
-        addFileAPIFixtureAndIntercept()
-        addLayerFixtureAndIntercept()
-        addTopicFixtureAndIntercept()
-        addCatalogFixtureAndIntercept()
-        addWhat3WordFixtureAndIntercept()
-        addHeightFixtureAndIntercept()
+        // If parameters have been passed inside a wrapper object, unwrap the object
+        if (typeof lang === 'object' && !(lang instanceof String)) {
+            const params = lang
+            return cy.goToMapView(
+                params.lang,
+                params.otherParams,
+                params.withHash,
+                params.geolocationMockupOptions,
+                params.fixturesAndIntercepts
+            )
+        }
+        fixturesAndIntercepts.addLayerTileFixture()
+        fixturesAndIntercepts.addFileAPIFixtureAndIntercept()
+        fixturesAndIntercepts.addLayerFixtureAndIntercept()
+        fixturesAndIntercepts.addTopicFixtureAndIntercept()
+        fixturesAndIntercepts.addCatalogFixtureAndIntercept()
+        fixturesAndIntercepts.addWhat3WordFixtureAndIntercept()
+        fixturesAndIntercepts.addHeightFixtureAndIntercept()
         let flattenedOtherParams = ''
         Object.keys(otherParams).forEach((key) => {
             flattenedOtherParams += `&${key}=${otherParams[key]}`


### PR DESCRIPTION
- Menu size is now limited by the size of the viewport and the different opened subsections receive automatically one part of the total height. This is done with a combination of css flexbox and css grid.
- Opening the settings or share sections (i.e. nonscrollable menu sections) automatically closes all other sections and if a non-scrollable menu section is open, no other menu sections can be open at the same time. Useful in particular for small screens where the menu may be cut otherwise.
- This PR also fixed some issues with the z-indexes.
- It did not fix an issue when shrinking the window from desktop to tablet size, which was instead moved to ticket [BGDIINF_SB-2521](https://jira.swisstopo.ch/browse/BGDIINF_SB-2521).

[Test link](https://sys-map.dev.bgdi.ch/feat-2271-limit-menu-height/index.html)