### PR TITLE
Feat 2406 preview position on map when moving mouse on profile graph

### DIFF
--- a/src/modules/drawing/lib/ProfileChart.js
+++ b/src/modules/drawing/lib/ProfileChart.js
@@ -36,6 +36,37 @@ export default class ProfileChart {
         return this.lineString.getCoordinateAt(ratio)
     }
 
+    /**
+     * Given a distance from origin, calculate the height.
+     *
+     * @param {Number} dist Distance (must be in the unit specified by this.unitX, i.e. depending on
+     *   the length of the path, either km or m)
+     * @returns The height in meter at the given distance
+     */
+    getHeightAtDist(dist) {
+        const maxDist = this.data[this.data.length - 1].domainDist || 0
+        dist = Math.min(Math.max(dist, 0), maxDist)
+        let lowerIndex = Math.trunc(((this.data.length - 1) * dist) / maxDist)
+        lowerIndex = Math.min(lowerIndex, this.data.length - 1)
+        while (dist < this.data[lowerIndex].domainDist) {
+            lowerIndex--
+        }
+        while (lowerIndex < this.data.length - 1 && dist > this.data[lowerIndex + 1].domainDist) {
+            lowerIndex++
+        }
+        const lowerAlti = this.data[lowerIndex].alts[this.elevationModel] || 0
+        const lowerDist = this.data[lowerIndex].domainDist
+        if (lowerIndex >= this.data.length - 1) {
+            return lowerAlti
+        }
+        let higherIndex = lowerIndex + 1
+        const higherAlti = this.data[higherIndex].alts[this.elevationModel] || 0
+        const higherDist = this.data[higherIndex].domainDist
+        const higherRatio = (dist - lowerDist) / (higherDist - lowerDist)
+        const lowerRatio = 1 - higherRatio
+        return lowerRatio * lowerAlti + higherRatio * higherAlti
+    }
+
     formatData(data) {
         if (data.length) {
             const coords = []

--- a/src/modules/drawing/lib/ProfileChart.js
+++ b/src/modules/drawing/lib/ProfileChart.js
@@ -44,22 +44,29 @@ export default class ProfileChart {
      * @returns The height in meter at the given distance
      */
     getHeightAtDist(dist) {
+        // Find lowerindex, such that dist[lowerindex] <= dist <= dist[lowerindex+1] = dist[higherIndex]
+        /* The distance increase between each index is approximately regular, so we can make a
+           first guess with a complexity of O(1) */
         const maxDist = this.data[this.data.length - 1].domainDist || 0
         dist = Math.min(Math.max(dist, 0), maxDist)
         let lowerIndex = Math.trunc(((this.data.length - 1) * dist) / maxDist)
         lowerIndex = Math.min(lowerIndex, this.data.length - 1)
+        /* As it is not perfectly regular (maybe as a result of trunking the decimals in the
+           backend?) we still need to correct our first guess with these two while loops. */
         while (dist < this.data[lowerIndex].domainDist) {
             lowerIndex--
         }
         while (lowerIndex < this.data.length - 1 && dist > this.data[lowerIndex + 1].domainDist) {
             lowerIndex++
         }
+        /* Now we can linearly interpolate between lowerindex and higherindex to find the exact
+           altitude. */
         const lowerAlti = this.data[lowerIndex].alts[this.elevationModel] || 0
         const lowerDist = this.data[lowerIndex].domainDist
         if (lowerIndex >= this.data.length - 1) {
             return lowerAlti
         }
-        let higherIndex = lowerIndex + 1
+        const higherIndex = lowerIndex + 1
         const higherAlti = this.data[higherIndex].alts[this.elevationModel] || 0
         const higherDist = this.data[higherIndex].domainDist
         const higherRatio = (dist - lowerDist) / (higherDist - lowerDist)

--- a/src/modules/drawing/lib/__tests__/profileChart.spec.js
+++ b/src/modules/drawing/lib/__tests__/profileChart.spec.js
@@ -1,0 +1,49 @@
+import { describe, it } from 'vitest'
+import { expect } from 'chai'
+import ProfileChart from '@/modules/drawing/lib/ProfileChart'
+
+function generateProfileChart(data) {
+    const options = {
+        margin: { left: 0, right: 0, bottom: 0, top: 0 },
+        width: 0,
+        height: 0,
+    }
+    const chart = new ProfileChart(options)
+    chart.data = chart.formatData(data)
+    return chart
+}
+
+describe('Validate ProfileChart class', () => {
+    describe('Validate getHeightAtDist()', () => {
+        it('test with test data that has regular increase of width', () => {
+            const testData = [
+                { alts: { COMB: 10 }, dist: 0 },
+                { alts: { COMB: 20 }, dist: 100 },
+                { alts: { COMB: 30 }, dist: 200 },
+            ]
+            const chart = generateProfileChart(testData)
+            expect(chart.getHeightAtDist(-10)).to.be.closeTo(10, 1e-9)
+            expect(chart.getHeightAtDist(0)).to.be.closeTo(10, 1e-9)
+            expect(chart.getHeightAtDist(150)).to.be.closeTo(25, 1e-9)
+            expect(chart.getHeightAtDist(200)).to.be.closeTo(30, 1e-9)
+            expect(chart.getHeightAtDist(300)).to.be.closeTo(30, 1e-9)
+
+            // Check that results are also correct if they are floating point numbers
+            expect(chart.getHeightAtDist(1)).to.be.closeTo(10.1, 1e-9)
+            expect(chart.getHeightAtDist(1.1)).to.be.closeTo(10.11, 1e-9)
+        })
+        it('test with test data that has irregular increase of width', () => {
+            const testData = [
+                { alts: { COMB: 10 }, dist: 0 },
+                { alts: { COMB: 20 }, dist: 10 },
+                { alts: { COMB: 30 }, dist: 200 },
+            ]
+            const chart = generateProfileChart(testData)
+            expect(chart.getHeightAtDist(0)).to.be.closeTo(10, 1e-9)
+            expect(chart.getHeightAtDist(5)).to.be.closeTo(15, 1e-9)
+            expect(chart.getHeightAtDist(10)).to.be.closeTo(20, 1e-9)
+            expect(chart.getHeightAtDist(105)).to.be.closeTo(25, 1e-9)
+            expect(chart.getHeightAtDist(200)).to.be.closeTo(30, 1e-9)
+        })
+    })
+})

--- a/src/modules/infobox/components/FeatureProfile.vue
+++ b/src/modules/infobox/components/FeatureProfile.vue
@@ -283,20 +283,11 @@ export default {
         },
         attachPathListeners(areaChartPath, glass) {
             glass.on('mousemove', (evt) => {
-                const [x] = d3.pointer(evt)
-                let pos = areaChartPath.node().getPointAtLength(x)
-                const start = x
-                const end = pos.x
-                const accuracy = 5
-                for (let i = start; i > end; i += accuracy) {
-                    pos = areaChartPath.node().getPointAtLength(i)
-                    if (pos.x >= x) {
-                        break
-                    }
-                }
                 // Get the coordinate value of x and y
+                const [x] = d3.pointer(evt)
                 const xCoord = this.profileChart.domain.X.invert(x)
-                const yCoord = this.profileChart.domain.Y.invert(pos.y)
+                const yCoord = this.profileChart.getHeightAtDist(xCoord)
+                const y = this.profileChart.domain.Y(yCoord)
                 const toltipEl = this.$refs.profileTooltip
                 const tooltipArrow = this.$refs.profileTooltipArrow
                 // Calculate center of tooltip (relative to graph)
@@ -319,12 +310,12 @@ export default {
                     'px'
                 // Y position of arrowhead
                 toltipEl.style.top =
-                    pos.y +
+                    y +
                     this.options.margin.top +
                     this.$refs.profilePopupContent.getBoundingClientRect().y -
                     this.$refs.profileTooltipAnchor.getBoundingClientRect().y +
                     'px'
-
+                // Tooltip text
                 toltipEl.querySelector('.distance').innerText = `${xCoord.toFixed(2)} ${
                     this.profileInfo.unitX
                 }`

--- a/src/modules/infobox/components/FeatureProfile.vue
+++ b/src/modules/infobox/components/FeatureProfile.vue
@@ -331,6 +331,8 @@ export default {
             })
             glass.on('mouseover', () => {
                 this.showTooltip = true
+                /* Must be reset everytime we show the overlay, as the user may have changed the
+                color in between. */
                 this.currentHoverPosOverlay.getElement().style.backgroundColor =
                     this.feature.fillColor.fill
                 this.getMap().addOverlay(this.currentHoverPosOverlay)

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -5,9 +5,10 @@
             <DrawingModule />
             <!-- The footer also need to receive the map (for mouse position) -->
             <MapFooter />
+            <!-- Needed to be able to set an overlay when hovering over the profile with the mouse -->
+            <InfoboxModule />
         </MapModule>
         <MenuModule />
-        <InfoboxModule />
         <I18nModule />
     </div>
 </template>


### PR DESCRIPTION
An overlay (circle) that shows the corresponding position on the map when hovering over the profile graph was added.
In addition, an infinite looop bug was fixed that sometimes happend when moving the mouse over the profile graph. I also used this opportunity to make the calculations of the height more precise.

[Test link](https://sys-map.dev.bgdi.ch/feat-2406-preview-position-on-map-when-moving-mouse-on-profile-graph/index.html)