### PR TITLE
Feat 2434 show compass on map rotate second PR

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
     <head>
         <meta charset="UTF-8" />
         <link rel="icon" href="/favicon.ico" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <!-- Disallow zooming on touch, as the zoom gesture is already reserved for zooming the map -->
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
         <title>Vite App</title>
     </head>
     <body>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,4 +1,6 @@
 <template>
+    <!-- Disallow zooming on touch, as the zoom gesture is already reserved for zooming the map -->
+    <meta name="viewport" content="width=device-width, user-scalable=no" />
     <div
         id="main-component"
         :class="{ outlines: showOutlines }"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,4 @@
 <template>
-    <!-- Disallow zooming on touch, as the zoom gesture is already reserved for zooming the map -->
-    <meta name="viewport" content="width=device-width, user-scalable=no" />
     <div
         id="main-component"
         :class="{ outlines: showOutlines }"

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -86,6 +86,10 @@ import log from '@/utils/logging'
 import { round } from '@/utils/numberUtils'
 import { Map, View } from 'ol'
 import DoubleClickZoomInteraction from 'ol/interaction/DoubleClickZoom'
+import DragRotateInteraction from 'ol/interaction/DragRotate'
+import { defaults as getDefaultInteractions } from 'ol/interaction'
+import { platformModifierKeyOnly } from 'ol/events/condition'
+
 import 'ol/ol.css'
 import { register } from 'ol/proj/proj4'
 import proj4 from 'proj4'
@@ -252,7 +256,17 @@ export default {
     beforeCreate() {
         // we build the OL instance right away as it is required for "provide" below (otherwise
         // children components will receive a null instance and won't ask for another one later on)
-        this.map = new Map({ controls: [] })
+
+        /* Make it possible to rotate the map with ctrl+drag (in addition to openlayers default
+        Alt+Shift+Drag). This is probably more intuitive. Also, Windows and some Linux distros use
+        alt+shift to switch the keyboard layout, so using alt+shift may have unintended side effects
+        or not work at all. */
+        const interactions = getDefaultInteractions().extend([
+            new DragRotateInteraction({
+                condition: platformModifierKeyOnly,
+            }),
+        ])
+        this.map = new Map({ controls: [], interactions })
 
         if (IS_TESTING_WITH_CYPRESS) {
             window.map = this.map

--- a/src/modules/menu/MenuModule.vue
+++ b/src/modules/menu/MenuModule.vue
@@ -9,14 +9,7 @@
                 @click="toggleMenuTray"
             />
         </transition>
-        <HeaderWithSearch
-            v-show="showHeader"
-            class="header"
-            :show-loading-bar="showLoadingBar"
-            :show-menu-button="!shouldMenuTrayAlwaysBeVisible"
-            :current-lang="currentLang"
-            :current-topic-id="currentTopic && currentTopic.id"
-        />
+        <HeaderWithSearch v-show="showHeader" class="header" />
         <div class="toolbox-right">
             <GeolocButton
                 class="mb-1"

--- a/src/modules/menu/components/header/HeaderWithSearch.vue
+++ b/src/modules/menu/components/header/HeaderWithSearch.vue
@@ -39,6 +39,8 @@ import HeaderMenuButton from '@/modules/menu/components/header/HeaderMenuButton.
 import HeaderSwissConfederationText from '@/modules/menu/components/header/HeaderSwissConfederationText.vue'
 import SwissFlag from '@/modules/menu/components/header/SwissFlag.vue'
 import SearchBar from '@/modules/menu/components/search/SearchBar.vue'
+import { mapGetters, mapState } from 'vuex'
+import { UIModes } from '@/store/modules/ui.store'
 
 export default {
     components: {
@@ -48,28 +50,22 @@ export default {
         SwissFlag,
         HeaderLoadingBar,
     },
-    props: {
-        showLoadingBar: {
-            type: Boolean,
-            default: false,
-        },
-        showMenuButton: {
-            type: Boolean,
-            default: false,
-        },
-        currentLang: {
-            type: String,
-            required: true,
-        },
-        currentTopicId: {
-            type: String,
-            default: 'ech',
-        },
-    },
     data() {
         return {
             devSiteWarning: DEV_SITE_WARNING,
         }
+    },
+    computed: {
+        ...mapState({
+            showLoadingBar: (state) => state.ui.showLoadingBar,
+            currentLang: (state) => state.i18n.lang,
+            currentTopic: (state) => state.topics.current,
+            currentUiMode: (state) => state.ui.mode,
+        }),
+        ...mapGetters(['currentTopicId']),
+        showMenuButton() {
+            return this.currentUiMode !== UIModes.MENU_ALWAYS_OPEN
+        },
     },
     methods: {
         resetApp() {

--- a/src/modules/menu/components/toolboxRight/CompassButton.vue
+++ b/src/modules/menu/components/toolboxRight/CompassButton.vue
@@ -2,7 +2,7 @@
     <!-- The rotation constraint of the openlayers view by default snaps to zero. This means that
     even if the angle is not normalized, it will automatically be set to zero if pointing to the
     north -->
-    <div v-if="Math.abs(rotation_) >= 1e-9" class="zoom d-print-none">
+    <div v-if="Math.abs(rotation) >= 1e-9" class="zoom d-print-none">
         <button
             class="compass-button"
             data-cy="compass-button"
@@ -16,7 +16,7 @@
                 class="compass-button-icon"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="-100 -240 200 480"
-                :style="{ transform: `rotate(${rotation_}rad)` }"
+                :style="{ transform: `rotate(${rotation}rad)` }"
             >
                 <polygon style="fill: #cd2a00" points="-100,0 100,0 0,240" />
                 <polygon style="fill: #ff3501" points="-100,0 100,0 0,-240" />
@@ -33,7 +33,7 @@ export default {
 
     data() {
         return {
-            rotation_: 0,
+            rotation: 0,
         }
     },
     mounted() {
@@ -48,9 +48,9 @@ export default {
             this.setRotation(0)
         },
         onRotate(mapEvent) {
-            const rotation = mapEvent.frameState.viewState.rotation
-            if (rotation !== this.rotation_) {
-                this.rotation_ = rotation
+            const newRotation = mapEvent.frameState.viewState.rotation
+            if (newRotation !== this.rotation) {
+                this.rotation = newRotation
             }
         },
     },

--- a/src/views/LoadingView.vue
+++ b/src/views/LoadingView.vue
@@ -1,13 +1,13 @@
 <template>
     <div id="splashscreen">
-        <MenuModule />
+        <HeaderWithSearch />
     </div>
 </template>
 
 <script>
-import MenuModule from '@/modules/menu/MenuModule.vue'
+import HeaderWithSearch from '@/modules/menu/components/header/HeaderWithSearch.vue'
 export default {
-    components: { MenuModule },
+    components: { HeaderWithSearch },
 }
 </script>
 

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -7,8 +7,9 @@
             <MapFooter />
             <!-- Needed to be able to set an overlay when hovering over the profile with the mouse -->
             <InfoboxModule />
+            <!-- needed to e.g. set register an event to set the compass position -->
+            <MenuModule />
         </MapModule>
-        <MenuModule />
         <I18nModule />
     </div>
 </template>


### PR DESCRIPTION
This is the second PR for the feat 2434 ticket.

- The map can now also be rotated by clicking on Ctrl (but the default alt+shift still works)
- The compass is now updated in real time when rotating the map. To be able to do this, the menu had to be put inside the openlayers map, so that it can register openlayers events, as using the store for real time updates of the map rotation would be way too slow.

[Test link](https://sys-map.dev.bgdi.ch/feat-2434-show-compass-on-map-rotate/index.html)