### PR TITLE
Changes API base URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # local and development env
-VITE_API_BASE_URL=https://mf-chsdi3.dev.bgdi.ch/
+VITE_API_BASE_URL=https://sys-api3.dev.bgdi.ch/
 VITE_API_SERVICE_ALTI_BASE_URL=https://sys-api3.dev.bgdi.ch/
 VITE_API_SERVICE_SEARCH_BASE_URL=https://sys-api3.dev.bgdi.ch/
 VITE_DATA_BASE_URL=https://data.geo.admin.ch/

--- a/.env.integration
+++ b/.env.integration
@@ -1,4 +1,4 @@
-VITE_API_BASE_URL=https://mf-chsdi3.int.bgdi.ch/
+VITE_API_BASE_URL=https://sys-api3.int.bgdi.ch/
 VITE_API_SERVICE_ALTI_BASE_URL=https://sys-api3.int.bgdi.ch/
 VITE_API_SERVICE_SEARCH_BASE_URL=https://sys-api3.int.bgdi.ch/
 VITE_DATA_BASE_URL=https://data.geo.admin.ch/


### PR DESCRIPTION
As we have finished our migration of most (if not all) our backends to Frankfurt, and thus to the new sys-... URL naming convention, old URLs starts to be decommissioned. We then have to change the last one that was still pointing to the old backend's DNS entry.

[Test link](https://sys-map.dev.bgdi.ch/backends_url_after_migration/index.html)