### PR TITLE
Fix aggregate layers not showing up anymore

### DIFF
--- a/src/modules/map/components/openlayers/OpenLayersInternalLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersInternalLayer.vue
@@ -35,7 +35,13 @@
             <div
                 v-for="aggregateSubLayer in layerConfig.subLayers"
                 :key="aggregateSubLayer.subLayerId"
-            ></div>
+            >
+                <open-layers-internal-layer
+                    v-if="shouldAggregateSubLayerBeVisible(aggregateSubLayer)"
+                    :layer-config="aggregateSubLayer.layer"
+                    :z-index="zIndex"
+                />
+            </div>
         </div>
         <OpenLayersKMLLayer
             v-if="layerConfig.type === LayerTypes.KML"
@@ -50,10 +56,10 @@
 
 <script>
 import LayerTypes from '@/api/layers/LayerTypes.enum'
-import OpenLayersWMTSLayer from './OpenLayersWMTSLayer.vue'
-import OpenLayersWMSLayer from './OpenLayersWMSLayer.vue'
-import OpenLayersGeoJSONLayer from './OpenLayersGeoJSONLayer.vue'
 import OpenLayersKMLLayer from '@/modules/map/components/openlayers/OpenLayersKMLLayer.vue'
+import OpenLayersGeoJSONLayer from './OpenLayersGeoJSONLayer.vue'
+import OpenLayersWMSLayer from './OpenLayersWMSLayer.vue'
+import OpenLayersWMTSLayer from './OpenLayersWMTSLayer.vue'
 
 /** Transforms a layer config (metadata) into the correct OpenLayers counterpart depending on the layer type. */
 export default {


### PR DESCRIPTION
Somehow during Vue3 migration, this part of the template was removed, making the aggregate layers invisible (as they weren't added to the template anymore)

A good test layer is `ch.bfs.gebaeude_wohnungs_register`, under zoom level 13.5 it is a WMTS, but closer to the ground it is a WMS

[Test link](https://sys-map.dev.bgdi.ch/fix_aggregate_layers/index.html)