### PR TITLE
Bugfix 2539 profile issue with closed polygon

### DIFF
--- a/src/modules/drawing/lib/drawingUtils.js
+++ b/src/modules/drawing/lib/drawingUtils.js
@@ -139,7 +139,7 @@ export function getMeasureDelta(length) {
 
 export function extractOpenLayersFeatureCoordinates(feature) {
     let coordinates = feature.getGeometry().getCoordinates()
-    if (feature.getGeometry().getType() === Polygon) {
+    if (feature.getGeometry().getType() === 'Polygon') {
         // in case of a polygon, the coordinates structure is
         // [
         //   [ (poly1)


### PR DESCRIPTION
Fixed an issue where the profile was not showing up after drawing a closed polygon. Also added some cypress tests to check for this bug in the future.

[Test link](https://sys-map.dev.bgdi.ch/bugfix-2539-profile-issue-with-closed-polygon/index.html)