### PR TITLE
Feat 2437 remove footer on smaller devices

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -188,7 +188,8 @@ export const MAP_CENTER = [915602.81, 5911929.47]
 /**
  * Horizontal threshold for the phone view. (max-width) This will change the menu and also some interactions.
  *
- * The value is taken from the "sm" breakpoint from Bootstrap.
+ * The value is taken from the "sm" breakpoint from Bootstrap. If this value is modified, the
+ * variable with the same name defined in 'src/scss/media-query.mixin' must also be modified.
  *
  * @type {Number}
  */
@@ -197,11 +198,17 @@ export const BREAKPOINT_PHONE_WIDTH = 576
  * Horizontal threshold for the phone view. (max-height) The height is needed to catch landscape
  * view on mobile.
  *
+ * If this value is modified, the variable with the same name defined in
+ * 'src/scss/media-query.mixin' must also be modified.
+ *
  * @type {Number}
  */
 export const BREAKPOINT_PHONE_HEIGHT = 500
 /**
  * Horizontal threshold for the tablet view. (max-width)
+ *
+ * If this value is modified, the variable with the same name defined in
+ * 'src/scss/media-query.mixin' must also be modified.
  *
  * @type {Number}
  */

--- a/src/modules/map/components/footer/MapFooter.vue
+++ b/src/modules/map/components/footer/MapFooter.vue
@@ -2,8 +2,11 @@
     <div class="map-footer" :class="{ 'map-footer-fullscreen': isFullscreenMode }">
         <div class="map-footer-top">
             <MapFooterAttribution />
-            <div class="map-background-selector">
-                <MapFooterBackgroundSelector />
+            <div>
+                <div class="map-background-selector">
+                    <MapFooterBackgroundSelector />
+                </div>
+                <MapFooterScale :current-zoom="zoom" class="scale-line-phone" />
             </div>
         </div>
         <div id="map-footer-middle" class="map-footer-middle">
@@ -56,6 +59,16 @@ export default {
 }
 </script>
 
+<style lang="scss">
+@import 'src/scss/webmapviewer-bootstrap-theme';
+/* Must be unscoped, as the scaleLine is defined in the child component MapFooterScale.vue */
+.scale-line-phone .scale-line-inner {
+    /* If in phone mode, we need a background color, as the scale line is directly displayed on the
+    map in this case. */
+    background-color: rgba($white, 0.7);
+}
+</style>
+
 <style lang="scss" scoped>
 @import 'src/scss/media-query.mixin';
 @import 'src/scss/webmapviewer-bootstrap-theme';
@@ -92,6 +105,12 @@ $flex-gap: 1em;
         @include respond-above(lg) {
             flex-direction: column-reverse;
         }
+        .scale-line-phone {
+            font-size: 0.6rem;
+            @include respond-above(phone) {
+                display: none;
+            }
+        }
     }
 
     &-middle {
@@ -108,13 +127,17 @@ $flex-gap: 1em;
         background-color: rgba($white, 0.9);
         font-size: 0.6rem;
 
-        display: flex;
+        display: none;
         align-items: center;
         gap: 0 $flex-gap;
         flex-wrap: wrap;
 
         &-spacer {
             flex-grow: 1;
+        }
+
+        @include respond-above(phone) {
+            display: flex;
         }
     }
 }

--- a/src/modules/map/components/footer/MapFooter.vue
+++ b/src/modules/map/components/footer/MapFooter.vue
@@ -102,7 +102,7 @@ $flex-gap: 1em;
         .map-background-selector {
             padding: $screen-padding-for-ui-elements;
         }
-        @include respond-above(lg) {
+        @include respond-above(tablet) {
             flex-direction: column-reverse;
         }
         .scale-line-phone {

--- a/src/modules/map/components/footer/MapFooterBackgroundSelector.vue
+++ b/src/modules/map/components/footer/MapFooterBackgroundSelector.vue
@@ -230,7 +230,7 @@ $menu-button-diameter: 3px;
     animation-duration: $transition-duration;
 }
 
-@include respond-above(lg) {
+@include respond-above(tablet) {
     $desktop-map-button-width: 96px;
     .bg-selector-button {
         width: $desktop-map-button-width;

--- a/src/scss/media-query.mixin.scss
+++ b/src/scss/media-query.mixin.scss
@@ -8,11 +8,16 @@ $breakpoint_phone_width: 576px;
 $breakpoint_phone_height: 500px;
 $breakpoint_tablet: 768px;
 
-// Respond above.
+/**
+* Automatically selects the correct media tag to respond above the specified threshold
+*
+* @param breakpoint 'phone' for the phone threshold, 'tablet' for the tablet threshold. The function
+                    also accepts the bootstrap values sm, md, lg, xl, xxl
+*/
 @mixin respond-above($breakpoint) {
 
   // If the breakpoint exists in the map (from Bootstrap).
-  @if map-has-key($grid-breakpoints, $breakpoint) {
+  @if map-has-key($grid-breakpoints, $breakpoint) and $breakpoint != xs {
     /* Following values are accepted:
        xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px, xxl: 1400px */
 
@@ -20,7 +25,7 @@ $breakpoint_tablet: 768px;
     $breakpoint-value: map-get($grid-breakpoints, $breakpoint);
 
     // Write the media query.
-    @media (min-width: $breakpoint-value) {
+    @media (min-width: $breakpoint-value) and (min-height: $breakpoint_phone_height) {
       @content;
     }
   } @else if $breakpoint == phone {
@@ -32,7 +37,6 @@ $breakpoint_tablet: 768px;
       @content;
     }
   } @else {
-
     // Log a warning.
     @warn 'Invalid breakpoint: #{$breakpoint}.';
   }

--- a/src/scss/media-query.mixin.scss
+++ b/src/scss/media-query.mixin.scss
@@ -2,11 +2,19 @@
 
 @import 'node_modules/bootstrap/scss/bootstrap-grid';
 
+/* Important: These constants are duplicates from the variables defined in '@/config'. If a const
+is changed, the constant must also be changed in the config file */
+$breakpoint_phone_width: 576px;
+$breakpoint_phone_height: 500px;
+$breakpoint_tablet: 768px;
+
 // Respond above.
 @mixin respond-above($breakpoint) {
 
   // If the breakpoint exists in the map (from Bootstrap).
   @if map-has-key($grid-breakpoints, $breakpoint) {
+    /* Following values are accepted:
+       xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px, xxl: 1400px */
 
     // Get the breakpoint value.
     $breakpoint-value: map-get($grid-breakpoints, $breakpoint);
@@ -15,8 +23,14 @@
     @media (min-width: $breakpoint-value) {
       @content;
     }
-
-    // If the breakpoint doesn't exist in the map.
+  } @else if $breakpoint == phone {
+    @media (min-width: $breakpoint_phone_width) and (min-height: $breakpoint_phone_height) {
+      @content;
+    }
+  } @else if $breakpoint == tablet {
+    @media (min-width: $breakpoint_tablet) and (min-height: $breakpoint_phone_height) {
+      @content;
+    }
   } @else {
 
     // Log a warning.


### PR DESCRIPTION
As on mf-geoadmin3, remove the footer when on mobile, only show layer attributions, and the scale (if applicable)

[Test link](https://sys-map.dev.bgdi.ch/feat-2437-remove-footer-on-smaller-devices/index.html)