### PR TITLE
Desktop UI of drawing mode now looks similar to "mf-geoadmin3"

### DIFF
--- a/src/modules/drawing/components/DrawingHeader.vue
+++ b/src/modules/drawing/components/DrawingHeader.vue
@@ -1,0 +1,55 @@
+<template>
+    <div class="drawing-header">
+        <ButtonWithIcon
+            class="drawing-header-close-button"
+            :button-font-awesome-icon="['fas', 'arrow-left']"
+            :button-title="$t('draw_back')"
+            icons-before-text
+            dark
+            @click="$emit('close')"
+        >
+        </ButtonWithIcon>
+        <h1 class="drawing-header-title">{{ $t('draw_mode_title') }}</h1>
+    </div>
+</template>
+
+<script>
+import ButtonWithIcon from '@/utils/ButtonWithIcon.vue'
+
+export default {
+    components: { ButtonWithIcon },
+    emits: ['close'],
+}
+</script>
+
+<style lang="scss" scoped>
+@import 'src/scss/media-query.mixin';
+@import 'src/scss/variables';
+.drawing-header {
+    position: relative;
+    height: $header-height;
+    width: 100%;
+    background-color: #e6e6e6;
+    box-shadow: 6px 6px 12px rgb(0 0 0 / 18%);
+    display: grid;
+    grid-template: 1fr / auto 1fr;
+    place-items: center;
+    &-title {
+        font-size: 2rem;
+        font-weight: 700;
+    }
+    &-close-button {
+        margin-left: 10px;
+    }
+}
+@include respond-above(lg) {
+    .drawing-header {
+        &-title {
+            position: absolute;
+            left: 50%;
+            top: 50%;
+            transform: translate(-50%, -50%);
+        }
+    }
+}
+</style>

--- a/src/modules/drawing/components/DrawingToolbox.vue
+++ b/src/modules/drawing/components/DrawingToolbox.vue
@@ -204,7 +204,7 @@ $zindex-drawing-toolbox: -1;
         display: none;
     }
     &-mode-selector {
-        margin: 1rem 0;
+        margin: 0.5rem 0;
         display: grid;
         grid-template: 1fr / 1fr 1fr 1fr 1fr;
         gap: 0.25rem;

--- a/src/modules/drawing/components/DrawingToolboxButton.vue
+++ b/src/modules/drawing/components/DrawingToolboxButton.vue
@@ -7,7 +7,7 @@
         :button-font-awesome-icon="buttonIcon"
         :icons-before-text="true"
         direction="column"
-        :class="buttonClasses"
+        :class="[{ 'drawing-toolbox-button-active': isActive }, 'drawing-toolbox-button']"
         :data-cy="`drawing-${drawingMode.toLowerCase()}`"
         @click="emitSetDrawingMode"
     />
@@ -57,14 +57,6 @@ export default {
                 return undefined
             }
         },
-        buttonClasses() {
-            // Set a fixed width on large viewports for a consistent look.
-            if (this.uiMode === UIModes.MENU_ALWAYS_OPEN) {
-                return 'button-with-icon-uniform'
-            } else {
-                return undefined
-            }
-        },
     },
     methods: {
         emitSetDrawingMode() {
@@ -74,8 +66,34 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
-.button-with-icon-uniform {
-    width: 5em;
+<style lang="scss">
+@import 'src/scss/media-query.mixin';
+@import 'src/scss/webmapviewer-bootstrap-theme';
+
+.drawing-toolbox-button {
+    border-width: 2px;
+    border-radius: 15px;
+    border-color: rgb(238, 238, 238);
+    padding: 1rem 0;
+}
+.drawing-toolbox-button-active {
+    border-radius: 4px;
+    color: white !important;
+}
+
+@include respond-above(sm) {
+    .drawing-toolbox-button {
+        padding: 0.5rem 0;
+    }
+}
+@include respond-above(md) {
+    .drawing-toolbox-button {
+        font-weight: bold;
+
+        & > .icon {
+            font-weight: normal;
+            font-size: 1.6rem;
+        }
+    }
 }
 </style>

--- a/src/modules/menu/MenuModule.vue
+++ b/src/modules/menu/MenuModule.vue
@@ -179,7 +179,7 @@ $animation-time: 0.5s;
             .menu-tray-content {
                 transition: opacity $animation-time;
             }
-            max-width: 22rem;
+            max-width: $menu-tray-width;
         }
         $openCloseButtonHeight: 2.5rem;
         &.desktop-menu-closed {

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -26,6 +26,7 @@ $zindex-drawing-toolbox: 3;
 $header-height: 3rem;
 $footer-height: 1.5rem;
 $overlay-width: 360px;
+$menu-tray-width: 22rem;
 
 $screen-padding-for-ui-elements: 0.5rem;
 

--- a/src/setup-fontawesome.js
+++ b/src/setup-fontawesome.js
@@ -10,6 +10,7 @@ import {
 } from '@fortawesome/free-regular-svg-icons'
 import {
     faArrowDown,
+    faArrowLeft,
     faArrowsAltH,
     faArrowsAltV,
     faArrowUp,
@@ -48,6 +49,7 @@ import {
 library.add(
     // Solid
     faArrowDown,
+    faArrowLeft,
     faArrowUp,
     faArrowsAltH,
     faArrowsAltV,

--- a/src/utils/ButtonWithIcon.vue
+++ b/src/utils/ButtonWithIcon.vue
@@ -1,5 +1,5 @@
 <template>
-    <button class="button-with-icon d-flex btn" :class="buttonClasses" @click="forwardClickEvent">
+    <button class="button-with-icon btn" :class="buttonClasses" @click="forwardClickEvent">
         <FontAwesomeIcon
             v-if="iconsBeforeText && buttonFontAwesomeIcon && buttonFontAwesomeIcon.length > 0"
             class="icon"
@@ -134,6 +134,7 @@ export default {
 
 <style lang="scss" scoped>
 .button-with-icon {
+    display: flex;
     align-items: center;
     &.btn-no-style {
         background: none;

--- a/tests/e2e-cypress/integration/drawing/drawing-layer.cy.js
+++ b/tests/e2e-cypress/integration/drawing/drawing-layer.cy.js
@@ -5,6 +5,9 @@ describe('A drawing layer is added at the end of the drawing session', () => {
         cy.goToDrawing()
         cy.drawGeoms()
         cy.get('[data-cy="drawing-toolbox-close-button"]').click()
+        cy.waitUntilState((state) => {
+            return state.layers.activeLayers.length === 1
+        })
         cy.readStoreValue('state.layers.activeLayers').then((layers) => {
             expect(layers).to.be.an('Array').lengthOf(1)
             const [drawingLayer] = layers


### PR DESCRIPTION
The desktop and tablet UI of the drawing mode now is similar to what we have on "mf-geoadmin3".

I found it confusing for the buttons to switch from red to grey after selecting them like we discussed, as grey is also used when hovering. Also I think that a selected drawing mode should be marked by a single color and not two. That's why for now I left the red marking. 

[Test link](https://sys-map.dev.bgdi.ch/feat-2600-change-drawing-toolbox-ui-for-desktop/index.html)