### PR TITLE
Add contrast to the main BG selector button on desktop

### DIFF
--- a/src/modules/map/components/footer/MapFooterBackgroundSelector.vue
+++ b/src/modules/map/components/footer/MapFooterBackgroundSelector.vue
@@ -265,6 +265,8 @@ $menu-button-diameter: 3px;
 
     .bg-selector-button-label {
         display: block;
+        background-color: rgba(0,0,0,.7);
+        color: white;
     }
 
     .bg-selector-open {


### PR DESCRIPTION
So that it catches more the eye, even when you are using a gray BG map (otherwise it blends too much with the map and it's difficult to see there's a button there)

[Test link](https://sys-map.dev.bgdi.ch/add_contrast_to_bg_text/index.html)