### PR TITLE
BGDIINF_SB-2009: share geolocation position when creating shortlink

### DIFF
--- a/src/modules/map/components/openlayers/OpenLayersMarker.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMarker.vue
@@ -5,13 +5,18 @@
 </template>
 
 <script>
-import { Circle as CircleStyle, Fill, Icon as IconStyle, Stroke, Style } from 'ol/style'
-import { Vector as VectorLayer } from 'ol/layer'
-import { Vector as VectorSource } from 'ol/source'
-import Feature from 'ol/Feature'
-import { Point } from 'ol/geom'
+import markerImage from '@/modules/map/assets/marker.png'
+import bowlImage from '@/modules/map/assets/bowl.png'
+import circleImage from '@/modules/map/assets/circle.png'
+import crossImage from '@/modules/map/assets/cross.png'
+import pointImage from '@/modules/map/assets/point.png'
 
 import { randomIntBetween } from '@/utils/numberUtils'
+import Feature from 'ol/Feature'
+import { Point } from 'ol/geom'
+import { Vector as VectorLayer } from 'ol/layer'
+import { Vector as VectorSource } from 'ol/source'
+import { Circle as CircleStyle, Fill, Icon as IconStyle, Stroke, Style } from 'ol/style'
 import addLayerToMapMixin from './utils/addLayerToMap-mixins'
 
 // style for feature highlighting (we export it so that they can be re-used by OpenLayersHighlightedFeature)
@@ -40,6 +45,22 @@ export const markerStyles = {
     CIRCLE: 'circle',
     CROSS: 'cross',
     POINT: 'point',
+}
+
+function imageForMarkerStyle(markerStyle) {
+    switch(markerStyle) {
+        case markerStyles.BOWL:
+            return bowlImage
+        case markerStyles.BALLOON:
+            return markerImage
+        case markerStyles.CIRCLE:
+            return circleImage
+        case markerStyles.CROSS:
+            return crossImage
+        case markerStyles.POINT:
+            return pointImage
+    }
+    return undefined
 }
 
 /** Renders a marker on the map (different styling are available) */
@@ -92,7 +113,7 @@ export default {
                     return new Style({
                         image: new IconStyle({
                             anchor: [0.5, 1],
-                            src: require('@/modules/map/assets/marker.png'),
+                            src: markerImage,
                         }),
                     })
 
@@ -105,7 +126,7 @@ export default {
                             anchor: [0.5, 0.5],
                             anchorXUnits: 'fraction',
                             anchorYUnits: 'fraction',
-                            src: require(`@/modules/map/assets/${this.markerStyle}.png`),
+                            src: imageForMarkerStyle(this.markerStyle),
                         }),
                     })
 

--- a/src/modules/menu/components/share/MenuShareSection.vue
+++ b/src/modules/menu/components/share/MenuShareSection.vue
@@ -36,6 +36,7 @@ export default {
         ...mapState({
             shortLink: (state) => state.share.shortLink,
             isSectionShown: (state) => state.share.isMenuSectionShown,
+            isTrackingGeolocation: (state) => state.geolocation.active && state.geolocation.tracking,
         }),
     },
     methods: {
@@ -48,7 +49,7 @@ export default {
         toggleShareMenu() {
             this.toggleShareMenuSection()
             if (!this.shortLink) {
-                this.generateShortLink()
+                this.generateShortLink(this.isTrackingGeolocation)
             } else {
                 this.clearShortLink()
             }

--- a/src/store/modules/share.store.js
+++ b/src/store/modules/share.store.js
@@ -22,9 +22,14 @@ export default {
     },
     getters: {},
     actions: {
-        async generateShortLink({ commit }) {
+        async generateShortLink({ commit }, withBalloonMarker = false) {
             try {
-                const shortLink = await createShortLink(window.location.href)
+                const shortLink = await createShortLink(
+                    // we do not want the geolocation of the user clicking the link to kick in, so we force the flag out of the URL
+                    window.location.href.replace('&geolocation=true', '') +
+                        // if the geolocation was being tracked by the user generating the link, we place a balloon (dropped pin) marker at his position (center of the screen, so no need to change any x/y position)
+                        (withBalloonMarker ? '&crosshair=marker' : '')
+                )
                 if (shortLink) {
                     commit('setShortLink', shortLink)
                 }


### PR DESCRIPTION
If the user has activated his geolocation, the generated share link (shortlink) will point to his current position with a marker. Geolocation URL param is also removed from the generated shortlink, so that the person opening the link is not placed where he currently stands, but where the person that has generated the link was.

Quick note on static image handling : I had to fix how images were imported in OpenLayersMarker.vue,. Seems like it went through without us noticing, but since Vite migration, static assets can't be imported through a require anymore, but through an import.

[Test link](https://sys-map.dev.bgdi.ch/feat_bgdiinf_sb-2009_sharelink_with_position/index.html)