### PR TITLE
BGDIINF_SB-2615 : adding a shadowbox over the search result

### DIFF
--- a/src/modules/menu/components/search/SearchResultList.vue
+++ b/src/modules/menu/components/search/SearchResultList.vue
@@ -29,10 +29,7 @@
 import { mapActions, mapState } from 'vuex'
 import SearchResultCategory from './SearchResultCategory.vue'
 
-/**
- * Component showing all results from the search, divided in two groups (categories) : layers and
- * locations
- */
+/** Component showing all results from the search, divided in two groups (categories) : layers and locations */
 export default {
     components: { SearchResultCategory },
     emits: ['close'],
@@ -62,6 +59,8 @@ export default {
     left: 0%;
     width: 100%;
     max-height: calc(75vh - 3rem);
+    border: 1px solid #ccc;
+    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
 }
 @include respond-above(lg) {
     #search-results {


### PR DESCRIPTION
Adding a small border and shadow box over the search result to separate them from the map. Used the old viewer style for the colors

[Test link](https://sys-map.dev.bgdi.ch/feature_bgdiinf_sb-2211-shadowbox-over-search-result/index.html)

Warning : I messed up when naming the branch. I was checking another ticket and thought its number was for this issue. I changed the PR title.