### PR TITLE
BGDIINF_SB-2508: Added feedback in drawing marker icon selection

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -75,10 +75,13 @@ phases:
       # As the cypress/download folder is not added to git, and (somehow) not created by Cypress at startup, we create it
       - mkdir -p cypress/downloads/
       # will build the application in dev mode before testing
-      - CYPRESS_CACHE_FOLDER=/tmp/.cache npm run test:ci
+      - CYPRESS_CACHE_FOLDER=/tmp/.cache npm run test:unit
 
-  post_build:
-    commands:
       # switching role for deploy (otherwise the S3 bucket won't be visible as it's another account)
       # the application will be built by the npm target before deploying
       - npm run deploy:${DEPLOY_TARGET} -- --role=arn:aws:iam::${AWS_ACCOUNT_TO_USE} --branch=${GIT_BRANCH}
+
+      # will build the application in dev mode before testing
+      - CYPRESS_CACHE_FOLDER=/tmp/.cache npm run test:e2e:ci
+
+

--- a/src/modules/infobox/components/styling/DrawingStyleColorSelector.vue
+++ b/src/modules/infobox/components/styling/DrawingStyleColorSelector.vue
@@ -81,8 +81,8 @@ export default {
     }
 
     .color-circle {
-        width: 1.5rem;
-        height: 1.5rem;
+        width: 1.25rem;
+        height: 1.25rem;
         border: 1px solid black;
     }
 }

--- a/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
+++ b/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
@@ -192,5 +192,9 @@ export default {
         width: 2rem;
         height: 2rem;
     }
+
+    button {
+        --bs-btn-padding-x: 0.25rem;
+    }
 }
 </style>

--- a/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
+++ b/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
@@ -57,7 +57,13 @@
                         :alt="icon.name"
                         :src="generateColorizedURL(icon)"
                         class="marker-icon-image"
-                        :class="getImageStrokeClass(feature.fillColor)"
+                        :class="
+                            getImageStrokeClass(
+                                currentIconSet.isColorable,
+                                feature.icon.name === icon.name,
+                                feature.fillColor.name
+                            )
+                        "
                         crossorigin="anonymous"
                     />
                 </button>
@@ -140,11 +146,15 @@ export default {
         changeDisplayedIconSet(dropdownItem) {
             this.currentIconSet = dropdownItem.value
         },
-        getImageStrokeClass(color) {
-            if (color.name === WHITE.name || color.name === YELLOW.name) {
-                return 'marker-icon-image-stroke-black'
+        getImageStrokeClass(isColorable, isSelected, color) {
+            if (isColorable) {
+                if (color === WHITE.name || color === YELLOW.name) {
+                    return 'marker-icon-image-stroke-black'
+                }
+                return 'marker-icon-image-stroke-white'
+            } else if (isSelected) {
+                return 'marker-icon-image-stroke-white-babs'
             }
-            return 'marker-icon-image-stroke-white'
         },
     },
 }
@@ -180,6 +190,10 @@ export default {
     .marker-icon-image {
         width: 2rem;
         height: 2rem;
+    }
+
+    .marker-icon-image-stroke-white-babs {
+        filter: drop-shadow(0px 0px 0 white);
     }
 
     .marker-icon-image-stroke-white {

--- a/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
+++ b/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
@@ -29,7 +29,7 @@
 
         <div
             v-if="currentIconSet && currentIconSet.icons.length > 0"
-            class="border-2 bg-light"
+            class="border-2 bg-light rounded"
             :class="{ 'transparent-bottom': !showAllSymbols }"
         >
             <div
@@ -42,16 +42,25 @@
                 <font-awesome-icon :icon="['fas', showAllSymbols ? 'caret-down' : 'caret-right']" />
             </div>
             <div class="marker-icon-select-box" :class="{ 'one-line': !showAllSymbols }">
-                <img
+                <button
                     v-for="icon in currentIconSet.icons"
                     :key="icon.name"
-                    :alt="icon.name"
-                    :src="generateColorizedURL(icon)"
+                    class="btn btn-sm"
+                    :class="{
+                        'btn-light': feature.icon.name !== icon.name,
+                        'btn-primary': feature.icon.name === icon.name,
+                    }"
                     :data-cy="`drawing-style-icon-selector-${icon.name}`"
-                    class="marker-icon-image"
-                    crossorigin="anonymous"
                     @click="showAllSymbols && onCurrentIconChange(icon)"
-                />
+                >
+                    <img
+                        :alt="icon.name"
+                        :src="generateColorizedURL(icon)"
+                        class="marker-icon-image"
+                        :class="getImageStrokeClass(feature.fillColor)"
+                        crossorigin="anonymous"
+                    />
+                </button>
             </div>
             <div class="transparent-overlay" @click="showAllSymbols = true" />
         </div>
@@ -63,7 +72,7 @@ import { EditableFeature } from '@/api/features.api'
 import DrawingStyleColorSelector from '@/modules/infobox/components/styling/DrawingStyleColorSelector.vue'
 import DrawingStyleSizeSelector from '@/modules/infobox/components/styling/DrawingStyleSizeSelector.vue'
 import DropdownButton, { DropdownItem } from '@/utils/DropdownButton.vue'
-import { MEDIUM } from '@/utils/featureStyleUtils'
+import { MEDIUM, YELLOW, WHITE } from '@/utils/featureStyleUtils'
 
 export default {
     components: {
@@ -131,6 +140,12 @@ export default {
         changeDisplayedIconSet(dropdownItem) {
             this.currentIconSet = dropdownItem.value
         },
+        getImageStrokeClass(color) {
+            if (color.name === WHITE.name || color.name === YELLOW.name) {
+                return 'marker-icon-image-stroke-black'
+            }
+            return 'marker-icon-image-stroke-white'
+        },
     },
 }
 </script>
@@ -163,9 +178,16 @@ export default {
     grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
     transition: max-height 0.3s linear;
     .marker-icon-image {
-        cursor: pointer;
-        width: 3rem;
-        height: 3rem;
+        width: 2rem;
+        height: 2rem;
+    }
+
+    .marker-icon-image-stroke-white {
+        filter: drop-shadow(1px 1px 0 white) drop-shadow(-1px -1px 0 white);
+    }
+
+    .marker-icon-image-stroke-black {
+        filter: drop-shadow(1px 1px 0 black) drop-shadow(-1px -1px 0 black);
     }
 }
 </style>

--- a/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
+++ b/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
@@ -51,7 +51,7 @@
                         'btn-primary': feature.icon.name === icon.name,
                     }"
                     :data-cy="`drawing-style-icon-selector-${icon.name}`"
-                    @click="showAllSymbols && onCurrentIconChange(icon)"
+                    @click="onCurrentIconChange(icon)"
                 >
                     <img
                         :alt="icon.name"
@@ -136,6 +136,7 @@ export default {
             this.$emit('change')
         },
         onCurrentIconChange(icon) {
+            this.showAllSymbols = true
             this.$emit('change:icon', icon)
             this.$emit('change')
         },
@@ -174,6 +175,7 @@ export default {
         height: 2rem;
         background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, $light 100%);
         bottom: 0;
+        pointer-events: none;
     }
 }
 .marker-icon-select-box {

--- a/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
+++ b/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
@@ -57,11 +57,11 @@
                         :alt="icon.name"
                         :src="generateColorizedURL(icon)"
                         class="marker-icon-image"
-                        :class="
-                            getImageStrokeClass(
+                        :style="
+                            getImageStrokeStyle(
                                 currentIconSet.isColorable,
                                 feature.icon.name === icon.name,
-                                feature.fillColor.name
+                                feature.fillColor
                             )
                         "
                         crossorigin="anonymous"
@@ -78,7 +78,7 @@ import { EditableFeature } from '@/api/features.api'
 import DrawingStyleColorSelector from '@/modules/infobox/components/styling/DrawingStyleColorSelector.vue'
 import DrawingStyleSizeSelector from '@/modules/infobox/components/styling/DrawingStyleSizeSelector.vue'
 import DropdownButton, { DropdownItem } from '@/utils/DropdownButton.vue'
-import { MEDIUM, YELLOW, WHITE } from '@/utils/featureStyleUtils'
+import { MEDIUM } from '@/utils/featureStyleUtils'
 
 export default {
     components: {
@@ -146,14 +146,13 @@ export default {
         changeDisplayedIconSet(dropdownItem) {
             this.currentIconSet = dropdownItem.value
         },
-        getImageStrokeClass(isColorable, isSelected, color) {
+        getImageStrokeStyle(isColorable, isSelected, color) {
             if (isColorable) {
-                if (color === WHITE.name || color === YELLOW.name) {
-                    return 'marker-icon-image-stroke-black'
+                return {
+                    filter: `drop-shadow(1px 1px 0 ${color.border}) drop-shadow(-1px -1px 0 ${color.border})`,
                 }
-                return 'marker-icon-image-stroke-white'
             } else if (isSelected) {
-                return 'marker-icon-image-stroke-white-babs'
+                return { filter: 'drop-shadow(0px 0px 0 white)' }
             }
         },
     },
@@ -190,18 +189,6 @@ export default {
     .marker-icon-image {
         width: 2rem;
         height: 2rem;
-    }
-
-    .marker-icon-image-stroke-white-babs {
-        filter: drop-shadow(0px 0px 0 white);
-    }
-
-    .marker-icon-image-stroke-white {
-        filter: drop-shadow(1px 1px 0 white) drop-shadow(-1px -1px 0 white);
-    }
-
-    .marker-icon-image-stroke-black {
-        filter: drop-shadow(1px 1px 0 black) drop-shadow(-1px -1px 0 black);
     }
 }
 </style>

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -52,6 +52,7 @@
             <template #extra-buttons>
                 <ButtonWithIcon
                     :button-font-awesome-icon="['fa', 'caret-down']"
+                    small
                     data-cy="toggle-floating-off"
                     @click="toggleFloatingTooltip"
                 />

--- a/src/modules/map/components/openlayers/OpenLayersPopover.vue
+++ b/src/modules/map/components/openlayers/OpenLayersPopover.vue
@@ -9,11 +9,13 @@
                 <ButtonWithIcon
                     v-if="authorizePrint"
                     :button-font-awesome-icon="['fa', 'print']"
+                    small
                     @click="printContent"
                 />
                 <ButtonWithIcon
                     data-cy="map-popover-close-button"
                     :button-font-awesome-icon="['fa', 'times']"
+                    small
                     @click="onClose"
                 />
             </div>

--- a/src/scss/webmapviewer-bootstrap-theme.scss
+++ b/src/scss/webmapviewer-bootstrap-theme.scss
@@ -18,3 +18,5 @@ $map-button-hover-border-color: $gray-700;
 .form-control:focus {
   box-shadow: 0 1px 4px lighten($dark, 8%);
 }
+
+$card-cap-padding-y: 0.25rem;

--- a/src/utils/PopoverButton.vue
+++ b/src/utils/PopoverButton.vue
@@ -136,10 +136,6 @@ export default {
             // shows an arrow at the border of the popover that points to the button location
             arrow: true,
             trigger: 'click',
-            // The default tippy maxWidth is 350px, we need to add one more pixel here in order
-            // to avoid a useless horizontal scrollbar in the drawing icon selection menu on
-            // Windows Edge Browser.
-            maxWidth: 351,
         })
     },
     beforeUnmount() {

--- a/src/utils/PopoverButton.vue
+++ b/src/utils/PopoverButton.vue
@@ -136,6 +136,10 @@ export default {
             // shows an arrow at the border of the popover that points to the button location
             arrow: true,
             trigger: 'click',
+            // The default tippy maxWidth is 350px, we need to add one more pixel here in order
+            // to avoid a useless horizontal scrollbar in the drawing icon selection menu on
+            // Windows Edge Browser.
+            maxWidth: 351,
         })
     },
     beforeUnmount() {


### PR DESCRIPTION
This PR depends on #268.
[Test link](https://sys-map.dev.bgdi.ch/feat-bgdiinf_sb-2508-drawing-marker-icons/index.html)

NOTE: There is still a bug on iphone with the stroke of icons. When the icon selection is close, everything works as intended but when it is opened and we change the color, the icon stroke won't but correctly updated (changing from black to white depending on the color). To fix the stroke the use as to close the icon selection and reopen it. I could not find any solution to this bug and it seems that only iphone is affected. Tested on following devices
- Ubuntu Chrome and Firefox : OK
- Android tablet: OK
- **Iphone 11 IOS 16.1 Safari, Chrome, Firefox: NOK**
- Windows Edge: OK