### PR TITLE
BGDIINF_SB-2657: Added dynamic app versioning based on git tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
     "packages": {
         "": {
             "name": "web-mapviewer",
-            "version": "0.1.0",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^6.2.0",
                 "@fortawesome/free-brands-svg-icons": "^6.2.0",
@@ -63,6 +62,7 @@
                 "eslint-plugin-prettier-vue": "^4.2.0",
                 "eslint-plugin-vue": "^9.7.0",
                 "git-branch": "^2.0.1",
+                "git-describe": "^4.1.1",
                 "googleapis": "^109.0.0",
                 "jsdom": "^20.0.2",
                 "mime-types": "^2.1.35",
@@ -951,6 +951,12 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.2.tgz",
             "integrity": "sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ=="
+        },
+        "node_modules/@types/semver": {
+            "version": "7.3.13",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+            "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+            "dev": true
         },
         "node_modules/@types/sinonjs__fake-timers": {
             "version": "8.1.1",
@@ -2696,19 +2702,6 @@
                 "inherits": "^2.0.3",
                 "readable-stream": "^3.0.2",
                 "typedarray": "^0.0.6"
-            }
-        },
-        "node_modules/concat-stream/node_modules/readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/consolidate": {
@@ -5510,6 +5503,32 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/git-describe": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/git-describe/-/git-describe-4.1.1.tgz",
+            "integrity": "sha512-JC8ganO5kO80G8+XE98TDDjnMXQN3Estk3qdJuG2EGRF/l6zuMTMcN+8OSfQZ5FWpqIRLB015anWX4aSRgnxAQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/semver": "^7.3.8",
+                "lodash": "^4.17.21"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            },
+            "optionalDependencies": {
+                "semver": "^5.6.0"
+            }
+        },
+        "node_modules/git-describe/node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true,
+            "optional": true,
+            "bin": {
+                "semver": "bin/semver"
             }
         },
         "node_modules/gl-matrix": {
@@ -8988,6 +9007,19 @@
                 "safe-buffer": "^5.1.0"
             }
         },
+        "node_modules/readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/readdirp": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -12189,6 +12221,12 @@
             "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.2.tgz",
             "integrity": "sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ=="
         },
+        "@types/semver": {
+            "version": "7.3.13",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+            "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+            "dev": true
+        },
         "@types/sinonjs__fake-timers": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
@@ -13527,18 +13565,6 @@
                 "inherits": "^2.0.3",
                 "readable-stream": "^3.0.2",
                 "typedarray": "^0.0.6"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "requires": {
-                        "inherits": "^2.0.3",
-                        "string_decoder": "^1.1.1",
-                        "util-deprecate": "^1.0.1"
-                    }
-                }
             }
         },
         "consolidate": {
@@ -15630,6 +15656,26 @@
             "dev": true,
             "requires": {
                 "findup-sync": "^2.0.0"
+            }
+        },
+        "git-describe": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/git-describe/-/git-describe-4.1.1.tgz",
+            "integrity": "sha512-JC8ganO5kO80G8+XE98TDDjnMXQN3Estk3qdJuG2EGRF/l6zuMTMcN+8OSfQZ5FWpqIRLB015anWX4aSRgnxAQ==",
+            "dev": true,
+            "requires": {
+                "@types/semver": "^7.3.8",
+                "lodash": "^4.17.21",
+                "semver": "^5.6.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true,
+                    "optional": true
+                }
             }
         },
         "gl-matrix": {
@@ -18165,6 +18211,16 @@
             "dev": true,
             "requires": {
                 "safe-buffer": "^5.1.0"
+            }
+        },
+        "readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
             }
         },
         "readdirp": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
     "name": "web-mapviewer",
-    "version": "0.1.0",
     "private": true,
     "scripts": {
         "start": "npm run dev",
@@ -76,6 +75,7 @@
         "eslint-plugin-prettier-vue": "^4.2.0",
         "eslint-plugin-vue": "^9.7.0",
         "git-branch": "^2.0.1",
+        "git-describe": "^4.1.1",
         "googleapis": "^109.0.0",
         "jsdom": "^20.0.2",
         "mime-types": "^2.1.35",

--- a/src/modules/map/components/footer/MapFooterAppVersion.vue
+++ b/src/modules/map/components/footer/MapFooterAppVersion.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="showAppVersion" class="app-version">v{{ appVersion }}</div>
+    <div v-if="showAppVersion" class="app-version">{{ appVersion }}</div>
 </template>
 
 <script>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath, URL } from 'url'
+import { gitDescribeSync } from 'git-describe'
 
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
@@ -15,8 +16,7 @@ export default defineConfig(({ command, mode }) => {
             },
         },
         define: {
-            // Getting package.json version in order to expose it to the app
-            __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+            __APP_VERSION__: JSON.stringify(gitDescribeSync().raw),
             VITE_ENVIRONMENT: JSON.stringify(mode),
         },
         test: {


### PR DESCRIPTION
Unfortunately we cannot make use of the `version` field in `package.json` because it is static which means that we would need to modify it during a PR merge before tagging. They are already tools and github action for such use case, the issue is that they won't work with branch protection as we have.
[Test link](https://sys-map.dev.bgdi.ch/feat-bgdiinf_sb-2657-versioning/index.html)