### PR TITLE
BGDIINF_SB-2657: Fixed versioning

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig(({ command, mode }) => {
             },
         },
         define: {
-            __APP_VERSION__: JSON.stringify(gitDescribeSync().raw),
+            __APP_VERSION__: JSON.stringify('v' + gitDescribeSync().semverString),
             VITE_ENVIRONMENT: JSON.stringify(mode),
         },
         test: {


### PR DESCRIPTION
The git hash was always appended to the version even if the version was from
a clean tag (not dirty and with extra commit).
By using semverString instead of raw, this solve the issue, but we need to
prepend the `v` prefix.

[Test link](https://sys-map.dev.bgdi.ch/feat-bgdiinf_sb-2657-versioning/index.html)