### PR TITLE
Feat 2235 rework click on mobile device

### DIFF
--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -103,7 +103,7 @@ import stringifyQuery from '@/router/stringifyQuery'
 import { CoordinateSystems, printHumanReadableCoordinates } from '@/utils/coordinateUtils'
 import { round } from '@/utils/numberUtils'
 import proj4 from 'proj4'
-import { mapActions, mapGetters, mapState } from 'vuex'
+import { mapActions, mapState } from 'vuex'
 
 /** Right click pop up which shows the coordinates of the position under the cursor. */
 export default {
@@ -124,8 +124,8 @@ export default {
         ...mapState({
             clickInfo: (state) => state.map.clickInfo,
             currentLang: (state) => state.i18n.lang,
+            displayLocationPopup: (state) => state.map.displayLocationPopup,
         }),
-        ...mapGetters(['displayLocationPopup']),
         clickCoordinates() {
             return this.clickInfo?.coordinate
         },

--- a/src/modules/menu/MenuModule.vue
+++ b/src/modules/menu/MenuModule.vue
@@ -9,12 +9,17 @@
         <HeaderWithSearch v-show="isHeaderShown" class="header" />
         <div class="toolbox-right">
             <GeolocButton
+                v-if="!isFullscreenMode"
                 class="mb-1"
                 :is-active="isGeolocationActive"
                 :is-denied="isGeolocationDenied"
                 @click="toggleGeolocation"
             />
-            <ZoomButtons @zoom-in="increaseZoom" @zoom-out="decreaseZoom" />
+            <ZoomButtons
+                v-if="!isFullscreenMode"
+                @zoom-in="increaseZoom"
+                @zoom-out="decreaseZoom"
+            />
             <CompassButton />
         </div>
         <div
@@ -76,6 +81,7 @@ export default {
             isGeolocationActive: (state) => state.geolocation.active,
             isGeolocationDenied: (state) => state.geolocation.denied,
             showMenu: (state) => state.ui.showMenu,
+            isFullscreenMode: (state) => state.ui.fullscreenMode,
         }),
         ...mapGetters([
             'isHeaderShown',

--- a/src/store/modules/map.store.js
+++ b/src/store/modules/map.store.js
@@ -112,6 +112,13 @@ export default {
                 commit('setDisplayedProjection', CoordinateSystems[projectionId])
             }
         },
+
+        displayLocationPopup({ commit }) {
+            commit('setDisplayLocationPopup', true)
+        },
+        hideLocationPopup({ commit }) {
+            commit('setDisplayLocationPopup', false)
+        },
     },
     mutations: {
         setHighlightedLayer: (state, layer) => (state.highlightedLayer = layer),
@@ -120,7 +127,6 @@ export default {
         mapStoppedBeingDragged: (state) => (state.isBeingDragged = false),
         setPinnedLocation: (state, coordinates) => (state.pinnedLocation = coordinates),
         setDisplayedProjection: (state, projection) => (state.displayedProjection = projection),
-        displayLocationPopup: (state) => (state.displayLocationPopup = true),
-        hideLocationPopup: (state) => (state.displayLocationPopup = false),
+        setDisplayLocationPopup: (state, display) => (state.displayLocationPopup = display),
     },
 }

--- a/src/store/modules/map.store.js
+++ b/src/store/modules/map.store.js
@@ -2,16 +2,16 @@ import { CoordinateSystems } from '@/utils/coordinateUtils'
 
 /** @enum */
 export const ClickType = {
-    RIGHT_CLICK: 'RIGHT_CLICK',
-    LEFT_CLICK: 'LEFT_CLICK',
+    /* Any action that triggers the context menu, so for example right click with a mouse or
+    a long click with the finger on a touch device.*/
+    CONTEXTMENU: 'CONTEXTMENU',
+    /* A single click, with the left mouse button or with the finger on a touch device */
+    LEFT_SINGLECLICK: 'LEFT_SINGLECLICK',
 }
 
 export class ClickInfo {
     /**
      * @param {Number[]} coordinate Of the last click expressed in EPSG:3857
-     * @param {Number} millisecondsSpentMouseDown Time spend with the mouse button down for the last
-     *   click. Useful to determine if this was a quick touch or a long press on mobile (not the
-     *   same feedback to the user, see click-on-map-management.plugin .js)
      * @param {Number[]} pixelCoordinate Position of the last click on the screen [x, y] in pixels
      *   (counted from top left corner)
      * @param {Object[]} geoJsonFeatures List of potential GeoJSON features that where under the
@@ -20,13 +20,11 @@ export class ClickInfo {
      */
     constructor(
         coordinate = [],
-        millisecondsSpentMouseDown = -1,
         pixelCoordinate = [],
         geoJsonFeatures = [],
-        clickType = ClickType.LEFT_CLICK
+        clickType = ClickType.LEFT_SINGLECLICK
     ) {
         this.coordinate = [...coordinate]
-        this.millisecondsSpentMouseDown = millisecondsSpentMouseDown
         this.pixelCoordinate = [...pixelCoordinate]
         this.geoJsonFeatures = [...geoJsonFeatures]
         this.clickType = clickType
@@ -70,15 +68,8 @@ export default {
          * @type {CoordinateSystems}
          */
         displayedProjection: CoordinateSystems.LV95,
-    },
-    getters: {
-        displayLocationPopup(state, getters) {
-            return (
-                getters.isDesktopMode &&
-                state.clickInfo?.clickType === ClickType.RIGHT_CLICK &&
-                Array.isArray(state.clickInfo?.coordinate)
-            )
-        },
+
+        displayLocationPopup: false,
     },
     actions: {
         /**
@@ -129,5 +120,7 @@ export default {
         mapStoppedBeingDragged: (state) => (state.isBeingDragged = false),
         setPinnedLocation: (state, coordinates) => (state.pinnedLocation = coordinates),
         setDisplayedProjection: (state, projection) => (state.displayedProjection = projection),
+        displayLocationPopup: (state) => (state.displayLocationPopup = true),
+        hideLocationPopup: (state) => (state.displayLocationPopup = false),
     },
 }

--- a/src/store/plugins/click-on-map-management.plugin.js
+++ b/src/store/plugins/click-on-map-management.plugin.js
@@ -12,7 +12,7 @@ import log from '@/utils/logging'
  *   visible layers on the map
  * @param {String} lang
  */
-const runIdentify = (store, clickInfo, visibleLayers, lang) => {
+const runIdentify = async (store, clickInfo, visibleLayers, lang) => {
     // we run identify only if there are visible layers (other than background)
     if (visibleLayers.length > 0) {
         const allRequests = []
@@ -35,15 +35,11 @@ const runIdentify = (store, clickInfo, visibleLayers, lang) => {
                 log.debug('ignoring layer', layer, 'no tooltip')
             }
         })
-        Promise.all(allRequests).then((values) => {
-            // grouping all features from the different requests
-            const allFeatures = values.flat()
-            // dispatching all features by going through them in order to keep only one time each of them (no double)
-            store.dispatch(
-                'setSelectedFeatures',
-                allFeatures.filter((feature, index) => allFeatures.indexOf(feature) === index)
-            )
-        })
+        const values = await Promise.all(allRequests)
+        // grouping all features from the different requests
+        const allFeatures = values.flat()
+        // dispatching all features by going through them in order to keep only one time each of them (no double)
+        return allFeatures.filter((feature, index) => allFeatures.indexOf(feature) === index)
     }
 }
 
@@ -59,25 +55,45 @@ const clickOnMapManagementPlugin = (store) => {
         // when the user is not currently drawing something on the map
         if (mutation.type === 'setClickInfo' && !state.ui.showDrawingOverlay) {
             const clickInfo = mutation.payload
-            const isDesktopMode = store.getters.isDesktopMode
-            const isLeftClick = clickInfo?.clickType === ClickType.LEFT_CLICK
-            const isLongClick = clickInfo?.millisecondsSpentMouseDown >= 500
+            const isLeftSingleClick = clickInfo?.clickType === ClickType.LEFT_SINGLECLICK
+            const isContextMenuClick = clickInfo?.clickType === ClickType.CONTEXTMENU
+            const isFullscreenMode = store.state.ui.fullscreenMode
 
-            if (
-                (isDesktopMode && isLeftClick) ||
-                (!isDesktopMode && isLeftClick && isLongClick) ||
-                (!isDesktopMode && !isLeftClick)
-            ) {
+            if (isLeftSingleClick) {
+                // Execute this before the then clause, as else the result could be wrong
+                // Still to do: why sometimes two clicks needed to fullscreen?
+                // Why crash when selecting search bar while popup is open?
+                const allowActivateFullscreen =
+                    !isFullscreenMode &&
+                    !state.features.selectedFeatures?.length &&
+                    !state.map.displayLocationPopup &&
+                    !state.search.show
+
                 // if there are some search result shown, we hide the search list
                 if (state.search.show) {
                     store.dispatch('hideSearchResults')
                 }
                 // running an identification of feature even if we cleared the search result
-                runIdentify(store, clickInfo, store.getters.visibleLayers, store.state.i18n.lang)
-            } else if (!isDesktopMode && isLeftClick && !isLongClick) {
-                store.dispatch('toggleFullscreenMode')
-            } else if (isDesktopMode && !isLeftClick) {
+                runIdentify(
+                    store,
+                    clickInfo,
+                    store.getters.visibleLayers,
+                    store.state.i18n.lang
+                ).then((newSelectedFeatures) => {
+                    if (!newSelectedFeatures?.length && allowActivateFullscreen) {
+                        store.dispatch('toggleFullscreenMode')
+                    }
+                    store.dispatch('setSelectedFeatures', newSelectedFeatures)
+                })
+            }
+            if (isContextMenuClick) {
                 store.dispatch('clearAllSelectedFeatures')
+                store.commit('displayLocationPopup')
+            } else {
+                store.commit('hideLocationPopup')
+            }
+            if (isFullscreenMode) {
+                store.dispatch('toggleFullscreenMode')
             }
         }
     })

--- a/src/store/plugins/click-on-map-management.plugin.js
+++ b/src/store/plugins/click-on-map-management.plugin.js
@@ -88,9 +88,9 @@ const clickOnMapManagementPlugin = (store) => {
             }
             if (isContextMenuClick) {
                 store.dispatch('clearAllSelectedFeatures')
-                store.commit('displayLocationPopup')
+                store.dispatch('displayLocationPopup')
             } else {
-                store.commit('hideLocationPopup')
+                store.dispatch('hideLocationPopup')
             }
             if (isFullscreenMode) {
                 store.dispatch('toggleFullscreenMode')

--- a/tests/e2e-cypress/integration/infobox.cy.js
+++ b/tests/e2e-cypress/integration/infobox.cy.js
@@ -1,14 +1,5 @@
 /// <reference types="cypress" />
 
-function longClickOnMap() {
-    cy.readWindowValue('map').then((map) => {
-        cy.simulateEvent(map, 'pointerdown')
-        cy.wait(500) // eslint-disable-line
-        cy.simulateEvent(map, 'pointerup')
-        cy.simulateEvent(map, 'singleclick')
-    })
-}
-
 describe('The infobox', () => {
     beforeEach(() => {
         const layer = 'test.wmts.layer'
@@ -60,7 +51,7 @@ describe('The infobox', () => {
         cy.get('[data-cy="infobox"]').should('be.visible')
     })
     it('sets its height dynamically if at the bottom', () => {
-        longClickOnMap()
+        cy.get('[data-cy="map"]').click()
         cy.waitUntilState((state) => {
             return state.features.selectedFeatures.length > 0
         })

--- a/tests/e2e-cypress/integration/infobox.cy.js
+++ b/tests/e2e-cypress/integration/infobox.cy.js
@@ -24,15 +24,26 @@ describe('The infobox', () => {
     it('is visible if features selected', () => {
         cy.get('[data-cy="highlighted-features"]').should('not.exist')
 
-        longClickOnMap()
+        cy.get('[data-cy="map"]').click()
         cy.waitUntilState((state) => {
             return state.features.selectedFeatures.length > 0
         })
 
         cy.get('[data-cy="highlighted-features"]').should('be.visible')
     })
+    it('blocks direct activation of fullscreen', () => {
+        cy.get('[data-cy="map"]').click()
+        cy.waitUntilState((state) => {
+            return state.features.selectedFeatures.length > 0
+        })
+        cy.get('[data-cy="infobox"]').should('be.visible')
+        cy.intercept('**/MapServer/identify**', {})
+        cy.get('[data-cy="map"]').click()
+        cy.get('[data-cy="infobox"]').should('not.be.visible')
+        cy.activateFullscreen()
+    })
     it('can float or stick to the bottom', () => {
-        longClickOnMap()
+        cy.get('[data-cy="map"]').click()
         cy.waitUntilState((state) => {
             return state.features.selectedFeatures.length > 0
         })

--- a/tests/e2e-cypress/integration/mouseposition.cy.js
+++ b/tests/e2e-cypress/integration/mouseposition.cy.js
@@ -88,7 +88,7 @@ describe('Test mouse position', () => {
             checkMousePositionNumberValue(2604624.64, 1261029.16, parseLV)
         })
     })
-    context.skip('LocationPopUp when rightclick on the map', function () {
+    context('LocationPopUp when rightclick on the map', function () {
         const lat = 45
         const lon = 8
         beforeEach(() => {
@@ -140,7 +140,7 @@ describe('Test mouse position', () => {
             })
             it('Uses the coordination system WGS84 in the popup', () => {
                 cy.get('[data-cy="location-popup-coordinates-wgs84"]').contains(
-                    `${lat}° 00′ 00.00″ N ${lon}° 00′ 00.00″ E`
+                    `${lat}° N ${lon}° E`
                 )
             })
             it('Uses the coordination system UTM in the popup', () => {

--- a/tests/e2e-cypress/integration/mouseposition.cy.js
+++ b/tests/e2e-cypress/integration/mouseposition.cy.js
@@ -88,6 +88,18 @@ describe('Test mouse position', () => {
             checkMousePositionNumberValue(2604624.64, 1261029.16, parseLV)
         })
     })
+    context('Fullscreen trigger', function () {
+        it('Activates fullscreen when nothing is under the cursor', () => {
+            cy.goToMapView()
+            cy.activateFullscreen()
+            cy.readStoreValue('getters.isPhoneMode').then((isPhoneMode) => {
+                if (isPhoneMode) {
+                    cy.get('[data-cy="map"]').click('center')
+                    cy.waitUntilState((state) => !state.ui.fullscreenMode)
+                }
+            })
+        })
+    })
     context('LocationPopUp when rightclick on the map', function () {
         const lat = 45
         const lon = 8
@@ -99,6 +111,12 @@ describe('Test mouse position', () => {
         })
         it('Test the LocationPopUp is visible', () => {
             cy.get('[data-cy="location-popup"]').should('be.visible')
+        })
+        it('Test that it prevents direct activation of the full screen', () => {
+            cy.get('[data-cy="location-popup"]').should('be.visible')
+            cy.get('[data-cy="map"]').click(150, 150)
+            cy.get('[data-cy="location-popup"]').should('not.exist')
+            cy.activateFullscreen()
         })
         it('Uses the what3words in the popup', () => {
             cy.wait('@convert-to-w3w')

--- a/tests/e2e-cypress/integration/search/search-results.cy.js
+++ b/tests/e2e-cypress/integration/search/search-results.cy.js
@@ -297,11 +297,14 @@ describe('Test the search bar result handling', () => {
     })
     it('hides the results when the user clicks on the map', () => {
         cy.goToMapView()
+        cy.readStoreValue('state.ui.fullscreenMode').should('be.false')
         cy.get(searchbarSelector).paste('test')
         cy.wait(`@search-locations`)
         cy.get('[data-cy="search-result-entry-location"]').should('be.visible')
         cy.get('[data-cy="map"]').click()
         cy.get('[data-cy="search-result-entry-location"]').should('not.be.visible')
+        cy.activateFullscreen()
+        cy.get(searchbarSelector).should('be.hidden')
     })
     it('shows the results once again if the user clicks back on the search input', () => {
         cy.goToMapView()

--- a/tests/e2e-cypress/support/commands.js
+++ b/tests/e2e-cypress/support/commands.js
@@ -219,6 +219,18 @@ Cypress.Commands.add('readWindowValue', (key) => {
     return cy.window().its(key)
 })
 
+Cypress.Commands.add('activateFullscreen', () => {
+    cy.readStoreValue('state.ui.fullscreenMode').should('be.false')
+    cy.get('[data-cy="map"]').click('center')
+    cy.readStoreValue('getters.isPhoneMode').then((isPhoneMode) => {
+        if (isPhoneMode) {
+            cy.waitUntilState((state) => state.ui.fullscreenMode)
+        } else {
+            cy.readStoreValue('state.ui.fullscreenMode').should('be.false')
+        }
+    })
+})
+
 // from https://github.com/cypress-io/cypress/issues/1123#issuecomment-672640129
 Cypress.Commands.add(
     'paste',


### PR DESCRIPTION
Reworked click on mobile device. Implementation is as stated in the ticked, but with one small modification. If one needs to right click or long click to display the location popup only depends on the input device (mouse or touch screen) and not on the the ui mode (desktop or phone ui). On the other hand, if fullscreen mode can be activated or not only depends on the ui mode and not on the input device.

@pakb Can you please test the if long click to display the location popup works on IOS? I have read that safari may not implement correctly the oncontextmenu event. I have already a fix ready, but only want to add it if it is really necessary.

[Test link](https://sys-map.dev.bgdi.ch/feat-2235-rework-click-on-mobile-device/index.html)