### PR TITLE
BGDIINF_SB-2608: Fixed missmatch between profile and geodesic line

### DIFF
--- a/src/api/features.api.js
+++ b/src/api/features.api.js
@@ -168,6 +168,7 @@ export class EditableFeature extends Feature {
         this._fillColor = fillColor
         this._icon = icon
         this._iconSize = iconSize
+        this._geodesicCoordinates = null
     }
 
     /**
@@ -370,6 +371,17 @@ export class EditableFeature extends Feature {
     set isDragged(flag) {
         this._isDragged = flag
         this.emitChangeEvent('isDragged')
+    }
+
+    /**
+     * Get/Set the Geodesic Coordinates. Those coordinates are used with a geodesic filling between
+     * the coordinates. Those coordinates are used to draw the feature and for the height profile.
+     */
+    get geodesicCoordinates() {
+        return this._geodesicCoordinates
+    }
+    set geodesicCoordinates(coordinates) {
+        this._geodesicCoordinates = coordinates
     }
 }
 

--- a/src/modules/drawing/components/DrawingModifyInteraction.vue
+++ b/src/modules/drawing/components/DrawingModifyInteraction.vue
@@ -4,7 +4,10 @@
 
 <script>
 import { DRAWING_HIT_TOLERANCE } from '@/config'
-import { extractOpenLayersFeatureCoordinates } from '@/modules/drawing/lib/drawingUtils'
+import {
+    extractOlFeatureCoordinates,
+    extractOlFeatureGeodesicCoordinates,
+} from '@/modules/drawing/lib/drawingUtils'
 import { editingVertexStyleFunction } from '@/modules/drawing/lib/style'
 import { noModifierKeys, singleClick } from 'ol/events/condition'
 import ModifyInteraction from '@/modules/drawing/lib/modifyInteraction'
@@ -102,7 +105,8 @@ export default {
                 })
                 this.changeFeatureCoordinates({
                     feature: storeFeature,
-                    coordinates: extractOpenLayersFeatureCoordinates(feature),
+                    coordinates: extractOlFeatureCoordinates(feature),
+                    geodesicCoordinates: extractOlFeatureGeodesicCoordinates(feature),
                 })
                 this.getMap().getTarget().classList.remove(cursorGrabbingClass)
                 this.$emit('modifyEnd', feature)

--- a/src/modules/drawing/components/drawingInteraction.mixin.js
+++ b/src/modules/drawing/components/drawingInteraction.mixin.js
@@ -1,5 +1,8 @@
 import { EditableFeature } from '@/api/features.api'
-import { extractOpenLayersFeatureCoordinates } from '@/modules/drawing/lib/drawingUtils'
+import {
+    extractOlFeatureCoordinates,
+    extractOlFeatureGeodesicCoordinates,
+} from '@/modules/drawing/lib/drawingUtils'
 import { editingFeatureStyleFunction, featureStyleFunction } from '@/modules/drawing/lib/style'
 import DrawInteraction from 'ol/interaction/Draw'
 import { getUid } from 'ol/util'
@@ -123,8 +126,10 @@ const drawingInteractionMixin = {
             const normalizedCoords = wrapWebmercatorCoords(geometry.getCoordinates(), true)
             geometry.setCoordinates(normalizedCoords) // needed probably to trigger rerender
 
-            feature.get('editableFeature').coordinates =
-                extractOpenLayersFeatureCoordinates(feature)
+            let editableFeature = feature.get('editableFeature')
+            editableFeature.coordinates = extractOlFeatureCoordinates(feature)
+            editableFeature.geodesicCoordinates = extractOlFeatureGeodesicCoordinates(feature)
+
             // removing the flag we've set above in onDrawStart (this feature is now drawn)
             feature.unset('isDrawing')
             // setting the definitive style function for this feature (thus replacing the editing style from the interaction)

--- a/src/modules/drawing/lib/drawingUtils.js
+++ b/src/modules/drawing/lib/drawingUtils.js
@@ -14,8 +14,8 @@ export function toLv95(input, epsg) {
 }
 
 /**
- * Wraps the provided webmercator coordinates in the world extents (i.e. the coordinate range
- * that if equivalent to the wgs84 [-180, 180))
+ * Wraps the provided webmercator coordinates in the world extents (i.e. the coordinate range that
+ * if equivalent to the wgs84 [-180, 180))
  *
  * @param coords The coordinates (or array of coordinates) to wrap
  * @param inPlace If false, the original coordinates remain untouched and only a copy is modified
@@ -102,7 +102,7 @@ export function formatAngle(value, digits = 2) {
     return `${value.toFixed(digits)}°`
 }
 
-export function extractOpenLayersFeatureCoordinates(feature) {
+export function extractOlFeatureCoordinates(feature) {
     let coordinates = feature.getGeometry().getCoordinates()
     if (feature.getGeometry().getType() === 'Polygon') {
         // in case of a polygon, the coordinates structure is
@@ -117,6 +117,10 @@ export function extractOpenLayersFeatureCoordinates(feature) {
         coordinates = coordinates[0]
     }
     return coordinates
+}
+
+export function extractOlFeatureGeodesicCoordinates(feature) {
+    return feature.geodesic?.getGeodesicGeom().getCoordinates()[0]
 }
 
 /**

--- a/src/modules/infobox/components/FeatureProfile.vue
+++ b/src/modules/infobox/components/FeatureProfile.vue
@@ -267,7 +267,7 @@ export default {
                 return await apiFunction({
                     geom: { type: 'LineString', coordinates: coordinatesLv95 },
                     offset: 0,
-                    sr: CoordinateSystems.LV95.espgNumber,
+                    sr: CoordinateSystems.LV95.epsgNumber,
                     distinct_points: true,
                 })
             } catch (e) {

--- a/src/modules/map/components/openlayers/OpenLayersInternalLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersInternalLayer.vue
@@ -11,7 +11,7 @@
             v-if="layerConfig.type === LayerTypes.WMTS"
             :layer-id="layerConfig.getID()"
             :opacity="layerConfig.opacity"
-            :url="layerConfig.getURL(LV95.espgNumber)"
+            :url="layerConfig.getURL(LV95.epsgNumber)"
             :z-index="zIndex"
             :projection="LV95.epsg"
         />
@@ -19,7 +19,7 @@
             v-if="layerConfig.type === LayerTypes.WMS"
             :layer-id="layerConfig.getID()"
             :opacity="layerConfig.opacity"
-            :url="layerConfig.getURL(LV95.espgNumber)"
+            :url="layerConfig.getURL(LV95.epsgNumber)"
             :gutter="layerConfig.gutter"
             :z-index="zIndex"
             :projection="LV95.epsg"

--- a/src/store/modules/features.store.js
+++ b/src/store/modules/features.store.js
@@ -60,12 +60,13 @@ export default {
          * @param {EditableFeature} feature
          * @param {Number[][]} coordinates
          */
-        changeFeatureCoordinates({ commit, state }, { feature, coordinates }) {
+        changeFeatureCoordinates({ commit, state }, { feature, coordinates, geodesicCoordinates }) {
             const selectedFeature = getSelectedFeatureWithId(state, feature.id)
             if (selectedFeature && selectedFeature.isEditable && Array.isArray(coordinates)) {
                 commit('changeFeatureCoordinates', {
                     feature: selectedFeature,
                     coordinates,
+                    geodesicCoordinates,
                 })
             }
         },
@@ -221,8 +222,9 @@ export default {
         setSelectedFeatures(state, features) {
             state.selectedFeatures = [...features]
         },
-        changeFeatureCoordinates(state, { feature, coordinates }) {
+        changeFeatureCoordinates(state, { feature, coordinates, geodesicCoordinates }) {
             feature.coordinates = coordinates
+            feature.geodesicCoordinates = geodesicCoordinates
         },
         changeFeatureTitle(state, { feature, title }) {
             feature.title = title

--- a/src/utils/coordinateUtils.js
+++ b/src/utils/coordinateUtils.js
@@ -345,7 +345,7 @@ export const CoordinateSystems = {
     LV95: {
         id: 'LV95',
         epsg: 'EPSG:2056',
-        espgNumber: 2056,
+        epsgNumber: 2056,
         label: 'CH1903+ / LV95',
         /**
          * @param {Number[]} coordinate Coordinates in LV95 as [easting, northing]

--- a/src/utils/geodesicManager.js
+++ b/src/utils/geodesicManager.js
@@ -20,7 +20,7 @@ const DEG360_IN_WEBMERCATOR = CoordinateSystems.WEBMERCATOR.deg360
 /**
  * Class responsible for:
  *
- * - Generating the geodesic geometries of a given Polygon or LineString. The generated geometires are
+ * - Generating the geodesic geometries of a given Polygon or LineString. The generated geometries are
  *   of type "MultiPolygon" / "MultiLineString", so that the 180deg datetime limit is correctly
  *   handled by openlayers.
  * - Generating the measure styles that the measure feature uses to display intermediate distances,

--- a/tests/e2e-cypress/integration/drawing/geodesicDrawing.cy.js
+++ b/tests/e2e-cypress/integration/drawing/geodesicDrawing.cy.js
@@ -1,7 +1,7 @@
 import { EditableFeatureTypes } from '@/api/features.api'
 import { CoordinateSystems } from '@/utils/coordinateUtils'
 import { wrapWebmercatorCoords } from '@/modules/drawing/lib/drawingUtils'
-import { extractOpenLayersFeatureCoordinates } from '@/modules/drawing/lib/drawingUtils'
+import { extractOlFeatureCoordinates } from '@/modules/drawing/lib/drawingUtils'
 
 const DEG360 = CoordinateSystems.WEBMERCATOR.deg360
 const olSelector = '.ol-viewport'
@@ -72,7 +72,7 @@ function checkFeatureSelected(featureCoords, precision) {
     cy.readWindowValue('drawingLayer').should((layer) => {
         const features = layer.getSource().getFeatures()
         expect(features, 'Expected the drawing layer to contain exactly one feat').to.have.length(1)
-        const coords = extractOpenLayersFeatureCoordinates(features[0])
+        const coords = extractOlFeatureCoordinates(features[0])
         checkCoordsEqual(coords, featureCoords, precision)
     })
     cy.readStoreValue('state.features.selectedFeatures').then((features) => {


### PR DESCRIPTION
When drawing a line or a measurement, we use a geodesic line. However the profile
backend did a flat filling to have at least 200 points. This lead to a missmatch
of a few pixels when drawing a line across switzerland.

To solve the issue we use the geodesic points as coordinate to pass to the
profile backend, this way the filling is done by the frontend instead of the
backend.

[Test link](https://sys-map.dev.bgdi.ch/bug-bgdiinf_sb-2608-profile/index.html)