### PR TITLE
BGDIINF_SB-2660: Fixed index out of bounds exceptions when adding layers

### DIFF
--- a/src/modules/map/components/openlayers/OpenLayersInternalLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersInternalLayer.vue
@@ -2,6 +2,7 @@
     <div>
         <OpenLayersVectorLayer
             v-if="layerConfig.type === LayerTypes.VECTOR"
+            :z-index="zIndex"
             :layer-id="layerConfig.getID()"
             :opacity="layerConfig.opacity"
             :style-url="layerConfig.getURL()"

--- a/src/modules/map/components/openlayers/utils/addLayerToMap-mixins.js
+++ b/src/modules/map/components/openlayers/utils/addLayerToMap-mixins.js
@@ -40,11 +40,10 @@ const addLayerToMapMixin = {
     methods: {
         addLayerToMap(zIndex, layer) {
             const map = this.getMap()
-            if (zIndex < 0) {
-                map.addLayer(layer)
-            } else {
-                map.getLayers().insertAt(zIndex, layer)
+            if (zIndex >= 0) {
+                layer.setZIndex(zIndex)
             }
+            map.addLayer(layer)
             this.isPresentOnMap = true
         },
         removeLayerFromMap(layer) {
@@ -55,8 +54,7 @@ const addLayerToMapMixin = {
     watch: {
         zIndex(zIndex) {
             if (this.layer) {
-                this.removeLayerFromMap(this.layer)
-                this.addLayerToMap(zIndex, this.layer)
+                this.layer.setZIndex(zIndex)
             }
         },
     },


### PR DESCRIPTION
Do not set the z-index anymore by reordering the layers in the layers array, but by setting the zIndex property of the layer, so the z indicies can be set to anything without having to fear to throw an index out of bounds exception.

This new way of definining the z indices has also the advantage that the z indices do not need to follow a strict chronological order anymore. But I haven't tried to simplify this code for the moment.

[Test link](https://sys-map.dev.bgdi.ch/bugfix-2660-index-out-of-bounds-in-addlayertomap/index.html)