### PR TITLE
BGDIINF_SB-2671: Put assets in version directory during build

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -27,7 +27,7 @@ phases:
       - export GIT_BRANCH="${CODEBUILD_WEBHOOK_HEAD_REF#refs/heads/}"
       - export GIT_BASE_BRANCH="${CODEBUILD_WEBHOOK_BASE_REF#refs/heads/}"
       - export GIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
-      - export GIT_TAG="$(git describe --tags || echo 'unknown')"
+      - export GIT_TAG="$(git describe --tags --dirty || echo 'unknown')"
       - export GIT_DIRTY="$(git status --porcelain)"
       # When build are manually triggered by a user, the CODEBUILD_WEBHOOK_HEAD_REF is not
       # set resulting to an empty GIT_BRANCH. Usually Codebuild don't checkout the branch but
@@ -55,6 +55,8 @@ phases:
       - if [ "${DEPLOY_TARGET}" = "int" ] ; then
           export AWS_ACCOUNT_TO_USE="${AWS_SWISSTOPO_BGDI_ACCOUNT_ID}:role/BgdiCodebuildAccess";
         fi
+      # Set the app version to the git tag
+      - export APP_VERSION=${GIT_TAG}
       - echo "=== Environment Variables ======================================="
       - echo CODEBUILD_INITIATOR=${CODEBUILD_INITIATOR}
       - echo CODEBUILD_RESOLVED_SOURCE_VERSION=${CODEBUILD_RESOLVED_SOURCE_VERSION}
@@ -76,6 +78,7 @@ phases:
       - echo BUILD_TYPE=${BUILD_TYPE}
       - echo DEPLOY_TARGET=${DEPLOY_TARGET}
       - echo AWS_ACCOUNT_TO_USE=${AWS_ACCOUNT_TO_USE}
+      - echo APP_VERSION=${GIT_TAG}
       # As the cypress/download folder is not added to git, and (somehow) not created by Cypress at startup, we create it
       - mkdir -p cypress/downloads/
 
@@ -84,7 +87,6 @@ phases:
       - echo ===================================================================
       - echo Building application for ${BUILD_TYPE}
       - npm run build-${BUILD_TYPE}
-      - export VERSION=$(jq '.version' -r dist/info.json)
 
 
   post_build:
@@ -109,7 +111,7 @@ phases:
 
 artifacts:
   # The name below is only used for manual build (not by build started by the webhook)
-  name: ${BUILD_TYPE}/web-mapviewer/${VERSION}
+  name: ${BUILD_TYPE}/web-mapviewer/${APP_VERSION}
   files:
     - '**/*'
   base-directory: dist

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
         "build": "npm run type-check && vite build",
         "build-dev": "npm run build -- --mode development",
         "build-prod": "npm run build -- --mode production",
-        "deploy:dev": "DEPLOY=true npm run build-dev && node scripts/deploy.js dev",
-        "deploy:int": "DEPLOY=true npm run build-prod && node scripts/deploy.js int",
+        "deploy:dev": "node scripts/deploy.js dev",
+        "deploy:int": "node scripts/deploy.js int",
         "update:translations": "node scripts/generate-i18n-files.js",
         "update:browserlist": "npx browserslist@latest --update-db"
     },

--- a/vite-plugins/generate-build-info.js
+++ b/vite-plugins/generate-build-info.js
@@ -23,7 +23,7 @@ export default function generateBuildInfo(version) {
                 const localChanges = execSync('git status --porcelain').toString().trim()
                 this.emitFile({
                     type: 'asset',
-                    fileName: 'info.json',
+                    fileName: `${version}/info.json`,
                     source: JSON.stringify(
                         {
                             version: version,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,12 +4,21 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import generateBuildInfo from './vite-plugins/generate-build-info'
 
-const appVersion = 'v' + gitDescribeSync().semverString
+// We take the version from APP_VERSION but if not set, then take
+// it from git describe command
+let appVersion = process.env.APP_VERSION
+if (!appVersion) {
+    appVersion = 'v' + gitDescribeSync().semverString
+}
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {
     return {
         base: './',
+        build: {
+            emptyOutDir: true,
+            assetsDir: `${appVersion}/assets`,
+        },
         plugins: [vue(), generateBuildInfo(appVersion)],
         resolve: {
             alias: {
@@ -26,3 +35,4 @@ export default defineConfig(({ command, mode }) => {
         },
     }
 })
+


### PR DESCRIPTION
This allow a better deployment approach on S3. We can copy first the versioned
assets directory (containing the images but also the javascript and css code)
into S3 without disturbing the current version, once it is copied, we
can copy the public files from the root and finally the index.html.

This procedure reduce the risk of downtime.

I tried to put also the public files in a versioned directory but this is quite complex and require also to implement parsing and changes in the index.html. So I left them at the root to keep it simple and out of the box.
[Test link](https://sys-map.dev.bgdi.ch/feat-bgdiinf_sb-2671-dist-version/index.html)