### PR TITLE
Replace UNIX specific script in build pipeline

### DIFF
--- a/vite-plugins/generate-build-info.js
+++ b/vite-plugins/generate-build-info.js
@@ -22,14 +22,6 @@ function getGitBranch(gitHash) {
     return branches[0]
 }
 
-const currentHash = execSync('git rev-parse HEAD').toString().trim()
-
-// We take the version from GIT_BRANCH but if not set, then take it from git show-ref
-let gitBranch = process.env.GIT_BRANCH
-if (!gitBranch) {
-    gitBranch = getGitBranch(currentHash)
-}
-
 /**
  * Small Rollout / Vite plugin that writes a JSON containing build information, such as date or app
  * version.
@@ -43,6 +35,14 @@ export default function generateBuildInfo(version) {
             sequential: true,
             order: 'post',
             async handler() {
+                const currentHash = execSync('git rev-parse HEAD').toString().trim()
+
+                // We take the version from GIT_BRANCH but if not set, then take it from git show-ref
+                let gitBranch = process.env.GIT_BRANCH
+                if (!gitBranch) {
+                    gitBranch = getGitBranch(currentHash)
+                }
+
                 const now = new Date()
                 const localChanges = execSync('git status --porcelain').toString().trim()
                 this.emitFile({

--- a/vite-plugins/generate-build-info.js
+++ b/vite-plugins/generate-build-info.js
@@ -1,6 +1,36 @@
 import { execSync } from 'child_process'
 
 /**
+ * Javascriptifaction of
+ * https://github.com/geoadmin/web-mapviewer/blob/4826f4a05df9a5a12fc3eea2a902618800fc9425/buildspec.yml#L43-L44
+ * so that it also functions properly on a window10/11 machine in PowerShell (or Window terminal)
+ *
+ * Original cmd is git show-ref | grep "$(git rev-parse HEAD)" | awk '!/refs/tags// {print $2}' |
+ * head -1
+ *
+ * @param {String} gitHash The current git hash
+ * @returns {String} The git branch without "origin/" or "refs/" portion
+ */
+function getGitBranch(gitHash) {
+    const headRefs = execSync('git show-ref --heads').toString().trim().split('\n')
+    // we now do a grep-like operation, only keeping refs that have the hash found in gitHash
+    // we also have to remove all prefixes on the branch, i.e. /refs/tags or /origin/ etc...
+    const branches = headRefs
+        .filter((ref) => ref.indexOf(gitHash) !== -1)
+        .map((matchingRef) => matchingRef.substring(matchingRef.lastIndexOf('/') + 1)) // +1 so that we skip the /
+    // only taking into account the last item (like doing a head -1)
+    return branches[0]
+}
+
+const currentHash = execSync('git rev-parse HEAD').toString().trim()
+
+// We take the version from GIT_BRANCH but if not set, then take it from git show-ref
+let gitBranch = process.env.GIT_BRANCH
+if (!gitBranch) {
+    gitBranch = getGitBranch(currentHash)
+}
+
+/**
  * Small Rollout / Vite plugin that writes a JSON containing build information, such as date or app
  * version.
  *
@@ -14,12 +44,6 @@ export default function generateBuildInfo(version) {
             order: 'post',
             async handler() {
                 const now = new Date()
-                const gitBranch = execSync(
-                    `git show-ref --heads | grep "$(git --no-pager show --format=%H)" | head -1 | awk '{gsub("refs/heads/", ""); print $2}'`
-                )
-                    .toString()
-                    .trim()
-                const gitHash = execSync('git rev-parse HEAD').toString().trim()
                 const localChanges = execSync('git status --porcelain').toString().trim()
                 this.emitFile({
                     type: 'asset',
@@ -33,7 +57,7 @@ export default function generateBuildInfo(version) {
                             },
                             git: {
                                 branch: gitBranch,
-                                hash: gitHash,
+                                hash: currentHash,
                                 dirty: !!localChanges,
                                 localChanges: localChanges,
                             },


### PR DESCRIPTION
so that the CI can still decipher which branch it is running on, and window users can still build the project

[Test link](https://sys-map.dev.bgdi.ch/feat-replace-unix-specific-script/index.html)