### PR TITLE
BGDIINF_SB-2660 : fix drawing layer not having a zIndex

### DIFF
--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -220,6 +220,7 @@ export default {
         this.drawingLayer = new VectorLayer({
             source: new VectorSource({ useSpatialIndex: false, wrapX: true }),
         })
+        this.drawingLayer.setZIndex(9999)
         // if icons have not yet been loaded, we do so
         if (this.availableIconSets.length === 0) {
             this.loadAvailableIconSets()


### PR DESCRIPTION
and thus going under the base layer while drawing

[Test link](https://sys-map.dev.bgdi.ch/bugfix-bgdiinf_sb-2660_fix_drawing_layer_zindex/index.html)