### PR TITLE
BGDIINF_SB-2662: Various bugfixes on position popup

### DIFF
--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -78,7 +78,7 @@
             </div>
             <div v-else>-</div>
             <div class="location-popup-link lp-label">
-                {{ $t('link_bowl_crosshair') }}
+                {{ $t('share_link') }}
             </div>
             <div class="location-popup-link lp-data">
                 <LocationPopupCopyInput

--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -325,7 +325,7 @@ export default {
         margin-bottom: 0.1rem;
     }
 }
-@media (min-height: 650px) {
+@media (min-height: 850px) {
     .location-popup-qrcode {
         display: block;
     }

--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -270,6 +270,7 @@ export default {
 <style lang="scss" scoped>
 @import 'src/scss/webmapviewer-bootstrap-theme';
 .location-popup {
+    // Triangle border
     &::before {
         $arrow-height: 15px;
         position: absolute;
@@ -277,9 +278,20 @@ export default {
         left: 50%;
         margin-left: -$arrow-height;
         border: $arrow-height solid transparent;
-        border-bottom-color: $light;
+        border-bottom-color: var(--bs-border-color-translucent);
         pointer-events: none;
         content: '';
+    }
+    // Triangle background
+    &::after {
+        $arrow-border-height: 14px;
+        content: '';
+        border: $arrow-border-height solid transparent;
+        border-bottom-color: $light;
+        position: absolute;
+        top: -($arrow-border-height * 2);
+        left: 50%;
+        margin-left: -$arrow-border-height;
     }
     &-coordinates {
         display: grid;

--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -298,6 +298,7 @@ export default {
         grid-template-columns: min-content auto;
         grid-column-gap: 8px;
         font-size: 0.75rem;
+        grid-row-gap: 2px;
         .lp-label {
             white-space: nowrap;
         }

--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -278,7 +278,7 @@ export default {
         left: 50%;
         margin-left: -$arrow-height;
         border: $arrow-height solid transparent;
-        border-bottom-color: var(--bs-border-color-translucent);
+        border-bottom-color: $border-color-translucent;
         pointer-events: none;
         content: '';
     }

--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -8,28 +8,28 @@
         @close="onClose"
     >
         <div class="location-popup-coordinates ol-selectable">
-            <div>
+            <div class="lp-label">
                 <a :href="$t('contextpopup_lv95_url')" target="_blank">CH1903+ / LV95</a>
             </div>
-            <div>
+            <div class="lp-data">
                 <span data-cy="location-popup-coordinates-lv95">
                     {{ coordinateLV95 }}
                 </span>
                 <LocationPopupCopySlot :value="coordinateLV95" />
             </div>
-            <div>
+            <div class="lp-label">
                 <a :href="$t('contextpopup_lv03_url')" target="_blank">CH1903 / LV03</a>
             </div>
-            <div>
+            <div class="lp-data">
                 <span data-cy="location-popup-coordinates-lv03">
                     {{ coordinateLV03 }}
                 </span>
                 <LocationPopupCopySlot :value="coordinateLV03" />
             </div>
-            <div>
+            <div class="lp-label">
                 <a href="https://epsg.io/4326" target="_blank">WGS 84 (lat/lon)</a>
             </div>
-            <div>
+            <div class="lp-data">
                 <span
                     class="location-popup-coordinates-wgs84-plain"
                     data-cy="location-popup-coordinates-plain-wgs84"
@@ -42,45 +42,45 @@
                     {{ coordinateWGS84 }}
                 </span>
             </div>
-            <div>
+            <div class="lp-label">
                 <a href="https://epsg.io/32632" target="_blank">UTM</a>
             </div>
-            <div>
+            <div class="lp-data">
                 <span data-cy="location-popup-coordinates-utm">
                     {{ coordinateUTM }}
                 </span>
                 <LocationPopupCopySlot :value="coordinateUTM" />
             </div>
-            <div>{{ 'MGRS' }}</div>
-            <div>
+            <div class="lp-label">{{ 'MGRS' }}</div>
+            <div class="lp-data">
                 <span data-cy="location-popup-coordinates-mgrs">
                     {{ coordinateMGRS }}
                 </span>
                 <LocationPopupCopySlot :value="coordinateMGRS" />
             </div>
-            <div>
+            <div class="lp-label">
                 <a href="http://what3words.com/" target="_blank">what3words</a>
             </div>
-            <div v-if="what3Words">
+            <div v-if="what3Words" class="lp-data what-3-words">
                 <span v-show="what3Words" data-cy="location-popup-w3w">
                     {{ what3Words }}
                 </span>
                 <LocationPopupCopySlot :value="what3Words" />
             </div>
             <div v-else>-</div>
-            <div>
+            <div class="lp-label">
                 <a :href="$t('elevation_href')" target="_blank">{{ $t('elevation') }}</a>
             </div>
-            <div v-if="height">
+            <div v-if="height" class="lp-data">
                 <span data-cy="location-popup-height"> {{ heightInMeter }} m</span> /
                 <span>{{ heightInFeet }} ft</span>
                 <LocationPopupCopySlot :value="heightInMeter" />
             </div>
             <div v-else>-</div>
-            <div class="location-popup-link">
+            <div class="location-popup-link lp-label">
                 {{ $t('link_bowl_crosshair') }}
             </div>
-            <div class="location-popup-link">
+            <div class="location-popup-link lp-data">
                 <LocationPopupCopyInput
                     :value="shareLinkUrlDisplay"
                     data-cy="location-popup-link-bowl-crosshair"
@@ -295,8 +295,21 @@ export default {
     }
     &-coordinates {
         display: grid;
-        grid-template-columns: 1fr 2fr;
+        grid-template-columns: min-content auto;
+        grid-column-gap: 8px;
         font-size: 0.75rem;
+        .lp-label {
+            white-space: nowrap;
+        }
+        .lp-data.what-3-words {
+            display: grid;
+            grid-template-columns: auto min-content;
+            span {
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+        }
     }
     &-link {
         display: flex;

--- a/src/modules/map/components/LocationPopupCopyInput.vue
+++ b/src/modules/map/components/LocationPopupCopyInput.vue
@@ -19,6 +19,7 @@
 <script>
 import { Tooltip } from 'bootstrap'
 import { mapGetters } from 'vuex'
+import log from '@/utils/logging'
 
 export default {
     inheritAttrs: false,
@@ -63,11 +64,14 @@ export default {
             event.target.select()
         },
         async copyValue() {
-            await navigator.clipboard.writeText(this.value)
-
-            // Change button text and start the reset timer.
-            this.buttonText = 'copy_success'
-            this.resetTimeout = setTimeout(this.resetButton, this.resetDelay)
+            try {
+                await navigator.clipboard.writeText(this.value)
+                // Change button text and start the reset timer.
+                this.buttonText = 'copy_success'
+                this.resetTimeout = setTimeout(this.resetButton, this.resetDelay)
+            } catch (error) {
+                log.error(`Failed to copy to clipboard: ${error}`)
+            }
         },
     },
 }

--- a/src/modules/map/components/LocationPopupCopyInput.vue
+++ b/src/modules/map/components/LocationPopupCopyInput.vue
@@ -70,7 +70,7 @@ export default {
                 this.buttonText = 'copy_success'
                 this.resetTimeout = setTimeout(this.resetButton, this.resetDelay)
             } catch (error) {
-                log.error(`Failed to copy to clipboard: ${error}`)
+                log.error(`Failed to copy to clipboard:`, error)
             }
         },
     },

--- a/src/modules/map/components/LocationPopupCopySlot.vue
+++ b/src/modules/map/components/LocationPopupCopySlot.vue
@@ -11,6 +11,8 @@
 </template>
 
 <script>
+import log from '@/utils/logging'
+
 export default {
     props: {
         value: {
@@ -35,11 +37,15 @@ export default {
             this.buttonText = 'copy_cta'
         },
         async copyValue() {
-            await navigator.clipboard.writeText(this.value)
+            try {
+                await navigator.clipboard.writeText(this.value)
 
-            // Change button text and start the reset timer.
-            this.buttonText = 'copy_done'
-            this.resetTimeout = setTimeout(this.resetButton, this.resetDelay)
+                // Change button text and start the reset timer.
+                this.buttonText = 'copy_done'
+                this.resetTimeout = setTimeout(this.resetButton, this.resetDelay)
+            } catch (error) {
+                log.error(`Failed to copy to clipboard: ${error}`)
+            }
         },
     },
 }

--- a/src/modules/map/components/LocationPopupCopySlot.vue
+++ b/src/modules/map/components/LocationPopupCopySlot.vue
@@ -44,7 +44,7 @@ export default {
                 this.buttonText = 'copy_done'
                 this.resetTimeout = setTimeout(this.resetButton, this.resetDelay)
             } catch (error) {
-                log.error(`Failed to copy to clipboard: ${error}`)
+                log.error(`Failed to copy to clipboard:`, error)
             }
         },
     },

--- a/src/modules/map/components/openlayers/OpenLayersPopover.vue
+++ b/src/modules/map/components/openlayers/OpenLayersPopover.vue
@@ -96,7 +96,6 @@ export default {
         overflow-y: auto;
         display: flex;
         flex-direction: column;
-        gap: 8px;
     }
     &::before {
         $arrow-height: 15px;


### PR DESCRIPTION
Various bugfixes and improvements, see commits message for more details.

- Added border to position css triangle, needed on light background to add more contrast
- Fixed some error handling
- Do not display qrcode on mobile display
- Fixed long What3Words which pushed the copy button on a new line (see printscreen below)
  ![image](https://user-images.githubusercontent.com/67745584/204231664-077cd524-46ec-4033-ad3f-e59eb5d897ff.png)
  Now the Whats3word is truncated with ellipsis, but you can still copy the whole address with the copy button. The position label space has been also reduced to let more space for the values. This reduced the risk of what3words truncate which now happens quite rarely.
  Here below is an example of a truncate what3words
  ![image](https://user-images.githubusercontent.com/67745584/204232226-1e7cf539-829d-4514-a83b-56a100c82c7e.png)


[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2662-position-popup/index.html)