### PR TITLE
BGDIINF_SB-2683: Fixed GeoJSON layers

### DIFF
--- a/src/api/features.api.js
+++ b/src/api/features.api.js
@@ -44,9 +44,9 @@ export class SelectableFeature extends EventEmitter {
         super()
         this._id = id
         // using the setter for coordinate (see below)
-        this._coordinates = coordinates
-        this._title = title
-        this._description = description
+        this.coordinates = coordinates
+        this.title = title
+        this.description = description
         this._isEditable = !!isEditable
         this._isDragged = false
     }
@@ -97,6 +97,10 @@ export class SelectableFeature extends EventEmitter {
                 this._coordinates = newCoordinates
             }
             this.emitChangeEvent('coordinates')
+        } else if (newCoordinates === null) {
+            this._coordinates = newCoordinates
+        } else {
+            log.error(`feature.api new coordinates is not an array`, newCoordinates)
         }
     }
     get lastCoordinate() {

--- a/src/modules/map/components/openlayers/OpenLayersGeoJSONLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersGeoJSONLayer.vue
@@ -52,9 +52,15 @@ export default {
         this.layer = new VectorLayer({ id: this.layerId, opacity: this.opacity })
 
         // loading the GeoJSON data and style with and wait for both the be loaded
-        axios
-            .all([axios.get(this.geojsonUrl), axios.get(this.styleUrl)])
+        // WARNING: axios.get(this.styleUrl) will not work on localhost and will fire a CORS error !!
+        // this is due to the fact that the backend send the styleUrl agnostic whitout HTTP scheme !
+        Promise.all([axios.get(this.geojsonUrl), axios.get(this.styleUrl)])
             .then((responses) => {
+                if (!this.layer) {
+                    // It could be that the layer has been removed meanwhile therefore check for
+                    // its existence
+                    return
+                }
                 const geojsonData = responses[0].data
                 const geojsonStyleLiterals = responses[1].data
                 const style = new OlStyleForPropertyValue(geojsonStyleLiterals)

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -385,7 +385,7 @@ export default {
                         this.map
                             .getFeaturesAtPixel(event.pixel, {
                                 // filtering other layers out
-                                layerFilter: (layer) => layer.get('id') === geoJsonLayer.id,
+                                layerFilter: (layer) => layer.get('id') === geoJsonLayer.getID(),
                             })
                             .forEach((feature) => {
                                 const featureGeometry = feature.getGeometry()
@@ -394,7 +394,8 @@ export default {
                                 // (not very fancy but otherwise the look and feel is different from a typical backend tooltip)
                                 const geoJsonFeature = new LayerFeature(
                                     geoJsonLayer,
-                                    feature.get('id') || feature.getId(),
+                                    geoJsonLayer.getID(),
+                                    geoJsonLayer.name,
                                     `<div class="htmlpopup-container">
                                         <div class="htmlpopup-header">
                                             <span>${geoJsonLayer.name}</span>

--- a/src/modules/map/components/openlayers/utils/styleFromLiterals.js
+++ b/src/modules/map/components/openlayers/utils/styleFromLiterals.js
@@ -71,7 +71,7 @@ function getOlStyleFromLiterals(value) {
     const olStyles = {}
     const { vectorOptions: style, geomType } = value
 
-    if (geomType === 'Point') {
+    if (geomType === 'point') {
         let olText
         if (style.label) {
             olText = getOlBasicStyles(style.label).text

--- a/src/modules/menu/components/search/SearchResultCategory.vue
+++ b/src/modules/menu/components/search/SearchResultCategory.vue
@@ -51,7 +51,7 @@ export default {
             default: false,
         },
     },
-    emits: ['preview'],
+    emits: ['preview', 'previewStart', 'previewStop'],
     data() {
         return {
             showLayerLegendForId: null,

--- a/src/utils/__tests__/legacyKmlUtils.spec.js
+++ b/src/utils/__tests__/legacyKmlUtils.spec.js
@@ -83,7 +83,12 @@ function performStandardChecks(
     expectedCoordinateCount = 2
 ) {
     expect(feature).to.be.not.null.and.not.undefined
-    expect(feature.coordinates).to.have.length(expectedCoordinateCount)
+    expect(feature.coordinates).to.have.length.greaterThan(0)
+    if (feature.coordinates.length === 1) {
+        expect(feature.coordinates[0]).to.have.length(expectedCoordinateCount)
+    } else {
+        expect(feature.coordinates).to.have.length(expectedCoordinateCount)
+    }
     // checking that it matches also what is defined in the underlying OL object
     const olCoordinates = feature.olFeature.getGeometry().getCoordinates()
     // if olCoordinates is only 1 in length, it means it is a closed polygon and we


### PR DESCRIPTION
Some GeoJSON layers were not displayed correctly. Styling with a geometry type
of `point` where not displayed due to a wrong string comparison (`'point' === 'Point'`)

Also sometimes we could have a crash due to a non existing layer object which
was due to the fact that when hovering a search result a layer is created and
asynchronously the layer style was loaded, meanwhile when the hover is gone
the layer is destroyed which can happen before the layer style load from backend.

Updated some missing event in emit list to prevents vue warning.

- [x] Click on geojson feature don't open popup !

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2683-geojson/index.html)