### PR TITLE
BGDIINF_SB-2683: Improved html popover style

### DIFF
--- a/src/modules/infobox/components/FeatureList.vue
+++ b/src/modules/infobox/components/FeatureList.vue
@@ -93,9 +93,7 @@ export default {
     margin-bottom: 7px;
     font-weight: 700;
 }
-.htmlpopup-content table {
-    width: 100%;
-    border: 0;
-    margin: 0 7px;
+.htmlpopup-content {
+    padding: 7px;
 }
 </style>

--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -4,6 +4,7 @@
         :title="$t('position')"
         :coordinates="coordinate"
         class="location-popup"
+        use-content-padding
         data-cy="location-popup"
         @close="onClose"
     >

--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -270,29 +270,6 @@ export default {
 <style lang="scss" scoped>
 @import 'src/scss/webmapviewer-bootstrap-theme';
 .location-popup {
-    // Triangle border
-    &::before {
-        $arrow-height: 15px;
-        position: absolute;
-        top: -($arrow-height * 2);
-        left: 50%;
-        margin-left: -$arrow-height;
-        border: $arrow-height solid transparent;
-        border-bottom-color: $border-color-translucent;
-        pointer-events: none;
-        content: '';
-    }
-    // Triangle background
-    &::after {
-        $arrow-border-height: 14px;
-        content: '';
-        border: $arrow-border-height solid transparent;
-        border-bottom-color: $light;
-        position: absolute;
-        top: -($arrow-border-height * 2);
-        left: 50%;
-        margin-left: -$arrow-border-height;
-    }
     &-coordinates {
         display: grid;
         grid-template-columns: min-content auto;

--- a/src/modules/map/components/openlayers/OpenLayersPopover.vue
+++ b/src/modules/map/components/openlayers/OpenLayersPopover.vue
@@ -97,6 +97,7 @@ export default {
         display: flex;
         flex-direction: column;
     }
+    // Triangle border
     &::before {
         $arrow-height: 15px;
         position: absolute;
@@ -104,9 +105,20 @@ export default {
         left: 50%;
         margin-left: -$arrow-height;
         border: $arrow-height solid transparent;
-        border-bottom-color: $light;
+        border-bottom-color: $border-color-translucent;
         pointer-events: none;
         content: '';
+    }
+    // Triangle background
+    &::after {
+        $arrow-border-height: 14px;
+        content: '';
+        border: $arrow-border-height solid transparent;
+        border-bottom-color: $light;
+        position: absolute;
+        top: -($arrow-border-height * 2);
+        left: 50%;
+        margin-left: -$arrow-border-height;
     }
 }
 @media (min-height: 600px) {

--- a/src/modules/map/components/openlayers/OpenLayersPopover.vue
+++ b/src/modules/map/components/openlayers/OpenLayersPopover.vue
@@ -19,7 +19,12 @@
                     @click="onClose"
                 />
             </div>
-            <div id="mapPopoverContent" ref="mapPopoverContent" class="card-body">
+            <div
+                id="mapPopoverContent"
+                ref="mapPopoverContent"
+                class="map-popover-content"
+                :class="{ 'card-body': useContentPadding }"
+            >
                 <slot />
             </div>
         </div>
@@ -50,6 +55,10 @@ export default {
         title: {
             type: String,
             default: '',
+        },
+        useContentPadding: {
+            type: Boolean,
+            default: false,
         },
     },
     emits: ['close'],
@@ -89,11 +98,14 @@ export default {
 @import 'src/scss/webmapviewer-bootstrap-theme';
 
 .map-popover {
-    .card-body {
-        width: $overlay-width;
-        max-width: 100%;
+    .card {
+        max-width: $overlay-width;
+    }
+    .map-popover-content {
         max-height: 350px;
         overflow-y: auto;
+    }
+    .card-body {
         display: flex;
         flex-direction: column;
     }


### PR DESCRIPTION
Change the style of html popup to match mf-geoadmin3:
![image](https://user-images.githubusercontent.com/67745584/204625852-387e0ab8-fffe-4b25-98d1-c77e4cebcc50.png)

Was before:
![image](https://user-images.githubusercontent.com/67745584/204626322-74ca593b-58c5-4b5c-b1fb-5b7e88e21968.png)

And now is:
![image](https://user-images.githubusercontent.com/67745584/204628065-0230b7e0-9868-4a35-a0ef-02fac9f8910b.png)


[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2683-popover/index.html)