### PR TITLE
Fixed elevation profile crash on windows resize

### DIFF
--- a/src/modules/infobox/components/FeatureElevationProfilePlot.vue
+++ b/src/modules/infobox/components/FeatureElevationProfilePlot.vue
@@ -137,6 +137,11 @@ export default {
             this.$nextTick(this.updateElevationProfilePlot)
         },
         updateElevationProfilePlot() {
+            if (!this.$refs.profilePlot) {
+                // The $refs.profilePlot might be null because this method is
+                // executed within a Promise on the onResize() method.
+                return
+            }
             const { domainX, domainY, axisX, axisY } = updateD3ProfileChart(
                 this.$refs.profilePlot,
                 this.elevationProfile,


### PR DESCRIPTION
When resizing the windows or on mobile when switching between portrait
and landscape, the method updateElevationProfilePlot() crashed because it is
executed within a promise and due to timing the refs.profilePlot might be null.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-elevation-profile-crash/index.html)