### PR TITLE
BGDIINF_SB-2683: Fixed padding in infobox and popover

### DIFF
--- a/src/modules/drawing/components/DrawingToolbox.vue
+++ b/src/modules/drawing/components/DrawingToolbox.vue
@@ -2,7 +2,7 @@
     <teleport v-if="readyForTeleport" to=".drawing-toolbox-in-menu">
         <DrawingHeader v-if="isDesktopMode" @close="emitCloseEvent" />
         <div :class="[{ 'drawing-toolbox-closed': !drawMenuOpen }, 'drawing-toolbox']">
-            <div class="card text-center drawing-toolbox-content">
+            <div class="card text-center drawing-toolbox-content rounded-0">
                 <div class="card-body position-relative">
                     <ButtonWithIcon
                         class="drawing-toolbox-close-button"

--- a/src/modules/infobox/InfoboxModule.vue
+++ b/src/modules/infobox/InfoboxModule.vue
@@ -34,18 +34,19 @@
             <div
                 v-show="showContent"
                 ref="content"
-                class="infobox-content card-body"
+                class="infobox-content"
                 data-cy="infobox-content"
             >
                 <FeatureElevationProfile
                     v-if="showElevationProfile"
+                    class="card-body"
                     :feature="selectedFeature"
                     @update-elevation-profile-plot="setMaxHeight"
                 />
 
-                <FeatureCombo v-else-if="isCombo" :feature="selectedFeature" />
+                <FeatureCombo v-else-if="isCombo" class="card-body" :feature="selectedFeature" />
 
-                <FeatureEdit v-else-if="isEdit" :feature="selectedFeature" />
+                <FeatureEdit v-else-if="isEdit" class="card-body" :feature="selectedFeature" />
 
                 <FeatureList v-else-if="isList" />
             </div>

--- a/src/modules/infobox/InfoboxModule.vue
+++ b/src/modules/infobox/InfoboxModule.vue
@@ -1,6 +1,11 @@
 <template>
     <teleport v-if="readyForTeleport" to="#map-footer-middle">
-        <div v-show="showContainer" class="infobox card" data-cy="infobox" @contextmenu.stop>
+        <div
+            v-show="showContainer"
+            class="infobox card rounded-0"
+            data-cy="infobox"
+            @contextmenu.stop
+        >
             <div
                 class="infobox-header card-header"
                 data-cy="infobox-header"
@@ -9,12 +14,18 @@
                 <ButtonWithIcon
                     v-if="showFloatingToggle"
                     :button-font-awesome-icon="['fa', 'caret-up']"
+                    small
                     data-cy="infobox-toggle-floating"
                     @click.stop="onToggleFloating"
                 />
-                <ButtonWithIcon :button-font-awesome-icon="['fa', 'print']" @click.stop="onPrint" />
+                <ButtonWithIcon
+                    :button-font-awesome-icon="['fa', 'print']"
+                    small
+                    @click.stop="onPrint"
+                />
                 <ButtonWithIcon
                     :button-font-awesome-icon="['fa', 'times']"
+                    small
                     data-cy="infobox-close"
                     @click.stop="onClose"
                 />

--- a/src/modules/infobox/components/styling/FeatureStyleEdit.vue
+++ b/src/modules/infobox/components/styling/FeatureStyleEdit.vue
@@ -32,6 +32,7 @@
             <div class="d-flex feature-style-edit-control">
                 <PopoverButton
                     v-if="isFeatureMarker || isFeatureText"
+                    class="control-button"
                     data-cy="drawing-style-text-button"
                     with-close-button
                     popover-position="top"
@@ -52,6 +53,7 @@
 
                 <PopoverButton
                     v-if="isFeatureMarker"
+                    class="control-button"
                     data-cy="drawing-style-marker-button"
                     with-close-button
                     popover-position="top"
@@ -71,6 +73,7 @@
                     v-if="isFeatureLine"
                     data-cy="drawing-style-line-button"
                     popover-position="top"
+                    class="control-button"
                     with-close-button
                     :popover-title="$t('modify_color_label')"
                     :button-font-awesome-icon="['fas', 'paint-brush']"
@@ -83,6 +86,7 @@
                 </PopoverButton>
 
                 <ButtonWithIcon
+                    class="control-button"
                     data-cy="drawing-style-delete-button"
                     :button-font-awesome-icon="['far', 'trash-alt']"
                     @click="onDelete"
@@ -209,8 +213,7 @@ export default {
 <style lang="scss" scoped>
 @import 'src/scss/variables';
 
-.feature-style-edit-control button,
-div {
+.control-button {
     margin-right: $button-spacer;
 }
 </style>

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -55,6 +55,7 @@
             v-if="showFeaturesPopover"
             :coordinates="popoverCoordinates"
             authorize-print
+            :use-content-padding="editFeature"
             @close="clearAllSelectedFeatures"
         >
             <template #extra-buttons>


### PR DESCRIPTION
In infobox for html popup we don't want any padding while we need padding for
other infobox elements (drawing infos,...).

In the drawing popover the button margin was applied to all div elements instead
of just the buttons. This has been fixed.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2683-popover-new/index.html)