### PR TITLE
BGDIINF_SB-2305 : replace SwissImage WMTS layer with VectorTile

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -244,9 +244,23 @@ export const BREAKPOINT_TABLET = 768
  */
 export const DRAWING_HIT_TOLERANCE = 6
 
-export const VECTOR_TILES_STYLE_ID = 'ch.swisstopo.leichte-basiskarte_world.vt'
+/**
+ * Light base map style ID
+ *
+ * from https://www.swisstopo.admin.ch/de/geodata/maps/smw/smw_lightbase.html
+ *
+ * @type {string}
+ */
+export const VECTOR_LIGHT_BASE_MAP_STYLE_ID = 'ch.swisstopo.leichte-basiskarte_world.vt'
 
-export const VECTOR_TILES_STYLE_URL = `https://vectortiles.geo.admin.ch/styles/${VECTOR_TILES_STYLE_ID}/style.json`
+/**
+ * Imagery base map style ID
+ *
+ * from https://www.swisstopo.admin.ch/de/geodata/maps/smw/smw_imagerybase.html
+ *
+ * @type {string}
+ */
+export const VECTOR_TILES_IMAGERY_STYLE_ID = 'ch.swisstopo.leichte-basiskarte-imagery_world.vt'
 
 /**
  * Display a big developpment banner on all but these hosts.

--- a/src/modules/map/components/footer/MapFooterBackgroundSelector.vue
+++ b/src/modules/map/components/footer/MapFooterBackgroundSelector.vue
@@ -47,7 +47,7 @@
 </template>
 
 <script>
-import { VECTOR_TILES_STYLE_ID } from '@/config'
+import { VECTOR_LIGHT_BASE_MAP_STYLE_ID, VECTOR_TILES_IMAGERY_STYLE_ID } from '@/config'
 import { mapActions, mapGetters, mapState } from 'vuex'
 
 const voidLayer = {
@@ -107,8 +107,9 @@ export default {
                 case 'ch.swisstopo.pixelkarte-grau':
                     return 'bg_pixel_grey'
                 case 'ch.swisstopo.swissimage':
+                case VECTOR_TILES_IMAGERY_STYLE_ID:
                     return 'bg_luftbild'
-                case VECTOR_TILES_STYLE_ID:
+                case VECTOR_LIGHT_BASE_MAP_STYLE_ID:
                     return 'basis'
                 default:
                     return layer.name || layer.getID()

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -91,7 +91,7 @@
 import { EditableFeatureTypes, LayerFeature } from '@/api/features.api'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
 
-import { IS_TESTING_WITH_CYPRESS, VECTOR_TILES_STYLE_ID } from '@/config'
+import { IS_TESTING_WITH_CYPRESS, VECTOR_LIGHT_BASE_MAP_STYLE_ID } from '@/config'
 import FeatureEdit from '@/modules/infobox/components/FeatureEdit.vue'
 import FeatureList from '@/modules/infobox/components/FeatureList.vue'
 import OpenLayersPopover from '@/modules/map/components/openlayers/OpenLayersPopover.vue'
@@ -202,7 +202,7 @@ export default {
             // we currently only have the case of a light base map vector tile background with our national map on top
             if (
                 this.isBackgroundVectorTile &&
-                this.currentBackgroundLayer.getID() === VECTOR_TILES_STYLE_ID
+                this.currentBackgroundLayer.getID() === VECTOR_LIGHT_BASE_MAP_STYLE_ID
             ) {
                 return this.backgroundLayers.find(
                     (layer) => layer.getID() === 'ch.swisstopo.pixelkarte-farbe'

--- a/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
@@ -68,7 +68,7 @@ export default {
                     vectorStyle.layers = vectorStyle.layers.filter(
                         (layer) => layer.source !== this.excludeSource
                     )
-                    this.mapLibreInstance.setStyle(vectorStyle)
+                    this.mapLibreInstance?.setStyle(vectorStyle)
                 })
             } else if (this.layerId === VECTOR_TILES_IMAGERY_STYLE_ID) {
                 // special case here, as the imagery is only over Switzerland (for now)
@@ -94,10 +94,10 @@ export default {
                         source: 'sentinel2_wmts',
                         type: 'raster',
                     })
-                    this.mapLibreInstance.setStyle(vectorStyle)
+                    this.mapLibreInstance?.setStyle(vectorStyle)
                 })
             } else {
-                this.mapLibreInstance.setStyle(styleUrl)
+                this.mapLibreInstance?.setStyle(styleUrl)
             }
         },
     },

--- a/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
@@ -5,8 +5,11 @@
 </template>
 
 <script>
+import { TILEGRID_EXTENT, VECTOR_TILES_IMAGERY_STYLE_ID } from '@/config'
+import { CoordinateSystems } from '@/utils/coordinateUtils'
 import MapLibreLayer from '@geoblocks/ol-maplibre-layer'
 import axios from 'axios'
+import proj4 from 'proj4'
 import addLayerToMapMixin from './utils/addLayerToMap-mixins'
 
 /** Renders a Vector layer on the map with MapLibre */
@@ -37,7 +40,7 @@ export default {
     computed: {
         mapLibreInstance() {
             return this.layer?.maplibreMap
-        }
+        },
     },
     watch: {
         opacity(newOpacity) {
@@ -63,14 +66,47 @@ export default {
                 axios.get(styleUrl).then((response) => {
                     const vectorStyle = response.data
                     vectorStyle.layers = vectorStyle.layers.filter(
-                      (layer) => layer.source !== this.excludeSource
+                        (layer) => layer.source !== this.excludeSource
                     )
+                    this.mapLibreInstance.setStyle(vectorStyle)
+                })
+            } else if (this.layerId === VECTOR_TILES_IMAGERY_STYLE_ID) {
+                // special case here, as the imagery is only over Switzerland (for now)
+                // we inject a fair-use WMTS that covers the globe under our aerial images
+                axios.get(styleUrl).then((response) => {
+                    const vectorStyle = response.data
+                    // settings bounds for swissimage, otherwise it covers the whole world with white tiles
+                    vectorStyle.sources.swissimage_wmts.bounds = [
+                        ...proj4(CoordinateSystems.LV95.epsg, CoordinateSystems.WGS84.epsg, [
+                            TILEGRID_EXTENT[0] + 50000,
+                            TILEGRID_EXTENT[1],
+                        ]),
+                        ...proj4(CoordinateSystems.LV95.epsg, CoordinateSystems.WGS84.epsg, [
+                            TILEGRID_EXTENT[2] - 20000,
+                            TILEGRID_EXTENT[3],
+                        ]),
+                    ]
+                    // setting up Sentinel2 WMTS to cover the globe outside of Switzerland
+                    vectorStyle.sources['sentinel2_wmts'] = {
+                        minzoom: 0,
+                        maxzoom: 22,
+                        tileSize: 256,
+                        type: 'raster',
+                        tiles: [
+                            'https://tiles.maps.eox.at/wmts?layer=s2cloudless-2020_3857&style=default&tilematrixset=g&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={z}&TileCol={x}&TileRow={y}',
+                        ],
+                    }
+                    vectorStyle.layers.splice(1, 0, {
+                        id: 'sentinel2',
+                        source: 'sentinel2_wmts',
+                        type: 'raster',
+                    })
                     this.mapLibreInstance.setStyle(vectorStyle)
                 })
             } else {
                 this.mapLibreInstance.setStyle(styleUrl)
             }
-        }
-    }
+        },
+    },
 }
 </script>

--- a/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
@@ -34,9 +34,19 @@ export default {
             default: null,
         },
     },
+    computed: {
+        mapLibreInstance() {
+            return this.layer?.mapLibreInstance
+        }
+    },
     watch: {
         opacity(newOpacity) {
             this.layer.setOpacity(newOpacity)
+        },
+        styleUrl(newStyleUrl) {
+            if (this.mapLibreInstance) {
+                this.mapLibreInstance.setStyle(newStyleUrl)
+            }
         },
     },
     created() {
@@ -51,7 +61,7 @@ export default {
             axios.get(this.styleUrl).then((response) => {
                 const vectorStyle = response.data
                 vectorStyle.layers = vectorStyle.layers.filter(
-                    (layer) => layer.source !== this.excludeSource
+                  (layer) => layer.source !== this.excludeSource
                 )
                 this.layer.maplibreMap.setStyle(vectorStyle)
             })

--- a/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
@@ -11,7 +11,12 @@ import MapLibreLayer from '@geoblocks/ol-maplibre-layer'
 import axios from 'axios'
 import addLayerToMapMixin from './utils/addLayerToMap-mixins'
 
-/** Renders a Vector layer on the map with MapLibre */
+/**
+ * Renders a Vector layer on the map with MapLibre This component should be heavily modified as soon
+ * as https://jira.swisstopo.ch/browse/BGDIINF_SB-2741 can be done (as soon as layers config serves
+ * configs for VT layers) Most of the specific code found bellow, plus import of layer ID should be
+ * removed then.
+ */
 export default {
     mixins: [addLayerToMapMixin],
     props: {
@@ -58,42 +63,53 @@ export default {
     },
     methods: {
         setMapLibreStyle(styleUrl) {
+            // most of this methods will be edited while doing https://jira.swisstopo.ch/browse/BGDIINF_SB-2741
             if (this.excludeSource) {
                 // we load the style on the side in order to be able to filter out some source
-                axios.get(styleUrl).then((response) => {
-                    const vectorStyle = response.data
-                    vectorStyle.layers = vectorStyle.layers.filter(
-                        (layer) => layer.source !== this.excludeSource
-                    )
-                    this.layer.maplibreMap.setStyle(vectorStyle)
-                })
+                axios
+                    .get(styleUrl)
+                    .then((response) => {
+                        const vectorStyle = response.data
+                        vectorStyle.layers = vectorStyle.layers.filter(
+                            (layer) => layer.source !== this.excludeSource
+                        )
+                        this.layer.maplibreMap.setStyle(vectorStyle)
+                    })
+                    .catch((err) => {
+                        log.error('Error while fetching MapLibre style', styleUrl, err)
+                    })
             } else if (this.layerId === VECTOR_TILES_IMAGERY_STYLE_ID) {
                 // special case here, as the imagery is only over Switzerland (for now)
                 // we inject a fair-use WMTS that covers the globe under our aerial images
-                axios.get(styleUrl).then((response) => {
-                    const vectorStyle = response.data
-                    // settings SwissImage to use the tiled WMS instead
-                    // otherwise it covers the whole world with white tiles (when no data is present)
-                    vectorStyle.sources.swissimage_wmts.tiles = [
-                        'https://wms.geo.admin.ch/?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS=ch.swisstopo.swissimage&LANG=en&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&STYLES=&BBOX={bbox-epsg-3857}',
-                    ]
-                    // setting up Sentinel2 WMTS to cover the globe outside of Switzerland
-                    vectorStyle.sources['sentinel2_wmts'] = {
-                        minzoom: 0,
-                        maxzoom: 22,
-                        tileSize: 256,
-                        type: 'raster',
-                        tiles: [
-                            'https://tiles.maps.eox.at/wmts?layer=s2cloudless-2020_3857&style=default&tilematrixset=g&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={z}&TileCol={x}&TileRow={y}',
-                        ],
-                    }
-                    vectorStyle.layers.splice(1, 0, {
-                        id: 'sentinel2',
-                        source: 'sentinel2_wmts',
-                        type: 'raster',
+                axios
+                    .get(styleUrl)
+                    .then((response) => {
+                        const vectorStyle = response.data
+                        // settings SwissImage to use the tiled WMS instead
+                        // otherwise it covers the whole world with white tiles (when no data is present)
+                        vectorStyle.sources.swissimage_wmts.tiles = [
+                            'https://wms.geo.admin.ch/?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS=ch.swisstopo.swissimage&LANG=en&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&STYLES=&BBOX={bbox-epsg-3857}',
+                        ]
+                        // setting up Sentinel2 WMTS to cover the globe outside of Switzerland
+                        vectorStyle.sources['sentinel2_wmts'] = {
+                            minzoom: 0,
+                            maxzoom: 22,
+                            tileSize: 256,
+                            type: 'raster',
+                            tiles: [
+                                'https://tiles.maps.eox.at/wmts?layer=s2cloudless-2020_3857&style=default&tilematrixset=g&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={z}&TileCol={x}&TileRow={y}',
+                            ],
+                        }
+                        vectorStyle.layers.splice(1, 0, {
+                            id: 'sentinel2',
+                            source: 'sentinel2_wmts',
+                            type: 'raster',
+                        })
+                        this.layer.maplibreMap.setStyle(vectorStyle)
                     })
-                    this.layer.maplibreMap.setStyle(vectorStyle)
-                })
+                    .catch((err) => {
+                        log.error('Error while fetching MapLibre style', styleUrl, err)
+                    })
             } else {
                 this.layer.maplibreMap.setStyle(styleUrl)
             }

--- a/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
@@ -36,7 +36,7 @@ export default {
     },
     computed: {
         mapLibreInstance() {
-            return this.layer?.mapLibreInstance
+            return this.layer?.maplibreMap
         }
     },
     watch: {
@@ -44,9 +44,7 @@ export default {
             this.layer.setOpacity(newOpacity)
         },
         styleUrl(newStyleUrl) {
-            if (this.mapLibreInstance) {
-                this.mapLibreInstance.setStyle(newStyleUrl)
-            }
+            this.setMapLibreStyle(newStyleUrl)
         },
     },
     created() {
@@ -56,16 +54,23 @@ export default {
                 style: this.styleUrl,
             },
         })
-        if (this.excludeSource) {
-            // we load the style on the side in order to be able to filter out some source
-            axios.get(this.styleUrl).then((response) => {
-                const vectorStyle = response.data
-                vectorStyle.layers = vectorStyle.layers.filter(
-                  (layer) => layer.source !== this.excludeSource
-                )
-                this.layer.maplibreMap.setStyle(vectorStyle)
-            })
-        }
+        this.setMapLibreStyle(this.styleUrl)
     },
+    methods: {
+        setMapLibreStyle(styleUrl) {
+            if (this.excludeSource) {
+                // we load the style on the side in order to be able to filter out some source
+                axios.get(styleUrl).then((response) => {
+                    const vectorStyle = response.data
+                    vectorStyle.layers = vectorStyle.layers.filter(
+                      (layer) => layer.source !== this.excludeSource
+                    )
+                    this.mapLibreInstance.setStyle(vectorStyle)
+                })
+            } else {
+                this.mapLibreInstance.setStyle(styleUrl)
+            }
+        }
+    }
 }
 </script>

--- a/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
@@ -75,17 +75,10 @@ export default {
                 // we inject a fair-use WMTS that covers the globe under our aerial images
                 axios.get(styleUrl).then((response) => {
                     const vectorStyle = response.data
-                    // settings bounds for swissimage, otherwise it covers the whole world with white tiles
-                    vectorStyle.sources.swissimage_wmts.bounds = [
-                        ...proj4(CoordinateSystems.LV95.epsg, CoordinateSystems.WGS84.epsg, [
-                            TILEGRID_EXTENT[0] + 50000,
-                            TILEGRID_EXTENT[1],
-                        ]),
-                        ...proj4(CoordinateSystems.LV95.epsg, CoordinateSystems.WGS84.epsg, [
-                            TILEGRID_EXTENT[2] - 20000,
-                            TILEGRID_EXTENT[3],
-                        ]),
-                    ]
+                    // settings SwissImage to use the tiled WMS instead
+                    // otherwise it covers the whole world with white tiles (when no data is present)
+                    vectorStyle.sources.swissimage_wmts.tiles = [
+                        'https://wms.geo.admin.ch/?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS=ch.swisstopo.swissimage&LANG=en&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&STYLES=&BBOX={bbox-epsg-3857}',                    ]
                     // setting up Sentinel2 WMTS to cover the globe outside of Switzerland
                     vectorStyle.sources['sentinel2_wmts'] = {
                         minzoom: 0,

--- a/src/store/plugins/load-layersconfig-on-lang-change.js
+++ b/src/store/plugins/load-layersconfig-on-lang-change.js
@@ -1,6 +1,6 @@
 import { LayerAttribution } from '@/api/layers/AbstractLayer.class'
-import { loadLayersConfigFromBackend } from '@/api/layers/layers.api'
 import GeoAdminVectorLayer from '@/api/layers/GeoAdminVectorLayer.class'
+import { loadLayersConfigFromBackend } from '@/api/layers/layers.api'
 import loadTopicsFromBackend, { loadTopicTreeForTopic } from '@/api/topics.api'
 import { VECTOR_LIGHT_BASE_MAP_STYLE_ID, VECTOR_TILES_IMAGERY_STYLE_ID } from '@/config'
 import { SET_LANG_MUTATION_KEY } from '@/store/modules/i18n.store'
@@ -47,10 +47,17 @@ const loadLayersAndTopicsConfigAndDispatchToStore = async (store) => {
         // for our vector tile background layer
         const lightBaseMapBackgroundLayer = new GeoAdminVectorLayer(
             VECTOR_LIGHT_BASE_MAP_STYLE_ID,
+            openStreetMapAndMapTilersAttributions,
             // filtering out any layer that uses swisstopo data (meaning all layers that are over Switzerland)
             'swissmaptiles'
         )
-        const imageryBackgroundLayer = new GeoAdminVectorLayer(VECTOR_TILES_IMAGERY_STYLE_ID)
+        const imageryBackgroundLayer = new GeoAdminVectorLayer(VECTOR_TILES_IMAGERY_STYLE_ID, [
+            ...openStreetMapAndMapTilersAttributions,
+            new LayerAttribution(
+                'Sentinel-2 cloudless by EOX IT Services GmbH (Contains modified Copernicus Sentinel data 2020)',
+                'https://s2maps.eu/'
+            ),
+        ])
         const layersConfig = [
             lightBaseMapBackgroundLayer,
             imageryBackgroundLayer,

--- a/tests/e2e-cypress/integration/layers.cy.js
+++ b/tests/e2e-cypress/integration/layers.cy.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { BREAKPOINT_TABLET, VECTOR_TILES_STYLE_ID } from '@/config'
+import { BREAKPOINT_TABLET, VECTOR_LIGHT_BASE_MAP_STYLE_ID } from '@/config'
 import { randomIntBetween } from '@/utils/numberUtils'
 
 /**
@@ -233,7 +233,7 @@ describe('Test of layer handling', () => {
                     'eq',
                     // for no we force the background to be the VT layer as we can't rely on the backend to give it to us
                     // (otherwise mf-geoadmin3 PROD will also receive it...)
-                    VECTOR_TILES_STYLE_ID
+                    VECTOR_LIGHT_BASE_MAP_STYLE_ID
                 )
             })
         })
@@ -246,7 +246,7 @@ describe('Test of layer handling', () => {
                 cy.readStoreValue('state.layers.backgroundLayerId').should(
                     'eq',
                     // same remark as above, we now overwrite the default BG given by the backend to the vector tile layer
-                    VECTOR_TILES_STYLE_ID
+                    VECTOR_LIGHT_BASE_MAP_STYLE_ID
                 )
                 cy.readStoreValue('getters.visibleLayers').then((layers) => {
                     expect(layers).to.be.an('Array')


### PR DESCRIPTION
There's an issue because our style.json doesn't define any boundary or extent with the embedded WMTS, and tiles are requested outside of Switzerland (resulting in many HTTP 404 responses). Same with the PBF tiles, they are not more detailed outside of Switzerland, looking a bit weird without any satellite imagery on top.

[Test link with SwissImage BG selected](https://sys-map.dev.bgdi.ch/preview/feat_bgdiinf_sb-2305_vector_imagery_bg_layer/index.html#/map?bgLayer=ch.swisstopo.leichte-basiskarte-imagery_world.vt)

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_bgdiinf_sb-2305_vector_imagery_bg_layer/index.html)