### PR TITLE
BGDIINF_SB-2678 Made the test banner dynamic based on hostname

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -16,12 +16,6 @@ export const ENVIRONMENT = VITE_ENVIRONMENT
 export const IS_TESTING_WITH_CYPRESS = !!window.Cypress
 
 /**
- * Flag that tells if users should be warned that it is a development site. Also used to hide
- * development specific features in production (like the app version)
- */
-export const DEV_SITE_WARNING = !IS_TESTING_WITH_CYPRESS && ENVIRONMENT !== 'production'
-
-/**
  * Current app version (from package.json)
  *
  * @type {String}
@@ -253,3 +247,19 @@ export const DRAWING_HIT_TOLERANCE = 6
 export const VECTOR_TILES_STYLE_ID = 'ch.swisstopo.leichte-basiskarte_world.vt'
 
 export const VECTOR_TILES_STYLE_URL = `https://vectortiles.geo.admin.ch/styles/${VECTOR_TILES_STYLE_ID}/style.json`
+
+/**
+ * Display a big developpment banner on all but these hosts.
+ *
+ * @type {String[]}
+ */
+ export const NO_WARNING_BANNER_HOSTNAMES = ['test.map.geo.admin.ch', 'map.geo.admin.ch']
+
+ /**
+ * Display a warning ribbon ('TEST') on the top-left (mobile) or bottom-left (desktop)
+ * corner on all these hosts.
+ *
+ * @type {String[]}
+ */
+
+ export const WARNING_RIBBON_HOSTNAMES = ['test.map.geo.admin.ch']

--- a/src/modules/map/MapModule.vue
+++ b/src/modules/map/MapModule.vue
@@ -5,15 +5,17 @@
             <slot />
             <LocationPopup />
         </OpenLayersMap>
+        <WarningRibbon />
     </div>
 </template>
 
 <script>
 import LocationPopup from './components/LocationPopup.vue'
 import OpenLayersMap from './components/openlayers/OpenLayersMap.vue'
+import WarningRibbon from './components/WarningRibbon.vue'
 
 export default {
-    components: { OpenLayersMap, LocationPopup },
+    components: { OpenLayersMap, LocationPopup, WarningRibbon },
 }
 </script>
 

--- a/src/modules/map/components/WarningRibbon.vue
+++ b/src/modules/map/components/WarningRibbon.vue
@@ -1,0 +1,56 @@
+<template>
+    <div v-if="hasWarningRibbon" class="corner-ribbon" data-cy="warning-ribbon">TEST</div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+
+export default {
+  computed: {
+      ...mapGetters([
+            'hasWarningRibbon',
+      ]),
+
+    }
+
+}
+</script>
+
+<style lang="scss" scoped>
+@import 'src/scss/media-query.mixin';
+@import 'src/scss/variables-admin';
+@import 'src/scss/variables';
+
+/* Corner ribbons, from http://codepen.io/eode9/pen/twkKm
+* mobile: ribbon top left, desktop: bottom left
+*/
+
+.corner-ribbon {
+  position: absolute;
+  /* top-left */
+  top: 78px;
+  bottom: auto;
+  left: -50px;
+  width: 200px;
+  transform: rotate(-45deg);
+  z-index: $zindex-warning;
+  background: $red;
+  color: white;
+  text-align: center;
+  line-height: 50px;
+  letter-spacing: 1px;
+  font-weight: bold;
+}
+
+
+@include respond-above(phone) {
+  .corner-ribbon {
+    /* bottom-left */
+    top: auto;
+    bottom: 50px; /* Under cesium inspectors */
+    left: -100px;
+    width: 300px;
+    transform: rotate(45deg);
+  }
+}
+</style>

--- a/src/modules/map/components/footer/MapFooterAppVersion.vue
+++ b/src/modules/map/components/footer/MapFooterAppVersion.vue
@@ -3,15 +3,20 @@
 </template>
 
 <script>
-import { APP_VERSION, DEV_SITE_WARNING } from '@/config'
+import { APP_VERSION } from '@/config'
+import { mapGetters } from 'vuex'
 
 export default {
     data() {
         return {
             appVersion: APP_VERSION,
-            showAppVersion: DEV_SITE_WARNING,
         }
     },
+    computed: {
+      ...mapGetters({
+        showAppVersion: 'hasDevSiteWarning'
+      }),
+    }
 }
 </script>
 

--- a/src/modules/menu/components/header/HeaderSwissConfederationText.vue
+++ b/src/modules/menu/components/header/HeaderSwissConfederationText.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         class="swiss-confederation-text"
-        :class="{ 'dev-site': devSiteWarning }"
+        :class="{ 'dev-site': hasDevSiteWarning }"
         @click="$emit('click', $event)"
     >
         <div class="multi-lang-title"></div>
@@ -13,9 +13,10 @@
 </template>
 
 <script>
-import { DEV_SITE_WARNING } from '@/config'
+import { mapGetters } from 'vuex'
 
 export default {
+
     props: {
         currentLang: {
             type: String,
@@ -23,12 +24,11 @@ export default {
         },
     },
     emits: ['click'],
-    data() {
-        return {
-            devSiteWarning: DEV_SITE_WARNING,
-        }
-    },
+    computed: {
+      ...mapGetters(['hasDevSiteWarning']),
+    }
 }
+
 </script>
 
 <style lang="scss" scoped>

--- a/src/modules/menu/components/header/HeaderWithSearch.vue
+++ b/src/modules/menu/components/header/HeaderWithSearch.vue
@@ -20,7 +20,7 @@
                 <SearchBar />
                 <!-- eslint-disable vue/no-v-html-->
                 <div
-                    v-if="devSiteWarning"
+                    v-if="hasDevSiteWarning"
                     class="header-warning-dev"
                     v-html="$t('test_host_warning')"
                 ></div>
@@ -32,7 +32,6 @@
 </template>
 
 <script>
-import { DEV_SITE_WARNING } from '@/config'
 import HeaderMenuButton from '@/modules/menu/components/header/HeaderMenuButton.vue'
 import HeaderSwissConfederationText from '@/modules/menu/components/header/HeaderSwissConfederationText.vue'
 import SwissFlag from '@/modules/menu/components/header/SwissFlag.vue'
@@ -49,17 +48,12 @@ export default {
         SwissFlag,
         LoadingBar,
     },
-    data() {
-        return {
-            devSiteWarning: DEV_SITE_WARNING,
-        }
-    },
     computed: {
         ...mapState({
             showLoadingBar: (state) => state.ui.showLoadingBar,
             currentLang: (state) => state.i18n.lang,
         }),
-        ...mapGetters(['currentTopicId', 'isPhoneMode']),
+        ...mapGetters(['currentTopicId', 'isPhoneMode', 'hasDevSiteWarning']),
     },
     methods: {
         resetApp() {

--- a/src/modules/menu/components/header/SwissFlag.vue
+++ b/src/modules/menu/components/header/SwissFlag.vue
@@ -1,7 +1,7 @@
 <template>
     <img
         class="swiss-flag"
-        :class="{ 'dev-site': devSiteWarning }"
+        :class="{ 'dev-site': hasDevSiteWarning }"
         :src="swissFlagIcon"
         alt="swiss-flag"
         @click="$emit('click', $event)"
@@ -10,16 +10,21 @@
 
 <script>
 import swissFlagIcon from '@/assets/svg/swiss-flag.svg'
-import { DEV_SITE_WARNING } from '@/config'
+import { mapGetters } from 'vuex'
 
 export default {
     emits: ['click'],
     data() {
         return {
             swissFlagIcon,
-            devSiteWarning: DEV_SITE_WARNING,
+
         }
     },
+    computed: {
+      ...mapGetters([
+        'hasDevSiteWarning',
+      ]),
+    }
 }
 </script>
 

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -1,4 +1,3 @@
-
 /* Z Indices are not an absolute value. Different css attributes (most importantly the z-index
 attribute) can trigger the generation of a new stacking context. An element cannot break out of its
 stacking context, independently of the value of its z-index. Inatall an extension like
@@ -8,6 +7,7 @@ browser dev tools. */
 // Main stacking context
 $zindex-map: 1;
 $zindex-footer: $zindex-map + 1; // The menu should be displayed above the footer in phone mode
+$zindex-warning: 1;
 $zindex-menu: $zindex-footer + 1;
 $zindex-footer-infobox: $zindex-menu + 1; //Is part of the footer, but should be displayed above other menu items
 $zindex-swipable-element: $zindex-menu + 1; //Not used for the moment, please check the value before using it.

--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -1,4 +1,4 @@
-import { BREAKPOINT_TABLET } from '@/config'
+import { BREAKPOINT_TABLET, WARNING_RIBBON_HOSTNAMES, NO_WARNING_BANNER_HOSTNAMES } from '@/config'
 
 /**
  * Describes the different mode the UI can have. Either desktop / tablet (menu is always shown, info
@@ -77,6 +77,13 @@ export default {
          * @type Boolean
          */
         floatingTooltip: false, // Configured in screen-size-management.plugin.js
+        /**
+         * Hostname on which the application is running (use to display warnings to the user on
+         * 'non-production' hosts)
+         *
+         * @type String
+         */
+        hostname: window.location.hostname,
     },
     getters: {
         screenDensity(state) {
@@ -133,6 +140,19 @@ export default {
         },
         isTraditionalDesktopSize(state, getters) {
             return getters.isDesktopMode && state.width >= BREAKPOINT_TABLET
+        },
+        /**
+         * Flag to display a warning ribbon ('TEST') at the top/bottom right corner
+         */
+        hasWarningRibbon(state) {
+            return WARNING_RIBBON_HOSTNAMES.some(hostname=>state.hostname.includes(hostname))
+        },
+        /**
+        * Flag that tells if users should be warned that it is a development site. Also used to hide
+        * development specific features in production (like the app version)
+        */
+        hasDevSiteWarning(state) {
+            return true //!NO_WARNING_BANNER_HOSTNAMES.some(hostname=>state.hostname.includes(hostname))
         },
     },
     actions: {

--- a/tests/e2e-cypress/integration/footer.cy.js
+++ b/tests/e2e-cypress/integration/footer.cy.js
@@ -21,5 +21,6 @@ describe('Testing the footer content', () => {
             cy.get(dezoomSelector).click().click().click()
             cy.get(scaleLineSelector).should('not.be.visible')
         })
+
     })
 })

--- a/tests/e2e-cypress/integration/ribbon.cy.js
+++ b/tests/e2e-cypress/integration/ribbon.cy.js
@@ -1,0 +1,40 @@
+/// <reference types="cypress" />
+
+const ribbonSelector = '[data-cy="warning-ribbon"]'
+const BREAKPOINT_PHONE_WIDTH = 576
+
+
+
+describe('Testing the warning ribbon', () => {
+    beforeEach(() => {
+      cy.goToMapView()
+    })
+    context('Checking the warning ribbon', () => {
+      /*
+       * Normally, 'localhost' in not in the `WARNING_RIBBON_HOSTNAMES`constant,
+       * so the warning banner is not present on Cypress.
+       */
+
+      it('Ribbon shouldn\'t be be visible on localhost', () => {
+        cy.get(ribbonSelector).should('not.exist');
+      })
+
+      it('If ribbon do exist, it should be at top on a phone, bottom on desktop', () => {
+        // Conditional tests are bad on Cypress, but the banner we or not be present,
+        // depending on the hostname
+        cy.get(ribbonSelector)
+          // Bypassing the built-in existence assertion
+          .should(Cypress._.noop)
+          .then(($el) => {
+            if (!$el.length) {
+              return
+            }
+            if (Cypress.config().viewportWidth < BREAKPOINT_PHONE_WIDTH) {
+              cy.get(ribbonSelector).invoke('css', 'top').should('equal', '78px');
+            } else {
+              cy.get(ribbonSelector).invoke('css', 'bottom').should('equal', '50px');
+            }
+          })
+      })
+    })
+  })


### PR DESCRIPTION
Display a warning ribbon like: https://test.map.geo.admin.ch/

The test link won't work as the ribbon is only shown if `DEV_SITE_WARNING` is set to False and the hostname is matching `WARNING_RIBBON_HOSTNAMES`. Build locally and run `npm run preview`  (production preview)

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_bgdiinf_sb-2678_warning_banners/index.html)