### PR TITLE
BGDIINF_SB-2729: Fixed save KML drawing error handling - from post review of #326

### DIFF
--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -152,7 +152,14 @@ export default {
             return null
         },
         isDrawingModified() {
-            return this.drawingState !== DrawingState.INITIAL
+            switch (this.drawingState) {
+                case DrawingState.INITIAL:
+                case DrawingState.LOADED:
+                case DrawingState.LOAD_ERROR:
+                    return false
+                default:
+                    return true
+            }
         },
     },
     watch: {

--- a/src/modules/drawing/components/DrawingToolbox.vue
+++ b/src/modules/drawing/components/DrawingToolbox.vue
@@ -158,9 +158,9 @@ export default {
                 case DrawingState.SAVED:
                     return 'draw_file_saved'
                 case DrawingState.SAVE_ERROR:
-                    return 'upload_failed'
+                    return 'draw_file_load_error'
                 case DrawingState.LOAD_ERROR:
-                    return 'loading_failed'
+                    return 'draw_file_save_error'
                 default:
                     return ''
             }

--- a/src/modules/drawing/components/DrawingToolbox.vue
+++ b/src/modules/drawing/components/DrawingToolbox.vue
@@ -32,8 +32,11 @@
                             {{ $t('draw_button_delete_last_point') }}
                         </button>
                     </div>
-                    <div class="d-flex justify-content-center drawing-toolbox-saving-status">
-                        {{ $t(savingStatusMessage) }}
+                    <div
+                        class="d-flex justify-content-center drawing-toolbox-drawing-state"
+                        :class="{ 'text-danger': isDrawingStateError }"
+                    >
+                        {{ $t(drawingStateMessage) }}
                     </div>
                     <div class="d-flex justify-content-center">
                         <button
@@ -98,7 +101,7 @@ import ButtonWithIcon from '@/utils/ButtonWithIcon.vue'
 import ModalWithBackdrop from '@/utils/ModalWithBackdrop.vue'
 import { mapGetters } from 'vuex'
 import DrawingHeader from './DrawingHeader.vue'
-import { SavingStatus } from '../lib/export-utils'
+import { DrawingState } from '../lib/export-utils'
 
 export default {
     components: {
@@ -123,9 +126,9 @@ export default {
             default: false,
         },
         /** Current kml saving status */
-        savingStatus: {
+        drawingState: {
             type: String,
-            default: SavingStatus.INITIAL,
+            default: DrawingState.INITIAL,
         },
     },
     emits: ['close', 'setDrawingMode', 'export', 'clearDrawing', 'deleteLastPoint'],
@@ -148,17 +151,22 @@ export default {
         },
 
         /** Return a different translation key depending on the saving status */
-        savingStatusMessage() {
-            switch (this.savingStatus) {
-                case SavingStatus.SAVING:
+        drawingStateMessage() {
+            switch (this.drawingState) {
+                case DrawingState.SAVING:
                     return 'draw_file_saving'
-                case SavingStatus.SAVED:
+                case DrawingState.SAVED:
                     return 'draw_file_saved'
-                case SavingStatus.SAVE_ERROR:
+                case DrawingState.SAVE_ERROR:
                     return 'upload_failed'
+                case DrawingState.LOAD_ERROR:
+                    return 'loading_failed'
                 default:
                     return ''
             }
+        },
+        isDrawingStateError() {
+            return this.drawingState < 0
         },
     },
     mounted() {
@@ -227,7 +235,7 @@ $zindex-drawing-toolbox: -1;
     &-disclaimer {
         display: none;
     }
-    &-saving-status {
+    &-drawing-state {
         color: #d3d3d3;
         font-size: 12px;
         line-height: 1.25;

--- a/src/modules/drawing/lib/export-utils.js
+++ b/src/modules/drawing/lib/export-utils.js
@@ -15,13 +15,24 @@ const gpxFormat = new GPX()
  *
  * @enum
  */
-export const SavingStatus = {
-    SAVING: 'SAVING',
-    SAVED: 'SAVED',
-    SAVE_ERROR: 'SAVE_ERROR',
-    UNSAVED_CHANGES: 'UNSAVED_CHANGES',
-    INITIAL: 'INITIAL',
-}
+export const DrawingState = Object.freeze({
+    // First state when entering the drawing mode
+    INITIAL: 0,
+    // Drawing has been loaded
+    LOADED: 1,
+    // Pending changes -> drawing has been modified and is not saved
+    UNSAVED_CHANGES: 2,
+    // Drawing is being saved
+    SAVING: 3,
+    // Drawing has been saved and no pending changes are remaining
+    SAVED: 4,
+    // ------------------------------------------------------------------------
+    // ERROR states should always be negative !
+    // Could not save drawing
+    SAVE_ERROR: -1,
+    // Could not load drawing
+    LOAD_ERROR: -2,
+})
 
 /**
  * Returns a string representing the features given in param as a GPX


### PR DESCRIPTION
Now if the loading of the KML failed in the drawing mode, we remove the
kml layer as it is not selectable and we print an error message. The loading
of the kml to translate it to a drawing will be automatically retried. In case
of error we also display an error message at the same place as for saving error.

Those errors message are also now displayed in red.

Also renamed the savingStatus to drawingState which refer more to a drawing state
to make the code clearer as it is also used to check if any modification on
the drawing has been done.

Improved the error handling and user experience in case of network failure.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2729-save-drawing/index.html)