### PR TITLE
BGDIINF_SB-2737, BGDIINF_SB-2729: Fixed kml drawing element move

### DIFF
--- a/src/modules/map/components/openlayers/OpenLayersPopover.vue
+++ b/src/modules/map/components/openlayers/OpenLayersPopover.vue
@@ -69,7 +69,10 @@ export default {
     },
     beforeCreate() {
         this.overlay = new Overlay({
-            offset: [0, 15],
+            // NOTE: the 12 offset is due to the arrow size $arrow-height in css and must always
+            // equal this variable in order to have the arrow point to the center of the selected
+            // element.
+            offset: [0, 12],
             positioning: 'top-center',
             className: 'map-popover-overlay',
             autoPan: { margin: 0 },
@@ -98,8 +101,10 @@ export default {
 @import 'src/scss/webmapviewer-bootstrap-theme';
 
 .map-popover {
+    pointer-events: none;
     .card {
         max-width: $overlay-width;
+        pointer-events: auto;
     }
     .map-popover-content {
         max-height: 350px;
@@ -110,20 +115,19 @@ export default {
         flex-direction: column;
     }
     // Triangle border
+    $arrow-height: 12px;
     &::before {
-        $arrow-height: 15px;
         position: absolute;
         top: -($arrow-height * 2);
         left: 50%;
         margin-left: -$arrow-height;
         border: $arrow-height solid transparent;
         border-bottom-color: $border-color-translucent;
-        pointer-events: none;
         content: '';
     }
     // Triangle background
     &::after {
-        $arrow-border-height: 14px;
+        $arrow-border-height: $arrow-height - 1;
         content: '';
         border: $arrow-border-height solid transparent;
         border-bottom-color: $light;


### PR DESCRIPTION
Due to the popover arrow we could not anymore move the kml element in drawing
mode.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2737-move-drawing-element/index.html)