### PR TITLE
BGDIINF_SB-2738: Fixed location popup in drawing mode

### DIFF
--- a/src/store/plugins/click-on-map-management.plugin.js
+++ b/src/store/plugins/click-on-map-management.plugin.js
@@ -51,9 +51,17 @@ const runIdentify = async (store, clickInfo, visibleLayers, lang) => {
  */
 const clickOnMapManagementPlugin = (store) => {
     store.subscribe((mutation, state) => {
+        if (
+            mutation.type === 'setShowDrawingOverlay' &&
+            mutation.payload &&
+            state.map.displayLocationPopup
+        ) {
+            // when entering the drawing menu we need to clear the location popup
+            store.dispatch('hideLocationPopup')
+        }
         // if a click occurs, we only take it into account (for identify and fullscreen toggle)
-        // when the user is not currently drawing something on the map
-        if (mutation.type === 'setClickInfo' && !state.ui.showDrawingOverlay) {
+        // when the user is not currently drawing something on the map.
+        else if (mutation.type === 'setClickInfo' && !state.ui.showDrawingOverlay) {
             const clickInfo = mutation.payload
             const isLeftSingleClick = clickInfo?.clickType === ClickType.LEFT_SINGLECLICK
             const isContextMenuClick = clickInfo?.clickType === ClickType.CONTEXTMENU
@@ -61,8 +69,6 @@ const clickOnMapManagementPlugin = (store) => {
 
             if (isLeftSingleClick) {
                 // Execute this before the then clause, as else the result could be wrong
-                // Still to do: why sometimes two clicks needed to fullscreen?
-                // Why crash when selecting search bar while popup is open?
                 const allowActivateFullscreen =
                     !isFullscreenMode &&
                     !state.features.selectedFeatures?.length &&

--- a/tests/e2e-cypress/integration/mouseposition.cy.js
+++ b/tests/e2e-cypress/integration/mouseposition.cy.js
@@ -2,6 +2,7 @@
 
 import { CoordinateSystems } from '@/utils/coordinateUtils'
 import setupProj4 from '@/utils/setupProj4'
+import { BREAKPOINT_PHONE_WIDTH } from '@/config'
 import proj4 from 'proj4'
 
 setupProj4()
@@ -115,6 +116,7 @@ describe('Test mouse position', () => {
             cy.intercept(`**/api/qrcode/generate**`, {
                 fixture: 'service-qrcode/position-popup.png',
             }).as('qrcode')
+            cy.intercept(`**/api/icons/*`, { statusCode: 200 }).as('icons')
             cy.viewport(320, 1000)
             cy.goToMapView('en', { lat, lon })
             cy.get('[data-cy="map"]').rightclick()
@@ -124,6 +126,16 @@ describe('Test mouse position', () => {
         })
         it('Test the LocationPopUp is visible', () => {
             cy.get('[data-cy="location-popup"]').should('be.visible')
+        })
+        it('Test that LocationPopUp is hidden on entering drawing mode', () => {
+            cy.get('[data-cy="location-popup"]').should('be.visible')
+            const viewportWidth = Cypress.config('viewportWidth')
+            if (viewportWidth && viewportWidth < BREAKPOINT_PHONE_WIDTH) {
+                cy.get('[data-cy="menu-button"]').click()
+            }
+            cy.get('[data-cy="menu-tray-drawing-section"]').click()
+            cy.readStoreValue('state.ui.showDrawingOverlay').should('be.true')
+            cy.get('[data-cy="location-popup"]').should('not.exist')
         })
         it('Test that it prevents direct activation of the full screen', () => {
             cy.get('[data-cy="location-popup"]').should('be.visible')


### PR DESCRIPTION
If a location popup was displayed and then we were entering the drawing mode,
the location popup was not cleared and stayed in drawing mode.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2738-location-popup/index.html)