### PR TITLE
BGDIINF_SB-2736: Fixed tippy PovoverButtons (drawing styling and time selector)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -70,6 +70,9 @@ export default {
 // this import needs to happen only once, otherwise bootstrap is import/added
 // to the output CSS as many time as this file is imported
 @import 'node_modules/bootstrap/scss/bootstrap';
+// tippy-theme needs to be imported once and for the whole app in order to work
+// properly therefore it is imported here in the un-scoped app styling.
+@import 'src/scss/tippy-theme';
 
 #main-component {
     font-family: $frutiger;
@@ -83,27 +86,6 @@ export default {
     .outlines & {
         outline-offset: 1px;
         outline: $focus-outline;
-    }
-}
-
-// Importing Tippy globally, so that we do not need to import it in each component using it
-@import 'tippy.js/dist/tippy.css';
-// Tippy custom style, with a red background color
-.tippy-box[data-theme~='danger'] {
-    $bgColor: $danger;
-    background-color: $bgColor;
-    color: $white;
-    &[data-placement^='top'] > .tippy-arrow::before {
-        border-top-color: $bgColor;
-    }
-    &[data-placement^='bottom'] > .tippy-arrow::before {
-        border-bottom-color: $bgColor;
-    }
-    &[data-placement^='left'] > .tippy-arrow::before {
-        border-left-color: $bgColor;
-    }
-    &[data-placement^='right'] > .tippy-arrow::before {
-        border-right-color: $bgColor;
     }
 }
 </style>

--- a/src/config.js
+++ b/src/config.js
@@ -286,4 +286,6 @@ export const WARNING_RIBBON_HOSTNAMES = ['test.map.geo.admin.ch']
 export const DISABLE_DRAWING_MENU_FOR_LEGACY_ON_HOSTNAMES = [
     'test.map.geo.admin.ch',
     'sys-map.dev.bgdi.ch',
+    'localhost',
+    '192.168.1.112',
 ]

--- a/src/config.js
+++ b/src/config.js
@@ -286,6 +286,4 @@ export const WARNING_RIBBON_HOSTNAMES = ['test.map.geo.admin.ch']
 export const DISABLE_DRAWING_MENU_FOR_LEGACY_ON_HOSTNAMES = [
     'test.map.geo.admin.ch',
     'sys-map.dev.bgdi.ch',
-    'localhost',
-    '192.168.1.112',
 ]

--- a/src/main.js
+++ b/src/main.js
@@ -32,6 +32,7 @@ import 'animate.css'
 
 import { createApp } from 'vue'
 import VueSocialSharing from 'vue-social-sharing'
+import tippy from 'tippy.js'
 
 import App from './App.vue'
 // setting up font awesome vue component
@@ -59,6 +60,7 @@ log.debug('Config is', {
     BREAKPOINT_TABLET,
 })
 
+tippy.setDefaultProps({ theme: 'light-border' })
 setupProj4()
 
 const app = createApp(App)

--- a/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
+++ b/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
@@ -29,11 +29,11 @@
 
         <div
             v-if="currentIconSet && currentIconSet.icons.length > 0"
-            class="border-2 bg-light rounded"
+            class="icon-selector border-2 bg-light rounded"
             :class="{ 'transparent-bottom': !showAllSymbols }"
         >
             <div
-                class="bg-light d-flex align-content-center p-2"
+                class="rounded d-flex align-content-center p-2"
                 data-cy="drawing-style-show-all-icons-button"
                 @click="showAllSymbols = !showAllSymbols"
             >
@@ -168,6 +168,9 @@ export default {
 <style lang="scss" scoped>
 @import 'src/scss/webmapviewer-bootstrap-theme';
 
+.icon-selector {
+    overflow-y: hidden;
+}
 .transparent-overlay {
     display: none;
 }

--- a/src/modules/map/components/LocationPopupCopySlot.vue
+++ b/src/modules/map/components/LocationPopupCopySlot.vue
@@ -13,7 +13,7 @@
 <script>
 import log from '@/utils/logging'
 import tippy from 'tippy.js'
-import 'tippy.js/dist/tippy.css' // optional for styling
+import { mapState } from 'vuex'
 
 export default {
     props: {
@@ -22,15 +22,24 @@ export default {
             default: '',
         },
     },
+    computed: {
+        ...mapState({
+            lang: (state) => state.i18n.lang,
+        }),
+    },
+    watch: {
+        lang() {
+            this.setTooltipContent()
+        },
+    },
     mounted() {
         this.copyTooltip = tippy('#copyButton', {
-            content: this.$i18n.t('copy_cta'),
             arrow: true,
             placement: 'right',
             touch: 'hold',
         })
+
         this.copiedTooltip = tippy('#copyButton', {
-            content: this.$i18n.t('copy_done'),
             arrow: true,
             placement: 'right',
             trigger: 'click',
@@ -41,6 +50,7 @@ export default {
             },
             allowHTML: true,
         })
+        this.setTooltipContent()
     },
     unmounted() {
         this.copyTooltip?.forEach((tooltip) => tooltip.destroy())
@@ -53,6 +63,14 @@ export default {
             } catch (error) {
                 log.error(`Failed to copy to clipboard:`, error)
             }
+        },
+        setTooltipContent() {
+            this.copyTooltip?.forEach((instance) => {
+                instance.setContent(this.$i18n.t('copy_cta'))
+            })
+            this.copiedTooltip?.forEach((instance) => {
+                instance.setContent(this.$i18n.t('copy_done'))
+            })
         },
     },
 }

--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItemTimeSelector.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItemTimeSelector.vue
@@ -6,8 +6,9 @@
         :popover-title="$t('time_select_year')"
         :small="compact"
         secondary
+        body-class="p-0"
     >
-        <div class="timestamps-popover-content" data-cy="time-selection-popup">
+        <div class="timestamps-popover-content p-2" data-cy="time-selection-popup">
             <button
                 v-for="timestamp in allTimestampsIncludingAllIfNeeded"
                 :key="timestamp"

--- a/src/modules/menu/components/menu/MenuTray.vue
+++ b/src/modules/menu/components/menu/MenuTray.vue
@@ -111,7 +111,7 @@ export default {
                     arrow: true,
                     followCursor: 'initial',
                     plugins: [followCursor],
-                    touch: 'hold',
+                    hideOnClick: false,
                     delay: 500,
                     onShow: (instance) => {
                         // On show we might need to update the content to the correct language

--- a/src/modules/menu/components/menu/MenuTray.vue
+++ b/src/modules/menu/components/menu/MenuTray.vue
@@ -56,8 +56,6 @@ import MenuTopicSection from '@/modules/menu/components/topics/MenuTopicSection.
 import { mapActions, mapState } from 'vuex'
 import { DISABLE_DRAWING_MENU_FOR_LEGACY_ON_HOSTNAMES } from '@/config'
 import tippy, { followCursor } from 'tippy.js'
-import 'tippy.js/dist/tippy.css' // optional for styling
-import log from '@/utils/logging'
 
 export default {
     components: {
@@ -86,6 +84,7 @@ export default {
             activeLayers: (state) => state.layers.activeLayers,
             activeKmlLayer: (state) => state.drawing.activeKmlLayer,
             hostname: (state) => state.ui.hostname,
+            lang: (state) => state.i18n.lang,
         }),
         showLayerList() {
             return this.activeLayers.length > 0
@@ -107,24 +106,24 @@ export default {
         disableDrawing(disableDrawing) {
             if (disableDrawing) {
                 this.disableDrawingTooltip = tippy('#drawSectionTooltip', {
-                    content: this.$i18n.t('legacy_drawing_warning'),
+                    theme: 'danger',
                     arrow: true,
                     followCursor: 'initial',
                     plugins: [followCursor],
                     hideOnClick: false,
                     delay: 500,
-                    onShow: (instance) => {
-                        // On show we might need to update the content to the correct language
-                        // if its changed since last display
-                        instance.setContent(this.$i18n.t('legacy_drawing_warning'))
-                    },
+                    offset: [15, 15],
                 })
+                this.setDisableDrawingTooltipContent()
             } else {
                 if (this.disableDrawingTooltip) {
                     this.disableDrawingTooltip.forEach((tooltip) => tooltip.destroy())
                     this.disableDrawingTooltip = null
                 }
             }
+        },
+        lang() {
+            this.setDisableDrawingTooltipContent()
         },
     },
     methods: {
@@ -135,6 +134,11 @@ export default {
                 toClose = toClose.concat(this.scrollableMenuSections)
             }
             toClose.forEach((section) => this.$refs[section].close())
+        },
+        setDisableDrawingTooltipContent() {
+            this.disableDrawingTooltip?.forEach((instance) => {
+                instance.setContent(this.$i18n.t('legacy_drawing_warning'))
+            })
         },
     },
 }

--- a/src/scss/tippy-theme.scss
+++ b/src/scss/tippy-theme.scss
@@ -1,0 +1,51 @@
+// Importing Tippy globally, so that we do not need to import it in each component using it
+@import 'tippy.js/dist/tippy.css';
+@import 'tippy.js/themes/light-border.css';
+
+
+// Tippy custom style, with a danger red background color
+.tippy-box[data-theme~='danger'] {
+    $bgColor: $danger;
+    background-color: $bgColor;
+    color: $white;
+    &[data-placement^='top'] > .tippy-arrow::before {
+        border-top-color: $bgColor;
+    }
+    &[data-placement^='bottom'] > .tippy-arrow::before {
+        border-bottom-color: $bgColor;
+    }
+    &[data-placement^='left'] > .tippy-arrow::before {
+        border-left-color: $bgColor;
+    }
+    &[data-placement^='right'] > .tippy-arrow::before {
+        border-right-color: $bgColor;
+    }
+}
+
+
+// Tippy custom style, with a primary red background color
+.tippy-box[data-theme~='primary'] {
+    $bgColor: $primary;
+    background-color: $bgColor;
+    color: $white;
+    &[data-placement^='top'] > .tippy-arrow::before {
+        border-top-color: $bgColor;
+    }
+    &[data-placement^='bottom'] > .tippy-arrow::before {
+        border-bottom-color: $bgColor;
+    }
+    &[data-placement^='left'] > .tippy-arrow::before {
+        border-left-color: $bgColor;
+    }
+    &[data-placement^='right'] > .tippy-arrow::before {
+        border-right-color: $bgColor;
+    }
+}
+
+
+.tippy-box[data-theme~='popover-button'] {
+    border-radius: 0.375rem;
+    .tippy-content {
+        padding: 0;
+    }
+}

--- a/src/utils/PopoverButton.vue
+++ b/src/utils/PopoverButton.vue
@@ -33,7 +33,7 @@
                         @click="hidePopover"
                     />
                 </div>
-                <div class="card-body" :class="bodyClass">
+                <div class="popover-content card-body rounded-bottom" :class="bodyClass">
                     <slot />
                 </div>
             </div>
@@ -164,3 +164,10 @@ export default {
     },
 }
 </script>
+
+<style lang="scss" scoped>
+.popover-content {
+    // avoid scrollbar corner if the content has one, the corners get with this hidden.
+    overflow-y: hidden;
+}
+</style>

--- a/src/utils/PopoverButton.vue
+++ b/src/utils/PopoverButton.vue
@@ -14,7 +14,7 @@
             class="popover-container"
             @click="!withCloseButton && hidePopover()"
         >
-            <div class="card">
+            <div class="card border-0">
                 <div
                     v-if="popoverTitle || withCloseButton"
                     class="card-header d-flex align-items-center"
@@ -33,7 +33,7 @@
                         @click="hidePopover"
                     />
                 </div>
-                <div class="card-body">
+                <div class="card-body" :class="bodyClass">
                     <slot />
                 </div>
             </div>
@@ -120,6 +120,11 @@ export default {
             type: Boolean,
             default: false,
         },
+        /** Additional Class to add to the card-body element */
+        bodyClass: {
+            type: String,
+            default: '',
+        },
     },
     watch: {
         popoverPosition(newValue) {
@@ -133,6 +138,7 @@ export default {
     mounted() {
         // creating the TippyJS instance
         this.popover = tippy(this.$refs.popoverButton.$el, {
+            theme: 'popover-button light-border',
             content: this.$refs.popoverContent,
             // so that it doesn't sanitize the content of the slot
             allowHTML: true,
@@ -158,7 +164,3 @@ export default {
     },
 }
 </script>
-
-<style scoped>
-@import 'tippy.js/dist/svg-arrow.css';
-</style>


### PR DESCRIPTION
The popover button uses tippy and its style has been broken due to the import
of the tippy css. Tippy css can only be imported globally to work. So in order
to not broke the popover button styling. I created a new tippy theme for it.

Also fixed the location popup tippy language change, before when the language
setting changed the tippy language was not updated.

Also use the light-border theme as default for tooltips.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2736-tippy/index.html)

[Test link with legacy drawing](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2736-tippy/index.html#/map?lang=it&lat=46.74122&lon=7.812521&z=7.617&bgLayer=ch.swisstopo.pixelkarte-farbe&topic=ech&layers=ch.astra.wanderland-sperrungen_umleitungen,f;ch.swisstopo.swisstlm3d-wanderwege,f;ch.bav.haltestellen-oev,f;ch.bfs.gebaeude_wohnungs_register,f;ch.swisstopo.zeitreihen@time=18641231,f;KML|https%3A%2F%2Fsys-public.dev.bgdi.ch%2Fapi%2Fkml%2Ffiles%2Foo-VqoIzRv20NewKZEaGBg|Dessin,,1)
[External WMS with mf-geoadmin3 URL syntax](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2736-tippy/index.html?lang=en&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=WMS%7C%7CAargauer%20Wanderweg%7C%7Chttps:%2F%2Fwms.geo.ag.ch%2Fpublic%2Fows%3FSERVICE%3DWMS%26%7C%7Cch_ag_geo_are_divwanderweg%7C%7C1.3.0)


[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2736-tippy/index.html)