### PR TITLE
BGDIINF_SB-2728: Fixed legacy drawing initial load

### DIFF
--- a/src/api/features.api.js
+++ b/src/api/features.api.js
@@ -250,6 +250,8 @@ export class EditableFeature extends SelectableFeature {
      *
      * @param {Feature} olFeature An olFeature that was just deserialized with
      * @param {DrawingIconSet[]} availableIconSets {@link ol/format/KML}.
+     * @returns {EditableFeature | Null} Returns the EditableFeature in case of success or null
+     *   otherwise
      */
     static deserialize(olFeature, availableIconSets) {
         const serializedEditableFeature = olFeature.get('editableFeature')

--- a/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
@@ -11,7 +11,7 @@ import { CoordinateSystems } from '@/utils/coordinateUtils'
 import KML from 'ol/format/KML'
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
-import { mapState } from "vuex";
+import { mapState } from 'vuex'
 import addLayerToMapMixin from './utils/addLayerToMap-mixins'
 import { getKmlFromUrl } from '@/api/files.api'
 
@@ -44,7 +44,7 @@ export default {
     computed: {
         ...mapState({
             availableIconSets: (state) => state.drawing.iconSets,
-        })
+        }),
     },
     watch: {
         url(newUrl) {
@@ -53,6 +53,9 @@ export default {
         },
         opacity(newOpacity) {
             this.layer.setOpacity(newOpacity)
+        },
+        availableIconSets(availableIconSets) {
+            this.updateFeatures(availableIconSets)
         },
     },
     created() {
@@ -79,15 +82,20 @@ export default {
                 // Reproject all features to webmercator, as this is the projection used for the view
                 featureProjection: CoordinateSystems.WEBMERCATOR.epsg,
             })
-            features.forEach((olFeature) => {
-                EditableFeature.deserialize(olFeature, this.availableIconSets)
-            })
             this.layer.getSource().addFeatures(features)
+            if (this.availableIconSets && this.availableIconSets.length) {
+                this.updateFeatures(this.availableIconSets)
+            }
 
             if (IS_TESTING_WITH_CYPRESS) {
                 window.kmlLayer = this.layer
                 window.kmlLayerUrl = url
             }
+        },
+        updateFeatures(availableIconSets) {
+            this.layer.getSource().forEachFeature((feature) => {
+                EditableFeature.deserialize(feature, availableIconSets)
+            })
         },
     },
 }

--- a/src/utils/legacyKmlUtils.js
+++ b/src/utils/legacyKmlUtils.js
@@ -5,8 +5,11 @@ import {
     allStylingColors,
     allStylingSizes,
     FeatureStyleColor,
-    FeatureStyleSize, MEDIUM, RED, SMALL
-} from "@/utils/featureStyleUtils";
+    FeatureStyleSize,
+    MEDIUM,
+    RED,
+    SMALL,
+} from '@/utils/featureStyleUtils'
 import log from '@/utils/logging'
 import Feature from 'ol/Feature'
 import { getDefaultStyle } from 'ol/format/KML'
@@ -29,6 +32,11 @@ export function getEditableFeatureFromLegacyKmlFeature(legacyKmlFeature, availab
         !Array.isArray(availableIconSets) ||
         availableIconSets.length === 0
     ) {
+        log.error(
+            `Cannot generate EditableFeature from Legacy KML feature`,
+            legacyKmlFeature,
+            availableIconSets
+        )
         return null
     }
     const geom = legacyKmlFeature.getGeometry()


### PR DESCRIPTION
On initial load of legacy drawing, it was not visible. To make it visible we
had to toggle the visible flag.

This was a race condition between the icons backend and the kml backend. In
order to display legacy drawings we need to have the icons sets information
from the icons backend. In our case the kml was loaded and added to openlayer
before the icons backend answered.

Now we update the drawing features on changes from the icons backend.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2728-legacy-drawing/index.html)