### PR TITLE
BGDIINF_SB-2733: Fixed layer cloning

### DIFF
--- a/src/api/layers/AbstractLayer.class.js
+++ b/src/api/layers/AbstractLayer.class.js
@@ -10,6 +10,10 @@ export class LayerAttribution {
         this.name = name
         this.url = url
     }
+
+    clone() {
+        return Object.assign(Object.create(Object.getPrototypeOf(this)), this)
+    }
 }
 
 /**
@@ -71,6 +75,8 @@ export default class AbstractLayer {
     }
 
     clone() {
-        return Object.assign(Object.create(Object.getPrototypeOf(this)), this)
+        let clone = Object.assign(Object.create(Object.getPrototypeOf(this)), this)
+        clone.attributions = this.attributions.map((attribution) => attribution.clone())
+        return clone
     }
 }

--- a/src/api/layers/GeoAdminAggregateLayer.class.js
+++ b/src/api/layers/GeoAdminAggregateLayer.class.js
@@ -25,6 +25,12 @@ export class AggregateSubLayer {
         this.minResolution = minResolution
         this.maxResolution = maxResolution
     }
+
+    clone() {
+        let clone = Object.assign(Object.create(Object.getPrototypeOf(this)), this)
+        clone.layer = this.layer.clone()
+        return clone
+    }
 }
 
 /**
@@ -84,5 +90,12 @@ export default class GeoAdminAggregateLayer extends GeoAdminLayer {
         throw new Error(
             "Aggregate layers shouldn't be asked directly for URL, but sub-layers should"
         )
+    }
+
+    clone() {
+        let clone = super.clone()
+        clone.timeConfig = this.timeConfig.clone()
+        clone.subLayers = this.subLayers.map((subLayer) => subLayer.clone())
+        return clone
     }
 }

--- a/src/api/layers/KMLLayer.class.js
+++ b/src/api/layers/KMLLayer.class.js
@@ -75,4 +75,15 @@ export default class KMLLayer extends AbstractLayer {
         }
         return true
     }
+
+    clone() {
+        let clone = super.clone()
+        if (this.metadata) {
+            clone.metadata = Object.assign(
+                Object.create(Object.getPrototypeOf(this.metadata)),
+                this.metadata
+            )
+        }
+        return clone
+    }
 }

--- a/src/api/layers/LayerTimeConfig.class.js
+++ b/src/api/layers/LayerTimeConfig.class.js
@@ -43,4 +43,8 @@ export default class LayerTimeConfig {
             this.currentTimestamp = 'current'
         }
     }
+
+    clone() {
+        return Object.assign(Object.create(Object.getPrototypeOf(this)), this)
+    }
 }

--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -259,12 +259,6 @@ export default {
         if (this.availableIconSets.length === 0) {
             this.loadAvailableIconSets()
         }
-
-        /**
-         * Flag used internally in the "show(show)" watcher function. Look at the comment at the top
-         * of the beforementioned function to understand how this flag is used.
-         */
-        this.abortedToggleOverlay = false
     },
     mounted() {
         // We can enable the teleport after the view has been rendered.

--- a/src/modules/drawing/components/DrawingToolbox.vue
+++ b/src/modules/drawing/components/DrawingToolbox.vue
@@ -81,7 +81,6 @@
             v-if="showClearConfirmationModal"
             show-confirmation-buttons
             fluid
-            data-cy="drawing-toolbox-delete-confirmation-modal"
             @close="onCloseClearConfirmation"
         >
             {{ $t('confirm_remove_all_features') }}

--- a/src/modules/drawing/components/DrawingToolbox.vue
+++ b/src/modules/drawing/components/DrawingToolbox.vue
@@ -86,7 +86,7 @@
             {{ $t('confirm_remove_all_features') }}
         </ModalWithBackdrop>
         <ModalWithBackdrop v-if="showShareModal" fluid :title="$t('share')" @close="onCloseShare">
-            <ShareForm :kml-metadata="kmlMetadata" />
+            <SharePopup :kml-metadata="kmlMetadata" />
         </ModalWithBackdrop>
     </teleport>
 </template>
@@ -95,7 +95,7 @@
 import { EditableFeatureTypes } from '@/api/features.api'
 import DrawingExporter from '@/modules/drawing/components/DrawingExporter.vue'
 import DrawingToolboxButton from '@/modules/drawing/components/DrawingToolboxButton.vue'
-import ShareForm from '@/modules/drawing/components/SharePopup.vue'
+import SharePopup from '@/modules/drawing/components/SharePopup.vue'
 import ButtonWithIcon from '@/utils/ButtonWithIcon.vue'
 import ModalWithBackdrop from '@/utils/ModalWithBackdrop.vue'
 import { mapGetters } from 'vuex'
@@ -108,7 +108,7 @@ export default {
         ModalWithBackdrop,
         ButtonWithIcon,
         DrawingToolboxButton,
-        ShareForm,
+        SharePopup,
         DrawingHeader,
     },
     props: {


### PR DESCRIPTION
Because the layers object are saved into the store, they are made reactive and
also cannot be changed outside a mutation. However there is some cases where
we want to change a copy outside a mutation in order to update the layer config
in the store. We do this with the clone() method. However this method did
not deeply cloned the objects.

In order to avoid using external library like lodash to do correct deep clone,
the clone method is overwritten in each subclass when needed.

This fix a future issue for the kml drawing admin id that needs to be removed
when exiting the drawing menu.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-2733-drawing-admin-id-part-1/index.html)


[Test link with legacy drawing](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-2733-drawing-admin-id-part-1/index.html#/map?lang=it&lat=46.74122&lon=7.812521&z=7.617&bgLayer=ch.swisstopo.pixelkarte-farbe&topic=ech&layers=ch.astra.wanderland-sperrungen_umleitungen,f;ch.swisstopo.swisstlm3d-wanderwege,f;ch.bav.haltestellen-oev,f;ch.bfs.gebaeude_wohnungs_register,f;ch.swisstopo.zeitreihen@time=18641231,f;KML|https%3A%2F%2Fsys-public.dev.bgdi.ch%2Fapi%2Fkml%2Ffiles%2Foo-VqoIzRv20NewKZEaGBg|Dessin,,1)
[External WMS with mf-geoadmin3 URL syntax](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-2733-drawing-admin-id-part-1/index.html?lang=en&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=WMS%7C%7CAargauer%20Wanderweg%7C%7Chttps:%2F%2Fwms.geo.ag.ch%2Fpublic%2Fows%3FSERVICE%3DWMS%26%7C%7Cch_ag_geo_are_divwanderweg%7C%7C1.3.0)

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-2733-drawing-admin-id-part-1/index.html)