### PR TITLE
BGDIINF_SB-2709 bugfix : drawings not interactive out of drawing mode

### DIFF
--- a/src/modules/infobox/InfoboxModule.vue
+++ b/src/modules/infobox/InfoboxModule.vue
@@ -41,12 +41,23 @@
                     v-if="showElevationProfile"
                     class="card-body"
                     :feature="selectedFeature"
+                    :read-only="!showDrawingOverlay"
                     @update-elevation-profile-plot="setMaxHeight"
                 />
 
-                <FeatureCombo v-else-if="isCombo" class="card-body" :feature="selectedFeature" />
+                <FeatureCombo
+                    v-else-if="isCombo"
+                    class="card-body"
+                    :feature="selectedFeature"
+                    :read-only="!showDrawingOverlay"
+                />
 
-                <FeatureEdit v-else-if="isEdit" class="card-body" :feature="selectedFeature" />
+                <FeatureEdit
+                    v-else-if="isEdit"
+                    class="card-body"
+                    :feature="selectedFeature"
+                    :read-only="!showDrawingOverlay"
+                />
 
                 <FeatureList v-else-if="isList" />
             </div>
@@ -63,7 +74,6 @@ import FeatureCombo from './components/FeatureCombo.vue'
 import FeatureEdit from './components/FeatureEdit.vue'
 import FeatureElevationProfile from './components/FeatureElevationProfile.vue'
 import FeatureList from './components/FeatureList.vue'
-
 export default {
     components: {
         ButtonWithIcon,
@@ -84,6 +94,7 @@ export default {
         ...mapState({
             selectedFeatures: (state) => state.features.selectedFeatures,
             floatingTooltip: (state) => state.ui.floatingTooltip,
+            showDrawingOverlay: (state) => state.ui.showDrawingOverlay,
         }),
 
         selectedFeature() {

--- a/src/modules/infobox/components/FeatureCombo.vue
+++ b/src/modules/infobox/components/FeatureCombo.vue
@@ -1,10 +1,14 @@
 <template>
     <div class="edit-feature" data-infobox="height-reference">
         <div class="edit-feature-form">
-            <FeatureStyleEdit :feature="feature" :available-icon-sets="availableIconSets" />
+            <FeatureStyleEdit
+                :feature="feature"
+                :available-icon-sets="availableIconSets"
+                :read-only="readOnly"
+            />
         </div>
 
-        <FeatureProfile class="edit-feature-plot" :feature="feature" />
+        <FeatureProfile class="edit-feature-plot" :feature="feature" :read-only="readOnly" />
     </div>
 </template>
 
@@ -23,6 +27,10 @@ export default {
         feature: {
             type: EditableFeature,
             required: true,
+        },
+        readOnly: {
+            type: Boolean,
+            default: false,
         },
     },
     computed: {

--- a/src/modules/infobox/components/FeatureEdit.vue
+++ b/src/modules/infobox/components/FeatureEdit.vue
@@ -1,6 +1,10 @@
 <template>
     <div class="feature-edit" data-infobox="height-reference">
-        <FeatureStyleEdit :feature="feature" :available-icon-sets="availableIconSets" />
+        <FeatureStyleEdit
+            :feature="feature"
+            :available-icon-sets="availableIconSets"
+            :read-only="readOnly"
+        />
     </div>
 </template>
 
@@ -17,6 +21,10 @@ export default {
         feature: {
             type: EditableFeature,
             required: true,
+        },
+        readOnly: {
+            type: Boolean,
+            default: false,
         },
     },
     computed: {

--- a/src/modules/infobox/components/FeatureElevationProfile.vue
+++ b/src/modules/infobox/components/FeatureElevationProfile.vue
@@ -47,6 +47,10 @@ export default {
             type: EditableFeature,
             required: true,
         },
+        readOnly: {
+            type: Boolean,
+            default: false,
+        },
     },
     emits: ['updateElevationProfilePlot'],
     data() {
@@ -75,7 +79,11 @@ export default {
          * @returns {Boolean} True if the feature being shown is of type "measure"
          */
         showDeleteButton() {
-            return this.feature && this.feature.featureType === EditableFeatureTypes.MEASURE
+            return (
+                !this.readOnly &&
+                this.feature &&
+                this.feature.featureType === EditableFeatureTypes.MEASURE
+            )
         },
     },
     watch: {

--- a/src/modules/infobox/components/styling/FeatureStyleEdit.vue
+++ b/src/modules/infobox/components/styling/FeatureStyleEdit.vue
@@ -7,6 +7,7 @@
             <textarea
                 id="drawing-style-feature-title"
                 v-model="text"
+                :read-only="readOnly"
                 data-cy="drawing-style-feature-title"
                 class="form-control"
                 rows="1"
@@ -20,6 +21,7 @@
             <textarea
                 id="drawing-style-feature-description"
                 v-model="description"
+                :read-only="readOnly"
                 data-cy="drawing-style-feature-description"
                 class="form-control"
                 rows="2"
@@ -29,7 +31,7 @@
         <div class="d-flex">
             <SelectedFeatureProfile :feature="feature" />
 
-            <div class="d-flex feature-style-edit-control">
+            <div v-if="!readOnly" class="d-flex feature-style-edit-control">
                 <PopoverButton
                     v-if="isFeatureMarker || isFeatureText"
                     class="control-button"
@@ -132,6 +134,10 @@ export default {
         availableIconSets: {
             type: Array,
             required: true,
+        },
+        readOnly: {
+            type: Boolean,
+            default: false,
         },
     },
     emits: ['close'],

--- a/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
@@ -64,6 +64,7 @@ export default {
         the getExtent() function and a wrong extent causes the features to sometimes disappear
         from the screen.  */
         this.layer = new VectorLayer({
+            id: this.layerId,
             opacity: this.opacity,
             source: new VectorSource({ wrapX: true }),
         })

--- a/src/store/modules/map.store.js
+++ b/src/store/modules/map.store.js
@@ -14,19 +14,19 @@ export class ClickInfo {
      * @param {Number[]} coordinate Of the last click expressed in EPSG:3857
      * @param {Number[]} pixelCoordinate Position of the last click on the screen [x, y] in pixels
      *   (counted from top left corner)
-     * @param {Object[]} geoJsonFeatures List of potential GeoJSON features that where under the
+     * @param {Object[]} features List of potential features (geoJSON or KML) that where under the
      *   click
      * @param {ClickType} clickType Which button of the mouse has been used to make this click
      */
     constructor(
         coordinate = [],
         pixelCoordinate = [],
-        geoJsonFeatures = [],
+        features = [],
         clickType = ClickType.LEFT_SINGLECLICK
     ) {
         this.coordinate = [...coordinate]
         this.pixelCoordinate = [...pixelCoordinate]
-        this.geoJsonFeatures = [...geoJsonFeatures]
+        this.features = [...features]
         this.clickType = clickType
     }
 }

--- a/src/store/plugins/click-on-map-management.plugin.js
+++ b/src/store/plugins/click-on-map-management.plugin.js
@@ -17,9 +17,12 @@ const runIdentify = async (store, clickInfo, visibleLayers, lang) => {
         const allRequests = []
         // for each layer we run a backend request
         visibleLayers.forEach((layer) => {
-            if (layer.type === LayerTypes.GEOJSON) {
-                allRequests.push(new Promise((resolve) => resolve(clickInfo.geoJsonFeatures)))
-            } else if (layer.hasTooltip) {
+
+            if (layer.type === LayerTypes.GEOJSON || layer.type === LayerTypes.KML) {
+                allRequests.push(new Promise((resolve) => resolve(clickInfo.features)))
+
+            }
+            else if (layer.hasTooltip) {
                 allRequests.push(
                     identify(
                         layer,
@@ -85,9 +88,12 @@ const clickOnMapManagementPlugin = (store) => {
                     store.getters.visibleLayers,
                     store.state.i18n.lang
                 ).then((newSelectedFeatures) => {
+
                     if (!newSelectedFeatures?.length && allowActivateFullscreen) {
+
                         store.dispatch('toggleFullscreenMode')
                     }
+
                     store.dispatch('setSelectedFeatures', newSelectedFeatures)
                 })
             }


### PR DESCRIPTION
Issue : user made kmls were not selectable outside the drawing mode
Fix : We made them selectable, and applied a read only property on them to hide the edition buttons, even if they were not usable outside the drawing mode.

[Test link](https://sys-map.dev.bgdi.ch/preview/bugfix_bgdiinf_sb-2709-drawings-not-interactive-out-of-drawing-mode/index.html)