### PR TITLE
BGDIINF_SB-2746: Fixed legacy url parsing for adminId

### DIFF
--- a/adr/2021_03_16_url_param_structure.md
+++ b/adr/2021_03_16_url_param_structure.md
@@ -89,11 +89,13 @@ The timestamp format must be ISO8601 compliant, i.e.
 
 External Layers are in the following format (note that only one `|` is used and the WMS order is changed to have consistently `TYPE|URL|OTHER OPTIONS`)
 
-- an external WMS:  `WMS|wms.geo.gr.ch%2Fadmineinteilung%3F|Gemeinden,layerb,layerc|1.3.0|Gemeinden`
+- an external WMS: `WMS|wms.geo.gr.ch%2Fadmineinteilung%3F|Gemeinden,layerb,layerc|1.3.0|Gemeinden`
 - an external WMTS: `WMTS|wmts.geo.ti.ch%2Fwmts%2F1.0.0%2FWMTSCapabilities.xml|ch.ti.051_1.piano_registro_fondiario_catasto_rdpp@time=18641231|Optionales Label`
-- an external KML:  `KML|www.slf.ch/avalanche/accidents/accidents_season_de.kml|Mein Titel`
-- an external GPX:  `GPX|www.slf.ch/avalanche/accidents/accidents_season_de.gpx`
-- an external KMZ:  `KMZ|www.slf.ch/avalanche/accidents/accidents_season_de.kmz` (needs to pass by proxy to be unzipped)
+- an external KML: `KML|www.slf.ch/avalanche/accidents/accidents_season_de.kml|Mein Titel`
+- a geoadmin KML: `KML|public.geo.admin.ch/api/files/KML_ID|Mein Titel`
+- a geoadmin KML with adminId: `KML|public.geo.admin.ch/api/files/KML_ID|Mein Titel@adminId=ADMIN_ID`
+- an external GPX: `GPX|www.slf.ch/avalanche/accidents/accidents_season_de.gpx`
+- an external KMZ: `KMZ|www.slf.ch/avalanche/accidents/accidents_season_de.kmz` (needs to pass by proxy to be unzipped)
 
 ## Consequences
 

--- a/src/api/layers/KMLLayer.class.js
+++ b/src/api/layers/KMLLayer.class.js
@@ -46,7 +46,7 @@ export default class KMLLayer extends AbstractLayer {
             // Based on the service-kml API reference the KML file URL has the following structure
             // <base-url>/kml/files/{kml_id}
             // or <base-url>/{kml_id} for legacy files, those one are redirected to <base-url>/kml/files/{kml_id}
-            this.fileId = kmlFileUrl.split('/').pop()
+            this.fileId = this.kmlFileUrl.split('/').pop()
         }
         this.metadata = metadata
     }

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -27,9 +27,9 @@ const parseLegacyParams = (search) => {
 }
 
 const handleLegacyKmlAdminIdParam = async (legacyParams, newQuery) => {
-    log.debug('Transforming legacy kml adminid, get KML ID from adminId...')
-    const kmlLayer = await getKmlLayerFromLegacyAdminIdParam(legacyParams['adminid'])
-    log.debug('Adding KML layer from legacy kml adminid')
+    log.debug('Transforming legacy kml adminId, get KML ID from adminId...')
+    const kmlLayer = await getKmlLayerFromLegacyAdminIdParam(legacyParams['adminId'])
+    log.debug('Adding KML layer from legacy kml adminId')
     if (newQuery.layers) {
         newQuery.layers = `${newQuery.layers};${transformLayerIntoUrlString(kmlLayer)}`
     } else {
@@ -37,7 +37,7 @@ const handleLegacyKmlAdminIdParam = async (legacyParams, newQuery) => {
     }
 
     // remove the legacy param from the newQuery
-    delete newQuery.adminid
+    delete newQuery.adminId
 
     return newQuery
 }
@@ -123,8 +123,8 @@ const handleLegacyParams = (legacyParams, store, to, next) => {
     const urlWithoutQueryParam = window.location.href.substr(0, window.location.href.indexOf('?'))
     window.history.replaceState(window.history.state, document.title, urlWithoutQueryParam)
 
-    if ('adminid' in legacyParams) {
-        // adminid legacy param cannot be handle above in the loop because it needs to add a layer
+    if ('adminId' in legacyParams) {
+        // adminId legacy param cannot be handle above in the loop because it needs to add a layer
         // to the layers param, thats why we do handle after.
         handleLegacyKmlAdminIdParam(legacyParams, newQuery)
             .then((updatedQuery) => {
@@ -135,8 +135,8 @@ const handleLegacyParams = (legacyParams, store, to, next) => {
             })
             .catch((error) => {
                 log.error(`Failed to retrieve KML from admin_id: ${error}`)
-                // make sure to remove the adminid from the query
-                delete newQuery.adminid
+                // make sure to remove the adminId from the query
+                delete newQuery.adminId
                 next({
                     name: 'MapView',
                     query: newQuery,

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -166,7 +166,7 @@ export function getBackgroundLayerFromLegacyUrlParams(layersConfig, legacyUrlPar
 }
 
 /**
- * Returns a KML Layer from the legacy adminid url param.
+ * Returns a KML Layer from the legacy adminId url param.
  *
  * @param {String} adminId KML admin ID
  * @returns {Promise<AbstractLayer>} KML Layer

--- a/tests/e2e-cypress/integration/legacyParamImport.cy.js
+++ b/tests/e2e-cypress/integration/legacyParamImport.cy.js
@@ -119,9 +119,9 @@ describe('Test on legacy param import', () => {
                 expect(kmlLayer.visible).to.be.true
             })
         })
-        it('is able to import an external KML from a legacy adminid query param', () => {
+        it('is able to import an external KML from a legacy adminId query param', () => {
             cy.goToMapView('en', {
-                adminid: adminId,
+                adminId: adminId,
             })
             cy.wait('@getKML_ID')
             cy.wait('@getKML')
@@ -133,10 +133,9 @@ describe('Test on legacy param import', () => {
                 expect(kmlLayer.visible).to.be.true
             })
         })
-        // TODO: reactivate this test while doing https://jira.swisstopo.ch/browse/BGDIINF_SB-2610
-        it.skip('is able to import an external KML from a legacy adminid query param with other layers', () => {
+        it('is able to import an external KML from a legacy adminId query param with other layers', () => {
             cy.goToMapView('en', {
-                adminid: adminId,
+                adminId: adminId,
                 layers: 'test.wms.layer,test.wmts.layer',
                 layers_opacity: '0.6,0.5',
                 layers_visibility: 'true,false',

--- a/tests/e2e-cypress/support/commands.js
+++ b/tests/e2e-cypress/support/commands.js
@@ -144,8 +144,8 @@ Cypress.Commands.add(
             // There are situations where neither value is falsey.
             // But the higher value seems to always be the right one.
             let target = Math.max(targetTopic, targetLayers)
-            // If a layer has been set via adminid we just increment by one.
-            target += Boolean(otherParams.adminid)
+            // If a layer has been set via adminId we just increment by one.
+            target += Boolean(otherParams.adminId)
 
             return active === target
         })


### PR DESCRIPTION
The admin id in url is camel case `adminId` not lower case.

- [x] TODO add an e2e test case to catch such issue as it seem to have been brocken a long while ago.

Also updated the ADR with more examples.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2746-legacy-url/index.html)