### PR TITLE
BGDIINF_SB-2744: Switch VectorTile background layer usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
                 "mime-types": "^2.1.35",
                 "prettier": "^2.8.2",
                 "prettier-plugin-jsdoc": "^0.4.2",
+                "rimraf": "^3.0.2",
                 "sass": "^1.57.1",
                 "start-server-and-test": "^1.15.2",
                 "typescript": "^4.9.4",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
         "build:prod": "npm run build -- --mode production",
         "update:translations": "node scripts/generate-i18n-files.js",
         "update:browserlist": "npx browserslist@latest --update-db",
-        "delete:reports": "rm -rf tests/results/ || true",
-        "delete:reports:unit": "rm -rf tests/results/unit/* || true",
-        "delete:reports:e2e": "rm -rf tests/results/e2e/* || true"
+        "delete:reports": "rimraf tests/results/ || true",
+        "delete:reports:unit": "rimraf tests/results/unit/* || true",
+        "delete:reports:e2e": "rimraf tests/results/e2e/* || true"
     },
     "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.2.1",
@@ -92,6 +92,7 @@
         "mime-types": "^2.1.35",
         "prettier": "^2.8.2",
         "prettier-plugin-jsdoc": "^0.4.2",
+        "rimraf": "^3.0.2",
         "sass": "^1.57.1",
         "start-server-and-test": "^1.15.2",
         "typescript": "^4.9.4",

--- a/src/config.js
+++ b/src/config.js
@@ -202,6 +202,14 @@ export const TILEGRID_RESOLUTIONS = [
 export const TILEGRID_EXTENT = [2420000, 1030000, 2900000, 1350000]
 
 /**
+ * Bounds of the LV95 projection expressed in metric mercator (WGS84). It is essentially
+ * TILEGRID_EXTENT (defined above) reprojected in EPSG:3857 through epsg.io website.
+ *
+ * @type {Number[]}
+ */
+export const LV95_EXTENT = [572215.44, 5684416.96, 1277662.37, 6145307.4]
+
+/**
  * Map center default value is the center of switzerland LV:95 projection's extent (from
  * {@link https://epsg.io/2056}) re-projected in EPSG:3857
  */

--- a/src/modules/map/components/openlayers/OpenLayersInternalLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersInternalLayer.vue
@@ -1,12 +1,13 @@
 <template>
     <div>
+        <!-- no source exclusion when adding VT layer through here, this is only required in the case the layer is under
+             another (see OpenLayersMap main component)-->
         <OpenLayersVectorLayer
             v-if="layerConfig.type === LayerTypes.VECTOR"
             :z-index="zIndex"
             :layer-id="layerConfig.getID()"
             :opacity="layerConfig.opacity"
             :style-url="layerConfig.getURL()"
-            :exclude-source="layerConfig.excludeSource"
         />
         <OpenLayersWMTSLayer
             v-if="layerConfig.type === LayerTypes.WMTS && !layerConfig.isExternal"

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -101,7 +101,7 @@
 import { EditableFeatureTypes, LayerFeature } from '@/api/features.api'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
 
-import { IS_TESTING_WITH_CYPRESS, VECTOR_LIGHT_BASE_MAP_STYLE_ID } from '@/config'
+import { IS_TESTING_WITH_CYPRESS, LV95_EXTENT, VECTOR_LIGHT_BASE_MAP_STYLE_ID } from '@/config'
 import FeatureEdit from '@/modules/infobox/components/FeatureEdit.vue'
 import FeatureList from '@/modules/infobox/components/FeatureList.vue'
 import OpenLayersPopover from '@/modules/map/components/openlayers/OpenLayersPopover.vue'
@@ -215,9 +215,21 @@ export default {
          */
         lightBaseMapConfigUnderMainBackgroundLayer() {
             if (this.currentBackgroundLayer?.getID() === 'ch.swisstopo.pixelkarte-farbe') {
-                return this.backgroundLayers.find(
-                    (layer) => layer.getID() === VECTOR_LIGHT_BASE_MAP_STYLE_ID
-                )
+                // we only want LightBaseMap behind pixelkarte-farbe when the map is showing things outside
+                // LV95 extent (outside of Switzerland)
+                const [currentExtentBottomLeft, currentExtentTopRight] = this.extent
+                if (
+                    currentExtentBottomLeft[0] >= LV95_EXTENT[0] &&
+                    currentExtentBottomLeft[1] >= LV95_EXTENT[1] &&
+                    currentExtentTopRight[0] <= LV95_EXTENT[2] &&
+                    currentExtentTopRight[1] <= LV95_EXTENT[3]
+                ) {
+                    log.debug('no need to show MapLibre, we are totally within LV95 extent')
+                } else {
+                    return this.backgroundLayers.find(
+                        (layer) => layer.getID() === VECTOR_LIGHT_BASE_MAP_STYLE_ID
+                    )
+                }
             }
             return null
         },

--- a/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
@@ -51,6 +51,7 @@ export default {
     },
     created() {
         this.layer = new MapLibreLayer({
+            id: this.layerId,
             opacity: this.opacity,
             maplibreOptions: {
                 style: this.styleUrl,

--- a/src/store/plugins/load-layersconfig-on-lang-change.js
+++ b/src/store/plugins/load-layersconfig-on-lang-change.js
@@ -42,13 +42,17 @@ const loadLayersAndTopicsConfigAndDispatchToStore = async (store) => {
                 'https://www.openstreetmap.org/copyright'
             ),
         ]
-        // adding vector tile backend through a hardcoded entry (for now)
-        // this should be removed as soon as the backend delivers a proper configuration
-        // for our vector tile background layer
+        /*
+         * adding vector tile backend through a hardcoded entry (for now)
+         *
+         * this should be removed as soon as the backend delivers a proper configuration for our vector tile background layer
+         */
         const lightBaseMapBackgroundLayer = new GeoAdminVectorLayer(
             VECTOR_LIGHT_BASE_MAP_STYLE_ID,
             openStreetMapAndMapTilersAttributions,
             // filtering out any layer that uses swisstopo data (meaning all layers that are over Switzerland)
+            // will be used when this layer is placed under pixelkarte-farbe, this should improve performances as lesser
+            // data will be on-screen hidden by the WMTS tiles
             'swissmaptiles'
         )
         const imageryBackgroundLayer = new GeoAdminVectorLayer(VECTOR_TILES_IMAGERY_STYLE_ID, [
@@ -68,8 +72,8 @@ const loadLayersAndTopicsConfigAndDispatchToStore = async (store) => {
         // the default topic ECH to have the vector layer as its default background
         const topicEch = topicsConfig.find((topic) => topic.id === 'ech')
         if (topicEch) {
+            // adding light base map as a background option
             topicEch.backgroundLayers.push(lightBaseMapBackgroundLayer)
-            topicEch.defaultBackgroundLayer = lightBaseMapBackgroundLayer
             // replacing the SWISSIMAGE WMTS layer with the SWISSIMAGE vector layer
             // same as the other one above, this should be removed ASAP (as soon as our backend
             // is serving this configuration through the standard layersConfig endpoint)

--- a/tests/e2e-cypress/integration/layers.cy.js
+++ b/tests/e2e-cypress/integration/layers.cy.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { BREAKPOINT_TABLET, VECTOR_LIGHT_BASE_MAP_STYLE_ID } from '@/config'
+import { BREAKPOINT_TABLET } from '@/config'
 import { randomIntBetween } from '@/utils/numberUtils'
 
 /**
@@ -231,9 +231,7 @@ describe('Test of layer handling', () => {
                 cy.goToMapView()
                 cy.readStoreValue('state.layers.backgroundLayerId').should(
                     'eq',
-                    // for no we force the background to be the VT layer as we can't rely on the backend to give it to us
-                    // (otherwise mf-geoadmin3 PROD will also receive it...)
-                    VECTOR_LIGHT_BASE_MAP_STYLE_ID
+                    defaultTopic.defaultBackground
                 )
             })
         })
@@ -245,8 +243,7 @@ describe('Test of layer handling', () => {
                 })
                 cy.readStoreValue('state.layers.backgroundLayerId').should(
                     'eq',
-                    // same remark as above, we now overwrite the default BG given by the backend to the vector tile layer
-                    VECTOR_LIGHT_BASE_MAP_STYLE_ID
+                    defaultTopic.defaultBackground
                 )
                 cy.readStoreValue('getters.visibleLayers').then((layers) => {
                     expect(layers).to.be.an('Array')

--- a/tests/e2e-cypress/integration/mouseposition.cy.js
+++ b/tests/e2e-cypress/integration/mouseposition.cy.js
@@ -1,8 +1,8 @@
 /// <reference types="cypress" />
 
+import { BREAKPOINT_PHONE_WIDTH } from '@/config'
 import { CoordinateSystems } from '@/utils/coordinateUtils'
 import setupProj4 from '@/utils/setupProj4'
-import { BREAKPOINT_PHONE_WIDTH } from '@/config'
 import proj4 from 'proj4'
 
 setupProj4()
@@ -231,9 +231,10 @@ describe('Test mouse position', () => {
                 expect(interception.request.body.url).be.a('string')
                 const query = interception.request.body.url.split('?')[1]
                 const params = new URLSearchParams(query)
-                expect(params.get('bgLayer')).to.be.equal(
-                    'ch.swisstopo.leichte-basiskarte_world.vt'
-                )
+                cy.fixture('topics.fixture').then((data) => {
+                    const [defaultTopic] = data.topics
+                    expect(params.get('bgLayer')).to.be.equal(defaultTopic.defaultBackground)
+                })
             })
             cy.get('[data-cy="location-popup-link-input"]').should('have.value', shortUrl1)
 


### PR DESCRIPTION
Reverts default ECH BG layer to given value (from topics) and add light base map behind `pixelkarte-farbe`, instead of switching to light base map by default.
Light base map is now added as an option in the BG selection wheel, and if chosen will be rendered in full (no exclusion over Switzerland).
The exclusion of data over Switzerland with LightBaseMap still occurs if it is used behind `pixelkarte-farbe`

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_bgdiinf_sb-2744_switch_vt_layer_usage/index.html)