### PR TITLE
BGDIINF_SB-2751: Moved the language toolbar in desktop mode

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -84,7 +84,7 @@ export default {
 :focus {
     outline-style: none;
     .outlines & {
-        outline-offset: 1px;
+        outline-offset: 0px;
         outline: $focus-outline;
     }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -255,7 +255,7 @@ export const DRAWING_HIT_TOLERANCE = 6
 /**
  * Light base map style ID
  *
- * from https://www.swisstopo.admin.ch/de/geodata/maps/smw/smw_lightbase.html
+ * From https://www.swisstopo.admin.ch/de/geodata/maps/smw/smw_lightbase.html
  *
  * @type {string}
  */
@@ -264,7 +264,7 @@ export const VECTOR_LIGHT_BASE_MAP_STYLE_ID = 'ch.swisstopo.leichte-basiskarte_w
 /**
  * Imagery base map style ID
  *
- * from https://www.swisstopo.admin.ch/de/geodata/maps/smw/smw_imagerybase.html
+ * From https://www.swisstopo.admin.ch/de/geodata/maps/smw/smw_imagerybase.html
  *
  * @type {string}
  */

--- a/src/modules/i18n/components/LangButton.vue
+++ b/src/modules/i18n/components/LangButton.vue
@@ -1,0 +1,93 @@
+<template>
+    <button
+        class="language-btn btn"
+        :class="buttonClass"
+        :title="lang.toUpperCase()"
+        :data-cy="`menu-lang-${lang}`"
+        @click="changeLang"
+    >
+        {{ lang.toUpperCase() }}
+    </button>
+</template>
+
+<script>
+import log from '@/utils/logging'
+import { mapActions, mapGetters, mapState } from 'vuex'
+
+export default {
+    props: {
+        lang: {
+            type: String,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            selected: false,
+        }
+    },
+    computed: {
+        ...mapGetters(['isDesktopMode']),
+        ...mapState({
+            currentLang: (state) => state.i18n.lang,
+        }),
+        buttonClass() {
+            let classes = ''
+            if (this.isDesktopMode) {
+                classes += 'm-0 px-1 btn-xs btn-link custom-text-decoration'
+                if (this.selected) {
+                    classes += ' text-primary'
+                } else {
+                    classes += ' text-black'
+                }
+            } else {
+                classes += ' mobile-view btn-sm mx-1'
+                if (this.selected) {
+                    classes += ' btn-primary'
+                } else {
+                    classes += ' btn-light'
+                }
+            }
+            return classes
+        },
+    },
+    watch: {
+        currentLang(newLang) {
+            this.updateSelection(newLang)
+        },
+    },
+    mounted() {
+        this.updateSelection(this.currentLang)
+    },
+    methods: {
+        ...mapActions(['setLang']),
+        changeLang() {
+            log.debug('switching locale', this.lang)
+            this.selected = true
+            this.setLang(this.lang)
+        },
+        updateSelection(currentLang) {
+            if (currentLang === this.lang) {
+                this.selected = true
+            } else {
+                this.selected = false
+            }
+        },
+    },
+}
+</script>
+
+<style lang="scss" scoped>
+@import 'src/scss/webmapviewer-bootstrap-theme';
+
+.mobile-view {
+    width: 40px;
+}
+
+.custom-text-decoration {
+    text-decoration: none;
+    &:hover {
+        text-decoration: underline;
+    }
+}
+</style>

--- a/src/modules/i18n/components/LangButton.vue
+++ b/src/modules/i18n/components/LangButton.vue
@@ -1,7 +1,16 @@
 <template>
     <button
         class="language-btn btn"
-        :class="buttonClass"
+        :class="{
+            // Desktop mode classes
+            'm-0 px-1 btn-xs btn-link custom-text-decoration': isDesktopMode,
+            'text-black': isDesktopMode,
+            'text-primary': isDesktopMode && selected,
+            // Mobile/tablet mode classes
+            'mobile-view btn-sm mx-1': !isDesktopMode,
+            'btn-light': !isDesktopMode,
+            'btn-primary': !isDesktopMode && selected,
+        }"
         :title="lang.toUpperCase()"
         :data-cy="`menu-lang-${lang}`"
         @click="changeLang"
@@ -31,25 +40,6 @@ export default {
         ...mapState({
             currentLang: (state) => state.i18n.lang,
         }),
-        buttonClass() {
-            let classes = ''
-            if (this.isDesktopMode) {
-                classes += 'm-0 px-1 btn-xs btn-link custom-text-decoration'
-                if (this.selected) {
-                    classes += ' text-primary'
-                } else {
-                    classes += ' text-black'
-                }
-            } else {
-                classes += ' mobile-view btn-sm mx-1'
-                if (this.selected) {
-                    classes += ' btn-primary'
-                } else {
-                    classes += ' btn-light'
-                }
-            }
-            return classes
-        },
     },
     watch: {
         currentLang(newLang) {

--- a/src/modules/i18n/components/LangSwitchToolbar.vue
+++ b/src/modules/i18n/components/LangSwitchToolbar.vue
@@ -1,10 +1,8 @@
 <template>
     <div
         :class="{
-            'lang-switch-menu': !isDesktopMode,
-            'p-1': !isDesktopMode,
-            'lang-switch-header': isDesktopMode,
-            'me-2': isDesktopMode,
+            'lang-switch-menu p-1': !isDesktopMode,
+            'lang-switch-header me-2': isDesktopMode,
         }"
     >
         <LangButton v-for="lang in languages" :key="lang" :lang="lang" />

--- a/src/modules/i18n/components/LangSwitchToolbar.vue
+++ b/src/modules/i18n/components/LangSwitchToolbar.vue
@@ -4,6 +4,7 @@
             'lang-switch-menu': !isDesktopMode,
             'p-1': !isDesktopMode,
             'lang-switch-header': isDesktopMode,
+            'me-2': isDesktopMode,
         }"
     >
         <LangButton v-for="lang in languages" :key="lang" :lang="lang" />

--- a/src/modules/i18n/components/LangSwitchToolbar.vue
+++ b/src/modules/i18n/components/LangSwitchToolbar.vue
@@ -1,15 +1,17 @@
 <template>
-    <div class="lang-switch-toolbar p-1">
+    <div
+        :class="{
+            'lang-switch-menu': !isDesktopMode,
+            'p-1': !isDesktopMode,
+            'lang-switch-header': isDesktopMode,
+        }"
+    >
         <button
             v-for="lang in languages"
             :key="lang"
-            class="btn btn-sm"
-            :class="{
-                'btn-light': lang !== currentLang,
-                'btn-primary': lang === currentLang,
-            }"
+            :class="buttonClass(lang)"
             :title="lang.toUpperCase()"
-            :data-cy="'menu-lang-' + lang"
+            :data-cy="`menu-lang-${lang}`"
             @click="changeLang(lang)"
         >
             {{ lang.toUpperCase() }}
@@ -40,6 +42,25 @@ export default {
             this.setLang(lang)
         },
         ...mapActions(['setLang']),
+        buttonClass(lang) {
+            let classes = 'btn'
+            if (this.isDesktopMode) {
+                classes += ' btn-xs btn-link custom-text-decoration'
+                if (lang === this.currentLang) {
+                    classes += ' text-primary'
+                } else {
+                    classes += ' text-black'
+                }
+            } else {
+                classes += ' btn-sm ms-2 me-2'
+                if (lang === this.currentLang) {
+                    classes += ' btn-primary'
+                } else {
+                    classes += ' btn-light'
+                }
+            }
+            return classes
+        },
     },
 }
 </script>
@@ -47,12 +68,13 @@ export default {
 <style lang="scss" scoped>
 @import 'src/scss/webmapviewer-bootstrap-theme';
 
-.lang-switch-toolbar {
-    transition: max-height 0.3s linear;
-    button {
-        width: 3rem;
-        margin-right: calc($button-spacer / 2);
-        margin-left: calc($button-spacer / 2);
+.custom-text-decoration {
+    text-decoration: none;
+    &:hover {
+        text-decoration: underline;
     }
+}
+.lang-switch-menu {
+    transition: max-height 0.3s linear;
 }
 </style>

--- a/src/modules/i18n/components/LangSwitchToolbar.vue
+++ b/src/modules/i18n/components/LangSwitchToolbar.vue
@@ -6,61 +6,26 @@
             'lang-switch-header': isDesktopMode,
         }"
     >
-        <button
-            v-for="lang in languages"
-            :key="lang"
-            :class="buttonClass(lang)"
-            :title="lang.toUpperCase()"
-            :data-cy="`menu-lang-${lang}`"
-            @click="changeLang(lang)"
-        >
-            {{ lang.toUpperCase() }}
-        </button>
+        <LangButton v-for="lang in languages" :key="lang" :lang="lang" />
     </div>
 </template>
 
 <script>
-import log from '@/utils/logging'
-import { mapActions, mapGetters, mapState } from 'vuex'
+import LangButton from './LangButton.vue'
+import { mapGetters } from 'vuex'
 import { languages } from '../index'
 
 export default {
+    components: {
+        LangButton,
+    },
     data() {
         return {
             languages: Object.keys(languages),
         }
     },
     computed: {
-        ...mapState({
-            currentLang: (state) => state.i18n.lang,
-        }),
         ...mapGetters(['isDesktopMode']),
-    },
-    methods: {
-        changeLang(lang) {
-            log.debug('switching locale', lang)
-            this.setLang(lang)
-        },
-        ...mapActions(['setLang']),
-        buttonClass(lang) {
-            let classes = 'btn'
-            if (this.isDesktopMode) {
-                classes += ' btn-xs btn-link custom-text-decoration'
-                if (lang === this.currentLang) {
-                    classes += ' text-primary'
-                } else {
-                    classes += ' text-black'
-                }
-            } else {
-                classes += ' btn-sm ms-2 me-2'
-                if (lang === this.currentLang) {
-                    classes += ' btn-primary'
-                } else {
-                    classes += ' btn-light'
-                }
-            }
-            return classes
-        },
     },
 }
 </script>
@@ -68,12 +33,6 @@ export default {
 <style lang="scss" scoped>
 @import 'src/scss/webmapviewer-bootstrap-theme';
 
-.custom-text-decoration {
-    text-decoration: none;
-    &:hover {
-        text-decoration: underline;
-    }
-}
 .lang-switch-menu {
     transition: max-height 0.3s linear;
 }

--- a/src/modules/i18n/index.js
+++ b/src/modules/i18n/index.js
@@ -6,7 +6,7 @@ import fr from './locales/fr.json'
 import it from './locales/it.json'
 import rm from './locales/rm.json'
 
-export const languages = { en, de, fr, it, rm }
+export const languages = { de, fr, it, en, rm }
 
 // detecting navigator's locale as the default language
 // (if it is a language served by this app)

--- a/src/modules/menu/MenuModule.vue
+++ b/src/modules/menu/MenuModule.vue
@@ -6,7 +6,7 @@
         <transition name="fade-in-out">
             <BlackBackdrop v-if="isPhoneMode && isMenuShown" @click="toggleMenu" />
         </transition>
-        <HeaderWithSearch v-show="isHeaderShown" class="header" />
+        <HeaderWithSearch v-if="isHeaderShown" class="header" />
         <div class="toolbox-right">
             <GeolocButton
                 v-if="!isFullscreenMode"

--- a/src/modules/menu/MenuModule.vue
+++ b/src/modules/menu/MenuModule.vue
@@ -125,14 +125,7 @@ $animation-time: 0.5s;
         z-index: $zindex-drawing-toolbox;
     }
     .header {
-        transition: height $animation-time;
-        width: 100%;
-        background: rgba($white, 0.9);
-        box-shadow: 6px 6px 12px rgb(0 0 0 / 18%);
         position: relative;
-        .header-content {
-            transition: height $animation-time;
-        }
     }
     .toolbox-right {
         float: right;

--- a/src/modules/menu/components/header/HeaderSwissConfederationText.vue
+++ b/src/modules/menu/components/header/HeaderSwissConfederationText.vue
@@ -16,7 +16,6 @@
 import { mapGetters } from 'vuex'
 
 export default {
-
     props: {
         currentLang: {
             type: String,
@@ -25,10 +24,9 @@ export default {
     },
     emits: ['click'],
     computed: {
-      ...mapGetters(['hasDevSiteWarning']),
-    }
+        ...mapGetters(['hasDevSiteWarning']),
+    },
 }
-
 </script>
 
 <style lang="scss" scoped>

--- a/src/modules/menu/components/header/HeaderWithSearch.vue
+++ b/src/modules/menu/components/header/HeaderWithSearch.vue
@@ -29,7 +29,7 @@
                 />
                 <!-- eslint-enable vue/no-v-html-->
             </div>
-            <div class="header-settings-section d-flex flex-shrink-0 flex-grow-0 ms-auto">
+            <div class="header-settings-section d-flex flex-shrink-0 flex-grow-0 ms-auto" data-cy="header-settings-section">
                 <LangSwitchToolbar id="menu-lang-selector" />
             </div>
             <HeaderMenuButton v-if="isPhoneMode" />

--- a/src/modules/menu/components/header/HeaderWithSearch.vue
+++ b/src/modules/menu/components/header/HeaderWithSearch.vue
@@ -29,7 +29,7 @@
                 />
                 <!-- eslint-enable vue/no-v-html-->
             </div>
-            <div v-if="!isPhoneMode" class="d-flex flex-shrink-0 flex-grow-0 ms-auto">
+            <div class="header-settings-section d-flex flex-shrink-0 flex-grow-0 ms-auto">
                 <LangSwitchToolbar id="menu-lang-selector" />
             </div>
             <HeaderMenuButton v-if="isPhoneMode" />
@@ -106,6 +106,13 @@ $animation-time: 0.5s;
 .search-header-swiss-confederation-text,
 .search-title {
     display: none;
+}
+
+@include respond-below(lg) {
+    .header-settings-section {
+        // See MenuTray.vue where the settings section is enable above lg
+        display: none !important;
+    }
 }
 
 @include respond-above(lg) {

--- a/src/modules/menu/components/header/HeaderWithSearch.vue
+++ b/src/modules/menu/components/header/HeaderWithSearch.vue
@@ -1,30 +1,36 @@
 <template>
-    <div class="header">
+    <div class="header d-flex">
         <LoadingBar v-if="showLoadingBar" />
-        <div class="header-content align-items-center p-1 d-flex justify-content-between">
-            <div class="justify-content-start d-flex">
+        <div class="header-content w-100 p-1 d-flex justify-content-start">
+            <div class="justify-content-start p-1 d-flex flex-shrink-0 flex-grow-0">
                 <SwissFlag
-                    class="swiss-flag ms-1 me-2 cursor-pointer"
+                    class="ms-1 me-2 cursor-pointer"
                     data-cy="menu-swiss-flag"
                     @click="resetApp"
                 />
                 <HeaderSwissConfederationText
                     :current-lang="currentLang"
-                    class="me-2 cursor-pointer search-header-swiss-confederation-text"
+                    class="mx-2 cursor-pointer search-header-swiss-confederation-text"
                     data-cy="menu-swiss-confederation-text"
                     @click="resetApp"
                 />
             </div>
-            <div class="mx-2 flex-grow-1 position-relative">
+            <div
+                class="search-bar-section mx-2 d-flex-column flex-grow-1"
+                :class="{ 'align-self-center': !hasDevSiteWarning }"
+            >
                 <span class="float-start search-title">{{ $t('search_title') }}</span>
                 <SearchBar />
                 <!-- eslint-disable vue/no-v-html-->
                 <div
                     v-if="hasDevSiteWarning"
-                    class="header-warning-dev"
+                    class="header-warning-dev bg-danger rounded text-white text-center text-wrap text-truncate fw-bold overflow-hidden p-1"
                     v-html="$t('test_host_warning')"
-                ></div>
+                />
                 <!-- eslint-enable vue/no-v-html-->
+            </div>
+            <div v-if="!isPhoneMode" class="d-flex flex-shrink-0 flex-grow-0 ms-auto">
+                <LangSwitchToolbar id="menu-lang-selector" />
             </div>
             <HeaderMenuButton v-if="isPhoneMode" />
         </div>
@@ -36,6 +42,7 @@ import HeaderMenuButton from '@/modules/menu/components/header/HeaderMenuButton.
 import HeaderSwissConfederationText from '@/modules/menu/components/header/HeaderSwissConfederationText.vue'
 import SwissFlag from '@/modules/menu/components/header/SwissFlag.vue'
 import SearchBar from '@/modules/menu/components/search/SearchBar.vue'
+import LangSwitchToolbar from '@/modules/i18n/components/LangSwitchToolbar.vue'
 
 import LoadingBar from '@/utils/LoadingBar.vue'
 import { mapGetters, mapState } from 'vuex'
@@ -47,6 +54,7 @@ export default {
         HeaderSwissConfederationText,
         SwissFlag,
         LoadingBar,
+        LangSwitchToolbar,
     },
     computed: {
         ...mapState({
@@ -67,41 +75,32 @@ export default {
 <style lang="scss" scoped>
 @import 'src/scss/media-query.mixin';
 @import 'src/scss/variables';
+
+$animation-time: 0.5s;
+
 .header {
-    height: $header-height;
-    width: 100%;
-    background: rgba(255, 255, 255, 0.9);
+    background: rgba($white, 0.9);
     box-shadow: 6px 6px 12px rgb(0 0 0 / 18%);
-    position: relative;
+    height: $header-height;
+    transition: height $animation-time;
     z-index: $zindex-menu-header;
     .header-content {
         height: $header-height;
+        transition: height $animation-time;
     }
     &-warning-dev {
-        border-radius: 0.25rem;
-        background-color: $danger;
-        color: $white;
-        text-align: center;
-        font-weight: bold;
-        // Position element below its parent.
-        position: absolute;
-        top: 100%;
-        left: 0;
-        // Set width and cut off overflowing text with ellipsis.
-        width: 40em;
-        max-width: 100%;
-        white-space: nowrap;
-        text-overflow: ellipsis;
-        overflow: hidden;
-        // (line-)height and padding work together to cut off the second line.
-        padding: 0.2em 0.5em;
         height: 1.5em;
         line-height: 1.2;
         &:hover {
             height: auto;
-            white-space: normal;
         }
     }
+}
+
+.search-bar-section {
+    // On desktop we limit hte maximum size of the search bar just
+    // to have a better look and feel.
+    max-width: 800px;
 }
 
 .search-header-swiss-confederation-text,
@@ -114,10 +113,6 @@ export default {
         height: 2 * $header-height;
         .header-content {
             height: 2 * $header-height;
-            .swiss-flag {
-                margin-top: 0.4rem;
-                align-self: flex-start;
-            }
             .menu-tray {
                 top: 2 * $header-height;
             }
@@ -126,6 +121,20 @@ export default {
     .search-header-swiss-confederation-text,
     .search-title {
         display: block;
+    }
+}
+
+// WARNING: We cannot use bootstrap img-fluid to automatically set the height of the swiss-flag
+// as it totally breaks the header and menu on Iphone !
+.swiss-flag {
+    height: 21px;
+    &.dev-site {
+        filter: hue-rotate(225deg);
+    }
+}
+@include respond-above(lg) {
+    .swiss-flag {
+        height: 34px;
     }
 }
 </style>

--- a/src/modules/menu/components/header/SwissFlag.vue
+++ b/src/modules/menu/components/header/SwissFlag.vue
@@ -17,29 +17,10 @@ export default {
     data() {
         return {
             swissFlagIcon,
-
         }
     },
     computed: {
-      ...mapGetters([
-        'hasDevSiteWarning',
-      ]),
-    }
+        ...mapGetters(['hasDevSiteWarning']),
+    },
 }
 </script>
-
-<style lang="scss" scoped>
-@import 'src/scss/webmapviewer-bootstrap-theme';
-@import 'src/scss/media-query.mixin';
-.swiss-flag {
-    height: 21px;
-    &.dev-site {
-        filter: hue-rotate(225deg);
-    }
-}
-@include respond-above(tablet) {
-    .swiss-flag {
-        height: 34px;
-    }
-}
-</style>

--- a/src/modules/menu/components/menu/MenuSettings.vue
+++ b/src/modules/menu/components/menu/MenuSettings.vue
@@ -8,8 +8,6 @@
 
 <script>
 import LangSwitchToolbar from '@/modules/i18n/components/LangSwitchToolbar.vue'
-import { UIModes } from '@/store/modules/ui.store'
-import { mapActions, mapGetters, mapState } from 'vuex'
 
 export default {
     components: {

--- a/src/modules/menu/components/menu/MenuTray.vue
+++ b/src/modules/menu/components/menu/MenuTray.vue
@@ -149,11 +149,11 @@ export default {
 <style lang="scss" scoped>
 .menu-tray-inner {
     display: grid;
-    /* One entry for each menu section.
-    - "min-content" means the menu section is non-scrollable (intrinsic size i.e. based solely on content)
-    - "auto" means the menu section is scrollable (size based on content and the container) */
-    grid-template-rows: min-content min-content min-content auto auto;
     overflow: hidden;
+
+    // Each menu section is in a grid row, to make them scrollable independently of each other we
+    // use the grid-auto-rows: auto
+    grid-auto-rows: auto;
 }
 
 // UI is compact if in desktop mode

--- a/src/modules/menu/components/menu/MenuTray.vue
+++ b/src/modules/menu/components/menu/MenuTray.vue
@@ -1,9 +1,9 @@
 <template>
     <div data-cy="menu-tray-inner" :class="[{ 'menu-tray-compact': compact }, 'menu-tray-inner']">
         <MenuSection
-            v-if="isPhoneMode"
             id="settingsSection"
             ref="settingsSection"
+            class="settings-section"
             :title="$t('settings')"
             :show-content="false"
             secondary
@@ -147,6 +147,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'src/scss/media-query.mixin';
+
 .menu-tray-inner {
     display: grid;
     overflow: hidden;
@@ -159,5 +161,12 @@ export default {
 // UI is compact if in desktop mode
 .menu-tray-compact {
     font-size: 0.825rem;
+}
+
+@include respond-above(lg) {
+    .settings-section {
+        // See HeaderWithSearch.vue css where the settings-section is enable below lg
+        display: none;
+    }
 }
 </style>

--- a/src/modules/menu/components/menu/MenuTray.vue
+++ b/src/modules/menu/components/menu/MenuTray.vue
@@ -1,6 +1,7 @@
 <template>
     <div data-cy="menu-tray-inner" :class="[{ 'menu-tray-compact': compact }, 'menu-tray-inner']">
         <MenuSection
+            v-if="isPhoneMode"
             id="settingsSection"
             ref="settingsSection"
             :title="$t('settings')"
@@ -53,7 +54,7 @@ import MenuSection from '@/modules/menu/components/menu/MenuSection.vue'
 import MenuSettings from '@/modules/menu/components/menu/MenuSettings.vue'
 import MenuShareSection from '@/modules/menu/components/share/MenuShareSection.vue'
 import MenuTopicSection from '@/modules/menu/components/topics/MenuTopicSection.vue'
-import { mapActions, mapState } from 'vuex'
+import { mapActions, mapState, mapGetters } from 'vuex'
 import { DISABLE_DRAWING_MENU_FOR_LEGACY_ON_HOSTNAMES } from '@/config'
 import tippy, { followCursor } from 'tippy.js'
 
@@ -86,6 +87,7 @@ export default {
             hostname: (state) => state.ui.hostname,
             lang: (state) => state.i18n.lang,
         }),
+        ...mapGetters(['isPhoneMode']),
         showLayerList() {
             return this.activeLayers.length > 0
         },
@@ -133,7 +135,7 @@ export default {
             if (this.nonScrollableMenuSections.includes(id)) {
                 toClose = toClose.concat(this.scrollableMenuSections)
             }
-            toClose.forEach((section) => this.$refs[section].close())
+            toClose.forEach((section) => this.$refs[section]?.close())
         },
         setDisableDrawingTooltipContent() {
             this.disableDrawingTooltip?.forEach((instance) => {

--- a/src/modules/menu/components/search/SearchBar.vue
+++ b/src/modules/menu/components/search/SearchBar.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="input-group d-flex" :class="{ 'search-bar-filled': searchQuery?.length > 0 }">
+    <div class="search-bar input-group d-flex rounded">
         <span class="input-group-text">
             <FontAwesomeIcon :icon="['fas', 'search']" />
         </span>
@@ -7,9 +7,10 @@
             ref="search"
             type="text"
             class="form-control"
+            :class="{ 'rounded-end': searchQuery?.length == 0 }"
             :placeholder="$t('search_placeholder')"
             aria-label="Search"
-            aria-describedby="search-icon"
+            aria-describedby="button-addon1"
             :value="searchQuery"
             data-cy="searchbar"
             @input="updateSearchQuery"
@@ -17,27 +18,27 @@
             @keydown.down.prevent="goToFirstResult"
             @keydown.esc.prevent="closeSearchResults"
         />
-        <SearchResultList ref="results" @close="closeSearchResults" />
-        <ButtonWithIcon
+        <button
             v-if="searchQuery?.length > 0"
-            :button-font-awesome-icon="['fas', 'times-circle']"
-            class="flex-shrink-1"
+            id="button-addon1"
+            class="btn btn-outline-group rounded-end"
+            type="button"
             data-cy="searchbar-clear"
-            transparent
             @click="clearSearchQuery"
-        />
+        >
+            <FontAwesomeIcon :icon="['fas', 'times-circle']" />
+        </button>
+        <SearchResultList v-show="resultsShown" ref="results" @close="closeSearchResults" />
     </div>
 </template>
 
 <script>
 import SearchResultList from '@/modules/menu/components/search/SearchResultList.vue'
-import ButtonWithIcon from '@/utils/ButtonWithIcon.vue'
 import { mapActions, mapState } from 'vuex'
 
 export default {
     components: {
         SearchResultList,
-        ButtonWithIcon,
     },
     computed: {
         ...mapState({

--- a/src/modules/menu/components/search/SearchResultCategory.vue
+++ b/src/modules/menu/components/search/SearchResultCategory.vue
@@ -7,7 +7,7 @@
         <div class="search-category-header p-2">
             {{ title }}
         </div>
-        <ul class="search-category-body bg-white">
+        <ul class="search-category-body">
             <SearchResultListEntry
                 v-for="(entry, index) in entries"
                 :key="index"

--- a/src/modules/menu/components/search/SearchResultList.vue
+++ b/src/modules/menu/components/search/SearchResultList.vue
@@ -1,8 +1,7 @@
 <template>
     <div
-        v-show="showResults"
         id="search-results"
-        class="bg-light rounded-bottom"
+        class="bg-light border rounded overflow-hidden"
         data-cy="search-results"
         @keydown.esc.prevent="$emit('close')"
     >
@@ -29,7 +28,10 @@
 import { mapActions, mapState } from 'vuex'
 import SearchResultCategory from './SearchResultCategory.vue'
 
-/** Component showing all results from the search, divided in two groups (categories) : layers and locations */
+/**
+ * Component showing all results from the search, divided in two groups (categories) : layers and
+ * locations
+ */
 export default {
     components: { SearchResultCategory },
     emits: ['close'],
@@ -59,7 +61,6 @@ export default {
     left: 0%;
     width: 100%;
     max-height: calc(75vh - 3rem);
-    border: 1px solid #ccc;
     box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
 }
 @include respond-above(lg) {

--- a/src/modules/menu/components/search/SearchResultListEntry.vue
+++ b/src/modules/menu/components/search/SearchResultListEntry.vue
@@ -1,7 +1,7 @@
 <template>
     <li
         ref="item"
-        class="search-category-entry border-bottom border-light"
+        class="search-category-entry d-flex"
         :data-cy="`search-result-entry-${resultType}`"
         :tabindex="index === 0 ? 0 : -1"
         @keydown.up.prevent="goToPrevious"
@@ -13,9 +13,13 @@
         @mouseleave="stopResultPreview"
     >
         <!-- eslint-disable vue/no-v-html-->
-        <div class="search-category-entry-main p-2" @click="selectItem" v-html="entry.title"></div>
+        <div
+            class="search-category-entry-main p-2 flex-grow-1"
+            @click="selectItem"
+            v-html="entry.title"
+        ></div>
 
-        <div v-if="resultType === 'layer'" class="search-category-entry-controls">
+        <div v-if="resultType === 'layer'" class="search-category-entry-controls flex-grow-0">
             <button
                 class="btn btn-default"
                 :data-cy="`button-show-legend-layer-${entry.layerId}`"
@@ -95,20 +99,12 @@ export default {
 @import 'src/scss/webmapviewer-bootstrap-theme';
 @import 'src/scss/media-query.mixin';
 .search-category-entry {
-    display: flex;
-    align-items: center;
     &-main {
-        flex-grow: 1;
         cursor: pointer;
-    }
-    .btn {
-        padding-top: 0;
-        padding-bottom: 0;
-        line-height: 1;
     }
     @include respond-above(phone) {
         &:hover {
-            background-color: $dark;
+            background-color: $secondary;
             color: $light;
             .btn {
                 color: $light;

--- a/src/scss/media-query.mixin.scss
+++ b/src/scss/media-query.mixin.scss
@@ -41,3 +41,36 @@ $breakpoint_tablet: 768px;
     @warn 'Invalid breakpoint: #{$breakpoint}.';
   }
 }
+
+/**
+* Automatically selects the correct media tag to respond below the specified threshold
+*
+* @param breakpoint 'phone' for the phone threshold, 'tablet' for the tablet threshold. The function
+                    also accepts the bootstrap values sm, md, lg, xl, xxl
+*/
+@mixin respond-below($breakpoint) {
+
+  // If the breakpoint exists in the map.
+  @if map-has-key($grid-breakpoints, $breakpoint) {
+
+    // Get the breakpoint value.
+    $breakpoint-value: map-get($grid-breakpoints, $breakpoint);
+
+    // Write the media query.
+    @media (max-width: ($breakpoint-value - 1)) or (max-height: ($breakpoint_phone_height - 1)) {
+      @content;
+    }
+  } @else if $breakpoint == phone {
+    @media (max-width: ($breakpoint_phone_width - 1)) or (max-height: ($breakpoint_phone_height - 1)) {
+      @content;
+    }
+  } @else if $breakpoint == tablet {
+    @media (max-width: ($breakpoint_tablet - 1)) or (max-height: ($breakpoint_phone_height - 1)) {
+      @content;
+    }
+  // If the breakpoint doesn't exist in the map.
+  } @else {
+    // Log a warning.
+    @warn 'Invalid breakpoint: #{$breakpoint}.';
+  }
+}

--- a/src/scss/variables-admin.scss
+++ b/src/scss/variables-admin.scss
@@ -46,4 +46,4 @@ $admin-icons: 'Admin Icons';
 
 // MISC
 //=============================================================================
-$focus-outline: 3px solid $coal;
+$focus-outline: 3px solid $malibu;

--- a/src/scss/webmapviewer-bootstrap-theme.scss
+++ b/src/scss/webmapviewer-bootstrap-theme.scss
@@ -23,3 +23,7 @@ $card-cap-padding-y: 0.25rem;
 $card-spacer-y: 0.75rem;
 
 $caret-spacing: 0.75rem;
+
+.btn-xs {
+  @include button-size(0.25rem, 0.25rem, 0.7rem, $border-radius)
+}

--- a/src/scss/webmapviewer-bootstrap-theme.scss
+++ b/src/scss/webmapviewer-bootstrap-theme.scss
@@ -12,6 +12,11 @@ $primary: $venetian-red;
 @import 'node_modules/bootstrap/scss/variables';
 @import 'node_modules/bootstrap/scss/mixins';
 
+.btn-outline-group {
+  @include button-outline-variant($gray-400);
+  border-color: $gray-400 !important;
+}
+
 $map-button-border-color: $gray-800;
 $map-button-hover-border-color: $gray-700;
 

--- a/src/store/modules/search.store.js
+++ b/src/store/modules/search.store.js
@@ -3,6 +3,7 @@ import { isWhat3WordsString, retrieveWhat3WordsLocation } from '@/api/what3words
 import { ActiveLayerConfig } from '@/store/modules/layers.store'
 import { coordinateFromString } from '@/utils/coordinateUtils'
 import { ZOOM_LEVEL_1_25000_MAP } from '@/utils/zoomLevelUtils'
+import log from '@/utils/logging'
 
 const state = {
     /**
@@ -61,14 +62,16 @@ const actions = {
                     dispatch('setPinnedLocation', what3wordLocation)
                 })
             } else {
-                search(query, rootState.i18n.lang).then((searchResults) => {
-                    if (searchResults) {
-                        commit('setSearchResults', searchResults)
-                        if (showResultsAfterRequest && searchResults.count() > 0) {
-                            commit('showSearchResults')
+                search(query, rootState.i18n.lang)
+                    .then((searchResults) => {
+                        if (searchResults) {
+                            commit('setSearchResults', searchResults)
+                            if (showResultsAfterRequest && searchResults.count() > 0) {
+                                commit('showSearchResults')
+                            }
                         }
-                    }
-                })
+                    })
+                    .catch((error) => log.error(`Search failed`, error))
             }
         } else if (query.length === 0) {
             dispatch('clearPinnedLocation')

--- a/tests/e2e-cypress/integration/layers.cy.js
+++ b/tests/e2e-cypress/integration/layers.cy.js
@@ -659,8 +659,7 @@ describe('Test of layer handling', () => {
 
             // Open the menu and change the language.
             clickOnMenuButtonIfMobile()
-            cy.get('[data-cy="menu-settings-section"]').click()
-            cy.get(`[data-cy="menu-lang-${langAfter}"`).click()
+            cy.clickOnLanguage(langAfter)
 
             // Wait until the active layers are updated.
             cy.waitUntilState((state) => {

--- a/tests/e2e-cypress/integration/search/search-results.cy.js
+++ b/tests/e2e-cypress/integration/search/search-results.cy.js
@@ -304,7 +304,7 @@ describe('Test the search bar result handling', () => {
         cy.get('[data-cy="map"]').click()
         cy.get('[data-cy="search-result-entry-location"]').should('not.be.visible')
         cy.activateFullscreen()
-        cy.get(searchbarSelector).should('be.hidden')
+        cy.get(searchbarSelector).should('not.exist')
     })
     it('shows the results once again if the user clicks back on the search input', () => {
         cy.goToMapView()

--- a/tests/e2e-cypress/support/commands.js
+++ b/tests/e2e-cypress/support/commands.js
@@ -1,5 +1,6 @@
 import 'cypress-wait-until'
 import { MapBrowserEvent } from 'ol'
+import { BREAKPOINT_TABLET } from '@/config'
 
 // ***********************************************
 // For more comprehensive examples of custom
@@ -173,6 +174,29 @@ Cypress.Commands.add(
         cy.get('[data-cy="map"]').should('be.visible')
     }
 )
+
+/**
+ * Click on language command
+ *
+ * This command change the application to the given language independently of the ui mode
+ * (mobile/tablet/desktop)
+ *
+ * @param {string} lang Language to click; de, fr, it, en or rm
+ */
+Cypress.Commands.add('clickOnLanguage', (lang) => {
+    let menuSection = null
+    const width = Cypress.config('viewportWidth')
+    if (width < BREAKPOINT_TABLET) {
+        // mobile/tablet : clicking on the menu button first
+        menuSection = cy.get('[data-cy="menu-settings-section"]')
+        menuSection.click()
+    } else {
+        // desktop
+        menuSection = cy.get('[data-cy="header-settings-section"]')
+    }
+    menuSection.should('be.visible')
+    menuSection.find(`[data-cy="menu-lang-${lang}"]`).click()
+})
 
 // cypress-wait-until wrapper to wait for a specific store state.
 // cy.readStoreValue doesn't work as `.its` will prevent retries.


### PR DESCRIPTION
Now in desktop mode the language toolbar is on top right corner using button
link.

Clean up some old css and made the header more reactive using bootstrap instead
of custom css rules.

Also improved search bar look and feel.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-2751-language-menu/index.html)