### PR TITLE
Add icons API intercept in cypress

### DIFF
--- a/tests/e2e-cypress/integration/drawing/marker-text.cy.js
+++ b/tests/e2e-cypress/integration/drawing/marker-text.cy.js
@@ -44,8 +44,8 @@ const createMarkerAndOpenIconStylePopup = () => {
         MAP_CENTER[0],
         6156527.960512564
     )
-    cy.wait('@iconSets')
-    cy.wait('@iconSet-default')
+    cy.wait('@icon-sets')
+    cy.wait('@icon-set-default')
     cy.get('[data-cy="drawing-style-marker-button"]').click()
     return kmlId
 }
@@ -205,7 +205,7 @@ describe('Drawing marker/points', () => {
                 createMarkerAndOpenIconStylePopup()
                 cy.get(drawingStyleMarkerIconSetSelector).click({ force: true })
                 cy.get('[data-cy="dropdown-item-civil symbols"]').click()
-                cy.wait('@iconSet-babs')
+                cy.wait('@icon-set-babs')
                 cy.wait('@icon-babs')
                     .its('request.url')
                     .should('include', '/api/icons/sets/babs/icons/')

--- a/tests/e2e-cypress/support/commands.js
+++ b/tests/e2e-cypress/support/commands.js
@@ -54,6 +54,24 @@ const addWhat3WordFixtureAndIntercept = () => {
     }).as('coordinates-for-w3w')
 }
 
+const addIconsSetIntercept = () => {
+    cy.intercept(`**/api/icons/sets`, {
+        fixture: 'service-icons/sets.fixture.json',
+    }).as('icon-sets')
+}
+
+const addDefaultIconsFixtureAndIntercept = () => {
+    cy.intercept(`**/api/icons/sets/default/icons`, {
+        fixture: 'service-icons/set-default.fixture.json',
+    }).as('icon-set-default')
+}
+
+const addSecondIconsFixtureAndIntercept = () => {
+    cy.intercept(`**/api/icons/sets/babs/icons`, {
+        fixture: 'service-icons/set-babs.fixture.json',
+    }).as('icon-set-babs')
+}
+
 export function getDefaultFixturesAndIntercepts() {
     return {
         addLayerTileFixture,
@@ -62,6 +80,9 @@ export function getDefaultFixturesAndIntercepts() {
         addCatalogFixtureAndIntercept,
         addHeightFixtureAndIntercept,
         addWhat3WordFixtureAndIntercept,
+        addIconsSetIntercept,
+        addDefaultIconsFixtureAndIntercept,
+        addSecondIconsFixtureAndIntercept,
     }
 }
 

--- a/tests/e2e-cypress/support/drawing.js
+++ b/tests/e2e-cypress/support/drawing.js
@@ -4,24 +4,6 @@ import pako from 'pako'
 
 const olSelector = '.ol-viewport'
 
-const addIconSetsFixtureAndIntercept = () => {
-    cy.intercept(`**/api/icons/sets`, {
-        fixture: 'service-icons/sets.fixture.json',
-    }).as('iconSets')
-}
-
-const addDefaultIconsFixtureAndIntercept = () => {
-    cy.intercept(`**/api/icons/sets/default/icons`, {
-        fixture: 'service-icons/set-default.fixture.json',
-    }).as('iconSet-default')
-}
-
-const addSecondIconsFixtureAndIntercept = () => {
-    cy.intercept(`**/api/icons/sets/babs/icons`, {
-        fixture: 'service-icons/set-babs.fixture.json',
-    }).as('iconSet-babs')
-}
-
 const addIconFixtureAndIntercept = () => {
     cy.intercept(`**/api/icons/sets/default/icons/**@1x-255,0,0.png`, {
         fixture: 'service-icons/placeholder.png',
@@ -126,9 +108,6 @@ Cypress.Commands.add('goToDrawing', (...args) => {
         delete args[0].kmlFileFixtureFile
     }
     addIconFixtureAndIntercept()
-    addIconSetsFixtureAndIntercept()
-    addDefaultIconsFixtureAndIntercept()
-    addSecondIconsFixtureAndIntercept()
     addProfileFixtureAndIntercept()
     addFileAPIFixtureAndIntercept(kmlFileFixtureFile)
     cy.goToMapView(...args)


### PR DESCRIPTION
The icons API is called also outside of the drawing module, so make the intercept
global on navigating the page. This avoid calling the backend.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-cypress-icons/index.html)