### PR TITLE
BGDIINF_SB-2618: Set the background selector button to swiss-image and fixed selected bug

### DIFF
--- a/src/modules/map/components/footer/MapFooterBackgroundSelector.vue
+++ b/src/modules/map/components/footer/MapFooterBackgroundSelector.vue
@@ -13,7 +13,7 @@
                 :class="[
                     getLayerClass(background),
                     `bg-index-${index}`,
-                    { active: background.getID() === currentBackgroundLayerId },
+                    { active: background.getID() === currentBackgroundLayerWithVoid.getID() },
                 ]"
                 type="button"
                 :tabindex="showBgWheel ? 0 : -1"
@@ -29,7 +29,7 @@
             class="bg-selector-trigger"
             :class="[
                 { 'bigger-pulse': animateMainButton },
-                getLayerClass(currentBackgroundLayerWithVoid),
+                'bg-ch-swisstopo-leichte-basiskarte-imagery_world-vt',
             ]"
             type="button"
             :title="$t('bg_toggle')"


### PR DESCRIPTION
Always uses the swiss-image background as selector button, this gives the best
contrast.

Also fixed the selected background selection feedback when void is selected,
in this case the void background button was not highlighted in red.