### PR TITLE
BGDIINF_SB-2182: Fixed E2E tests issue with `click({force: true})`

### DIFF
--- a/tests/e2e-cypress/integration/drawing/kml.cy.js
+++ b/tests/e2e-cypress/integration/drawing/kml.cy.js
@@ -84,7 +84,9 @@ describe('Drawing new KML', () => {
         // clicking just on the side of the first marker
         const width = Cypress.config('viewportWidth')
         const height = Cypress.config('viewportHeight')
-        cy.get(olSelector).click(width / 2.0 + 50, height / 2.0, { force: true })
+        cy.get(olSelector)
+            .should('be.visible')
+            .click(width / 2.0 + 50, height / 2.0, { force: true })
         cy.wait('@update-kml').then(
             (interception) =>
                 cy.checkKMLRequest(interception, [
@@ -96,7 +98,11 @@ describe('Drawing new KML', () => {
         cy.get('[data-cy="infobox-close"]').click()
         // adding a line and checking that the KML is updated again
         cy.clickDrawingTool(EditableFeatureTypes.LINEPOLYGON)
-        cy.get(olSelector).click(210, 200).click(220, 200).dblclick(230, 230, { force: true })
+        cy.get(olSelector)
+            .should('be.visible')
+            .click(210, 200)
+            .click(220, 200)
+            .dblclick(230, 230, { force: true })
         cy.wait('@update-kml').then(
             (interception) =>
                 cy.checkKMLRequest(interception, [

--- a/tests/e2e-cypress/integration/drawing/line-polygon.cy.js
+++ b/tests/e2e-cypress/integration/drawing/line-polygon.cy.js
@@ -50,7 +50,7 @@ describe('Line/Polygon tool', () => {
         )
     })
     it('creates a line with double click', () => {
-        cy.get(olSelector).dblclick(120, 240, { force: true })
+        cy.get(olSelector).should('be.visible').dblclick(120, 240, { force: true })
         cy.wait('@post-kml')
         cy.readDrawingFeatures('LineString', (features) => {
             const coos = features[0].getGeometry().getCoordinates()
@@ -60,7 +60,7 @@ describe('Line/Polygon tool', () => {
     it('delete last point', () => {
         cy.get(olSelector).click(180, 200)
         cy.get(drawingDeleteLastPointButton).click()
-        cy.get(olSelector).dblclick(120, 240, { force: true })
+        cy.get(olSelector).should('be.visible').dblclick(120, 240, { force: true })
         cy.wait('@post-kml')
         cy.readDrawingFeatures('LineString', (features) => {
             const coos = features[0].getGeometry().getCoordinates()

--- a/tests/e2e-cypress/integration/drawing/marker-text.cy.js
+++ b/tests/e2e-cypress/integration/drawing/marker-text.cy.js
@@ -62,7 +62,9 @@ const clickOnAColor = (color) => {
 const changeIconSize = (size) => {
     cy.get(
         `${drawingStyleMarkerPopup} ${drawingStyleSizeSelector} [data-cy="dropdown-main-button"]`
-    ).click({ force: true })
+    )
+        .should('be.visible')
+        .click({ force: true })
     cy.get(
         `${drawingStyleMarkerPopup} ${drawingStyleSizeSelector} [data-cy="dropdown-item-${size}"]`
     ).click()
@@ -88,12 +90,11 @@ describe('Drawing marker/points', () => {
         }).as('icon-default-green')
         cy.goToDrawing()
     })
-    // see : https://jira.swisstopo.ch/browse/BGDIINF_SB-2182
-    // it('Re-requests all icons from an icon sets with the new color whenever the color changed', () => {
-    //     createMarkerAndOpenIconStylePopup()
-    //     clickOnAColor(GREEN)
-    //     cy.wait('@icon-default-green')
-    // })
+    it('Re-requests all icons from an icon sets with the new color whenever the color changed', () => {
+        createMarkerAndOpenIconStylePopup()
+        clickOnAColor(GREEN)
+        cy.wait('@icon-default-green')
+    })
     context('simple interaction with a marker', () => {
         it('toggles the marker symbol popup when clicking button', () => {
             createMarkerAndOpenIconStylePopup()
@@ -194,7 +195,9 @@ describe('Drawing marker/points', () => {
             })
             it('Shows all available icon sets in the selector', () => {
                 createMarkerAndOpenIconStylePopup()
-                cy.get(drawingStyleMarkerIconSetSelector).click({ force: true })
+                cy.get(drawingStyleMarkerIconSetSelector)
+                    .should('be.visible')
+                    .click({ force: true })
                 cy.fixture('service-icons/sets.fixture.json').then((iconSets) => {
                     iconSets.items.forEach((iconSet) => {
                         cy.get(getCyDropdownItemIconSetName(iconSet.name)).should('be.visible')
@@ -203,7 +206,9 @@ describe('Drawing marker/points', () => {
             })
             it('Changes the icon selector box content when the icon set changes', () => {
                 createMarkerAndOpenIconStylePopup()
-                cy.get(drawingStyleMarkerIconSetSelector).click({ force: true })
+                cy.get(drawingStyleMarkerIconSetSelector)
+                    .should('be.visible')
+                    .click({ force: true })
                 cy.get('[data-cy="dropdown-item-civil symbols"]').click()
                 cy.wait('@icon-set-babs')
                 cy.wait('@icon-babs')
@@ -213,10 +218,11 @@ describe('Drawing marker/points', () => {
                 // as babs icon set is not colorable, the color box should have disappeared
                 cy.get(`${drawingStyleMarkerPopup} ${drawingStyleColorBox}`).should('not.exist')
             })
-            // see : https://jira.swisstopo.ch/browse/BGDIINF_SB-2182
-            it.skip('Changes the marker icon when a new one is selected in the icon selector', () => {
+            it('Changes the marker icon when a new one is selected in the icon selector', () => {
                 const kmlId = createMarkerAndOpenIconStylePopup()
-                cy.get(drawingStyleMarkerIconSetSelector).click({ force: true })
+                cy.get(drawingStyleMarkerIconSetSelector)
+                    .should('be.visible')
+                    .click({ force: true })
                 // showing all icons of this sets so that we may choose a new one
                 cy.get(`${drawingStyleMarkerPopup} ${drawingStyleMarkerShowAllIconsButton}`).click()
                 cy.fixture('service-icons/set-default.fixture.json').then((defaultIconSet) => {
@@ -224,7 +230,9 @@ describe('Drawing marker/points', () => {
                     const fourthIcon = defaultIconSet.items[3]
                     cy.get(
                         `${drawingStyleMarkerPopup} [data-cy="drawing-style-icon-selector-${fourthIcon.name}"]`
-                    ).click()
+                    )
+                        .should('be.visible')
+                        .click({ force: true })
                     cy.checkDrawnGeoJsonProperty('icon.name', fourthIcon.name, true)
                     cy.wait('@update-kml').then((interception) =>
                         cy.checkKMLRequest(


### PR DESCRIPTION
Sometimes for an unknown reason we have to set `{force: true}` on click() in
cypress otherwise cypress return an errors saying that the component is not
visible also it is visible.

Now we make sure before the click({force: true}) that the component is visible.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-2182-e2e/index.html)