### PR TITLE
BGDIINF_SB-2751: Fixed language menu on IOS devices

### DIFF
--- a/src/scss/media-query.mixin.scss
+++ b/src/scss/media-query.mixin.scss
@@ -57,15 +57,15 @@ $breakpoint_tablet: 768px;
     $breakpoint-value: map-get($grid-breakpoints, $breakpoint);
 
     // Write the media query.
-    @media (max-width: ($breakpoint-value - 1)) or (max-height: ($breakpoint_phone_height - 1)) {
+    @media (max-width: ($breakpoint-value - 1)), (max-height: ($breakpoint_phone_height - 1)) {
       @content;
     }
   } @else if $breakpoint == phone {
-    @media (max-width: ($breakpoint_phone_width - 1)) or (max-height: ($breakpoint_phone_height - 1)) {
+    @media (max-width: ($breakpoint_phone_width - 1)), (max-height: ($breakpoint_phone_height - 1)) {
       @content;
     }
   } @else if $breakpoint == tablet {
-    @media (max-width: ($breakpoint_tablet - 1)) or (max-height: ($breakpoint_phone_height - 1)) {
+    @media (max-width: ($breakpoint_tablet - 1)), (max-height: ($breakpoint_phone_height - 1)) {
       @content;
     }
   // If the breakpoint doesn't exist in the map.


### PR DESCRIPTION
The language toolbar from the header did not disapeared on IOS devices which
also prevent displaying the menu button.

Some devices like IOS and gnome web browser doesn't support `or` in css media
queries (`or` is an alias for `,` which has been introduced by Media Queries Level 4)

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2751-lang-menu-iphone/index.html)