### PR TITLE
Fix Swiss flag size on smaller devices

### DIFF
--- a/src/modules/menu/components/header/HeaderWithSearch.vue
+++ b/src/modules/menu/components/header/HeaderWithSearch.vue
@@ -3,11 +3,9 @@
         <LoadingBar v-if="showLoadingBar" />
         <div class="header-content w-100 p-1 d-flex justify-content-start">
             <div class="justify-content-start p-1 d-flex flex-shrink-0 flex-grow-0">
-                <SwissFlag
-                    class="ms-1 me-2 cursor-pointer"
-                    data-cy="menu-swiss-flag"
-                    @click="resetApp"
-                />
+                <div class="p-1 cursor-pointer text-center" data-cy="menu-swiss-flag" @click="resetApp">
+                    <SwissFlag />
+                </div>
                 <HeaderSwissConfederationText
                     :current-lang="currentLang"
                     class="mx-2 cursor-pointer search-header-swiss-confederation-text"
@@ -29,7 +27,10 @@
                 />
                 <!-- eslint-enable vue/no-v-html-->
             </div>
-            <div class="header-settings-section d-flex flex-shrink-0 flex-grow-0 ms-auto" data-cy="header-settings-section">
+            <div
+                class="header-settings-section d-flex flex-shrink-0 flex-grow-0 ms-auto"
+                data-cy="header-settings-section"
+            >
                 <FeedbackToolbar id="menu-feedback" :show-as-links="true" />
                 <LangSwitchToolbar id="menu-lang-selector" />
             </div>
@@ -39,12 +40,12 @@
 </template>
 
 <script>
+import LangSwitchToolbar from '@/modules/i18n/components/LangSwitchToolbar.vue'
 import HeaderMenuButton from '@/modules/menu/components/header/HeaderMenuButton.vue'
 import HeaderSwissConfederationText from '@/modules/menu/components/header/HeaderSwissConfederationText.vue'
 import SwissFlag from '@/modules/menu/components/header/SwissFlag.vue'
-import SearchBar from '@/modules/menu/components/search/SearchBar.vue'
-import LangSwitchToolbar from '@/modules/i18n/components/LangSwitchToolbar.vue'
 import FeedbackToolbar from '@/modules/menu/components/menu/feedback/FeedbackToolbar.vue'
+import SearchBar from '@/modules/menu/components/search/SearchBar.vue'
 
 import LoadingBar from '@/utils/LoadingBar.vue'
 import { mapGetters, mapState } from 'vuex'
@@ -57,7 +58,7 @@ export default {
         SwissFlag,
         LoadingBar,
         LangSwitchToolbar,
-        FeedbackToolbar
+        FeedbackToolbar,
     },
     computed: {
         ...mapState({
@@ -131,15 +132,6 @@ $animation-time: 0.5s;
     .search-header-swiss-confederation-text,
     .search-title {
         display: block;
-    }
-}
-
-// WARNING: We cannot use bootstrap img-fluid to automatically set the height of the swiss-flag
-// as it totally breaks the header and menu on Iphone !
-.swiss-flag {
-    height: 34px;
-    &.dev-site {
-        filter: hue-rotate(225deg);
     }
 }
 </style>

--- a/src/modules/menu/components/header/HeaderWithSearch.vue
+++ b/src/modules/menu/components/header/HeaderWithSearch.vue
@@ -137,14 +137,9 @@ $animation-time: 0.5s;
 // WARNING: We cannot use bootstrap img-fluid to automatically set the height of the swiss-flag
 // as it totally breaks the header and menu on Iphone !
 .swiss-flag {
-    height: 21px;
+    height: 34px;
     &.dev-site {
         filter: hue-rotate(225deg);
-    }
-}
-@include respond-above(lg) {
-    .swiss-flag {
-        height: 34px;
     }
 }
 </style>

--- a/src/modules/menu/components/header/SwissFlag.vue
+++ b/src/modules/menu/components/header/SwissFlag.vue
@@ -24,3 +24,21 @@ export default {
     },
 }
 </script>
+
+<style lang="scss" scoped>
+@import 'src/scss/media-query.mixin';
+
+// WARNING: We cannot use bootstrap img-fluid to automatically set the height of the swiss-flag
+// as it totally breaks the header and menu on Iphone !
+.swiss-flag {
+    height: 24px;
+    &.dev-site {
+        filter: hue-rotate(225deg);
+    }
+}
+@include respond-above(lg) {
+    .swiss-flag {
+        height: 34px;
+    }
+}
+</style>


### PR DESCRIPTION
the flag was shrinking on smaller devices, when the menu is also smaller, not covering the full extent of the space it was given.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_fix_swissflag_size_on_mobile/index.html)