### PR TITLE
BGDIINF_SB-2784 : fix Swiss flag position on smaller devices

### DIFF
--- a/src/modules/menu/MenuModule.vue
+++ b/src/modules/menu/MenuModule.vue
@@ -7,7 +7,12 @@
             <BlackBackdrop v-if="isPhoneMode && isMenuShown" @click="toggleMenu" />
         </transition>
         <HeaderWithSearch v-if="isHeaderShown" class="header" />
-        <div class="toolbox-right">
+        <div
+            class="toolbox-right"
+            :class="{
+                'dev-disclaimer-present': hasDevSiteWarning,
+            }"
+        >
             <GeolocButton
                 v-if="!isFullscreenMode"
                 class="mb-1"
@@ -26,6 +31,7 @@
             class="menu-tray-container"
             :class="{
                 'desktop-mode': isDesktopMode,
+                'dev-disclaimer-present': hasDevSiteWarning,
             }"
         >
             <transition name="slide-up">
@@ -93,6 +99,7 @@ export default {
             'isDesktopMode',
             'isMenuShown',
             'isMenuTrayShown',
+            'hasDevSiteWarning',
         ]),
     },
     methods: {
@@ -131,6 +138,9 @@ $animation-time: 0.5s;
         float: right;
         position: relative;
         margin: $screen-padding-for-ui-elements;
+        &.dev-disclaimer-present {
+            margin-top: $screen-padding-for-ui-elements + $dev-disclaimer-height;
+        }
     }
     .menu-tray-container {
         pointer-events: none;
@@ -139,6 +149,9 @@ $animation-time: 0.5s;
         bottom: 0;
         left: 0;
         width: 100%;
+        &.dev-disclaimer-present {
+            top: $header-height + $dev-disclaimer-height;
+        }
         &.desktop-mode {
             bottom: 70px;
         }
@@ -186,6 +199,9 @@ $animation-time: 0.5s;
     .menu {
         .menu-tray-container {
             top: 2 * $header-height;
+            &.dev-disclaimer-present {
+                top: 2 * $header-height + $dev-disclaimer-height;
+            }
         }
     }
 }

--- a/src/modules/menu/components/header/HeaderWithSearch.vue
+++ b/src/modules/menu/components/header/HeaderWithSearch.vue
@@ -3,11 +3,9 @@
         <LoadingBar v-if="showLoadingBar" />
         <div class="header-content w-100 p-1 d-flex justify-content-start">
             <div class="justify-content-start p-1 d-flex flex-shrink-0 flex-grow-0">
-                <SwissFlag
-                    class="ms-1 me-2 cursor-pointer"
-                    data-cy="menu-swiss-flag"
-                    @click="resetApp"
-                />
+                <div class="p-1 cursor-pointer text-center" data-cy="menu-swiss-flag" @click="resetApp">
+                    <SwissFlag />
+                </div>
                 <HeaderSwissConfederationText
                     :current-lang="currentLang"
                     class="mx-2 cursor-pointer search-header-swiss-confederation-text"
@@ -29,7 +27,10 @@
                 />
                 <!-- eslint-enable vue/no-v-html-->
             </div>
-            <div class="header-settings-section d-flex flex-shrink-0 flex-grow-0 ms-auto" data-cy="header-settings-section">
+            <div
+                class="header-settings-section d-flex flex-shrink-0 flex-grow-0 ms-auto"
+                data-cy="header-settings-section"
+            >
                 <FeedbackToolbar id="menu-feedback" :show-as-links="true" />
                 <LangSwitchToolbar id="menu-lang-selector" />
             </div>
@@ -39,12 +40,12 @@
 </template>
 
 <script>
+import LangSwitchToolbar from '@/modules/i18n/components/LangSwitchToolbar.vue'
 import HeaderMenuButton from '@/modules/menu/components/header/HeaderMenuButton.vue'
 import HeaderSwissConfederationText from '@/modules/menu/components/header/HeaderSwissConfederationText.vue'
 import SwissFlag from '@/modules/menu/components/header/SwissFlag.vue'
-import SearchBar from '@/modules/menu/components/search/SearchBar.vue'
-import LangSwitchToolbar from '@/modules/i18n/components/LangSwitchToolbar.vue'
 import FeedbackToolbar from '@/modules/menu/components/menu/feedback/FeedbackToolbar.vue'
+import SearchBar from '@/modules/menu/components/search/SearchBar.vue'
 
 import LoadingBar from '@/utils/LoadingBar.vue'
 import { mapGetters, mapState } from 'vuex'
@@ -57,7 +58,7 @@ export default {
         SwissFlag,
         LoadingBar,
         LangSwitchToolbar,
-        FeedbackToolbar
+        FeedbackToolbar,
     },
     computed: {
         ...mapState({
@@ -131,20 +132,6 @@ $animation-time: 0.5s;
     .search-header-swiss-confederation-text,
     .search-title {
         display: block;
-    }
-}
-
-// WARNING: We cannot use bootstrap img-fluid to automatically set the height of the swiss-flag
-// as it totally breaks the header and menu on Iphone !
-.swiss-flag {
-    height: 21px;
-    &.dev-site {
-        filter: hue-rotate(225deg);
-    }
-}
-@include respond-above(lg) {
-    .swiss-flag {
-        height: 34px;
     }
 }
 </style>

--- a/src/modules/menu/components/header/HeaderWithSearch.vue
+++ b/src/modules/menu/components/header/HeaderWithSearch.vue
@@ -1,7 +1,7 @@
 <template>
-    <div class="header d-flex">
+    <div class="header">
         <LoadingBar v-if="showLoadingBar" />
-        <div class="header-content w-100 p-1 d-flex justify-content-start">
+        <div class="header-content w-100 p-sm-0 p-md-1 d-flex align-items-center">
             <div class="justify-content-start p-1 d-flex flex-shrink-0 flex-grow-0">
                 <div class="p-1 cursor-pointer text-center" data-cy="menu-swiss-flag" @click="resetApp">
                     <SwissFlag />
@@ -14,21 +14,14 @@
                 />
             </div>
             <div
-                class="search-bar-section mx-2 d-flex-column flex-grow-1"
+                class="search-bar-section d-flex-column flex-grow-1"
                 :class="{ 'align-self-center': !hasDevSiteWarning }"
             >
                 <span class="float-start search-title">{{ $t('search_title') }}</span>
                 <SearchBar />
-                <!-- eslint-disable vue/no-v-html-->
-                <div
-                    v-if="hasDevSiteWarning"
-                    class="header-warning-dev bg-danger rounded text-white text-center text-wrap text-truncate fw-bold overflow-hidden p-1"
-                    v-html="$t('test_host_warning')"
-                />
-                <!-- eslint-enable vue/no-v-html-->
             </div>
             <div
-                class="header-settings-section d-flex flex-shrink-0 flex-grow-0 ms-auto"
+                class="header-settings-section align-self-start d-flex flex-shrink-0 flex-grow-0 ms-auto"
                 data-cy="header-settings-section"
             >
                 <FeedbackToolbar id="menu-feedback" :show-as-links="true" />
@@ -36,6 +29,13 @@
             </div>
             <HeaderMenuButton v-if="isPhoneMode" />
         </div>
+        <!-- eslint-disable vue/no-v-html-->
+        <div
+          v-if="hasDevSiteWarning"
+          class="header-warning-dev bg-danger text-white text-center text-wrap text-truncate overflow-hidden fw-bold p-1"
+          v-html="$t('test_host_warning')"
+        />
+        <!-- eslint-enable vue/no-v-html-->
     </div>
 </template>
 
@@ -92,12 +92,12 @@ $animation-time: 0.5s;
         height: $header-height;
         transition: height $animation-time;
     }
-    &-warning-dev {
-        height: 1.5em;
-        line-height: 1.2;
-        &:hover {
-            height: auto;
-        }
+}
+.header-warning-dev {
+    height: $dev-disclaimer-height;
+    line-height: 1.1;
+    &:hover {
+        height: auto;
     }
 }
 

--- a/src/modules/menu/components/header/HeaderWithSearch.vue
+++ b/src/modules/menu/components/header/HeaderWithSearch.vue
@@ -27,7 +27,7 @@
                 <FeedbackToolbar id="menu-feedback" :show-as-links="true" />
                 <LangSwitchToolbar id="menu-lang-selector" />
             </div>
-            <HeaderMenuButton v-if="isPhoneMode" />
+            <HeaderMenuButton v-if="isPhoneMode" class="mx-1" />
         </div>
         <!-- eslint-disable vue/no-v-html-->
         <div

--- a/src/modules/menu/components/header/SwissFlag.vue
+++ b/src/modules/menu/components/header/SwissFlag.vue
@@ -24,3 +24,21 @@ export default {
     },
 }
 </script>
+
+<style lang="scss" scoped>
+@import 'src/scss/media-query.mixin';
+
+// WARNING: We cannot use bootstrap img-fluid to automatically set the height of the swiss-flag
+// as it totally breaks the header and menu on Iphone !
+.swiss-flag {
+    height: 24px;
+    &.dev-site {
+        filter: hue-rotate(225deg);
+    }
+}
+@include respond-above(lg) {
+    .swiss-flag {
+        height: 34px;
+    }
+}
+</style>

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -24,6 +24,7 @@ occurs (teleported in the menu context)*/
 $zindex-drawing-toolbox: 3;
 
 $header-height: 3rem;
+$dev-disclaimer-height: 1.5rem;
 $footer-height: 1.5rem;
 $overlay-width: 360px;
 $menu-tray-width: 24rem;


### PR DESCRIPTION
Wrap Swiss flag in div to better center it, this way its position centered in the space it is given

replaces #374 

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_bgdiinf_sb-2784_responsive_swiss_flag/index.html)