### PR TITLE
BGDIINF_SB-2783 : add back light base map copyrights

### DIFF
--- a/src/modules/map/components/footer/MapFooterAttribution.vue
+++ b/src/modules/map/components/footer/MapFooterAttribution.vue
@@ -38,10 +38,10 @@
 </template>
 
 <script>
-import { mapGetters, mapState } from 'vuex'
-import tippy from 'tippy.js'
-
+import { VECTOR_LIGHT_BASE_MAP_STYLE_ID } from '@/config'
 import ModalWithBackdrop from '@/utils/ModalWithBackdrop.vue'
+import tippy from 'tippy.js'
+import { mapGetters, mapState } from 'vuex'
 
 export default {
     components: { ModalWithBackdrop },
@@ -51,13 +51,36 @@ export default {
     computed: {
         ...mapState({
             lang: (state) => state.i18n.lang,
+            layersConfig: (state) => state.layers.config,
         }),
-        ...mapGetters(['visibleLayers', 'currentBackgroundLayer', 'hasDataDisclaimer']),
+        ...mapGetters([
+            'visibleLayers',
+            'currentBackgroundLayer',
+            'hasDataDisclaimer',
+            'isExtentOnlyWithinLV95Bounds',
+        ]),
         layers() {
             const layers = []
             // when the background is void, we receive `undefined` here
             if (this.currentBackgroundLayer) {
                 layers.push(this.currentBackgroundLayer)
+            }
+            /*
+             Edge case that will be removed as soon as we have a proper VT pixelkarte layer.
+
+             As we are showing LightBaseMap layer behind pixelkarte-farbe whenever we are not
+             covering only Swiss grounds, we need to add the attribution of LightBaseMap depending
+             on the current extent of the app
+             */
+            if (
+                this.currentBackgroundLayer?.getID() === 'ch.swisstopo.pixelkarte-farbe' &&
+                !this.isExtentOnlyWithinLV95Bounds
+            ) {
+                layers.push(
+                    this.layersConfig.find(
+                        (layer) => layer.getID() === VECTOR_LIGHT_BASE_MAP_STYLE_ID
+                    )
+                )
             }
             layers.push(...this.visibleLayers)
             return layers

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -101,7 +101,7 @@
 import { EditableFeatureTypes, LayerFeature } from '@/api/features.api'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
 
-import { IS_TESTING_WITH_CYPRESS, LV95_EXTENT, VECTOR_LIGHT_BASE_MAP_STYLE_ID } from '@/config'
+import { IS_TESTING_WITH_CYPRESS, VECTOR_LIGHT_BASE_MAP_STYLE_ID } from '@/config'
 import FeatureEdit from '@/modules/infobox/components/FeatureEdit.vue'
 import FeatureList from '@/modules/infobox/components/FeatureList.vue'
 import OpenLayersPopover from '@/modules/map/components/openlayers/OpenLayersPopover.vue'
@@ -182,7 +182,7 @@ export default {
         ...mapGetters([
             'visibleLayers',
             'currentBackgroundLayer',
-            'extent',
+            'isExtentOnlyWithinLV95Bounds',
             'resolution',
             'isCurrentlyDrawing',
             'backgroundLayers',
@@ -217,13 +217,7 @@ export default {
             if (this.currentBackgroundLayer?.getID() === 'ch.swisstopo.pixelkarte-farbe') {
                 // we only want LightBaseMap behind pixelkarte-farbe when the map is showing things outside
                 // LV95 extent (outside of Switzerland)
-                const [currentExtentBottomLeft, currentExtentTopRight] = this.extent
-                if (
-                    currentExtentBottomLeft[0] >= LV95_EXTENT[0] &&
-                    currentExtentBottomLeft[1] >= LV95_EXTENT[1] &&
-                    currentExtentTopRight[0] <= LV95_EXTENT[2] &&
-                    currentExtentTopRight[1] <= LV95_EXTENT[3]
-                ) {
+                if (this.isExtentOnlyWithinLV95Bounds) {
                     log.debug('no need to show MapLibre, we are totally within LV95 extent')
                 } else {
                     return this.backgroundLayers.find(

--- a/src/store/modules/position.store.js
+++ b/src/store/modules/position.store.js
@@ -1,4 +1,4 @@
-import { MAP_CENTER } from '@/config'
+import { LV95_EXTENT, MAP_CENTER } from '@/config'
 import { CoordinateSystems } from '@/utils/coordinateUtils'
 import log from '@/utils/logging'
 import { round } from '@/utils/numberUtils'
@@ -140,6 +140,23 @@ const getters = {
             round(state.center[1] + halfScreenInMeter.height, 2),
         ]
         return [bottomLeft, topRight]
+    },
+    /**
+     * Flag telling if the current extent is contained into the LV95 bounds (meaning only things
+     * from our LV 95 services are currently in display)
+     *
+     * @param state
+     * @param getters
+     * @returns {Boolean}
+     */
+    isExtentOnlyWithinLV95Bounds(state, getters) {
+        const [currentExtentBottomLeft, currentExtentTopRight] = getters.extent
+        return (
+            currentExtentBottomLeft[0] >= LV95_EXTENT[0] &&
+            currentExtentBottomLeft[1] >= LV95_EXTENT[1] &&
+            currentExtentTopRight[0] <= LV95_EXTENT[2] &&
+            currentExtentTopRight[1] <= LV95_EXTENT[3]
+        )
     },
 }
 


### PR DESCRIPTION
whenever we show the lightbasemap layer behind pixelkarte-farbe, with the new extent detection we were not going through the standard layer pipeline, so we also need to add an exception in the attribution management for this case

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_bgdiinf_sb-2783_lightbasemap_copyrights/index.html)