### PR TITLE
feat_BGDIINF_SB-2788: removing pixelkarte grau background layer

### DIFF
--- a/src/modules/map/components/footer/MapFooterBackgroundSelector.vue
+++ b/src/modules/map/components/footer/MapFooterBackgroundSelector.vue
@@ -104,8 +104,6 @@ export default {
                     return 'void_layer'
                 case 'ch.swisstopo.pixelkarte-farbe':
                     return 'bg_pixel_color'
-                case 'ch.swisstopo.pixelkarte-grau':
-                    return 'bg_pixel_grey'
                 case 'ch.swisstopo.swissimage':
                 case VECTOR_TILES_IMAGERY_STYLE_ID:
                     return 'bg_luftbild'
@@ -126,6 +124,12 @@ export default {
 $transition-duration: 0.3s;
 $map-button-gap: 0.5rem;
 $menu-button-diameter: 3px;
+
+// Number of background layers (in addition to 'blank')
+// Caveat: the background layers are dynamically defined in the
+// layersConfig.js files, but how and if they will be displayed is pretty much
+// fixed.
+$numberOfBackgrounds: 3;
 
 .bg-selector {
     position: relative;
@@ -206,7 +210,7 @@ $menu-button-diameter: 3px;
         bottom: calc($map-button-diameter + $map-button-gap);
         opacity: 1;
     }
-    $numberOfBackgrounds: 4;
+
     @for $i from 0 through $numberOfBackgrounds {
         .bg-index-#{$i} {
             $offset: calc(($map-button-diameter + $map-button-gap) * ($i - $numberOfBackgrounds));
@@ -241,12 +245,12 @@ $menu-button-diameter: 3px;
         border-radius: initial;
         background-image: url('../../../menu/assets/backgrounds.jpg');
         background-size: 392px;
-        // Original size: 180px x 4 = 720px image, 5px x 3 = 15px border => 735px (100%)
-        // Size after reducing the size: 96px image x 4 = 384px, 2.666px x 3 = 8px => 392px (x0.5333)
+        // Original size: 180px x 3 = 540px image, 5px x 2 = 10px border => 550px (100%)
+        // Size after reducing the size: 96px image x 3 = 288px, 2.666px x 2= 5.3333px => 293px (x0.5333)
         &.bg-ch-swisstopo-swissimage {
             background-position: 0 0;
         }
-        &.bg-ch-swisstopo-pixelkarte-grau {
+        &.bg-ch-swisstopo-pixelkarte-grau{
             background-position: -98.6667px 0; // 96px (image) + 2.6667 (border)
         }
         &.bg-ch-swisstopo-pixelkarte-farbe {
@@ -255,7 +259,6 @@ $menu-button-diameter: 3px;
         &.bg-ch-swisstopo-leichte-basiskarte_world-vt {
             background-position: -296px 0; // 288px (3 images) + 8 (3 borders)
         }
-
         &:hover {
             border-color: $primary;
         }
@@ -279,7 +282,7 @@ $menu-button-diameter: 3px;
             left: calc(($desktop-map-button-width + $map-button-gap) * -1);
             bottom: 0;
         }
-        $numberOfBackgrounds: 4;
+
         @for $i from 0 through $numberOfBackgrounds {
             .bg-index-#{$i} {
                 $offset: calc(

--- a/src/scss/variables-admin.scss
+++ b/src/scss/variables-admin.scss
@@ -14,34 +14,34 @@
 // COLORS
 //=============================================================================
 
-$venetian-red:                               #dc0018;
-$red:                                        #f7001d;
-$mocassin:                                   #fffab2;
-$cerulean:                                   #006699;
-$pattens-blue:                               #d8e8ef;
-$malibu:                                     #66afe9;
-$solitude:                                   #e7edef;
-$clear-day:                                  #f2f7f9;
+$venetian-red: #dc0018;
+$red: #f7001d;
+$mocassin: #fffab2;
+$cerulean: #006699;
+$pattens-blue: #d8e8ef;
+$malibu: #66afe9;
+$solitude: #e7edef;
+$clear-day: #f2f7f9;
 
-$black:                                      #000000;
-$night-rider:                                #333333; // gray 80%;
-$coal:                                       #454545; // gray 73%;
-$empress:                                    #757575; // gray 54%;
-$silver:                                     #cccccc; // gray 20%;
-$light-grey:                                 #d5d5d5; // gray 16%;
-$gainsboro:                                  #e5e5e5; // gray 10%;
-$smoke:                                      #f5f5f5; // gray 4%;
-$white:                                      #ffffff;
+$black: #000000;
+$night-rider: #333333; // gray 80%;
+$coal: #454545; // gray 73%;
+$empress: #757575; // gray 54%;
+$silver: #cccccc; // gray 20%;
+$light-grey: #d5d5d5; // gray 16%;
+$gainsboro: #e5e5e5; // gray 10%;
+$smoke: #f5f5f5; // gray 4%;
+$white: #ffffff;
 
-$sherpa-blue:                                #03344d;
-$fire-engine-red:                            #bb1122;
-$cadillac:                                   #884488;
+$sherpa-blue: #03344d;
+$fire-engine-red: #bb1122;
+$cadillac: #884488;
 
 // TYPOGRAPHY
 //=============================================================================
 
 //** Fonts variables
-$frutiger:    'Frutiger Neue', Helvetica, Arial, sans-serif;
+$frutiger: 'Frutiger Neue', Helvetica, Arial, sans-serif;
 $admin-icons: 'Admin Icons';
 
 // MISC

--- a/src/store/plugins/load-layersconfig-on-lang-change.js
+++ b/src/store/plugins/load-layersconfig-on-lang-change.js
@@ -86,6 +86,15 @@ const loadLayersAndTopicsConfigAndDispatchToStore = async (store) => {
                 topicEch.backgroundLayers[topicEch.backgroundLayers.indexOf(swissimageLayer)] =
                     imageryBackgroundLayer
             }
+            // removing the Pixelkarte Grau from the background layers. Same hack as
+            // for the SWISSIMAGE above)
+            const pixelgreyLayer = topicEch.backgroundLayers.find(
+                (layer) => layer.geoAdminID === 'ch.swisstopo.pixelkarte-grau'
+            )
+            if (swissimageLayer) {
+                log.debug('removing "ch.swisstopo.pixelkarte-grau" from background layer')
+                pixelgreyLayer.isBackground = false
+            }
         }
         store.dispatch('setLayerConfig', layersConfig)
         store.dispatch('setTopics', topicsConfig)


### PR DESCRIPTION
It would be nice to have the original icons to be able to quicly reconstruct the `backgrounds.jpeg` and `backgrounds_mobile.jpeg` file (without quality loss). Left untouched for now.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_bgdiinf_sb-2788_background_layer/index.html)