### PR TITLE
BGDIINF_SB-2790: Test banner now covers screen under the header

### DIFF
--- a/src/modules/map/components/WarningRibbon.vue
+++ b/src/modules/map/components/WarningRibbon.vue
@@ -20,20 +20,23 @@ export default {
 /* Corner ribbons, from http://codepen.io/eode9/pen/twkKm
 * mobile: ribbon top left, desktop: bottom left
 */
+$ribbon-halfwidth: 180px;
+$ribbon-halfheight: 25px;
+$dist-from-border: 50px; // Distance of the text's center from the border
 
 .corner-ribbon {
     position: absolute;
     /* top-left */
-    top: 78px;
+    top: calc(#{-$ribbon-halfheight + $dist-from-border} + #{$header_height});
     bottom: auto;
-    left: -50px;
-    width: 200px;
+    left: -$ribbon-halfwidth + $dist-from-border;
+    width: 2 * $ribbon-halfwidth;
     transform: rotate(-45deg);
     z-index: $zindex-warning;
     background: $danger;
     color: white;
     text-align: center;
-    line-height: 50px;
+    line-height: 2 * $ribbon-halfheight;
     letter-spacing: 1px;
     font-weight: bold;
 }
@@ -42,9 +45,8 @@ export default {
     .corner-ribbon {
         /* bottom-left */
         top: auto;
-        bottom: 50px; /* Under cesium inspectors */
-        left: -100px;
-        width: 300px;
+        // 25px is ca. the height of the footer
+        bottom: -$ribbon-halfheight + $dist-from-border + 25px; /* Under cesium inspectors */
         transform: rotate(45deg);
     }
 }

--- a/src/modules/menu/components/header/HeaderWithSearch.vue
+++ b/src/modules/menu/components/header/HeaderWithSearch.vue
@@ -3,7 +3,11 @@
         <LoadingBar v-if="showLoadingBar" />
         <div class="header-content w-100 p-sm-0 p-md-1 d-flex align-items-center">
             <div class="justify-content-start p-1 d-flex flex-shrink-0 flex-grow-0">
-                <div class="p-1 cursor-pointer text-center" data-cy="menu-swiss-flag" @click="resetApp">
+                <div
+                    class="p-1 cursor-pointer text-center"
+                    data-cy="menu-swiss-flag"
+                    @click="resetApp"
+                >
                     <SwissFlag />
                 </div>
                 <HeaderSwissConfederationText
@@ -17,7 +21,6 @@
                 class="search-bar-section d-flex-column flex-grow-1"
                 :class="{ 'align-self-center': !hasDevSiteWarning }"
             >
-
                 <SearchBar />
             </div>
             <div
@@ -31,9 +34,9 @@
         </div>
         <!-- eslint-disable vue/no-v-html-->
         <div
-          v-if="hasDevSiteWarning"
-          class="header-warning-dev bg-danger text-white text-center text-wrap text-truncate overflow-hidden fw-bold p-1"
-          v-html="$t('test_host_warning')"
+            v-if="hasDevSiteWarning"
+            class="header-warning-dev bg-danger text-white text-center text-wrap text-truncate overflow-hidden fw-bold p-1"
+            v-html="$t('test_host_warning')"
         />
         <!-- eslint-enable vue/no-v-html-->
     </div>


### PR DESCRIPTION
When going in fullscreen mode, the banner now does not appear cut anymore.

[Test link](https://sys-map.dev.bgdi.ch/preview/bugfix-bgdiinf_sb-2790-extend-test-banner-to-cover-screen-under-head/index.html)