### PR TITLE
BGDIINF_SB-2793: leave menu open when searching

### DIFF
--- a/src/modules/menu/MenuModule.vue
+++ b/src/modules/menu/MenuModule.vue
@@ -40,7 +40,7 @@
                     class="menu-tray"
                     :class="{
                         'desktop-mode': isDesktopMode,
-                        'desktop-menu-closed': isDesktopMode && !showMenu,
+                        'desktop-menu-closed': isDesktopMode && !isMenuShown,
                     }"
                     data-cy="menu-tray"
                 >

--- a/src/modules/menu/components/header/HeaderWithSearch.vue
+++ b/src/modules/menu/components/header/HeaderWithSearch.vue
@@ -2,7 +2,7 @@
     <div class="header">
         <LoadingBar v-if="showLoadingBar" />
         <div class="header-content w-100 p-sm-0 p-md-1 d-flex align-items-center">
-            <div class="justify-content-start p-1 d-flex flex-shrink-0 flex-grow-0">
+            <div class="logo-section justify-content-start p-1 d-flex flex-shrink-0 flex-grow-0">
                 <div
                     class="p-1 cursor-pointer text-center"
                     data-cy="menu-swiss-flag"
@@ -23,14 +23,11 @@
             >
                 <SearchBar />
             </div>
-            <div
-                class="header-settings-section align-self-start d-flex flex-shrink-0 flex-grow-0 ms-auto"
-                data-cy="header-settings-section"
-            >
-                <FeedbackToolbar id="menu-feedback" :show-as-links="true" />
-                <LangSwitchToolbar id="menu-lang-selector" />
-            </div>
             <HeaderMenuButton v-if="isPhoneMode" class="mx-1" />
+        </div>
+        <div class="header-settings-section" data-cy="header-settings-section">
+            <FeedbackToolbar id="menu-feedback" :show-as-links="true" />
+            <LangSwitchToolbar id="menu-lang-selector" />
         </div>
         <!-- eslint-disable vue/no-v-html-->
         <div
@@ -110,6 +107,18 @@ $animation-time: 0.5s;
     max-width: 800px;
 }
 
+.header-settings-section {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: auto;
+    display: flex;
+}
+
+.logo-section {
+    min-width: $menu-tray-width;
+}
+
 .search-header-swiss-confederation-text,
 .search-title {
     display: none;
@@ -119,6 +128,10 @@ $animation-time: 0.5s;
     .header-settings-section {
         // See MenuTray.vue where the settings section is enable above lg
         display: none !important;
+    }
+
+    .logo-section {
+        min-width: auto;
     }
 }
 

--- a/src/store/plugins/menu-search-interaction.plugin.js
+++ b/src/store/plugins/menu-search-interaction.plugin.js
@@ -23,7 +23,9 @@ const menuSearchBarInteractionManagementPlugin = (store) => {
                 }
                 break
             case 'showSearchResults':
-                hideMenuIfShown()
+                if (store.getters.isPhoneMode) {
+                    hideMenuIfShown()
+                }
                 break
         }
     })


### PR DESCRIPTION
- In desktop mode, do not hide the menu anymore when showing search results, but still do that in phone mode.
- To make both the menu and the search results visible at the same time, above the size lg, the search bar starts after the menu tray so that the search results do not overlap with the menu.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-2793-open-menu-back-after-search-results-hidden/index.html)