### PR TITLE
BGDIINF_SB-2789: search results full width on phone

### DIFF
--- a/src/modules/menu/components/search/SearchResultCategory.vue
+++ b/src/modules/menu/components/search/SearchResultCategory.vue
@@ -1,9 +1,5 @@
 <template>
-    <div
-        v-show="entries.length > 0"
-        class="search-category"
-        :class="{ 'search-category-half-size': halfSize }"
-    >
+    <div v-show="entries.length > 0" class="search-category">
         <div class="search-category-header p-2">
             {{ title }}
         </div>
@@ -46,10 +42,6 @@ export default {
             type: String,
             required: true,
         },
-        halfSize: {
-            type: Boolean,
-            default: false,
-        },
     },
     emits: ['preview', 'previewStart', 'previewStop'],
     data() {
@@ -74,23 +66,23 @@ export default {
 <style lang="scss" scoped>
 @import 'src/scss/webmapviewer-bootstrap-theme';
 .search-category {
+    display: flex;
+    overflow: hidden;
+    flex-direction: column;
     &-header {
+        flex: none;
+        overflow: visible;
         font-size: 0.825rem;
         font-weight: bold;
         background-color: $input-group-addon-bg;
     }
     &-body {
+        flex: initial;
         margin: 0;
         padding: 0;
         list-style: none;
-
-        max-height: 15rem;
-        overflow-y: scroll;
+        overflow: auto;
         font-size: 0.8rem;
-
-        .search-category-half-size & {
-            max-height: 7rem;
-        }
     }
 }
 </style>

--- a/src/modules/menu/components/search/SearchResultList.vue
+++ b/src/modules/menu/components/search/SearchResultList.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="search-results-container"
+        class="search-results-container m-0"
         :class="{ 'search-results-dev-site-warning': hasDevSiteWarning && isPhoneMode }"
     >
         <div
@@ -72,7 +72,6 @@ export default {
     height: min(calc(100vh - $header-height), max(20rem, 45vh));
     left: 0;
     width: 100%;
-    margin: 0 !important; //overwrites a bootstrap property from parent module
     pointer-events: none;
 }
 .search-results-dev-site-warning {

--- a/src/modules/menu/components/search/SearchResultList.vue
+++ b/src/modules/menu/components/search/SearchResultList.vue
@@ -1,22 +1,20 @@
 <template>
     <div
-        id="search-results-container"
+        class="search-results-container"
         :class="{ 'search-results-dev-site-warning': hasDevSiteWarning && isPhoneMode }"
     >
         <div
             class="search-results bg-light"
-            :class="
-                isPhoneMode
-                    ? ['border-top', 'border-bottom', 'rounded-bottom']
-                    : ['border', 'rounded']
-            "
+            :class="{
+                'border-top border-bottom rounded-bottom': isPhoneMode,
+                'border rounded': !isPhoneMode,
+            }"
             data-cy="search-results"
             @keydown.esc.prevent="$emit('close')"
         >
             <div class="search-results-inner">
                 <SearchResultCategory
                     :title="$t('locations_results_header')"
-                    :half-size="results.locationResults.length > 0"
                     :entries="results.locationResults"
                     data-cy="search-results-locations"
                     @preview-start="setPinnedLocation"
@@ -24,7 +22,6 @@
                 />
                 <SearchResultCategory
                     :title="$t('layers_results_header')"
-                    :half-size="results.layerResults.length > 0"
                     :entries="results.layerResults"
                     data-cy="search-results-layers"
                     @preview-start="setPreviewLayer"
@@ -68,20 +65,19 @@ export default {
 @import 'src/scss/media-query.mixin';
 @import 'src/scss/variables';
 
-#search-results-container {
+.search-results-container {
     position: fixed;
     top: $header-height;
     // 45vh (so that previews are visible), but on small screen min 20rem (ca. 3 lines per category)
     height: min(calc(100vh - $header-height), max(20rem, 45vh));
     left: 0;
     width: 100%;
-    margin: 0; //overwrites a bootstrap property from parent module
+    margin: 0 !important; //overwrites a bootstrap property from parent module
     pointer-events: none;
 }
 .search-results-dev-site-warning {
-    // Must be important as it needs to overrite the top defined in #search-results-container
-    top: $header-height + $dev-disclaimer-height !important;
-    height: min(calc(100vh - $header-height - $dev-disclaimer-height), max(20rem, 45vh)) !important;
+    top: $header-height + $dev-disclaimer-height;
+    height: min(calc(100vh - $header-height - $dev-disclaimer-height), max(20rem, 45vh));
     // Put the search results under the rest of the header so hovering over the warning works
     // correctly
     z-index: -1;
@@ -103,7 +99,7 @@ export default {
 }
 
 @include respond-above(phone) {
-    #search-results-container {
+    .search-results-container {
         position: absolute;
         top: 100%;
     }

--- a/src/modules/menu/components/search/SearchResultList.vue
+++ b/src/modules/menu/components/search/SearchResultList.vue
@@ -1,30 +1,37 @@
 <template>
     <div
-        id="search-results"
-        :class="[
-            isPhoneMode ? ['border-top', 'border-bottom', 'rounded-bottom'] : ['border', 'rounded'],
-            { 'search-results-dev-site-warning': hasDevSiteWarning && isPhoneMode },
-            ['bg-light'],
-        ]"
-        data-cy="search-results"
-        @keydown.esc.prevent="$emit('close')"
+        id="search-results-container"
+        :class="{ 'search-results-dev-site-warning': hasDevSiteWarning && isPhoneMode }"
     >
-        <SearchResultCategory
-            :title="$t('locations_results_header')"
-            :half-size="results.locationResults.length > 0"
-            :entries="results.locationResults"
-            data-cy="search-results-locations"
-            @preview-start="setPinnedLocation"
-            @preview-stop="clearPinnedLocation"
-        />
-        <SearchResultCategory
-            :title="$t('layers_results_header')"
-            :half-size="results.layerResults.length > 0"
-            :entries="results.layerResults"
-            data-cy="search-results-layers"
-            @preview-start="setPreviewLayer"
-            @preview-stop="clearPreviewLayer"
-        />
+        <div
+            class="search-results bg-light"
+            :class="
+                isPhoneMode
+                    ? ['border-top', 'border-bottom', 'rounded-bottom']
+                    : ['border', 'rounded']
+            "
+            data-cy="search-results"
+            @keydown.esc.prevent="$emit('close')"
+        >
+            <div class="search-results-inner">
+                <SearchResultCategory
+                    :title="$t('locations_results_header')"
+                    :half-size="results.locationResults.length > 0"
+                    :entries="results.locationResults"
+                    data-cy="search-results-locations"
+                    @preview-start="setPinnedLocation"
+                    @preview-stop="clearPinnedLocation"
+                />
+                <SearchResultCategory
+                    :title="$t('layers_results_header')"
+                    :half-size="results.layerResults.length > 0"
+                    :entries="results.layerResults"
+                    data-cy="search-results-layers"
+                    @preview-start="setPreviewLayer"
+                    @preview-stop="clearPreviewLayer"
+                />
+            </div>
+        </div>
     </div>
 </template>
 
@@ -61,36 +68,47 @@ export default {
 @import 'src/scss/media-query.mixin';
 @import 'src/scss/variables';
 
-#search-results {
+#search-results-container {
     position: fixed;
     top: $header-height;
-    overflow: hidden;
-    left: 0%;
+    // 45vh (so that previews are visible), but on small screen min 20rem (ca. 3 lines per category)
+    height: min(calc(100vh - $header-height), max(20rem, 45vh));
+    left: 0;
     width: 100%;
-    max-height: calc(75vh - 3rem);
     margin: 0; //overwrites a bootstrap property from parent module
-    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+    pointer-events: none;
 }
-
 .search-results-dev-site-warning {
-    // Must be important as it needs to overrite the top defined in #search-results
+    // Must be important as it needs to overrite the top defined in #search-results-container
     top: $header-height + $dev-disclaimer-height !important;
+    height: min(calc(100vh - $header-height - $dev-disclaimer-height), max(20rem, 45vh)) !important;
     // Put the search results under the rest of the header so hovering over the warning works
     // correctly
     z-index: -1;
 }
+
+.search-results {
+    display: grid;
+    grid-auto-rows: 1fr;
+    max-height: 100%;
+    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+    pointer-events: all;
+}
+
+.search-results-inner {
+    display: grid;
+    //Split evenly between all search result categories
+    grid-auto-rows: auto;
+    overflow: hidden;
+}
+
 @include respond-above(phone) {
-    #search-results {
+    #search-results-container {
         position: absolute;
         top: 100%;
     }
     .search-results-dev-site-warning {
         z-index: initial;
-    }
-}
-@include respond-above(lg) {
-    #search-results {
-        max-height: calc(75vh - 6rem);
     }
 }
 </style>

--- a/src/modules/menu/components/search/SearchResultList.vue
+++ b/src/modules/menu/components/search/SearchResultList.vue
@@ -1,7 +1,11 @@
 <template>
     <div
         id="search-results"
-        class="bg-light border rounded overflow-hidden"
+        :class="[
+            isPhoneMode ? ['border-top', 'border-bottom', 'rounded-bottom'] : ['border', 'rounded'],
+            { 'search-results-dev-site-warning': hasDevSiteWarning && isPhoneMode },
+            ['bg-light'],
+        ]"
         data-cy="search-results"
         @keydown.esc.prevent="$emit('close')"
     >
@@ -25,7 +29,7 @@
 </template>
 
 <script>
-import { mapActions, mapState } from 'vuex'
+import { mapActions, mapState, mapGetters } from 'vuex'
 import SearchResultCategory from './SearchResultCategory.vue'
 
 /**
@@ -40,6 +44,7 @@ export default {
             results: (state) => state.search.results,
             showResults: (state) => state.search.show,
         }),
+        ...mapGetters(['isPhoneMode', 'hasDevSiteWarning']),
     },
     methods: {
         ...mapActions([
@@ -54,14 +59,34 @@ export default {
 
 <style lang="scss" scoped>
 @import 'src/scss/media-query.mixin';
+@import 'src/scss/variables';
 
 #search-results {
-    position: absolute;
-    top: 100%;
+    position: fixed;
+    top: $header-height;
+    overflow: hidden;
     left: 0%;
     width: 100%;
     max-height: calc(75vh - 3rem);
+    margin: 0; //overwrites a bootstrap property from parent module
     box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+}
+
+.search-results-dev-site-warning {
+    // Must be important as it needs to overrite the top defined in #search-results
+    top: $header-height + $dev-disclaimer-height !important;
+    // Put the search results under the rest of the header so hovering over the warning works
+    // correctly
+    z-index: -1;
+}
+@include respond-above(phone) {
+    #search-results {
+        position: absolute;
+        top: 100%;
+    }
+    .search-results-dev-site-warning {
+        z-index: initial;
+    }
 }
 @include respond-above(lg) {
     #search-results {

--- a/tests/e2e-cypress/integration/search/search-results.cy.js
+++ b/tests/e2e-cypress/integration/search/search-results.cy.js
@@ -12,6 +12,9 @@ const searchbarSelector = '[data-cy="searchbar"]'
 const locationsSelector = '[data-cy="search-results-locations"]'
 const layersSelector = '[data-cy="search-results-layers"]'
 
+const viewportHeight = Cypress.config('viewportHeight')
+const viewportWidth = Cypress.config('viewportWidth')
+
 /**
  * Configurable `.then` callback to check element index among siblings.
  *
@@ -301,7 +304,7 @@ describe('Test the search bar result handling', () => {
         cy.get(searchbarSelector).paste('test')
         cy.wait(`@search-locations`)
         cy.get('[data-cy="search-result-entry-location"]').should('be.visible')
-        cy.get('[data-cy="map"]').click()
+        cy.get('[data-cy="map"]').click(viewportWidth * 0.5, viewportHeight * 0.75)
         cy.get('[data-cy="search-result-entry-location"]').should('not.be.visible')
         cy.activateFullscreen()
         cy.get(searchbarSelector).should('not.exist')
@@ -311,7 +314,7 @@ describe('Test the search bar result handling', () => {
         cy.get(searchbarSelector).paste('test')
         cy.wait(`@search-locations`)
         cy.get('[data-cy="search-result-entry-location"]').should('be.visible')
-        cy.get('[data-cy="map"]').click()
+        cy.get('[data-cy="map"]').click(viewportWidth * 0.5, viewportHeight * 0.75)
         cy.get('[data-cy="search-result-entry-location"]').should('not.be.visible')
         cy.get(searchbarSelector).click()
         cy.get('[data-cy="search-result-entry-location"]').should('be.visible')


### PR DESCRIPTION
- Search results use full width on phone
- Search results take more screen real estate
- Do not blink when typing search terms

[Test link](https://sys-map.dev.bgdi.ch/preview/bgdiinf_sb-2789-search-results-full-width-on-phone/index.html)