### PR TITLE
BGDIINF_SB-2792 : fix layer ordering

### DIFF
--- a/src/modules/menu/components/activeLayers/MenuActiveLayersList.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersList.vue
@@ -58,7 +58,9 @@ export default {
     },
     computed: {
         ...mapState({
-            activeLayers: (state) => state.layers.activeLayers,
+            // users are used to have layers ordered top to bottom (first layer is on top) but we store them in the
+            // opposite order. So here we swap the order of this array to match the desired order on the UI
+            activeLayers: (state) => state.layers.activeLayers.slice().reverse(),
         }),
     },
     methods: {
@@ -86,10 +88,11 @@ export default {
             this.toggleLayerVisibility(layerId)
         },
         onOrderChange(layerId, delta) {
+            // raising the layer in the stack means the user wants the layer put front
             if (delta === 1) {
-                this.moveActiveLayerBack(layerId)
-            } else if (delta === -1) {
                 this.moveActiveLayerFront(layerId)
+            } else if (delta === -1) {
+                this.moveActiveLayerBack(layerId)
             }
         },
         onOpacityChange(layerId, opacity) {

--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
@@ -72,7 +72,7 @@
             <ButtonWithIcon
                 :button-font-awesome-icon="['fas', 'arrow-up']"
                 :disabled="isFirstLayer"
-                :data-cy="`button-lower-order-layer-${id}`"
+                :data-cy="`button-raise-order-layer-${id}`"
                 :large="!compact"
                 transparent
                 @click="onOrderChange(1)"
@@ -80,7 +80,7 @@
             <ButtonWithIcon
                 :button-font-awesome-icon="['fas', 'arrow-down']"
                 :disabled="isLastLayer"
-                :data-cy="`button-raise-order-layer-${id}`"
+                :data-cy="`button-lower-order-layer-${id}`"
                 :large="!compact"
                 transparent
                 @click="onOrderChange(-1)"

--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
@@ -72,7 +72,7 @@
             <ButtonWithIcon
                 :button-font-awesome-icon="['fas', 'arrow-up']"
                 :disabled="isFirstLayer"
-                :data-cy="`button-raise-order-layer-${id}`"
+                :data-cy="`button-lower-order-layer-${id}`"
                 :large="!compact"
                 transparent
                 @click="onOrderChange(1)"
@@ -80,7 +80,7 @@
             <ButtonWithIcon
                 :button-font-awesome-icon="['fas', 'arrow-down']"
                 :disabled="isLastLayer"
-                :data-cy="`button-lower-order-layer-${id}`"
+                :data-cy="`button-raise-order-layer-${id}`"
                 :large="!compact"
                 transparent
                 @click="onOrderChange(-1)"

--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItemTimeSelector.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItemTimeSelector.vue
@@ -2,6 +2,7 @@
     <PopoverButton
         v-if="hasMultipleTimestamps"
         ref="popover"
+        popover-position="left"
         :button-title="renderHumanReadableTimestamp(timeConfig.currentTimestamp)"
         :popover-title="$t('time_select_year')"
         :small="compact"
@@ -90,7 +91,6 @@ export default {
 <style lang="scss" scoped>
 .timestamps-popover-content {
     display: grid;
-    height: 20rem;
     max-height: 33vh;
     overflow-y: auto;
     background: white;

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -19,6 +19,8 @@ const state = {
      * Currently active layers (that have been selected by the user from the search bar or the layer
      * tree)
      *
+     * Layers are ordered from bottom to top (last layer is shown on top of all the others)
+     *
      * @type AbstractLayer[]
      */
     activeLayers: [],
@@ -40,6 +42,8 @@ const state = {
 const getters = {
     /**
      * Filter all the active layers and gives only those who have the flag `visible` to `true`
+     *
+     * Layers are ordered from bottom to top (last layer is shown on top of all the others)
      *
      * @param state
      * @returns {AbstractLayer[]} All layers that are currently visible on the map

--- a/src/store/plugins/topic-change-management.plugin.js
+++ b/src/store/plugins/topic-change-management.plugin.js
@@ -45,7 +45,8 @@ const topicChangeManagementPlugin = (store) => {
             // at init, if there is no active layer yet, but the topic has some, we add them
             // after init we always add all layers from topic
             if (!isFirstSetTopic || state.layers.activeLayers.length === 0) {
-                currentTopic.layersToActivate.forEach((layer) => {
+                // somehow topic layers are stored in reverse (top to bottom) so we swap the order before adding them
+                currentTopic.layersToActivate.slice().reverse().forEach((layer) => {
                     store.dispatch('addLayer', layer)
                 })
             }

--- a/tests/e2e-cypress/integration/layers.cy.js
+++ b/tests/e2e-cypress/integration/layers.cy.js
@@ -459,7 +459,7 @@ describe('Test of layer handling', () => {
                 const [firstLayerId, secondLayerId] = visibleLayerIds
                 // lower the order of the first layer
                 openLayerSettings(firstLayerId)
-                cy.get(`[data-cy="button-lower-order-layer-${firstLayerId}"]`)
+                cy.get(`[data-cy="button-raise-order-layer-${firstLayerId}"]`)
                     .should('be.visible')
                     .click()
                 // checking that the order has changed
@@ -468,7 +468,7 @@ describe('Test of layer handling', () => {
                     expect(visibleLayers[1].getID()).to.eq(firstLayerId)
                 })
                 // using the other button
-                cy.get(`[data-cy="button-raise-order-layer-${firstLayerId}"]`)
+                cy.get(`[data-cy="button-lower-order-layer-${firstLayerId}"]`)
                     .should('be.visible')
                     .click()
                 // re-checking the order that should be back to the starting values
@@ -541,20 +541,20 @@ describe('Test of layer handling', () => {
             beforeEach(() => {
                 goToMenuWithLayers()
             })
-            const checkOrderButtons = (layerId, raiseShouldBeDisabled, lowerShouldBeDisabled) => {
-                cy.get(`[data-cy="button-raise-order-layer-${layerId}"]`)
-                    .should('be.visible')
-                    .should(`${!raiseShouldBeDisabled ? 'not.' : ''}be.disabled`)
+            const checkOrderButtons = (layerId, lowerShouldBeDisabled, raiseShouldBeDisabled) => {
                 cy.get(`[data-cy="button-lower-order-layer-${layerId}"]`)
                     .should('be.visible')
                     .should(`${!lowerShouldBeDisabled ? 'not.' : ''}be.disabled`)
+                cy.get(`[data-cy="button-raise-order-layer-${layerId}"]`)
+                    .should('be.visible')
+                    .should(`${!raiseShouldBeDisabled ? 'not.' : ''}be.disabled`)
             }
-            it('Disable the "Raise Order" arrow on the top layer', () => {
+            it('Disable the "move front" arrow on the top layer', () => {
                 const layerId = visibleLayerIds[0]
                 openLayerSettings(layerId)
                 checkOrderButtons(layerId, true, false)
             })
-            it('Disable the "Lower Order" arrow on the bottom layer', () => {
+            it('Disable the "move back" arrow on the bottom layer', () => {
                 const layerId = visibleLayerIds[2]
                 openLayerSettings(layerId)
                 checkOrderButtons(layerId, false, true)
@@ -564,32 +564,32 @@ describe('Test of layer handling', () => {
                 openLayerSettings(layerId)
                 checkOrderButtons(layerId, false, false)
             })
-            it('disable the "raise order" arrow on a layer which gets to the top layer', () => {
-                const layerId = visibleLayerIds[1]
-                openLayerSettings(layerId)
-                checkOrderButtons(layerId, false, false)
-                cy.get(`[data-cy="button-raise-order-layer-${layerId}"]`).click()
-                checkOrderButtons(layerId, true, false)
-            })
-            it('disable the "lower order" arrow on a layer which gets to the bottom layer', () => {
+            it('disable the "move front" arrow on a layer which gets to the top layer', () => {
                 const layerId = visibleLayerIds[1]
                 openLayerSettings(layerId)
                 checkOrderButtons(layerId, false, false)
                 cy.get(`[data-cy="button-lower-order-layer-${layerId}"]`).click()
+                checkOrderButtons(layerId, true, false)
+            })
+            it('disable the "move back" arrow on a layer which gets to the bottom layer', () => {
+                const layerId = visibleLayerIds[1]
+                openLayerSettings(layerId)
+                checkOrderButtons(layerId, false, false)
+                cy.get(`[data-cy="button-raise-order-layer-${layerId}"]`).click()
                 checkOrderButtons(layerId, false, true)
             })
-            it('enable the "lower order" arrow on a layer which is raised from the bottom', () => {
+            it('enable the "move back" arrow on a layer which is raised from the bottom', () => {
                 const layerId = visibleLayerIds[2]
                 openLayerSettings(layerId)
                 checkOrderButtons(layerId, false, true)
-                cy.get(`[data-cy="button-raise-order-layer-${layerId}"]`).click()
+                cy.get(`[data-cy="button-lower-order-layer-${layerId}"]`).click()
                 checkOrderButtons(layerId, false, false)
             })
-            it('enable the "raise order" arrow on a layer which is lowered from the top', () => {
+            it('enable the "move front" arrow on a layer which is lowered from the top', () => {
                 const layerId = visibleLayerIds[0]
                 openLayerSettings(layerId)
                 checkOrderButtons(layerId, true, false)
-                cy.get(`[data-cy="button-lower-order-layer-${layerId}"]`).click()
+                cy.get(`[data-cy="button-raise-order-layer-${layerId}"]`).click()
                 checkOrderButtons(layerId, false, false)
             })
         })

--- a/tests/e2e-cypress/integration/topics.cy.js
+++ b/tests/e2e-cypress/integration/topics.cy.js
@@ -59,10 +59,15 @@ describe('Topics', () => {
             cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
                 expect(activeLayers).to.be.an('Array')
                 expect(activeLayers.length).to.eq(rawTopic.activatedLayers.length)
-                rawTopic.activatedLayers.forEach((layerIdThatMustBeActive, index) => {
-                    const activeLayer = activeLayers[index]
-                    expect(activeLayer.getID()).to.eq(layerIdThatMustBeActive)
-                })
+                // topics layer are in the reverse order as the store layer (topic: top->bottom, layer: bottom->top)
+                // so we have to revert the list of layers from the topic before checking their position in the store
+                rawTopic.activatedLayers
+                    .slice()
+                    .reverse()
+                    .forEach((layerIdThatMustBeActive, index) => {
+                        const activeLayer = activeLayers[index]
+                        expect(activeLayer.getID()).to.eq(layerIdThatMustBeActive)
+                    })
             })
         }
         it('clears all activate layers and change background layer on topic selection', () => {
@@ -117,7 +122,7 @@ describe('Topics', () => {
             const complexTopic = mockupTopics.topics[4]
             selectTopicWithId(complexTopic.id)
             // from the mocked up response above
-            const expectedActiveLayers = ['test.wmts.layer', 'test.wms.layer']
+            const expectedActiveLayers = ['test.wms.layer', 'test.wmts.layer']
             const expectedVisibleLayers = ['test.wmts.layer']
             const expectedOpacity = {
                 'test.wmts.layer': 0.6,


### PR DESCRIPTION
There was a discrepancy between mf-geoadmin3 layer ordering (in the menu and URL) and web-mapviewer way of handling them. In the URL, layers should be ordered from bottom to top, and on the side menu from top to bottom (layer "on top" of the layer stack is the top layer). Topics were an issue as they list their layers to activate in the opposite order (top -> bottom) so I've inverted those layer before importing them.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2792-layer_ordering/index.html)