### PR TITLE
BGDIINF_SB-2820 : legacy parameters double encoded

### DIFF
--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -50,6 +50,7 @@ const handleLegacyParams = (legacyParams, store, to, next) => {
     const legacyCoordinates = []
     Object.keys(legacyParams).forEach((param) => {
         let value
+
         let key = param
         switch (param) {
             // we need te re-evaluate LV95 zoom, as it was a zoom level tailor made for this projection
@@ -100,6 +101,7 @@ const handleLegacyParams = (legacyParams, store, to, next) => {
                 break
 
             // if no special work to do, we just copy past legacy params to the new viewer
+
             default:
                 value = legacyParams[param]
         }
@@ -115,7 +117,10 @@ const handleLegacyParams = (legacyParams, store, to, next) => {
             newQuery['lat'] = round(center[1], 6)
         }
         if (value) {
-            newQuery[key] = value
+            // When receiving a query, the application will encode the URI components
+            // We decode those so that the new query won't encode encoded character
+            // for example, we avoid having " " becoming %2520 in the URI
+            newQuery[key] = decodeURIComponent(value)
         }
     })
 

--- a/tests/e2e-cypress/integration/legacyParamImport.cy.js
+++ b/tests/e2e-cypress/integration/legacyParamImport.cy.js
@@ -188,5 +188,13 @@ describe('Test on legacy param import', () => {
                 expect(kmlLayer.visible).to.be.true
             })
         })
+        it("doesn't show encoding in the search bar when serving a swisssearch legacy url", () => {
+            cy.goToMapView('en', {
+                swisssearch: '1530 Payerne'
+            })
+            cy.readStoreValue('state.search.query').should('eq', '1530 Payerne')
+            cy.url().should('include', 'swisssearch=1530+Payerne')
+            cy.get('[data-cy="search-result-entry-location"]').should('be.visible')
+        })
     })
 })


### PR DESCRIPTION
Issue : Upon receiving legacy parameters, the application would encode them on reception (which is an expected behavior), then create a new query with those adapted parameters, which would encode them again (For example, a space would become `%20`, then `%2520`).

Fix : We decode the URI parameters before storing them in the new query Parameters, ensuring they won't be encoded twice.

[Test link](https://sys-map.dev.bgdi.ch/preview/bgdiinf_sb-2820-swisssearch-legacy-compatibility/index.html)