### PR TITLE
BGDIINF_SB-2785: Infobox does not hide menu anymore in phone mode

### DIFF
--- a/src/modules/map/components/footer/MapFooter.vue
+++ b/src/modules/map/components/footer/MapFooter.vue
@@ -115,8 +115,11 @@ $flex-gap: 1em;
 
     &-middle {
         position: relative;
-        z-index: $zindex-footer-infobox;
+        z-index: $zindex-footer;
         background-color: $white;
+        @include respond-above(phone) {
+            z-index: $zindex-desktop-footer-infobox;
+        }
     }
 
     &-bottom {

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -9,7 +9,9 @@ $zindex-map: 1;
 $zindex-footer: $zindex-map + 1; // The menu should be displayed above the footer in phone mode
 $zindex-warning: 1;
 $zindex-menu: $zindex-footer + 1;
-$zindex-footer-infobox: $zindex-menu + 1; //Is part of the footer, but should be displayed above other menu items
+//Is part of the footer, but should be displayed above other menu items if in desktop mode
+//In phone mode, it makes more sense for the menu to be above.
+$zindex-desktop-footer-infobox: $zindex-menu + 1;
 $zindex-swipable-element: $zindex-menu + 1; //Not used for the moment, please check the value before using it.
 
 // Modules teleported to the main stacking context (so that they can be on top of all other elements)


### PR DESCRIPTION
It makes sense for the menu to be above the infobox in phone mode, as in phone mode the menu is fullscreen and so opens on top of everything else. In desktop mode on the contrary, the menu is open most of the time so a user should never be forced to close the menu just to see a popup. Thats why we leave the popup on top of the menu in desktop mode.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-2785-scroll-not-possible-in-catalog-when-tooltip-open-mobile/index.html)