### PR TITLE
Enforce presence of IDs in GeoJSON data

### DIFF
--- a/src/api/layers/GeoAdminGeoJsonLayer.class.js
+++ b/src/api/layers/GeoAdminGeoJsonLayer.class.js
@@ -17,6 +17,11 @@ export default class GeoAdminGeoJsonLayer extends GeoAdminLayer {
         super(name, LayerTypes.GEOJSON, id, opacity, visible, attributions)
         this.geoJsonUrl = geoJsonUrl
         this.styleUrl = styleUrl
+        // enforcing HTTPS protocol if nothing has been set, will enable us to request GeoJSON data from localhost
+        // otherwise with the mixed methods (HTTP and HTTPS) the request will be rejected
+        if (this.styleUrl.startsWith('//')) {
+            this.styleUrl = `https:${this.styleUrl}`
+        }
     }
 
     getURL() {

--- a/src/modules/map/components/openlayers/OpenLayersGeoJSONLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersGeoJSONLayer.vue
@@ -10,8 +10,8 @@ import log from '@/utils/logging'
 import axios from 'axios'
 import GeoJSON from 'ol/format/GeoJSON'
 import { Vector as VectorLayer } from 'ol/layer'
+import { get as getProjection } from 'ol/proj'
 import { Vector as VectorSource } from 'ol/source'
-import { reproject } from 'reproject'
 import addLayerToMapMixin from './utils/addLayerToMap-mixins'
 import OlStyleForPropertyValue from './utils/styleFromLiterals'
 
@@ -46,66 +46,58 @@ export default {
                 this.layer.setOpacity(newOpacity)
             }
         },
+        geojsonUrl() {
+            this.loadData()
+        },
+        styleUrl() {
+            this.loadStyle()
+        },
     },
     created() {
-        // The layers needs to be set immediately. Otherwise, addLayerToMapMixin will fail.
+        // The layer needs to be set immediately. Otherwise, addLayerToMapMixin will fail.
         this.layer = new VectorLayer({ id: this.layerId, opacity: this.opacity })
+    },
+    mounted() {
+        this.loadStyle()
+        this.loadData()
+    },
+    methods: {
+        async loadStyle() {
+            try {
+                const style = new OlStyleForPropertyValue((await axios.get(this.styleUrl)).data)
 
-        // loading the GeoJSON data and style with and wait for both the be loaded
-        // WARNING: axios.get(this.styleUrl) will not work on localhost and will fire a CORS error !!
-        // this is due to the fact that the backend send the styleUrl agnostic whitout HTTP scheme !
-        Promise.all([axios.get(this.geojsonUrl), axios.get(this.styleUrl)])
-            .then((responses) => {
-                if (!this.layer) {
-                    // It could be that the layer has been removed meanwhile therefore check for
-                    // its existence
-                    return
-                }
-                const geojsonData = responses[0].data
-                const geojsonStyleLiterals = responses[1].data
-                const style = new OlStyleForPropertyValue(geojsonStyleLiterals)
-
-                // if the GeoJSON describes a CRS (projection) we grab it so that we can reproject on the fly if needed
-                const dataProjection = geojsonData.crs ? geojsonData.crs.properties.name : null
-
-                // reprojecting the GeoJSON if not in EPSG:3857, the default projection for GeoJSON is WGS84
-                // as stated in the reference https://tools.ietf.org/html/rfc7946#section-4
-                // if another projection was set in the GeoJSON (through the "crs" property) we use it instead
-                let reprojectedGeoJSON
-                if (dataProjection) {
-                    if (dataProjection !== CoordinateSystems.WEBMERCATOR.epsg) {
-                        reprojectedGeoJSON = reproject(
-                            geojsonData,
-                            dataProjection,
-                            CoordinateSystems.WEBMERCATOR.epsg
-                        )
-                    } else {
-                        // it's already in the correct projection, we don't reproject
-                        reprojectedGeoJSON = geojsonData
-                    }
-                } else {
-                    // according to the IETF reference, if nothing is said about the projection used, it should be WGS84
-                    reprojectedGeoJSON = reproject(
-                        geojsonData,
-                        CoordinateSystems.WGS84.epsg,
-                        CoordinateSystems.WEBMERCATOR.epsg
-                    )
-                }
-                this.layer.setSource(
-                    new VectorSource({
-                        features: new GeoJSON().readFeatures(reprojectedGeoJSON),
-                    })
-                )
                 this.layer.setStyle(function (feature, res) {
                     return style.getFeatureStyle(feature, res)
                 })
-            })
-            .catch((error) => {
-                log.error(
-                    'Error while fetching GeoJSON data/style for layer ' + this.layerId,
-                    error
+            } catch (err) {
+                log.error('Unable to load style for GeoJSON layer', this.layerId, err)
+            }
+        },
+        async loadData() {
+            try {
+                const geoJsonData = (await axios.get(this.geojsonUrl)).data
+
+                // filtering any feature that doesn't define an ID (otherwise it breaks the whole loading process in OL)
+                geoJsonData.features = geoJsonData.features.filter((feature) => feature.id)
+
+                // if the GeoJSON describes a CRS (projection) we grab it so that we can reproject on the fly if needed
+                // according to the IETF reference, if nothing is said about the projection used, it should be WGS84
+                const dataProjection = geoJsonData.crs
+                    ? geoJsonData.crs.properties.name
+                    : CoordinateSystems.WGS84.epsg
+
+                this.layer.setSource(
+                    new VectorSource({
+                        features: new GeoJSON().readFeatures(geoJsonData, {
+                            dataProjection,
+                            featureProjection: getProjection(CoordinateSystems.WEBMERCATOR.epsg),
+                        }),
+                    })
                 )
-            })
+            } catch (err) {
+                log.error('Unable to load data for GeoJSON layer', this.layerId, err)
+            }
+        },
     },
 }
 </script>


### PR DESCRIPTION
And also reload data whenever lang has changed

The issue with ID was detected while migrating DIEMO layer, as one feature had no ID and was breaking the whole loading of features in OpenLayers.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_fix_diemo_migration/index.html)