### PR TITLE
BGDIINF_SB-2816: drawing feature text boxes read only

### DIFF
--- a/src/modules/infobox/components/styling/FeatureStyleEdit.vue
+++ b/src/modules/infobox/components/styling/FeatureStyleEdit.vue
@@ -7,7 +7,7 @@
             <textarea
                 id="drawing-style-feature-title"
                 v-model="text"
-                :read-only="readOnly"
+                :readonly="readOnly"
                 data-cy="drawing-style-feature-title"
                 class="form-control"
                 rows="1"
@@ -21,7 +21,7 @@
             <textarea
                 id="drawing-style-feature-description"
                 v-model="description"
-                :read-only="readOnly"
+                :readonly="readOnly"
                 data-cy="drawing-style-feature-description"
                 class="form-control"
                 rows="2"


### PR DESCRIPTION
The text boxes of the drawing features are now read only again outside of the drawing mode.

[Test link](https://sys-map.dev.bgdi.ch/preview/bugfix-bgdiinf_sb-2816-drawing-feature-text-box-not-readonly/index.html)