### PR TITLE
BGDIINF_SB-2829: Text in tooltips is now selectable

### DIFF
--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -8,7 +8,7 @@
         data-cy="location-popup"
         @close="onClose"
     >
-        <div class="location-popup-coordinates ol-selectable">
+        <div class="location-popup-coordinates">
             <div class="lp-label">
                 <a :href="$t('contextpopup_lv95_url')" target="_blank">CH1903+ / LV95</a>
             </div>

--- a/src/modules/map/components/openlayers/OpenLayersPopover.vue
+++ b/src/modules/map/components/openlayers/OpenLayersPopover.vue
@@ -76,7 +76,6 @@ export default {
             // element.
             offset: [0, 12],
             positioning: 'top-center',
-            className: 'map-popover-overlay',
             autoPan: { margin: 0 },
         })
     },


### PR DESCRIPTION
Text in the tooltips of features was previously not selectable. This
commit fixes this. The classname map-popover-overlay did not exist.
Removing this classname activates instead the default class name
ol-selectable and ol-overlay-container which makes the text in the
overlay selectable. (The overlay is a child of the openlayersmap which
deactivates selection)


[Test link](https://sys-map.dev.bgdi.ch/preview/bugfix-bgdiinf_sb-2829-cant-copy-from-tooltip/index.html)