### PR TITLE
feat_BGDIINF_SB-2866 limit zoom value

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -188,6 +188,15 @@ export const TILEGRID_RESOLUTIONS = [
 ]
 
 /**
+ * Map view's mininal resolution
+ * Currently set so that OL scalebar displays 10 meters
+ * Scalebar about 1" on screen, hence about 100px.  So, 10 meters/100px = 0.1
+ * Caveat: setting resolution (mininum and maximum) has the precedence over zoom (minimum/maximum)
+ */
+
+export const VIEW_MIN_RESOLUTION = 0.1  // meters/pixel
+
+/**
  * Array of coordinates with bottom left / top right values of the extent. This can be used to
  * constrain OpenLayers (or other mapping framework) to only ask for tiles that are within the
  * extent. It should remove for instance the big white zone that are around the pixelkarte-farbe.

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -102,7 +102,7 @@
 import { EditableFeatureTypes, LayerFeature } from '@/api/features.api'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
 
-import { IS_TESTING_WITH_CYPRESS, VECTOR_LIGHT_BASE_MAP_STYLE_ID } from '@/config'
+import { IS_TESTING_WITH_CYPRESS, VECTOR_LIGHT_BASE_MAP_STYLE_ID, VIEW_MIN_RESOLUTION } from '@/config'
 import { extractOlFeatureGeodesicCoordinates } from "@/modules/drawing/lib/drawingUtils";
 import FeatureEdit from '@/modules/infobox/components/FeatureEdit.vue'
 import FeatureList from '@/modules/infobox/components/FeatureList.vue'
@@ -346,6 +346,7 @@ export default {
         this.view = new View({
             center: this.center,
             zoom: this.zoom,
+            minResolution: VIEW_MIN_RESOLUTION,
             rotation: this.rotation,
         })
         this.map.setView(this.view)
@@ -360,6 +361,7 @@ export default {
         this.map.on('singleclick', this.onMapSingleClick)
         this.map.on('pointerdrag', this.onMapPointerDrag)
         this.map.on('moveend', this.onMapMoveEnd)
+
     },
     unmounted() {
         this.map.un('pointerdown', this.onMapPointerDown)


### PR DESCRIPTION
Adding a configuration variable VIEW_MIN_RESOLUTION to limit the zoom in in the map's view to a reasonable value

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_bgdiinf_sb-2866_limit_view_min_zoom/index.html)