### PR TITLE
BGDIINF_SB-2859: Removing legend button

### DIFF
--- a/src/api/layers/AbstractLayer.class.js
+++ b/src/api/layers/AbstractLayer.class.js
@@ -1,5 +1,5 @@
 import { CoordinateSystems } from '@/utils/coordinateUtils'
-
+import LayerTypes from './LayerTypes.enum'
 /** Name (or description) of a data holder for a layer, with the possibility to define a URL */
 export class LayerAttribution {
     /**
@@ -87,5 +87,9 @@ export default class AbstractLayer {
      */
     async getMetadata() {
         return null
+    }
+
+    get hasLegend() {
+        return this.type !== LayerTypes.KML && !this.isExternal
     }
 }

--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
@@ -97,6 +97,7 @@
                 <FontAwesomeIcon icon="arrow-down" />
             </button>
             <button
+                v-if="showLegendIcon"
                 class="btn d-flex align-items-center"
                 :class="{ 'btn-lg': !compact }"
                 :data-cy="`button-show-legend-layer-${id}`"
@@ -177,6 +178,12 @@ export default {
                 return 'check-square'
             }
             return 'square'
+        },
+        showLegendIcon() {
+            if (this.layer !== null) {
+                return this.layer.hasLegend
+            }
+            return false
         },
     },
     methods: {


### PR DESCRIPTION
Issue : Some layers have no legend, and upon clicking the legend button, the legend popup shows up and looks like it's perpetually loading content.

Fix : We added a `hasLegend` getter in the abstractLayer class, which is then called to decide wheter we show the legend button or not.

Currently, we consider KML and external layers has having no legend. A refinement might be needed further down in the line to ensure layers with legends show the legend icon, but this is sufficient for now.

[Test link](https://sys-map.dev.bgdi.ch/preview/bgdiinf_sb-2859-remomve-legend-icon-when-no-legend/index.html)