### PR TITLE
BGDIINF_SB-2609: consistent rounding

### DIFF
--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -141,23 +141,19 @@ export default {
             return this.clickInfo?.coordinate
         },
         coordinateLV95() {
-            return printHumanReadableCoordinates(
-                reproject(CoordinateSystems.LV95.epsg, this.coordinate),
-                CoordinateSystems.LV95
-            )
+            const lv95_coordinates = reproject(CoordinateSystems.LV95.epsg, this.coordinate)
+            return `${round(lv95_coordinates[0], 2, true)}, ${round(lv95_coordinates[1], 2, true)}`
         },
         coordinateLV03() {
-            return printHumanReadableCoordinates(
-                reproject(CoordinateSystems.LV03.epsg, this.coordinate),
-                CoordinateSystems.LV03
-            )
+            const lv03_coordinates = reproject(CoordinateSystems.LV03.epsg, this.coordinate)
+            return `${round(lv03_coordinates[0], 2, true)}, ${round(lv03_coordinates[1], 2, true)}`
         },
         coordinateWGS84Metric() {
             return reproject(CoordinateSystems.WGS84.epsg, this.coordinate)
         },
         coordinateWGS84Plain() {
             const wgsMetric = this.coordinateWGS84Metric
-            return `${round(wgsMetric[1], 5)}, ${round(wgsMetric[0], 5)}`
+            return `${round(wgsMetric[1], 5, true)}, ${round(wgsMetric[0], 5, true)}`
         },
         coordinateWGS84() {
             const complete = printHumanReadableCoordinates(

--- a/src/utils/numberUtils.js
+++ b/src/utils/numberUtils.js
@@ -4,14 +4,19 @@
  * @param {number} value
  * @param {number} decimals How many decimals after the separator must be present after rounding
  *   (default to 0)
+ * @param {boolean} enforcedigit if set to true, we want to have that many figures after the period.
+ *   Otherwise, we don't care.
  * @returns {number} Value rounded
  */
-export function round(value, decimals = 0) {
+export function round(value, decimals = 0, enforcedigit=false) {
     if (!isNumber(value)) {
         return undefined
     }
     if (decimals === 0) {
         return Math.round(value)
+    }
+    if (enforcedigit) {
+        return value.toFixed(decimals)
     }
     const pow = Math.pow(10, decimals)
     return Math.round(value * pow) / pow

--- a/tests/e2e-cypress/integration/mouseposition.cy.js
+++ b/tests/e2e-cypress/integration/mouseposition.cy.js
@@ -178,7 +178,7 @@ describe('Test mouse position', () => {
             })
             it('Uses the coordination system Plain WGS84 in the popup', () => {
                 cy.get('[data-cy="location-popup-coordinates-plain-wgs84"]').contains(
-                    `${lat}, ${lon}`
+                    `${lat.toFixed(5)}, ${lon.toFixed(5)}`
                 )
             })
             it('Uses the coordination system WGS84 in the popup', () => {


### PR DESCRIPTION
Issue : When displaying longitude and latitude, when the last figure of a number was 0, we would display numbers with a different significant number after the decimal.

Fix : We now use the "toFixed" native js function to have a fixed amount of significant numbers after the decimal.

[Test link](https://sys-map.dev.bgdi.ch/preview/bgdiinf_sb-2609-round-position/index.html)