### PR TITLE
BGDIINF_SB-2501 : add support for embed URL param

### DIFF
--- a/src/modules/i18n/locales/de.json
+++ b/src/modules/i18n/locales/de.json
@@ -614,5 +614,6 @@
 	"send_failed": "Senden fehlgeschlagen",
 	"feedback_email": "Ihre E-Mail Adresse (optional)",
 	"feedback_invalid_email": "ungültige E-Mail",
-	"profile_no_data": "kein Datum"
+	"profile_no_data": "kein Datum",
+	"view_on_mapgeoadminch_webmapviewer": "In {url} ansehen"
 }

--- a/src/modules/i18n/locales/en.json
+++ b/src/modules/i18n/locales/en.json
@@ -614,5 +614,6 @@
 	"send_failed": "Sending failed",
 	"feedback_email": "Your Email (optional)",
 	"feedback_invalid_email": "Invalid email",
-	"profile_no_data": "No data"
+	"profile_no_data": "No data",
+	"view_on_mapgeoadminch_webmapviewer": "View on {url}"
 }

--- a/src/modules/i18n/locales/fr.json
+++ b/src/modules/i18n/locales/fr.json
@@ -614,5 +614,6 @@
 	"send_failed": "Envoi échoué",
 	"feedback_email": "Votre email (facultatif)",
 	"feedback_invalid_email": "e-mail invalide",
-	"profile_no_data": "Aucune donnée"
+	"profile_no_data": "Aucune donnée",
+	"view_on_mapgeoadminch_webmapviewer": "Voir sur {url}"
 }

--- a/src/modules/i18n/locales/it.json
+++ b/src/modules/i18n/locales/it.json
@@ -614,5 +614,6 @@
 	"send_failed": "Invio fallito",
 	"feedback_email": "La sua email (facoltativo)",
 	"feedback_invalid_email": "e-mail non valide",
-	"profile_no_data": "Nessun dato"
+	"profile_no_data": "Nessun dato",
+	"view_on_mapgeoadminch_webmapviewer": "Vedi in {url}"
 }

--- a/src/modules/i18n/locales/rm.json
+++ b/src/modules/i18n/locales/rm.json
@@ -612,5 +612,6 @@
 	"send_failed": "Senden fehlgeschlagen",
 	"feedback_email": "Ihre E-Mail Adresse (optional)",
 	"feedback_invalid_email": "ungültige E-Mail",
-	"profile_no_data": "kein Datum"
+	"profile_no_data": "kein Datum",
+	"view_on_mapgeoadminch_webmapviewer": "Contemplar in {url}"
 }

--- a/src/modules/menu/MenuModule.vue
+++ b/src/modules/menu/MenuModule.vue
@@ -14,7 +14,7 @@
             }"
         >
             <GeolocButton
-                v-if="!isFullscreenMode"
+                v-if="!isFullscreenMode && !isEmbedded"
                 class="mb-1"
                 :is-active="isGeolocationActive"
                 :is-denied="isGeolocationDenied"
@@ -90,6 +90,7 @@ export default {
             isGeolocationDenied: (state) => state.geolocation.denied,
             showMenu: (state) => state.ui.showMenu,
             isFullscreenMode: (state) => state.ui.fullscreenMode,
+            isEmbedded: (state) => state.ui.embeddedMode,
         }),
         ...mapGetters([
             'isHeaderShown',

--- a/src/modules/menu/components/header/SwissFlag.vue
+++ b/src/modules/menu/components/header/SwissFlag.vue
@@ -1,7 +1,7 @@
 <template>
     <img
         class="swiss-flag"
-        :class="{ 'dev-site': hasDevSiteWarning }"
+        :class="{ 'dev-site': hasDevSiteWarning, sm }"
         :src="swissFlagIcon"
         alt="swiss-flag"
         @click="$emit('click', $event)"
@@ -13,6 +13,12 @@ import swissFlagIcon from '@/assets/svg/swiss-flag.svg'
 import { mapGetters } from 'vuex'
 
 export default {
+    props: {
+        sm: {
+            type: Boolean,
+            default: false,
+        },
+    },
     emits: ['click'],
     data() {
         return {
@@ -32,6 +38,9 @@ export default {
 // as it totally breaks the header and menu on Iphone !
 .swiss-flag {
     height: 24px;
+    &.sm {
+        height: 16px;
+    }
     &.dev-site {
         filter: hue-rotate(225deg);
     }
@@ -39,6 +48,9 @@ export default {
 @include respond-above(lg) {
     .swiss-flag {
         height: 34px;
+        &.sm {
+            height: 16px;
+        }
     }
 }
 </style>

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -189,7 +189,7 @@ const legacyPermalinkManagementRouterPlugin = (router, store) => {
         // Waiting for the app to enter the MapView before dealing with legacy param, otherwise
         // the storeSync plugin might overwrite some parameters. To handle legacy param we also
         // need the app to be ready because some data are required (e.g. the layer config)
-        if (isFirstRequest && to.name == 'MapView') {
+        if (isFirstRequest && to.name === 'MapView') {
             // before the first request, we check out if we need to manage any legacy params
             // (from the old viewer)
             isFirstRequest = false

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -196,7 +196,7 @@ export default class LayerParamConfig extends AbstractParamConfig {
             ].join(','),
             dispatchLayersFromUrlIntoStore,
             generateLayerUrlParamFromStoreValues,
-            false,
+            true,
             String
         )
     }

--- a/src/router/storeSync/abstractParamConfig.class.js
+++ b/src/router/storeSync/abstractParamConfig.class.js
@@ -154,7 +154,7 @@ export default class AbstractParamConfig {
      */
     populateStoreWithQueryValue(store, query) {
         return new Promise((resolve, reject) => {
-            if (query && store && this.setValuesInStore) {
+            if ((!this.keepValueInUrlWhenEmpty || query) && store && this.setValuesInStore) {
                 const promiseSetValuesInStore = this.setValuesInStore(store, query)
                 if (promiseSetValuesInStore) {
                     promiseSetValuesInStore.then(() => {

--- a/src/router/storeSync/storeSync.config.js
+++ b/src/router/storeSync/storeSync.config.js
@@ -14,7 +14,7 @@ const storeSyncConfig = [
         'setLang',
         'setLang',
         (store) => store.state.i18n.lang,
-        false,
+        true,
         String
     ),
     new SimpleUrlParamConfig(
@@ -61,7 +61,7 @@ const storeSyncConfig = [
             }
             return backgroundLayerId
         },
-        false,
+        true,
         String
     ),
     new SimpleUrlParamConfig(
@@ -69,7 +69,7 @@ const storeSyncConfig = [
         'changeTopic',
         'setTopicById',
         (store) => store.getters.currentTopicId,
-        false,
+        true,
         String
     ),
     // as the setSearchQuery action requires an object as payload, we need
@@ -94,6 +94,14 @@ const storeSyncConfig = [
         String
     ),
     new LayerParamConfig(),
+    new SimpleUrlParamConfig(
+        'embed',
+        'setEmbeddedMode',
+        'setEmbeddedMode',
+        (store) => store.state.ui.embeddedMode,
+        false,
+        Boolean
+    ),
 ]
 
 export default storeSyncConfig

--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -1,4 +1,4 @@
-import { BREAKPOINT_TABLET, WARNING_RIBBON_HOSTNAMES, NO_WARNING_BANNER_HOSTNAMES } from '@/config'
+import { BREAKPOINT_TABLET, NO_WARNING_BANNER_HOSTNAMES, WARNING_RIBBON_HOSTNAMES } from '@/config'
 
 /**
  * Describes the different mode the UI can have. Either desktop / tablet (menu is always shown, info
@@ -50,6 +50,13 @@ export default {
          * @type Boolean
          */
         fullscreenMode: false,
+        /**
+         * Flag telling if the app must be displayed as an embedded iFrame app (broken down /
+         * simplified UI)
+         *
+         * @type Boolean
+         */
+        embeddedMode: false,
         /**
          * Flag telling if a loading bar should be shown to tell the user something is on going
          *
@@ -123,7 +130,7 @@ export default {
          * @returns {boolean}
          */
         isHeaderShown(state) {
-            return !state.fullscreenMode && !state.showDrawingOverlay
+            return !state.fullscreenMode && !state.showDrawingOverlay && !state.embeddedMode
         },
 
         isPhoneMode(state) {
@@ -170,6 +177,9 @@ export default {
                 commit('setFullscreenMode', !state.fullscreenMode)
             }
         },
+        setEmbeddedMode({ commit }, isEmbedded) {
+            commit('setEmbeddedMode', !!isEmbedded)
+        },
         toggleLoadingBar({ commit, state }) {
             commit('setShowLoadingBar', !state.showLoadingBar)
         },
@@ -202,6 +212,9 @@ export default {
         },
         setFullscreenMode(state, flagValue) {
             state.fullscreenMode = flagValue
+        },
+        setEmbeddedMode(state, flagValue) {
+            state.embeddedMode = flagValue
         },
         setShowLoadingBar(state, flagValue) {
             state.showLoadingBar = flagValue

--- a/src/utils/OpenFullAppLink.vue
+++ b/src/utils/OpenFullAppLink.vue
@@ -1,0 +1,43 @@
+<template>
+    <div class="open-full-app-link m-2 px-2 bg-light border-1 rounded d-flex align-items-center">
+        <SwissFlag :sm="true" class="my-1" />
+        <a class="ms-1 fw-bold text-black" target="_blank" :href="urlWithoutEmbed">
+            {{ linkMessage }}
+        </a>
+    </div>
+</template>
+<script>
+import SwissFlag from '@/modules/menu/components/header/SwissFlag.vue'
+
+export default {
+    components: { SwissFlag },
+    data() {
+        return {
+            currentHost: window.location.host,
+        }
+    },
+    computed: {
+        linkMessage() {
+            return this.$i18n.t('view_on_mapgeoadminch_webmapviewer', { url: this.currentHost })
+        },
+        urlWithoutEmbed() {
+            return window.location.href.replace('&embed=true', '').replace('?embed=true&', '?')
+        },
+    },
+}
+</script>
+
+<style lang="scss" scoped>
+@import 'src/scss/variables';
+.open-full-app-link {
+    position: absolute;
+    z-index: $zindex-map + 1;
+    a {
+        text-decoration: none;
+    }
+    a:hover {
+        text-decoration: underline;
+        cursor: pointer;
+    }
+}
+</style>

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -1,10 +1,11 @@
 <template>
     <div id="map-view">
+        <OpenFullAppLink v-if="embedded" />
         <MapModule>
             <!-- we place the drawing module here so that it can receive the OpenLayers map instance through provide/inject -->
-            <DrawingModule />
+            <DrawingModule v-show="!embedded" />
             <!-- The footer also need to receive the map (for mouse position) -->
-            <MapFooter />
+            <MapFooter v-show="!embedded" />
             <!-- Needed to be able to set an overlay when hovering over the profile with the mouse -->
             <InfoboxModule />
             <!-- needed to e.g. set register an event to set the compass position -->
@@ -21,15 +22,23 @@ import InfoboxModule from '@/modules/infobox/InfoboxModule.vue'
 import MapFooter from '@/modules/map/components/footer/MapFooter.vue'
 import MapModule from '@/modules/map/MapModule.vue'
 import MenuModule from '@/modules/menu/MenuModule.vue'
+import OpenFullAppLink from '@/utils/OpenFullAppLink.vue'
+import { mapState } from 'vuex'
 
 export default {
     components: {
+        OpenFullAppLink,
         DrawingModule,
         InfoboxModule,
         MenuModule,
         MapModule,
         MapFooter,
         I18nModule,
+    },
+    computed: {
+        ...mapState({
+            embedded: (state) => state.ui.embeddedMode,
+        }),
     },
 }
 </script>


### PR DESCRIPTION
when set to true, the UI is simplified to a minimum (zoom in zoom out and a link to open the app in a new tab)

I had to rework a bit the URL parsing tooling for this, as otherwise the embed=false or embed= were staying in the URL. But working on this opened another whole can of worms with app startup and I had to change the logic in some places in the storeSync plugin to fix that (layers and bgLayers were disappearing at startup somehow)