### PR TITLE
BGDIINF_SB-2949: using bgdi buckets serving the terrain.

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -9,3 +9,4 @@ VITE_API_SERVICES_BASE_URL=https://sys-map.dev.bgdi.ch/api/
 VITE_API_SERVICE_KML_BASE_URL=https://sys-public.dev.bgdi.ch/
 VITE_API_SERVICE_KML_STORAGE_BASE_URL=https://sys-public.dev.bgdi.ch/
 VITE_APP_API_SERVICE_SHORTLINK_BASE_URL=https://sys-s.dev.bgdi.ch/
+VITE_APP_3D_TILES_BASE_URL=https://sys-3d.dev.bgdi.ch/

--- a/.env.integration
+++ b/.env.integration
@@ -8,3 +8,4 @@ VITE_API_SERVICES_BASE_URL=https://sys-map.int.bgdi.ch/api/
 VITE_API_SERVICE_KML_BASE_URL=https://sys-public.int.bgdi.ch/
 VITE_API_SERVICE_KML_STORAGE_BASE_URL=https://sys-public.int.bgdi.ch/
 VITE_APP_API_SERVICE_SHORTLINK_BASE_URL=https://sys-s.int.bgdi.ch/
+VITE_APP_3D_TILES_BASE_URL=https://sys-3d.int.bgdi.ch/

--- a/.env.production
+++ b/.env.production
@@ -8,3 +8,4 @@ VITE_API_SERVICES_BASE_URL=https://map.geo.admin.ch/api/
 VITE_API_SERVICE_KML_BASE_URL=https://public.geo.admin.ch/
 VITE_API_SERVICE_KML_STORAGE_BASE_URL=https://public.geo.admin.ch/
 VITE_APP_API_SERVICE_SHORTLINK_BASE_URL=https://s.geo.admin.ch/
+VITE_APP_3D_TILES_BASE_URL=https://3d.geo.admin.ch/

--- a/src/config.js
+++ b/src/config.js
@@ -154,6 +154,13 @@ export const WMTS_BASE_URL = enforceEndingSlashInUrl(import.meta.env.VITE_WMTS_B
 export const WMS_BASE_URL = enforceEndingSlashInUrl(import.meta.env.VITE_WMS_BASE_URL)
 
 /**
+ * Root of the buckets serving 3D tiles
+ *
+ * @type {String}
+ */
+export const BASE_URL_3D_TILES = enforceEndingSlashInUrl(import.meta.env.VITE_APP_3D_TILES_BASE_URL)
+
+/**
  * Default tile size to use when requesting WMS tiles with our internal WMSs (512px)
  *
  * Comes from

--- a/src/modules/map/components/cesium/constants.js
+++ b/src/modules/map/components/cesium/constants.js
@@ -1,6 +1,8 @@
+import { BASE_URL_3D_TILES } from '@/config'
+
 /**
  * 3D terrain URL
  *
  * @type {string}
  */
-export const TERRAIN_URL = 'https://sys-3d.dev.bgdi.ch/ch.swisstopo.terrain.3d/v1/'
+export const TERRAIN_URL = `${BASE_URL_3D_TILES}/ch.swisstopo.terrain.3d/v1/`

--- a/src/modules/map/components/cesium/constants.js
+++ b/src/modules/map/components/cesium/constants.js
@@ -3,4 +3,4 @@
  *
  * @type {string}
  */
-export const TERRAIN_URL = 'https://download.swissgeol.ch/cli_terrain/ch-2m/'
+export const TERRAIN_URL = 'https://sys-3d.dev.bgdi.ch/ch.swisstopo.terrain.3d/v1/'


### PR DESCRIPTION
- DEV: https://sys-3d.dev.bgdi.ch/ch.swisstopo.terrain.3d/v1/
- INT: https://sys-3d.int.bgdi.ch/ch.swisstopo.terrain.3d/v1/
- PROD (not yet): https://3d.geo.admin.ch/ch.swisstopo.terrain.3d/v1/

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-2949-using-bgdi-terrain-dev/index.html)