### PR TITLE
Cesium fixes

### DIFF
--- a/src/modules/map/components/cesium/CesiumMap.vue
+++ b/src/modules/map/components/cesium/CesiumMap.vue
@@ -46,7 +46,7 @@ export default {
             '3d.geo.admin.ch:443': 18,
         })
     },
-    mounted() {
+    async mounted() {
         // The first layer of Cesium is special in that it is always stretched to cover the entire world
         // using a 1x1 transparent image to workaround it.
         // See https://github.com/AnalyticalGraphicsInc/cesium/issues/1323 for details.
@@ -78,9 +78,7 @@ export default {
             skyBox: false,
             imageryProvider: firstImageryProvider,
             useBrowserRecommendedResolution: true,
-            terrainProvider: new CesiumTerrainProvider({
-                url: TERRAIN_URL,
-            }),
+            terrainProvider: await CesiumTerrainProvider.fromUrl(TERRAIN_URL),
             requestRenderMode: true,
         })
 

--- a/src/modules/map/components/cesium/CesiumMap.vue
+++ b/src/modules/map/components/cesium/CesiumMap.vue
@@ -10,6 +10,7 @@ import {
     Rectangle,
     Color,
     Cartesian3,
+    RequestScheduler,
 } from 'cesium'
 import { addSwisstopoWMTSLayer } from './utils/imageryLayerUtils'
 import { mapGetters, mapState } from 'vuex'
@@ -35,6 +36,15 @@ export default {
         // Global variable required for Cesium and point to the URL where four static directories (see vite.config) are served
         // https://cesium.com/learn/cesiumjs-learn/cesiumjs-quickstart/#install-with-npm
         window['CESIUM_BASE_URL'] = '.'
+
+        // A per server key list of overrides to use for throttling limits.
+        // Useful when streaming data from a known HTTP/2 or HTTP/3 server.
+        Object.assign(RequestScheduler.requestsByServer, {
+            'wmts.geo.admin.ch:443': 18,
+            'sys-3d.dev.bgdi.ch:443': 18,
+            'sys-3d.int.bgdi.ch:443': 18,
+            '3d.geo.admin.ch:443': 18,
+        })
     },
     mounted() {
         // The first layer of Cesium is special in that it is always stretched to cover the entire world


### PR DESCRIPTION
@pakb two small fixes for cesium:
 - use `RequestScheduler` to increase the throttling limits, I've only put the wmts and (new) terrain. We can update the list later
 - use `CesiumTerrainProvider.fromUrl`, `url` option is deprecated

[Test link](https://sys-map.dev.bgdi.ch/preview/cesium_fixes/index.html)