### PR TITLE
Update cesium-compass to 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@fortawesome/free-regular-svg-icons": "^6.4.0",
                 "@fortawesome/free-solid-svg-icons": "^6.4.0",
                 "@fortawesome/vue-fontawesome": "^3.0.3",
-                "@geoblocks/cesium-compass": "^0.4.2",
+                "@geoblocks/cesium-compass": "^0.5.0",
                 "@geoblocks/ol-maplibre-layer": "^0.1.1",
                 "@ivanv/vue-collapse-transition": "^1.0.2",
                 "@popperjs/core": "^2.11.8",
@@ -579,9 +579,9 @@
             }
         },
         "node_modules/@geoblocks/cesium-compass": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@geoblocks/cesium-compass/-/cesium-compass-0.4.2.tgz",
-            "integrity": "sha512-B8vfxAvyBsJ/GwHG5BIxneimvQk1Vjq0jlfy+6QTtOwdHUYfS+xpDW1CUwaL4USFsnvfekHwUP3NR9fg3VOXPQ==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@geoblocks/cesium-compass/-/cesium-compass-0.5.0.tgz",
+            "integrity": "sha512-MTtacy3ATsNqkqMbuSWVgzhmgT2xvZNONux46+os7hig6Qk6jcKrU42jP6FVt2F1CBD1An+7qzgAm0GF60jpXw==",
             "dependencies": {
                 "lit": "2.x"
             },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@fortawesome/free-regular-svg-icons": "^6.4.0",
         "@fortawesome/free-solid-svg-icons": "^6.4.0",
         "@fortawesome/vue-fontawesome": "^3.0.3",
-        "@geoblocks/cesium-compass": "^0.4.2",
+        "@geoblocks/cesium-compass": "^0.5.0",
         "@geoblocks/ol-maplibre-layer": "^0.1.1",
         "@ivanv/vue-collapse-transition": "^1.0.2",
         "@popperjs/core": "^2.11.8",


### PR DESCRIPTION
This version applies the minimum distance to terrain 

[Test link](https://sys-map.dev.bgdi.ch/preview/bgdiinf_sb-3019_update_cesium-compass/index.html)