### PR TITLE
BGDIINF_SB-2927 : keep pin on search

### DIFF
--- a/src/api/__tests__/search.api.spec.js
+++ b/src/api/__tests__/search.api.spec.js
@@ -5,8 +5,8 @@ import { describe, it } from 'vitest'
 describe('Builds object by extracting all relevant attributes from the backend', () => {
     describe('FeatureSearchResult.getSimpleTitle', () => {
         it('Returns title removing HTML', () => {
-            const expectedResult = 'Test 123 Test'
-            const expectedResultWrappedInHtml = `<i>Some irrelevant stuff</i><b>${expectedResult}</b>`
+            const expectedResult = 'Some irrelevant stuff 123 Test'
+            const expectedResultWrappedInHtml = '<i>Some irrelevant stuff</i> <b>123 Test</b>'
             const testInstance = new FeatureSearchResult(
                 expectedResultWrappedInHtml,
                 '',

--- a/src/api/search.api.js
+++ b/src/api/search.api.js
@@ -17,8 +17,8 @@ export const RESULT_TYPE = {
     LOCATION: 'LOCATION',
 }
 
-// used to parse backend results and extract the title from sub-titles and other stuff
-const REGEX_RESULT_TITLE = /<b>(.*?)<\/b>/i
+// comes from https://stackoverflow.com/questions/5002111/how-to-strip-html-tags-from-string-in-javascript
+const REGEX_DETECT_HTML_TAGS = /<\/?[^>]+(>|$)/g
 
 /** @abstract */
 export class SearchResult {
@@ -37,12 +37,12 @@ export class SearchResult {
         return this.getSimpleTitle()
     }
 
-    /** @returns The title without any HTML tags (will only keep what's inside <b> tag if there are) */
+    /**
+     * @returns String The title without any HTML tags (will only keep what's inside <b> tag if
+     *   there are)
+     */
     getSimpleTitle() {
-        if (REGEX_RESULT_TITLE.test(this.title)) {
-            return REGEX_RESULT_TITLE.exec(this.title)[1]
-        }
-        return this.title
+        return this.title.replace(REGEX_DETECT_HTML_TAGS, '')
     }
 }
 

--- a/src/api/search.api.js
+++ b/src/api/search.api.js
@@ -37,10 +37,7 @@ export class SearchResult {
         return this.getSimpleTitle()
     }
 
-    /**
-     * @returns String The title without any HTML tags (will only keep what's inside <b> tag if
-     *   there are)
-     */
+    /** @returns String The title without any HTML tags (will keep what's inside <b> or <i> tags if there are) */
     getSimpleTitle() {
         return this.title.replace(REGEX_DETECT_HTML_TAGS, '')
     }

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -45,6 +45,12 @@
             :marker-style="markerStyles.BALLOON"
             :z-index="zIndexDroppedPinned"
         />
+        <OpenLayersMarker
+            v-if="previewedPinnedLocation"
+            :position="previewedPinnedLocation"
+            :marker-style="markerStyles.BALLOON"
+            :z-index="zIndexPreviewedDroppedPinned"
+        />
         <!-- Showing cross hair if needed-->
         <OpenLayersMarker
             v-if="crossHairStyle"
@@ -178,6 +184,7 @@ export default {
             center: (state) => state.position.center,
             selectedFeatures: (state) => state.features.selectedFeatures,
             pinnedLocation: (state) => state.map.pinnedLocation,
+            previewedPinnedLocation: (state) => state.map.previewedPinnedLocation,
             mapIsBeingDragged: (state) => state.map.isBeingDragged,
             geolocationActive: (state) => state.geolocation.active,
             geolocationPosition: (state) => state.geolocation.position,
@@ -247,8 +254,11 @@ export default {
         zIndexDroppedPinned() {
             return this.startingZIndexForVisibleLayers + this.visibleLayers.length
         },
+        zIndexPreviewedDroppedPinned() {
+            return this.zIndexDroppedPinned + (this.previewedPinnedLocation ? 1 : 0)
+        },
         zIndexCrossHair() {
-            return this.zIndexDroppedPinned + (this.pinnedLocation ? 1 : 0)
+            return this.zIndexPreviewedDroppedPinned + (this.pinnedLocation ? 1 : 0)
         },
         startingZIndexForHighlightedFeatures() {
             return this.zIndexCrossHair + (this.crossHairStyle ? 1 : 0)

--- a/src/modules/menu/components/search/SearchBar.vue
+++ b/src/modules/menu/components/search/SearchBar.vue
@@ -7,7 +7,7 @@
             ref="search"
             type="text"
             class="form-control search-bar-input"
-            :class="{ 'rounded-end': searchQuery?.length == 0 }"
+            :class="{ 'rounded-end': searchQuery?.length === 0 }"
             :placeholder="$t('search_placeholder')"
             aria-label="Search"
             aria-describedby="button-addon1"

--- a/src/modules/menu/components/search/SearchResultCategory.vue
+++ b/src/modules/menu/components/search/SearchResultCategory.vue
@@ -1,25 +1,11 @@
 <template>
-    <div v-show="entries.length > 0" class="search-category">
+    <div class="search-category">
         <div class="search-category-header p-2">
             {{ title }}
         </div>
         <ul class="search-category-body">
-            <SearchResultListEntry
-                v-for="(entry, index) in entries"
-                :key="index"
-                :index="index"
-                :entry="entry"
-                @show-layer-legend-popup="showLayerLegendPopup"
-                @preview-start="bubbleEvent('previewStart', $event)"
-                @preview-stop="bubbleEvent('previewStop', $event)"
-            />
+            <slot />
         </ul>
-
-        <LayerLegendPopup
-            v-if="showLayerLegendForId"
-            :layer-id="showLayerLegendForId"
-            @close="closeLayerLegendPopup"
-        />
     </div>
 </template>
 
@@ -32,32 +18,10 @@ import SearchResultListEntry from './SearchResultListEntry.vue'
  * component is there to show one of those category at a time
  */
 export default {
-    components: { SearchResultListEntry, LayerLegendPopup },
     props: {
-        entries: {
-            type: Array,
-            required: true,
-        },
         title: {
             type: String,
             required: true,
-        },
-    },
-    emits: ['preview', 'previewStart', 'previewStop'],
-    data() {
-        return {
-            showLayerLegendForId: null,
-        }
-    },
-    methods: {
-        showLayerLegendPopup(id) {
-            this.showLayerLegendForId = id
-        },
-        closeLayerLegendPopup() {
-            this.showLayerLegendForId = null
-        },
-        bubbleEvent(type, payload) {
-            this.$emit(type, payload)
         },
     },
 }

--- a/src/modules/menu/components/search/SearchResultList.vue
+++ b/src/modules/menu/components/search/SearchResultList.vue
@@ -17,45 +17,60 @@
                     :title="$t('locations_results_header')"
                     :entries="results.locationResults"
                     data-cy="search-results-locations"
-                    @preview-start="setPinnedLocation"
-                />
+                >
+                    <SearchResultListEntry
+                        v-for="(location, index) in results.locationResults"
+                        :key="index"
+                        :index="index"
+                        :entry="location"
+                    />
+                </SearchResultCategory>
                 <SearchResultCategory
                     :title="$t('layers_results_header')"
                     :entries="results.layerResults"
                     data-cy="search-results-layers"
-                    @preview-start="setPreviewLayer"
-                    @preview-stop="clearPreviewLayer"
-                />
+                >
+                    <SearchResultListEntry
+                        v-for="(layer, index) in results.layerResults"
+                        :key="index"
+                        :index="index"
+                        :entry="layer"
+                        @show-layer-legend-popup="showLayerLegendForId = layer.layerId"
+                    />
+                </SearchResultCategory>
             </div>
         </div>
+        <LayerLegendPopup
+            v-if="showLayerLegendForId"
+            :layer-id="showLayerLegendForId"
+            @close="showLayerLegendForId = null"
+        />
     </div>
 </template>
 
 <script>
 import { mapActions, mapState, mapGetters } from 'vuex'
 import SearchResultCategory from './SearchResultCategory.vue'
+import SearchResultListEntry from '@/modules/menu/components/search/SearchResultListEntry.vue'
+import LayerLegendPopup from '@/modules/menu/components/LayerLegendPopup.vue'
 
 /**
  * Component showing all results from the search, divided in two groups (categories) : layers and
  * locations
  */
 export default {
-    components: { SearchResultCategory },
+    components: { LayerLegendPopup, SearchResultListEntry, SearchResultCategory },
     emits: ['close'],
+    data() {
+        return {
+            showLayerLegendForId: null,
+        }
+    },
     computed: {
         ...mapState({
             results: (state) => state.search.results,
-            showResults: (state) => state.search.show,
         }),
         ...mapGetters(['isPhoneMode', 'hasDevSiteWarning']),
-    },
-    methods: {
-        ...mapActions([
-            'setPinnedLocation',
-            'clearPinnedLocation',
-            'setPreviewLayer',
-            'clearPreviewLayer',
-        ]),
     },
 }
 </script>
@@ -66,6 +81,7 @@ export default {
 
 .search-results-container {
     position: fixed;
+    z-index: $zindex-menu-header;
     top: $header-height;
     // 45vh (so that previews are visible), but on small screen min 20rem (ca. 3 lines per category)
     height: min(calc(100vh - $header-height), max(20rem, 45vh));

--- a/src/modules/menu/components/search/SearchResultList.vue
+++ b/src/modules/menu/components/search/SearchResultList.vue
@@ -18,7 +18,6 @@
                     :entries="results.locationResults"
                     data-cy="search-results-locations"
                     @preview-start="setPinnedLocation"
-                    @preview-stop="clearPinnedLocation"
                 />
                 <SearchResultCategory
                     :title="$t('layers_results_header')"

--- a/src/modules/menu/components/search/SearchResultListEntry.vue
+++ b/src/modules/menu/components/search/SearchResultListEntry.vue
@@ -8,7 +8,7 @@
         @keydown.down.prevent="goToNext"
         @keydown.home.prevent="goToFirst"
         @keydown.end.prevent="goToLast"
-        @keypress.enter.prevent="selectItem"
+        @keyup.enter="selectItem"
         @mouseenter="startResultPreview"
         @mouseleave="stopResultPreview"
     >
@@ -48,19 +48,26 @@ export default {
             required: true,
         },
     },
-    emits: ['showLayerLegendPopup', 'previewStart', 'previewStop'],
+    emits: ['showLayerLegendPopup'],
     computed: {
         resultType() {
             return this.entry.resultType.toLowerCase()
         },
     },
     methods: {
-        ...mapActions(['selectResultEntry']),
+        ...mapActions([
+            'selectResultEntry',
+            'setPinnedLocation',
+            'setPreviewedPinnedLocation',
+            'clearPinnedLocation',
+            'setPreviewLayer',
+            'clearPreviewLayer',
+        ]),
         selectItem() {
             this.selectResultEntry(this.entry)
         },
         showLayerLegendPopup() {
-            this.$emit('showLayerLegendPopup', this.entry.layerId)
+            this.$emit('showLayerLegendPopup')
         },
         goToPrevious() {
             this.changeFocus(this.$refs.item.previousElementSibling)
@@ -83,13 +90,17 @@ export default {
         },
         startResultPreview() {
             if (this.resultType === 'layer') {
-                this.$emit('previewStart', this.entry.layerId)
+                this.setPreviewLayer(this.entry.layerId)
             } else {
-                this.$emit('previewStart', this.entry.coordinates)
+                this.setPreviewedPinnedLocation(this.entry.coordinates)
             }
         },
         stopResultPreview() {
-            this.$emit('previewStop')
+            if (this.resultType === 'layer') {
+                this.clearPreviewLayer()
+            } else {
+                this.setPreviewedPinnedLocation(null)
+            }
         },
     },
 }

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -19,8 +19,8 @@ $zindex-modal: 100;
 $zindex-loading-screen: 101;
 
 // Menu stacking context
-$zindex-menu-tray: 1; // one step behind the header so that it can slip behind when closed, but above the toolbox buttons
-$zindex-menu-header: 2;
+$zindex-menu-tray: $zindex-menu; // one step behind the header so that it can slip behind when closed, but above the toolbox buttons
+$zindex-menu-header: $zindex-menu + 1;
 /* in order to have the header slip behind the drawing toolbox when the hiding animation
 occurs (teleported in the menu context)*/
 $zindex-drawing-toolbox: 3;

--- a/src/store/modules/map.store.js
+++ b/src/store/modules/map.store.js
@@ -79,10 +79,9 @@ export default {
          * @param {Number[]} coordinates Dropped pin location expressed in EPSG:3857
          */
         setPinnedLocation: ({ commit }, coordinates) => {
+            commit('setPinnedLocation', null)
             if (Array.isArray(coordinates) && coordinates.length === 2) {
                 commit('setPinnedLocation', coordinates)
-            } else {
-                commit('setPinnedLocation', null)
             }
         },
         clearPinnedLocation({ commit }) {

--- a/src/store/modules/map.store.js
+++ b/src/store/modules/map.store.js
@@ -52,6 +52,13 @@ export default {
          */
         pinnedLocation: null,
         /**
+         * @type Array<Number> Same thing as pinnedLocation, will be used to show location of search
+         *   entries when they are hovered. If we use the same pinned location as the one above, the
+         *   pinned location is lost as soon as another one is hovered (meaning that the search bar
+         *   is still filled with a search query, but no pinned location is present anymore)
+         */
+        previewedPinnedLocation: null,
+        /**
          * The current applied map projection for anything displayed to the user (footer mouse
          * position for instance)
          *
@@ -79,9 +86,21 @@ export default {
          * @param {Number[]} coordinates Dropped pin location expressed in EPSG:3857
          */
         setPinnedLocation: ({ commit }, coordinates) => {
-            commit('setPinnedLocation', null)
             if (Array.isArray(coordinates) && coordinates.length === 2) {
                 commit('setPinnedLocation', coordinates)
+            } else {
+                commit('setPinnedLocation', null)
+            }
+        },
+        /**
+         * @param commit
+         * @param {Number[]} coordinates Dropped pin location expressed in EPSG:3857
+         */
+        setPreviewedPinnedLocation({ commit }, coordinates) {
+            if (Array.isArray(coordinates) && coordinates.length === 2) {
+                commit('setPreviewedPinnedLocation', coordinates)
+            } else {
+                commit('setPreviewedPinnedLocation', null)
             }
         },
         clearPinnedLocation({ commit }) {
@@ -112,6 +131,8 @@ export default {
         mapStartBeingDragged: (state) => (state.isBeingDragged = true),
         mapStoppedBeingDragged: (state) => (state.isBeingDragged = false),
         setPinnedLocation: (state, coordinates) => (state.pinnedLocation = coordinates),
+        setPreviewedPinnedLocation: (state, coordinate) =>
+            (state.previewedPinnedLocation = coordinate),
         setDisplayedProjection: (state, projection) => (state.displayedProjection = projection),
         setDisplayLocationPopup: (state, display) => (state.displayLocationPopup = display),
     },

--- a/tests/e2e-cypress/integration/search/search-results.cy.js
+++ b/tests/e2e-cypress/integration/search/search-results.cy.js
@@ -255,7 +255,7 @@ describe('Test the search bar result handling', () => {
         // Enter should select the focused entry.
         cy.get(searchbarSelector).focus()
         cy.focused().trigger('keydown', { key: 'ArrowDown' })
-        cy.focused().trigger('keypress', { key: 'Enter' })
+        cy.focused().trigger('keyup', { key: 'Enter' })
 
         cy.readStoreValue('state.map.pinnedLocation').then((pinnedLocation) =>
             checkLocation(expectedCenterEpsg3857, pinnedLocation)
@@ -272,7 +272,7 @@ describe('Test the search bar result handling', () => {
 
         // Location - Enter
         cy.get(locationSelector).first().trigger('mouseenter')
-        cy.readStoreValue('state.map.pinnedLocation').then((pinnedLocation) => {
+        cy.readStoreValue('state.map.previewedPinnedLocation').then((pinnedLocation) => {
             checkLocation(expectedCenterEpsg3857, pinnedLocation)
         })
         // Location - Leave


### PR DESCRIPTION
Issue : When selecting a search option, the pin would then disappear, only remaining on preview.

Fix : The pin clear used to be done when the search selection was no longer selected. It's now called upon selecting a new search item, right before asking to pin the new location

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-2927-add-marker-after-address-selection/index.html)