### PR TITLE
BGDIINF_SB-3105 : layer's z-index rewrite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,6 @@
                 "jsdom": "^22.1.0",
                 "mime-types": "^2.1.35",
                 "mocha-junit-reporter": "^2.2.1",
-                "pre-commit": "^1.2.2",
                 "prettier": "^3.0.2",
                 "prettier-plugin-jsdoc": "^1.0.1",
                 "rimraf": "^5.0.1",
@@ -3443,12 +3442,6 @@
             "engines": {
                 "node": ">= 0.10.0"
             }
-        },
-        "node_modules/core-util-is": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "dev": true
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -8585,15 +8578,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/os-shim": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-            "integrity": "sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/ospath": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
@@ -8951,78 +8935,6 @@
             "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
             "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw=="
         },
-        "node_modules/pre-commit": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
-            "integrity": "sha512-qokTiqxD6GjODy5ETAIgzsRgnBWWQHQH2ghy86PU7mIn/wuWeTwF3otyNQZxWBwVn8XNr8Tdzj/QfUXpH+gRZA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "dependencies": {
-                "cross-spawn": "^5.0.1",
-                "spawn-sync": "^1.0.15",
-                "which": "1.2.x"
-            }
-        },
-        "node_modules/pre-commit/node_modules/cross-spawn": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-            "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-            }
-        },
-        "node_modules/pre-commit/node_modules/lru-cache": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-            "dev": true,
-            "dependencies": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-            }
-        },
-        "node_modules/pre-commit/node_modules/shebang-command": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-            "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-            "dev": true,
-            "dependencies": {
-                "shebang-regex": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/pre-commit/node_modules/shebang-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/pre-commit/node_modules/which": {
-            "version": "1.2.14",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-            "integrity": "sha512-16uPglFkRPzgiUXYMi1Jf8Z5EzN1iB4V0ZtMXcHZnwsBtQhhHeCqoWw7tsUY42hJGNDWtUsVLTjakIa5BgAxCw==",
-            "dev": true,
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "which": "bin/which"
-            }
-        },
-        "node_modules/pre-commit/node_modules/yallist": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-            "dev": true
-        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9127,12 +9039,6 @@
             "engines": {
                 "node": ">= 0.6.0"
             }
-        },
-        "node_modules/process-nextick-args": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "dev": true
         },
         "node_modules/proj4": {
             "version": "2.9.0",
@@ -9899,47 +9805,6 @@
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
-            }
-        },
-        "node_modules/spawn-sync": {
-            "version": "1.0.15",
-            "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-            "integrity": "sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "dependencies": {
-                "concat-stream": "^1.4.7",
-                "os-shim": "^0.1.2"
-            }
-        },
-        "node_modules/spawn-sync/node_modules/concat-stream": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-            "dev": true,
-            "engines": [
-                "node >= 0.8"
-            ],
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-            }
-        },
-        "node_modules/spawn-sync/node_modules/readable-stream": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-            "dev": true,
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
             }
         },
         "node_modules/split": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
         "jsdom": "^22.1.0",
         "mime-types": "^2.1.35",
         "mocha-junit-reporter": "^2.2.1",
-        "pre-commit": "^1.2.2",
         "prettier": "^3.0.2",
         "prettier-plugin-jsdoc": "^1.0.1",
         "rimraf": "^5.0.1",
@@ -116,10 +115,6 @@
         "vue-tsc": "^1.8.8",
         "yargs": "^17.7.2"
     },
-    "pre-commit": [
-        "lint",
-        "test:unit"
-    ],
     "engines": {
         "node": ">=18",
         "npm": "9.*.*"

--- a/src/api/layers/AbstractLayer.class.js
+++ b/src/api/layers/AbstractLayer.class.js
@@ -1,5 +1,6 @@
 import { WEBMERCATOR } from '@/utils/coordinateSystems'
 import LayerTypes from './LayerTypes.enum'
+
 /** Name (or description) of a data holder for a layer, with the possibility to define a URL */
 export class LayerAttribution {
     /**
@@ -48,7 +49,7 @@ export default class AbstractLayer {
         this.type = type
         this.opacity = opacity
         this.visible = visible
-        this.attributions = attributions
+        this.attributions = [...attributions]
         this.hasTooltip = hasTooltip
         this.isExternal = isExternal
         // default projection used, as we want to achieve worldwide coverage, is web mercator metric

--- a/src/api/layers/ExternalGroupOfLayers.class.js
+++ b/src/api/layers/ExternalGroupOfLayers.class.js
@@ -1,0 +1,23 @@
+import ExternalLayer from '@/api/layers/ExternalLayer.class'
+import LayerTypes from '@/api/layers/LayerTypes.enum'
+
+/**
+ * Description of a group of layers, that could be added altogether or separately, that stems from a getCapabilities XML parsing. (see https://www.mediamaps.ch/ogc/schemas-xsdoc/sld/1.2/capabilities_1_3_0_xsd.html#Layer)
+ *
+ * If the group of layer is added to the map, all layers being part of it should be added under this group's name "banner"
+ */
+export default class ExternalGroupOfLayers extends ExternalLayer {
+    /**
+     * @param {String} name Name of this layer to be shown to the user
+     * @param {String} hostname getCapabilities URL host name, so that it can be used in the ID generation
+     * @param {ExternalLayer[]} layers Description of the layers being part of this group (they will all be displayed at the same time, in contrast to an aggregate layer)
+     */
+    constructor(name, hostname, ...layers) {
+        super(name, LayerTypes.GROUP, `${hostname}:${name.replaceAll(' ', '_')}`, null, 1, true)
+        this.layers = [...layers]
+    }
+
+    getID() {
+        return this.externalLayerId
+    }
+}

--- a/src/api/layers/ExternalGroupOfLayers.class.js
+++ b/src/api/layers/ExternalGroupOfLayers.class.js
@@ -20,4 +20,10 @@ export default class ExternalGroupOfLayers extends ExternalLayer {
     getID() {
         return this.externalLayerId
     }
+
+    clone() {
+        let clone = super.clone()
+        clone.layers = this.layers.map((layer) => layer.clone())
+        return clone
+    }
 }

--- a/src/api/layers/GeoAdminWMTSLayer.class.js
+++ b/src/api/layers/GeoAdminWMTSLayer.class.js
@@ -29,7 +29,7 @@ export default class GeoAdminWMTSLayer extends GeoAdminLayer {
         id = '',
         opacity = 1.0,
         visible = false,
-        attributions,
+        attributions = [],
         format = 'png',
         timeConfig = null,
         isBackground = false,

--- a/src/api/layers/LayerTypes.enum.js
+++ b/src/api/layers/LayerTypes.enum.js
@@ -9,5 +9,6 @@ const LayerTypes = {
     AGGREGATE: 'aggregate',
     KML: 'kml',
     VECTOR: 'vector',
+    GROUP: 'group',
 }
 export default LayerTypes

--- a/src/modules/map/components/footer/MapFooterAttributionList.vue
+++ b/src/modules/map/components/footer/MapFooterAttributionList.vue
@@ -38,13 +38,9 @@ export default {
     computed: {
         ...mapState({
             layersConfig: (state) => state.layers.config,
+            currentBackgroundLayer: (state) => state.layers.currentBackgroundLayer,
         }),
-        ...mapGetters([
-            'visibleLayers',
-            'currentBackgroundLayer',
-            'hasDataDisclaimer',
-            'isExtentOnlyWithinLV95Bounds',
-        ]),
+        ...mapGetters(['visibleLayers', 'hasDataDisclaimer', 'isExtentOnlyWithinLV95Bounds']),
         layers() {
             const layers = []
             // when the background is void, we receive `undefined` here

--- a/src/modules/map/components/footer/MapFooterBackgroundSelector.vue
+++ b/src/modules/map/components/footer/MapFooterBackgroundSelector.vue
@@ -66,9 +66,9 @@ export default {
         }
     },
     computed: {
-        ...mapGetters(['backgroundLayers', 'currentBackgroundLayer']),
+        ...mapGetters(['backgroundLayers']),
         ...mapState({
-            currentBackgroundLayerId: (state) => state.layers.backgroundLayerId,
+            currentBackgroundLayer: (state) => state.layers.currentBackgroundLayer,
         }),
         currentBackgroundLayerWithVoid() {
             if (!this.currentBackgroundLayer) {

--- a/src/modules/map/components/openlayers/OpenLayersInternalLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersInternalLayer.vue
@@ -39,6 +39,14 @@
             :style-url="layerConfig.styleUrl"
             :z-index="zIndex"
         />
+        <div v-if="layerConfig.type === LayerTypes.GROUP">
+            <open-layers-internal-layer
+                v-for="(layer, index) in layerConfig.layers"
+                :key="`${layer.getID()}-${index}`"
+                :layer-config="layer"
+                :z-index="zIndex + index"
+            />
+        </div>
         <!--
         Aggregate layers are some kind of a edge case where two or more layers are joint together but only one of them
         is visible depending on the map resolution.

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -183,6 +183,7 @@ export default {
             zoom: (state) => state.position.zoom,
             rotation: (state) => state.position.rotation,
             center: (state) => state.position.center,
+            currentBackgroundLayer: (state) => state.layers.currentBackgroundLayer,
             selectedFeatures: (state) => state.features.selectedFeatures,
             pinnedLocation: (state) => state.map.pinnedLocation,
             previewedPinnedLocation: (state) => state.map.previewedPinnedLocation,
@@ -198,7 +199,6 @@ export default {
         }),
         ...mapGetters([
             'visibleLayers',
-            'currentBackgroundLayer',
             'isExtentOnlyWithinLV95Bounds',
             'resolution',
             'isCurrentlyDrawing',

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -31,12 +31,12 @@
         />
         <!-- Adding all other layers -->
         <OpenLayersInternalLayer
-            v-for="(layer, index) in visibleLayers"
+            v-for="layer in visibleLayers"
             :key="layer.getID()"
             :layer-config="layer"
             :preview-year="previewYear"
             :current-map-resolution="resolution"
-            :z-index="index + startingZIndexForVisibleLayers"
+            :z-index="zIndexForVisibleLayer(layer)"
         />
         <!-- Adding pinned location -->
         <OpenLayersMarker
@@ -204,6 +204,7 @@ export default {
             'isCurrentlyDrawing',
             'backgroundLayers',
             'isDesktopMode',
+            'zIndexForVisibleLayer',
         ]),
         crossHairStyle() {
             if (this.crossHair) {

--- a/src/modules/menu/components/topics/MenuTopicSection.vue
+++ b/src/modules/menu/components/topics/MenuTopicSection.vue
@@ -107,7 +107,7 @@ export default {
         onClickTopicItem(layerId) {
             const layer = this.getActiveLayerById(layerId)
             if (layer) {
-                this.toggleLayerVisibility(layerId)
+                this.toggleLayerVisibility(layer)
             } else {
                 this.addLayer(new ActiveLayerConfig(layerId, true))
             }

--- a/src/router/storeSync/storeSync.config.js
+++ b/src/router/storeSync/storeSync.config.js
@@ -1,8 +1,8 @@
+import CameraParamConfig from '@/router/storeSync/CameraParamConfig.class'
 import CustomDispatchUrlParamConfig from '@/router/storeSync/CustomDispatchUrlParamConfig.class'
 import LayerParamConfig from '@/router/storeSync/LayerParamConfig.class'
-import CameraParamConfig from '@/router/storeSync/CameraParamConfig.class'
-import SimpleUrlParamConfig from '@/router/storeSync/SimpleUrlParamConfig.class'
 import QueryToStoreOnlyParamConfig from '@/router/storeSync/QueryToStoreOnlyParamConfig.class'
+import SimpleUrlParamConfig from '@/router/storeSync/SimpleUrlParamConfig.class'
 
 /**
  * Configuration for all URL parameters of this app that need syncing with the store (and
@@ -70,12 +70,12 @@ const storeSyncConfig = [
         'setBackground',
         'setBackground',
         (store) => {
-            const backgroundLayerId = store.state.layers.backgroundLayerId
-            // if background layer ID is null (no background) we write 'void' in the URL
-            if (backgroundLayerId === null) {
+            const backgroundLayer = store.state.layers.currentBackgroundLayer
+            // if background layer is null (no background) we write 'void' in the URL
+            if (backgroundLayer === null) {
                 return 'void'
             }
-            return backgroundLayerId
+            return backgroundLayer.getID()
         },
         true,
         String

--- a/src/store/modules/__tests__/layers.store.spec.js
+++ b/src/store/modules/__tests__/layers.store.spec.js
@@ -1,0 +1,125 @@
+import AbstractLayer from '@/api/layers/AbstractLayer.class'
+import GeoAdminWMSLayer from '@/api/layers/GeoAdminWMSLayer.class'
+import GeoAdminWMTSLayer from '@/api/layers/GeoAdminWMTSLayer.class'
+import LayerTimeConfig from '@/api/layers/LayerTimeConfig.class'
+import store from '@/store'
+import { expect } from 'chai'
+import { beforeEach, describe, it } from 'vitest'
+
+const bgLayer = new GeoAdminWMTSLayer('background', 'bg.layer', 1.0, true, [], 'jpeg', null, true)
+const firstLayer = new GeoAdminWMTSLayer('First layer', 'first.layer', 1.0, true, [])
+const secondLayer = new GeoAdminWMSLayer(
+    'Second layer',
+    'second.layer',
+    1.0,
+    true,
+    [],
+    '',
+    'png',
+    new LayerTimeConfig()
+)
+
+const resetStore = async () => {
+    await store.dispatch('clearLayers')
+    await store.dispatch('setBackground', null)
+    await store.dispatch('setLayerConfig', [])
+}
+
+describe('Background layer is correctly set', () => {
+    const getBackgroundLayer = () => store.state.layers.currentBackgroundLayer
+
+    beforeEach(async () => {
+        await resetStore()
+    })
+
+    it('does not have a background selected by default', () => {
+        expect(getBackgroundLayer()).to.be.null
+    })
+    it('does not select a background if the one given is not present in the config', async () => {
+        await store.dispatch('setBackground', bgLayer.getID())
+        expect(getBackgroundLayer()).to.be.null
+    })
+    it('does select the background if it is present in the config', async () => {
+        await store.dispatch('setLayerConfig', [bgLayer])
+        await store.dispatch('setBackground', bgLayer.getID())
+        expect(getBackgroundLayer()).to.be.an.instanceof(AbstractLayer)
+        expect(getBackgroundLayer().getID()).to.eq(bgLayer.getID())
+    })
+    it('does not permit to select a background that has not the flag isBackground set to true', async () => {
+        await store.dispatch('setLayerConfig', [firstLayer])
+        await store.dispatch('setBackground', firstLayer.getID())
+        expect(getBackgroundLayer()).to.be.null
+    })
+})
+
+describe('Add layer creates copy of layers config (so that we may add multiple time the same layer)', () => {
+    const checkRefNotEqButDeepEq = (expected, result) => {
+        expect(result).to.not.be.eq(expected)
+        expect(result).to.deep.eq(expected)
+    }
+
+    beforeEach(async () => {
+        await resetStore()
+        await store.dispatch('setLayerConfig', [bgLayer, firstLayer, secondLayer])
+    })
+    it('creates a copy of the layers config when adding a layer through its ID', async () => {
+        await store.dispatch('addLayer', firstLayer.getID())
+        checkRefNotEqButDeepEq(firstLayer, store.getters.getActiveLayerById(firstLayer.getID()))
+    })
+    it('creates a copy of the layers config when adding with the config directly', async () => {
+        await store.dispatch('addLayer', firstLayer)
+        checkRefNotEqButDeepEq(firstLayer, store.getters.getActiveLayerById(firstLayer.getID()))
+        // now the same test, but by grabbing the first layer's config directly from the store's config
+        checkRefNotEqButDeepEq(
+            store.state.layers.config.find((layer) => layer.getID() === firstLayer.getID()),
+            store.getters.getActiveLayerById(firstLayer.getID())
+        )
+    })
+    it('does not force the visibility of the layer to true when adding it', async () => {
+        const invisibleLayer = firstLayer.clone()
+        invisibleLayer.visible = false
+        await store.dispatch('setLayerConfig', [bgLayer, invisibleLayer, secondLayer])
+        await store.dispatch('addLayer', invisibleLayer)
+        const addedLayer = store.getters.getActiveLayerById(invisibleLayer.getID())
+        expect(addedLayer).to.be.an.instanceof(AbstractLayer)
+        expect(addedLayer.visible).to.be.false
+    })
+})
+
+describe('Visible layers are filtered correctly by the store', () => {
+    const getVisibleLayers = () => store.getters.visibleLayers
+
+    beforeEach(async () => {
+        await resetStore()
+        await store.dispatch('setLayerConfig', [bgLayer, firstLayer, secondLayer])
+    })
+
+    it('gives an empty array if no layer has been added', () => {
+        expect(getVisibleLayers()).to.be.an('Array').empty
+    })
+    it('does not give background layers with the visible layers', async () => {
+        await store.dispatch('setBackground', bgLayer.getID())
+        expect(getVisibleLayers()).to.be.an('Array').empty
+    })
+    it('adds correctly a layer to the visible layers after it is added to the map', async () => {
+        await store.dispatch('addLayer', firstLayer)
+        expect(getVisibleLayers()).to.be.an('Array').lengthOf(1)
+        const [layer] = getVisibleLayers()
+        expect(layer).to.be.an.instanceof(AbstractLayer)
+        expect(layer.getID()).to.eq(firstLayer.getID())
+    })
+    it('removes a layer from the visible layers as soon as its visibility is toggled', async () => {
+        expect(getVisibleLayers()).to.be.an('Array').empty
+        await store.dispatch('addLayer', firstLayer)
+        expect(getVisibleLayers()).to.be.an('Array').lengthOf(1)
+        await store.dispatch('toggleLayerVisibility', firstLayer)
+        expect(getVisibleLayers()).to.be.an('Array').empty
+    })
+    it('does not adds a layer to the visible layers if its visible flag is set to false when added', async () => {
+        const invisibleLayer = firstLayer.clone()
+        invisibleLayer.visible = false
+        await store.dispatch('setLayersConfig', [bgLayer, invisibleLayer, secondLayer])
+        await store.dispatch('addLayer', invisibleLayer)
+        expect(getVisibleLayers()).to.be.an('Array').empty
+    })
+})

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -128,15 +128,18 @@ const getters = {
      *
      * If the layer is not part of the visible layers (or is null or invalid), this will return -1 as a result
      *
-     * @param {AbstractLayer} layerIdOrObject
+     * @param {AbstractLayer | String} layerIdOrObject
      * @returns {Number}
      */
     zIndexForVisibleLayer: (state, getters) => (layerIdOrObject) => {
         let lookupId
         if (layerIdOrObject instanceof AbstractLayer) {
             lookupId = layerIdOrObject.getID()
-        } else {
+        } else if (typeof layerIdOrObject === 'string') {
             lookupId = layerIdOrObject
+        } else {
+            log.error("wrong type of layer definition, can't toggle visibility", layerIdOrObject)
+            return -1
         }
         const matchingLayer = getters.visibleLayers.find((layer) => layer.getID() === lookupId)
         if (!matchingLayer) {

--- a/tests/e2e-cypress/integration/infobox.cy.js
+++ b/tests/e2e-cypress/integration/infobox.cy.js
@@ -133,7 +133,6 @@ describe('The infobox', () => {
             cy.get('[data-cy="3d-button"]').click()
             cy.readWindowValue('cesiumViewer').then(() => {
                 cy.get('[data-cy="3d-button"]').click()
-                cy.wait('@jpeg-tiles')
                 cy.get('[data-cy="highlighted-features"]').should('be.visible')
             })
         })

--- a/tests/e2e-cypress/integration/layers.cy.js
+++ b/tests/e2e-cypress/integration/layers.cy.js
@@ -197,10 +197,10 @@ describe('Test of layer handling', () => {
             cy.fixture('topics.fixture').then((topicFixtures) => {
                 const [defaultTopic] = topicFixtures.topics
                 cy.goToMapView()
-                cy.readStoreValue('state.layers.backgroundLayerId').should(
-                    'eq',
-                    defaultTopic.defaultBackground
-                )
+                cy.readStoreValue('state.layers.currentBackgroundLayer').then((bgLayer) => {
+                    expect(bgLayer).to.not.be.null
+                    expect(bgLayer.getID()).to.eq(defaultTopic.defaultBackground)
+                })
             })
         })
         it('sets the background to the topic default if none is defined in the URL, even if a layer (out of topic scope) is defined in it', () => {
@@ -209,10 +209,10 @@ describe('Test of layer handling', () => {
                 cy.goToMapView({
                     layers: 'test.timeenabled.wmts.layer',
                 })
-                cy.readStoreValue('state.layers.backgroundLayerId').should(
-                    'eq',
-                    defaultTopic.defaultBackground
-                )
+                cy.readStoreValue('state.layers.currentBackgroundLayer').then((bgLayer) => {
+                    expect(bgLayer).to.not.be.null
+                    expect(bgLayer.getID()).to.eq(defaultTopic.defaultBackground)
+                })
                 cy.readStoreValue('getters.visibleLayers').then((layers) => {
                     expect(layers).to.be.an('Array')
                     expect(layers.length).to.eq(1)
@@ -225,10 +225,10 @@ describe('Test of layer handling', () => {
             cy.goToMapView({
                 bgLayer: 'test.background.layer2',
             })
-            cy.readStoreValue('state.layers.backgroundLayerId').should(
-                'eq',
-                'test.background.layer2'
-            )
+            cy.readStoreValue('state.layers.currentBackgroundLayer').then((bgLayer) => {
+                expect(bgLayer).to.not.be.null
+                expect(bgLayer.getID()).to.eq('test.background.layer2')
+            })
         })
     })
     context('Layer settings in menu', () => {

--- a/tests/e2e-cypress/integration/topics.cy.js
+++ b/tests/e2e-cypress/integration/topics.cy.js
@@ -103,10 +103,10 @@ describe('Topics', () => {
                 expect(layers.length).to.eq(0)
             })
             // we expect background layer to have switch to the one of the topic
-            cy.readStoreValue('state.layers.backgroundLayerId').should(
-                'eq',
-                topicStandard.defaultBackground
-            )
+            cy.readStoreValue('state.layers.currentBackgroundLayer').then((bgLayer) => {
+                expect(bgLayer).to.not.be.null
+                expect(bgLayer.getID()).to.eq(topicStandard.defaultBackground)
+            })
         })
         it('activates layers of the topic after topic swap', () => {
             cy.goToMapView()
@@ -142,7 +142,6 @@ describe('Topics', () => {
                 'test.wmts.layer': 0.6,
                 'test.wms.layer': 0.8,
             }
-            const expectedBackgroundLayerId = null // void layer
             cy.readStoreValue('getters.visibleLayers').then((visibleLayers) => {
                 expect(visibleLayers).to.be.an('Array')
                 expect(visibleLayers.length).to.eq(expectedVisibleLayers.length)
@@ -161,10 +160,7 @@ describe('Topics', () => {
                     expect(activeLayer.opacity).to.eq(expectedOpacity[layerIdThatMustBeActive])
                 })
             })
-            cy.readStoreValue('state.layers.backgroundLayerId').should(
-                'eq',
-                expectedBackgroundLayerId
-            )
+            cy.readStoreValue('state.layers.currentBackgroundLayer').should('be.null') // void layer
         })
         if (isMobileViewport) {
             it('keeps the menu open/visible after a topic is selected', () => {
@@ -193,10 +189,10 @@ describe('Topics', () => {
             })
             const topicWithActiveLayers = mockupTopics.topics[2]
             selectTopicWithId(topicWithActiveLayers.id)
-            cy.readStoreValue('state.layers.backgroundLayerId').should(
-                'eq',
-                topicWithActiveLayers.defaultBackground
-            )
+            cy.readStoreValue('state.layers.currentBackgroundLayer').then((bgLayer) => {
+                expect(bgLayer).to.not.be.null
+                expect(bgLayer.getID()).to.eq(topicWithActiveLayers.defaultBackground)
+            })
         })
     })
 


### PR DESCRIPTION
In the process of calculating the z-index for group of layers, I've found some functionalities that were lacking precision or weren't well test covered or documented.

This includes changes in the layer module :
- Storing the background layer directly as a config object (instead of ID)
- Enabling the setting of the background layer, and visibility of layer, through the layer ID or the config object
- Reworking of addLayer to make sure it creates a clone of any given config object (the one in the args, or the one found in the config) so that the config stays pristine

I've also removed an unnecessary wait in the infobox Cypress test, that was sometime failing for unknown reasons on my local machine (might be also the case on the CI like on https://github.com/geoadmin/web-mapviewer/pull/441)


[Test link](https://sys-map.dev.bgdi.ch/preview/feat_bgdiinf_sb-3105_layer_zindex_rewrite/index.html)