### PR TITLE
BGDIINF_SB-2854 feature : Show area and length of drawings

### DIFF
--- a/src/modules/infobox/components/styling/FeatureStyleEdit.vue
+++ b/src/modules/infobox/components/styling/FeatureStyleEdit.vue
@@ -30,7 +30,10 @@
                 <font-awesome-icon :icon="['far', 'square']" /> {{ length }}
             </div>
             <div v-if="isFeaturePolygon">
-                <font-awesome-icon :icon="['far', 'square']" style="color: #888a85" />
+                <font-awesome-icon
+                    :icon="['far', 'square']"
+                    style="background: #888a85; color: #888a85"
+                />
                 {{ area }}<sup>2</sup>
             </div>
         </div>

--- a/src/modules/infobox/components/styling/FeatureStyleEdit.vue
+++ b/src/modules/infobox/components/styling/FeatureStyleEdit.vue
@@ -187,6 +187,12 @@ export default {
             return getLength(this.geometry)
         },
         isClosed() {
+            /*
+                The length parameter must be greater than 3, because the polygon has one point
+                twice : the first and last point are both existing in the same exact space.
+                A point would be length 2, a line would be length 3. We do not consider the
+                case where there are more than 3 points, but all in a single line.
+            */
             return (
                 this.feature.coordinates.length > 3 &&
                 this.feature.coordinates[0][0] ===

--- a/src/modules/infobox/components/styling/FeatureStyleEdit.vue
+++ b/src/modules/infobox/components/styling/FeatureStyleEdit.vue
@@ -30,8 +30,8 @@
                 <font-awesome-icon :icon="['far', 'square']" /> {{ length }}
             </div>
             <div v-if="isFeaturePolygon">
-                <font-awesome-icon :icon="['fas', 'square']" style="color: #888a85" /> {{ area
-                }}<sup>2</sup>
+                <font-awesome-icon :icon="['far', 'square']" style="color: #888a85" />
+                {{ area }}<sup>2</sup>
             </div>
         </div>
         <div class="d-flex">
@@ -109,6 +109,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { mapActions } from 'vuex'
 import { getArea, getLength } from 'ol/sphere.js'
 import { Polygon } from 'ol/geom'
+import { round } from '@/utils/numberUtils'
 
 /**
  * Display a popup on the map when a drawing is selected.
@@ -167,54 +168,40 @@ export default {
                 this.changeFeatureTitle({ feature: this.feature, title: value })
             },
         },
-        geometry: {
-            get() {
-                /*
+        geometry() {
+            /*
                 Openlayers polygons coordinates are in a triple array
                 The first array is the "ring", the second is to hold the coordinates, which are in an array themselves
                 We don't have rings in this case, so we need to create an ol geometry
                 */
 
-                const geom = [this.feature.coordinates]
+            const geom = [this.feature.coordinates]
 
-                return new Polygon(geom)
-            },
+            return new Polygon(geom)
         },
-        isClosed: {
-            get() {
-                return (
-                    this.feature.coordinates[0][0] ===
-                        this.feature.coordinates[this.feature.coordinates.length - 1][0] &&
-                    this.feature.coordinates[0][1] ===
-                        this.feature.coordinates[this.feature.coordinates.length - 1][1]
-                )
-            },
+        isClosed() {
+            return (
+                this.feature.coordinates.length > 3 &&
+                this.feature.coordinates[0][0] ===
+                    this.feature.coordinates[this.feature.coordinates.length - 1][0] &&
+                this.feature.coordinates[0][1] ===
+                    this.feature.coordinates[this.feature.coordinates.length - 1][1]
+            )
         },
-        length: {
-            get() {
-                const length = getLength(this.geometry)
+        length() {
+            const length = getLength(this.geometry)
 
-                let output
-
-                if (length > 100) {
-                    output = Math.round((length / 1000) * 100) / 100 + ' ' + 'km'
-                } else {
-                    output = Math.round(length * 100) / 100 + ' ' + 'm'
-                }
-                return output
-            },
+            if (length > 100) {
+                return `${round(length / 1000)} km`
+            }
+            return `${round(length)} m`
         },
-        area: {
-            get() {
-                const area = getArea(this.geometry)
-                let output
-                if (area > 10000) {
-                    output = Math.round((area / 1000000) * 100) / 100 + ' ' + 'km'
-                } else {
-                    output = Math.round(area * 100) / 100 + ' ' + 'm'
-                }
-                return output
-            },
+        area() {
+            const area = getArea(this.geometry)
+            if (area > 10000) {
+                return `${round(area / 1000000)} km`
+            }
+            return `${round(area)} m`
         },
         isFeatureMarker() {
             return this.feature.featureType === EditableFeatureTypes.MARKER
@@ -229,7 +216,6 @@ export default {
             return this.feature.featureType === EditableFeatureTypes.MEASURE
         },
         isFeaturePolygon() {
-            console.log(this.isClosed)
             return this.feature.featureType === EditableFeatureTypes.LINEPOLYGON && this.isClosed
         },
     },

--- a/src/modules/infobox/components/styling/FeatureStyleEdit.vue
+++ b/src/modules/infobox/components/styling/FeatureStyleEdit.vue
@@ -31,10 +31,7 @@
                 {{ lengthRounded }} {{ length > 100 ? 'km' : 'm' }}
             </div>
             <div v-if="isFeaturePolygon">
-                <font-awesome-icon
-                    :icon="['far', 'square']"
-                    style="background: #888a85; color: #888a85"
-                />
+                <font-awesome-icon :icon="['far', 'square']" class="bg-secondary text-secondary" />
                 {{ areaRounded }} {{ area > 10000 ? 'km' : 'm' }}<sup>2</sup>
             </div>
         </div>

--- a/src/modules/infobox/components/styling/FeatureStyleEdit.vue
+++ b/src/modules/infobox/components/styling/FeatureStyleEdit.vue
@@ -27,14 +27,15 @@
                 rows="2"
             ></textarea>
             <div v-if="isFeatureLine">
-                <font-awesome-icon :icon="['far', 'square']" /> {{ length }}m
+                <font-awesome-icon :icon="['far', 'square']" />
+                {{ lengthRounded }} {{ length > 100 ? 'km' : 'm' }}
             </div>
             <div v-if="isFeaturePolygon">
                 <font-awesome-icon
                     :icon="['far', 'square']"
                     style="background: #888a85; color: #888a85"
                 />
-                {{ area }}m<sup>2</sup>
+                {{ areaRounded }} {{ area > 10000 ? 'km' : 'm' }}<sup>2</sup>
             </div>
         </div>
         <div class="d-flex">
@@ -182,6 +183,9 @@ export default {
 
             return new Polygon(geom)
         },
+        length() {
+            return getLength(this.geometry)
+        },
         isClosed() {
             return (
                 this.feature.coordinates.length > 3 &&
@@ -191,20 +195,20 @@ export default {
                     this.feature.coordinates[this.feature.coordinates.length - 1][1]
             )
         },
-        length() {
-            const length = getLength(this.geometry)
-
-            if (length > 100) {
-                return `${round(length / 1000, 2)} k`
+        lengthRounded() {
+            if (this.length > 100) {
+                return `${round(this.length / 1000, 2)}`
             }
-            return `${round(length, 2)} `
+            return `${round(this.length, 2)}`
         },
         area() {
-            const area = getArea(this.geometry)
-            if (area > 10000) {
-                return `${round(area / 1000000, 2)} k`
+            return getArea(this.geometry)
+        },
+        areaRounded() {
+            if (this.area > 10000) {
+                return `${round(this.area / 1000000, 2)}`
             }
-            return `${round(area, 2)} `
+            return `${round(area, 2)}`
         },
         isFeatureMarker() {
             return this.feature.featureType === EditableFeatureTypes.MARKER

--- a/src/modules/infobox/components/styling/FeatureStyleEdit.vue
+++ b/src/modules/infobox/components/styling/FeatureStyleEdit.vue
@@ -27,14 +27,14 @@
                 rows="2"
             ></textarea>
             <div v-if="isFeatureLine">
-                <font-awesome-icon :icon="['far', 'square']" /> {{ length }}
+                <font-awesome-icon :icon="['far', 'square']" /> {{ length }}m
             </div>
             <div v-if="isFeaturePolygon">
                 <font-awesome-icon
                     :icon="['far', 'square']"
                     style="background: #888a85; color: #888a85"
                 />
-                {{ area }}<sup>2</sup>
+                {{ area }}m<sup>2</sup>
             </div>
         </div>
         <div class="d-flex">
@@ -195,16 +195,16 @@ export default {
             const length = getLength(this.geometry)
 
             if (length > 100) {
-                return `${round(length / 1000, 2)} km`
+                return `${round(length / 1000, 2)} k`
             }
-            return `${round(length, 2)} m`
+            return `${round(length, 2)} `
         },
         area() {
             const area = getArea(this.geometry)
             if (area > 10000) {
-                return `${round(area / 1000000, 2)} km`
+                return `${round(area / 1000000, 2)} k`
             }
-            return `${round(area, 2)} m`
+            return `${round(area, 2)} `
         },
         isFeatureMarker() {
             return this.feature.featureType === EditableFeatureTypes.MARKER

--- a/src/modules/infobox/components/styling/FeatureStyleEdit.vue
+++ b/src/modules/infobox/components/styling/FeatureStyleEdit.vue
@@ -195,16 +195,16 @@ export default {
             const length = getLength(this.geometry)
 
             if (length > 100) {
-                return `${round(length / 1000)} km`
+                return `${round(length / 1000, 2)} km`
             }
-            return `${round(length)} m`
+            return `${round(length, 2)} m`
         },
         area() {
             const area = getArea(this.geometry)
             if (area > 10000) {
-                return `${round(area / 1000000)} km`
+                return `${round(area / 1000000, 2)} km`
             }
-            return `${round(area)} m`
+            return `${round(area, 2)} m`
         },
         isFeatureMarker() {
             return this.feature.featureType === EditableFeatureTypes.MARKER


### PR DESCRIPTION
BGDIINF_SB-2854

Issue : Are and length of polygons drawn were not shown

Fix : We now check if the polygon are closed. If they are, we calculate both area and perimeter. If not, we only calculate the perimeter. We then show them in the popup.

Still to do :
Font Awesome Icon for filled area is not loading properly, I need to check this

[Test link](https://sys-map.dev.bgdi.ch/preview/bgdiinf_sb-2854-calculat_area_closed_polygons/index.html)