### PR TITLE
BGDIINF_SB-2890: Fixed KML coordinates format during exports

### DIFF
--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -325,7 +325,7 @@ export default {
             log.debug(`Save drawing retryOnError ${retryOnError}`)
             this.drawingState = DrawingState.SAVING
             clearTimeout(this.differSaveDrawingTimeout)
-            const kml = generateKmlString(this.drawingLayer.getSource().getFeatures())
+            const kml = generateKmlString(this.projection, this.drawingLayer.getSource().getFeatures())
             try {
                 if (!this.kmlAdminId) {
                     const oldKmlId = this.kmlLayerId

--- a/src/modules/drawing/components/DrawingExporter.vue
+++ b/src/modules/drawing/components/DrawingExporter.vue
@@ -19,6 +19,7 @@ import {
 } from '@/modules/drawing/lib/export-utils'
 import DropdownButton, { DropdownItem } from '@/utils/DropdownButton.vue'
 import { saveAs } from 'file-saver'
+import { mapState } from 'vuex'
 
 export default {
     components: { DropdownButton },
@@ -34,6 +35,11 @@ export default {
             exportSelection: 'KML',
             exportOptions: [new DropdownItem('KML'), new DropdownItem('GPX')],
         }
+    },
+    computed: {
+        ...mapState({
+            projection: (state) => state.position.projection,
+        }),
     },
     methods: {
         onExportOptionSelected(dropdownItem) {
@@ -56,7 +62,7 @@ export default {
                 type = 'application/gpx+xml;charset=UTF-8'
             } else {
                 fileName = generateFilename('.kml')
-                content = generateKmlString(features)
+                content = generateKmlString(this.projection, features)
                 type = 'application/vnd.google-earth.kml+xml;charset=UTF-8'
             }
             const blob = new Blob([content], { type })

--- a/src/modules/drawing/lib/export-utils.js
+++ b/src/modules/drawing/lib/export-utils.js
@@ -6,6 +6,7 @@ import { GPX, KML } from 'ol/format'
 import { LineString, Polygon } from 'ol/geom'
 import { Circle, Icon } from 'ol/style'
 import Style from 'ol/style/Style'
+import log from '@/utils/logging'
 
 const kmlFormat = new KML()
 const gpxFormat = new GPX()
@@ -64,14 +65,18 @@ export function generateGpxString(features = [], featureProjection = WEBMERCATOR
  * @param styleFunction
  * @returns {string}
  */
-export function generateKmlString(features = [], styleFunction = null) {
+export function generateKmlString(projection, features = [], styleFunction = null) {
+    if (!!!projection) {
+        log.error('Cannot generate KML string without projection')
+        return ''
+    }
     let kmlString = '<kml></kml>'
     let exportFeatures = []
     features.forEach((f) => {
         const clone = f.clone()
         clone.setId(f.getId())
         clone.getGeometry().setProperties(f.getGeometry().getProperties())
-        clone.getGeometry().transform(WEBMERCATOR.epsg, WGS84.epsg)
+        clone.getGeometry().transform(projection.epsg, WGS84.epsg)
         let styles = styleFunction || featureStyleFunction
         styles = styles(clone)
         const newStyle = {


### PR DESCRIPTION
The `<coordinate>` element in KML must be in WGS84 based on the specification.
During export the coordinates where re-projected from WebMercator even if another
projection was used.