### PR TITLE
BGDIINF_SB-2890: Fixed crash when editing a drawing component

### DIFF
--- a/src/modules/map/components/openlayers/OpenLayersHighlightedFeature.vue
+++ b/src/modules/map/components/openlayers/OpenLayersHighlightedFeature.vue
@@ -89,11 +89,10 @@ export default {
         },
     },
     watch: {
-        feature: {
-            handler() {
+        'feature.geometry'() {
+            if (this.doesFeatureHaveAGeometry) {
                 this.addFeatureToLayer()
-            },
-            deep: true,
+            }
         },
     },
     created() {
@@ -112,7 +111,7 @@ export default {
     },
     methods: {
         addFeatureToLayer() {
-            this.layer.setSource(
+            this.layer?.setSource(
                 new VectorSource({
                     features: [this.geometry],
                 })


### PR DESCRIPTION
When editing a drawing component (marker text or adding a text element)
the viewer crash because the feature watch deep was fired when no
layer was set.

To avoid we only watch on the geometry and make sure that we do have a geometry.