### PR TITLE
BGDIINF_SB-2890: Fixed drawing feature edit

### DIFF
--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -170,7 +170,7 @@ export default {
             if (show) {
                 this.isLoading = true
                 this.isDrawingOpen = true
-                await this.initDrawingOverlay()
+                await this.showDrawingOverlay()
                 this.isLoading = false
             } else {
                 this.isLoading = true
@@ -219,7 +219,7 @@ export default {
             window.drawingLayer = this.drawingLayer
         }
         if (this.show) {
-            this.initDrawingOverlay()
+            this.showDrawingOverlay()
         }
     },
     unmounted() {
@@ -243,7 +243,10 @@ export default {
             'setDrawingFeatures',
             'setKmlLayerAddToMap',
         ]),
-        async initDrawingOverlay() {
+        async showDrawingOverlay() {
+            // We need to make sure that no drawing features are selected when entering the drawing
+            // mode otherwise we cannot edit the selected features.
+            this.clearAllSelectedFeatures()
             this.drawingState = DrawingState.INITIAL
             this.isNewDrawing = true
 


### PR DESCRIPTION
When selecting a drawing feature outside the drawing mode (to see the details
and descriptions) and then entering the drawing mode, the feature stayed selected
but was not initialized properly to allow edition. This means that we could
edit it, but the changes were not reported to openlayer and thus not saved
on the kml, which means that the changes were lost when exiting the drawing mode.

A simple solution to this issue, is to simply deselect everything on entering
the drawing mode. This also make sense in user point of view.