### PR TITLE
BGDIINF_SB-2890: Fixed elevation profile tracking in lv95

### DIFF
--- a/src/api/features.api.js
+++ b/src/api/features.api.js
@@ -1,7 +1,6 @@
 import { DrawingIcon, DrawingIconSet } from '@/api/icon.api'
 import { API_BASE_URL } from '@/config'
 import { featureStyleFunction } from '@/modules/drawing/lib/style'
-import { WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
 import EventEmitter from '@/utils/EventEmitter.class'
 import {
     allStylingColors,
@@ -500,7 +499,7 @@ export const identify = (
     screenWidth,
     screenHeight,
     lang,
-    projection = WEBMERCATOR
+    projection
 ) => {
     return new Promise((resolve, reject) => {
         if (!layer || !layer.getID()) {
@@ -572,7 +571,7 @@ export const identify = (
  *   be expressed
  * @returns {Promise<LayerFeature>}
  */
-const getFeature = (layer, featureID, lang = 'en', projection = WEBMERCATOR) => {
+const getFeature = (layer, featureID, lang = 'en', projection) => {
     return new Promise((resolve, reject) => {
         if (!layer || !layer.getID()) {
             reject('Needs a valid layer with an ID')

--- a/src/api/features.api.js
+++ b/src/api/features.api.js
@@ -543,7 +543,7 @@ export const identify = (
                 if (response.data && response.data.results && response.data.results.length > 0) {
                     // for each feature that has been identify, we will now load their metadata and tooltip content
                     response.data.results.forEach((feature) => {
-                        featureRequests.push(getFeature(layer, feature.id, lang, projection))
+                        featureRequests.push(getFeature(layer, feature.id, projection, lang))
                     })
                     Promise.all(featureRequests)
                         .then((values) => {
@@ -567,12 +567,12 @@ export const identify = (
  *
  * @param {GeoAdminLayer} layer The layer from which the feature is part of
  * @param {String | Number} featureID The feature ID in the BGDI
- * @param {String} lang The language for the HTML popup
  * @param {CoordinateSystem} projection Projection in which the coordinates of the features should
  *   be expressed
+ * @param {String} lang The language for the HTML popup
  * @returns {Promise<LayerFeature>}
  */
-const getFeature = (layer, featureID, lang = 'en', projection) => {
+const getFeature = (layer, featureID, projection, lang = 'en') => {
     return new Promise((resolve, reject) => {
         if (!layer || !layer.getID()) {
             reject('Needs a valid layer with an ID')

--- a/src/api/features.api.js
+++ b/src/api/features.api.js
@@ -243,10 +243,11 @@ export class EditableFeature extends SelectableFeature {
      *
      * @param {ol/Feature} olFeature An olFeature that was just deserialized with
      * @param {DrawingIconSet[]} availableIconSets Icon sets to use for the EditableFeature.
+     * @param {CoordinateSystem} projection Projection currently in use
      * @returns {EditableFeature | Null} Returns the EditableFeature in case of success or null
      *   otherwise
      */
-    static deserialize(olFeature, availableIconSets) {
+    static deserialize(olFeature, availableIconSets, projection) {
         let editableFeature = olFeature.get('editableFeature')
         // in case we are deserializing a legacy KML (one made with mf-geoadmin3) the editableFeature object
         // will not be present, and we will have to rebuild one from the styles tags in the KML
@@ -278,7 +279,7 @@ export class EditableFeature extends SelectableFeature {
                 if present. The lines connecting the vertices of the geometry will appear
                 geodesic (follow the shortest path) in this case instead of linear (be straight on
                 the screen)  */
-                olFeature.geodesic = new GeodesicGeometries(olFeature)
+                olFeature.geodesic = new GeodesicGeometries(olFeature, projection)
             }
         }
         return editableFeature

--- a/src/api/profile/profile.api.js
+++ b/src/api/profile/profile.api.js
@@ -2,7 +2,7 @@ import ElevationProfile from '@/api/profile/ElevationProfile.class'
 import ElevationProfilePoint from '@/api/profile/ElevationProfilePoint.class'
 import ElevationProfileSegment from '@/api/profile/ElevationProfileSegment.class'
 import { API_SERVICE_ALTI_BASE_URL } from '@/config'
-import { LV95, WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
+import { LV95 } from '@/utils/coordinates/coordinateSystems'
 import log from '@/utils/logging'
 import { round } from '@/utils/numberUtils'
 import axios from 'axios'
@@ -29,12 +29,7 @@ function parseProfileFromBackendResponse(backendResponse, startingDist, outputPr
  * @param {CoordinateSystem} outputProjection
  * @returns {ElevationProfile}
  */
-async function getProfileDataForChunk(
-    chunk,
-    startingPoint,
-    startingDist = 0,
-    outputProjection = WEBMERCATOR
-) {
+async function getProfileDataForChunk(chunk, startingPoint, startingDist, outputProjection) {
     if (chunk.isWithinBounds) {
         try {
             const dataForChunk = await axios({
@@ -102,7 +97,7 @@ async function getProfileDataForChunk(
  * @returns {ElevationProfile | null} The profile, or null if there was no valid data to produce a
  *   profile
  */
-export default async (coordinates, projection = WEBMERCATOR) => {
+export default async (coordinates, projection) => {
     if (!coordinates || coordinates.length === 0) {
         const errorMessage = `Coordinates not provided`
         log.error(errorMessage)

--- a/src/modules/drawing/components/DrawingLineInteraction.vue
+++ b/src/modules/drawing/components/DrawingLineInteraction.vue
@@ -29,7 +29,7 @@ export default {
          * See {@link drawingInteractionMixin}
          */
         onDrawStart(feature) {
-            feature.geodesic = new GeodesicGeometries(feature)
+            feature.geodesic = new GeodesicGeometries(feature, this.projection)
         },
     },
 }

--- a/src/modules/drawing/components/DrawingMeasureInteraction.vue
+++ b/src/modules/drawing/components/DrawingMeasureInteraction.vue
@@ -4,11 +4,9 @@
 
 <script>
 import { EditableFeatureTypes } from '@/api/features.api'
-import { DEFAULT_PROJECTION } from '@/config'
 import drawingInteractionMixin from '@/modules/drawing/components/drawingInteraction.mixin'
 import drawingLineMixin from '@/modules/drawing/components/drawingLine.mixin'
 import { drawMeasureStyle } from '@/modules/drawing/lib/style'
-import CoordinateSystem from '@/utils/coordinates/CoordinateSystem.class'
 import { GeodesicGeometries } from '@/utils/geodesicManager'
 
 export default {

--- a/src/modules/drawing/components/DrawingMeasureInteraction.vue
+++ b/src/modules/drawing/components/DrawingMeasureInteraction.vue
@@ -32,7 +32,7 @@ export default {
          * See {@link drawingInteractionMixin}
          */
         onDrawStart(feature) {
-            feature.geodesic = new GeodesicGeometries(feature)
+            feature.geodesic = new GeodesicGeometries(feature, this.projection)
         },
     },
 }

--- a/src/modules/drawing/lib/drawingUtils.js
+++ b/src/modules/drawing/lib/drawingUtils.js
@@ -194,7 +194,7 @@ export function getVertexCoordinates(feature) {
  * Parse KML file into OL Features including deserialization of EditableFeature
  *
  * @param {String} kml KML content to parse
- * @param {ol/Projection} projection Projection to use for the OL Feature
+ * @param {CoordinateSystem} projection Projection to use for the OL Feature
  * @param {DrawingIconSet[]} iconSets Icon sets to use for EditabeFeature deserialization
  * @returns {ol/Feature[]} List of OL Features
  */
@@ -204,7 +204,7 @@ export function parseKml(kml, projection, iconSets) {
         featureProjection: projection.epsg,
     })
     features.forEach((olFeature) => {
-        EditableFeature.deserialize(olFeature, iconSets)
+        EditableFeature.deserialize(olFeature, iconSets, projection)
     })
 
     return features

--- a/src/modules/drawing/lib/drawingUtils.js
+++ b/src/modules/drawing/lib/drawingUtils.js
@@ -16,29 +16,6 @@ export function toLv95(input, epsg) {
 }
 
 /**
- * Wraps the provided webmercator coordinates in the world extents (i.e. the coordinate range that
- * if equivalent to the wgs84 [-180, 180))
- *
- * @param coords The coordinates (or array of coordinates) to wrap
- * @param inPlace If false, the original coordinates remain untouched and only a copy is modified
- * @returns If "inPlace", then the same reference as "coords", else a reference to the modified copy
- */
-export function wrapWebmercatorCoords(coords, inPlace = false) {
-    if (inPlace) {
-        if (Array.isArray(coords[0])) {
-            coords.forEach((coords) => wrapWebmercatorCoords(coords, true))
-            return coords
-        } else {
-            return wrapX(coords, getProjection(WEBMERCATOR.epsg))
-        }
-    } else {
-        return Array.isArray(coords[0])
-            ? coords.map((coords) => wrapWebmercatorCoords(coords, false))
-            : wrapX(coords.slice(), getProjection(WEBMERCATOR.epsg))
-    }
-}
-
-/**
  * Wraps the provided coordinates in the world extents (i.e. the coordinate range that if equivalent
  * to the wgs84 [-180, 180))
  *

--- a/src/modules/drawing/lib/drawingUtils.js
+++ b/src/modules/drawing/lib/drawingUtils.js
@@ -1,4 +1,4 @@
-import { LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
+import { LV95, WGS84 } from '@/utils/coordinates/coordinateSystems'
 import { format } from '@/utils/numberUtils'
 import { wrapX } from 'ol/coordinate'
 import { LineString, Point, Polygon } from 'ol/geom'

--- a/src/modules/drawing/lib/export-utils.js
+++ b/src/modules/drawing/lib/export-utils.js
@@ -1,6 +1,6 @@
 import { featureStyleFunction } from '@/modules/drawing/lib/style'
 import i18n from '@/modules/i18n/index'
-import { WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
+import { WGS84 } from '@/utils/coordinates/coordinateSystems'
 import Feature from 'ol/Feature'
 import { GPX, KML } from 'ol/format'
 import { LineString, Polygon } from 'ol/geom'

--- a/src/modules/drawing/lib/style.js
+++ b/src/modules/drawing/lib/style.js
@@ -1,7 +1,6 @@
 import { EditableFeatureTypes } from '@/api/features.api'
 import { LineString, MultiPoint, Polygon, Point } from 'ol/geom'
 import { Circle, Fill, Stroke, Style, Text } from 'ol/style'
-import { wrapWebmercatorCoords } from '@/modules/drawing/lib/drawingUtils'
 
 /* Z-INDICES
 The z indices for the styles are given according to the following table:
@@ -225,8 +224,7 @@ export function drawLineOrMeasureStyle(sketch, resolution, displayMeasures) {
     const type = sketch.getGeometry().getType()
     switch (type) {
         case 'Point':
-            const coord = wrapWebmercatorCoords(sketch.getGeometry().getCoordinates())
-            return getSketchPointStyle(coord)
+            return getSketchPointStyle(sketch.getGeometry().getCoordinates())
         case 'Polygon':
             const styles = [
                 new Style({

--- a/src/modules/infobox/FeatureElevationProfilePlotCesiumBridge.vue
+++ b/src/modules/infobox/FeatureElevationProfilePlotCesiumBridge.vue
@@ -2,10 +2,11 @@
     <slot />
 </template>
 <script>
-import { LV95, WGS84 } from '@/utils/coordinates/coordinateSystems'
+import { WGS84 } from '@/utils/coordinates/coordinateSystems'
 import { FeatureStyleColor, RED } from '@/utils/featureStyleUtils'
 import { CallbackProperty, Cartesian3, Color, Ellipsoid, Entity, HeightReference } from 'cesium'
 import proj4 from 'proj4'
+import { mapState } from 'vuex'
 
 export default {
     inject: ['getViewer'],
@@ -18,6 +19,11 @@ export default {
             type: FeatureStyleColor,
             default: RED,
         },
+    },
+    computed: {
+        ...mapState({
+            projection: (state) => state.position.projection,
+        }),
     },
     watch: {
         coordinates(newCoordinates) {
@@ -70,7 +76,7 @@ export default {
             this.getViewer()?.entities.remove(this.trackingPoint)
         },
         updatePosition() {
-            const wgs84Position = proj4(LV95.epsg, WGS84.epsg, this.coordinates)
+            const wgs84Position = proj4(this.projection.epsg, WGS84.epsg, this.coordinates)
             Cartesian3.fromDegrees(
                 wgs84Position[0],
                 wgs84Position[1],

--- a/src/modules/infobox/FeatureElevationProfilePlotOpenLayersBridge.vue
+++ b/src/modules/infobox/FeatureElevationProfilePlotOpenLayersBridge.vue
@@ -2,10 +2,8 @@
     <slot />
 </template>
 <script>
-import { LV95, WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
 import { FeatureStyleColor, RED } from '@/utils/featureStyleUtils'
 import Overlay from 'ol/Overlay'
-import proj4 from 'proj4'
 
 export default {
     inject: ['getMap'],
@@ -22,9 +20,7 @@ export default {
     watch: {
         coordinates(newCoordinates) {
             if (newCoordinates) {
-                this.currentHoverPosOverlay.setPosition(
-                    proj4(LV95.epsg, WEBMERCATOR.epsg, newCoordinates)
-                )
+                this.currentHoverPosOverlay.setPosition(newCoordinates)
                 this.addHoverPositionOverlay()
             } else {
                 this.currentHoverPosOverlay.setPosition(null)
@@ -47,9 +43,7 @@ export default {
         this.currentHoverPosOverlay.getElement().style.backgroundColor =
             this.trackingPointColor.fill
         if (this.coordinates) {
-            this.currentHoverPosOverlay.setPosition(
-                proj4(LV95.epsg, WEBMERCATOR.epsg, this.coordinates)
-            )
+            this.currentHoverPosOverlay.setPosition(this.coordinates)
             this.addHoverPositionOverlay()
         }
     },

--- a/src/modules/infobox/components/FeatureElevationProfile.vue
+++ b/src/modules/infobox/components/FeatureElevationProfile.vue
@@ -35,7 +35,6 @@
 <script>
 import { EditableFeature, EditableFeatureTypes } from '@/api/features.api'
 import getProfile from '@/api/profile/profile.api'
-import { DEFAULT_PROJECTION } from '@/config'
 import { generateFilename } from '@/modules/drawing/lib/export-utils'
 import FeatureElevationProfileInformation from '@/modules/infobox/components/FeatureElevationProfileInformation.vue'
 import FeatureElevationProfilePlot from '@/modules/infobox/components/FeatureElevationProfilePlot.vue'

--- a/src/modules/infobox/components/FeatureElevationProfile.vue
+++ b/src/modules/infobox/components/FeatureElevationProfile.vue
@@ -66,7 +66,7 @@ export default {
         },
         projection: {
             type: CoordinateSystem,
-            default: DEFAULT_PROJECTION,
+            required: true,
         },
     },
     emits: ['updateElevationProfilePlot'],

--- a/src/modules/infobox/components/styling/SelectedFeatureProfile.vue
+++ b/src/modules/infobox/components/styling/SelectedFeatureProfile.vue
@@ -19,8 +19,8 @@
 <script>
 import { EditableFeature, EditableFeatureTypes } from '@/api/features.api'
 import { geometryInfo } from '@/modules/drawing/lib/drawingUtils'
-import { WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { mapState } from 'vuex'
 
 export default {
     components: { FontAwesomeIcon },
@@ -31,6 +31,7 @@ export default {
         },
     },
     computed: {
+        ...mapState({ projection: (state) => state.position.projection }),
         geometry: function () {
             return (
                 this.feature &&
@@ -43,7 +44,7 @@ export default {
                 return geometryInfo(
                     this.geometry.getType(),
                     this.geometry.getCoordinates(),
-                    WEBMERCATOR.epsg
+                    this.projection.epsg
                 )
             }
             return null

--- a/src/store/plugins/reproject-everything-on-projection-change.plugin.js
+++ b/src/store/plugins/reproject-everything-on-projection-change.plugin.js
@@ -47,8 +47,8 @@ const reprojectEverythingOnProjectionChangePlugin = (store) => {
                             getFeature(
                                 selectedFeature.layer,
                                 selectedFeature.featureId,
-                                state.i18n.currentLang,
-                                newProjection
+                                newProjection,
+                                state.i18n.currentLang
                             ).then((feature) => reprojectedSelectedFeatures.push(feature))
                         )
                     } else if (selectedFeature.isEditable) {

--- a/src/utils/__tests__/geodesicManager.spec.js
+++ b/src/utils/__tests__/geodesicManager.spec.js
@@ -1,4 +1,5 @@
 import { HALFSIZE_WEBMERCATOR, GeodesicGeometries } from '@/utils/geodesicManager'
+import { WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
 import { Feature } from 'ol'
 import { expect } from 'chai'
 import { LineString, MultiLineString, MultiPolygon } from 'ol/geom'
@@ -8,7 +9,7 @@ import { Style } from 'ol/style'
 function constructGeodLineString(...coords) {
     const feature = new Feature(new LineString(coords))
     feature.set('isDrawing', true)
-    return new GeodesicGeometries(feature)
+    return new GeodesicGeometries(feature, WEBMERCATOR)
 }
 
 function checkCoordsEqual(coords1, coords2, precision) {

--- a/src/utils/geodesicManager.js
+++ b/src/utils/geodesicManager.js
@@ -113,12 +113,15 @@ export class GeodesicGeometries {
                 this.isPolygon = true
             }
         }
+        // The azimuth circle is only for non polygon and if we have two points.
+        // If we have 3 points check that the last two points are different otherwise also
+        // show the azimuth circle.
         this.hasAzimuthCircle =
             !this.isPolygon &&
             (this.coords.length === 2 ||
-                (this.coords.length === 3 && // ?
-                    this.coords[1][0] === this.coords[2][0] && // ?
-                    this.coords[1][1] === this.coords[2][1])) // ?
+                (this.coords.length === 3 &&
+                    this.coords[1][0] === this.coords[2][0] &&
+                    this.coords[1][1] === this.coords[2][1]))
         this.stylesReady = !(
             this.coords.length < 2 ||
             (this.coords.length === 2 &&

--- a/tests/e2e-cypress/integration/drawing/geodesicDrawing.cy.js
+++ b/tests/e2e-cypress/integration/drawing/geodesicDrawing.cy.js
@@ -1,9 +1,7 @@
 import { EditableFeatureTypes } from '@/api/features.api'
-import {
-    extractOlFeatureCoordinates,
-    wrapWebmercatorCoords,
-} from '@/modules/drawing/lib/drawingUtils'
+import { extractOlFeatureCoordinates, wrapXCoordinates } from '@/modules/drawing/lib/drawingUtils'
 import { HALFSIZE_WEBMERCATOR } from '@/utils/geodesicManager'
+import { WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
 
 const olSelector = '.ol-viewport'
 
@@ -125,7 +123,7 @@ describe('Correct handling of geodesic geometries', () => {
                 now, as we store the coordinates in their normalized form (We didn't normalize it
                 before drawing as we want to simulate a normal user that draws across the datetime
                 limit)*/
-                const lineDrawn = wrapWebmercatorCoords(lineToDraw)
+                const lineDrawn = wrapXCoordinates(lineToDraw, WEBMERCATOR)
                 checkFeatureSelected(lineDrawn)
 
                 const centerOfLinearLine = offsetX([x + 500000, y], selectOffset)
@@ -133,7 +131,7 @@ describe('Correct handling of geodesic geometries', () => {
                 const centerOfGeodesicLine = offsetX([x + 500000, 5990896.895875603], selectOffset)
                 const drawnLineWithCenterPoint = [
                     lineDrawn[0],
-                    wrapWebmercatorCoords(centerOfGeodesicLine),
+                    wrapXCoordinates(centerOfGeodesicLine, WEBMERCATOR),
                     lineDrawn[1],
                 ]
                 // As the line is not linear, clicking where the linear line passes should not trigger the
@@ -213,7 +211,7 @@ describe('Correct handling of geodesic geometries', () => {
                     [x, y],
                 ]
                 drawFeature(offsetX(lineToDraw, drawOffset), type)
-                const lineDrawn = wrapWebmercatorCoords(lineToDraw)
+                const lineDrawn = wrapXCoordinates(lineToDraw, WEBMERCATOR)
                 checkFeatureSelected(lineDrawn)
 
                 const inLinearPolygon = [


### PR DESCRIPTION
Fixed the profile tracking when hovering the profile, the point is tracked on the map. This has been brocken when passing to lv95.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2890-profile-tracking/index.html)