### PR TITLE
BGDIINF_SB-2890: Disable drawing menu when in 3D mode

### DIFF
--- a/src/modules/menu/components/menu/MenuTray.vue
+++ b/src/modules/menu/components/menu/MenuTray.vue
@@ -16,6 +16,7 @@
         <!-- Drawing section is a glorified button, we always keep it closed and listen to click events -->
         <div id="drawSectionTooltip" tabindex="0">
             <MenuSection
+                v-if="!is3dMode"
                 id="drawSection"
                 :title="$t('draw_panel_title')"
                 :always-keep-closed="true"
@@ -93,6 +94,7 @@ export default {
             activeLayers: (state) => state.layers.activeLayers,
             hostname: (state) => state.ui.hostname,
             lang: (state) => state.i18n.lang,
+            is3dMode: (state) => state.ui.showIn3d,
         }),
         ...mapGetters(['isPhoneMode']),
         showLayerList() {


### PR DESCRIPTION
Drawing while in 3d mode is not supported.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2890-drawing-buttons-2/index.html)