### PR TITLE
BGDIINF_SB-2685: Fixed legacy KML protection

### DIFF
--- a/src/modules/menu/components/menu/MenuTray.vue
+++ b/src/modules/menu/components/menu/MenuTray.vue
@@ -99,6 +99,7 @@ export default {
             return this.activeLayers.length > 0
         },
         disableDrawing() {
+            // TODO BGDIINF_SB-2685: remove this protection once on prod
             if (
                 DISABLE_DRAWING_MENU_FOR_LEGACY_ON_HOSTNAMES.some(
                     (hostname) => hostname === this.hostname

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -147,7 +147,11 @@ function dispatchLayersFromUrlIntoStore(store, urlParamValue) {
             )
         ) {
             const layerObject = createLayerObject(parsedLayer)
-            if (layerObject.type === LayerTypes.KML && layerObject.adminId) {
+            if (
+                layerObject.type === LayerTypes.KML &&
+                layerObject.adminId &&
+                !layerObject.isLegacy() // TODO BGDIINF_SB-2685: remove once on prod
+            ) {
                 promisesForAllDispatch.push(store.dispatch('setShowDrawingOverlay', true))
             }
             log.debug(`  Add layer ${parsedLayer.id} to active layers`, layerObject)


### PR DESCRIPTION
Until we are on PROD we should not be allowed to edit KML that has been created
by the old viewer, this means that in this case we should not move to the drawing
menu automatically.

[Test link with legacy drawing](https://sys-map.dev.bgdi.ch/preview/bug-legacy-drawing-protection/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=&adminId=5Ual-X6ZQoKc-XOMxkw9yw)

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-legacy-drawing-protection/index.html)