### PR TITLE
BGDIINF_SB-3146 : Fix: 3D drawing crash on camera move, disable 3D toggle button when draw

### DIFF
--- a/src/modules/map/components/cesium/CesiumPopover.vue
+++ b/src/modules/map/components/cesium/CesiumPopover.vue
@@ -42,13 +42,7 @@ export default {
 
             // if the user zooms in (or out) we want to be sure that the new loaded terrain
             // is taken into account for the tooltip positioning
-            viewer.scene.globe.tileLoadProgressEvent.addEventListener(() => {
-                // recalculating height and position as soon as all new terrain tiles are loaded (after camera movement, or at init)
-                if (viewer.scene.globe.tilesLoaded) {
-                    this.updateCoordinateHeight()
-                    this.updatePosition()
-                }
-            })
+            viewer.scene.globe.tileLoadProgressEvent.addEventListener(this.onTileLoadProgress)
             // implementing something similar to the sandcastle found on https://github.com/CesiumGS/cesium/issues/3247#issuecomment-1533505387
             // but taking into account height using globe.getHeight for the given coordinate
             // without taking height into account, the anchor for the tooltip will be the virtual bottom of the map (at sea level), rendering poorly as
@@ -63,6 +57,7 @@ export default {
         const viewer = this.getViewer()
         if (viewer) {
             viewer.camera.changed.removeEventListener(this.updatePosition)
+            viewer.scene.globe.tileLoadProgressEvent.removeEventListener(this.onTileLoadProgress)
             // Set back the camera change sensitivity to default value (see mounted())
             viewer.camera.percentageChanged = 0.5
         }
@@ -104,6 +99,14 @@ export default {
                 // adding 15px to the top so that the tip of the arrow of the tooltip is on the edge
                 // of the highlighting circle of the selected feature
                 mapPopover.style.top = `${cartesianCoords.y + 15}px`
+            }
+        },
+        onTileLoadProgress() {
+            const viewer = this.getViewer()
+            // recalculating height and position as soon as all new terrain tiles are loaded (after camera movement, or at init)
+            if (viewer.scene.globe.tilesLoaded) {
+                this.updateCoordinateHeight()
+                this.updatePosition()
             }
         },
     },

--- a/src/modules/menu/components/toolboxRight/Toggle3dButton.vue
+++ b/src/modules/menu/components/toolboxRight/Toggle3dButton.vue
@@ -3,7 +3,7 @@
         ref="toggle3dButton"
         class="toolbox-button"
         type="button"
-        :class="{ active: isActive, disabled: !webGlIsSupported }"
+        :class="{ active: isActive, disabled: !webGlIsSupported || showDrawingOverlay }"
         data-cy="3d-button"
         @click="toggle3d"
     >
@@ -45,6 +45,7 @@ export default {
         ...mapState({
             isActive: (state) => state.ui.showIn3d,
             currentLang: (state) => state.i18n.lang,
+            showDrawingOverlay: (state) => state.ui.showDrawingOverlay,
         }),
         tooltipContent() {
             if (this.webGlIsSupported) {
@@ -77,7 +78,7 @@ export default {
     methods: {
         ...mapActions(['setShowIn3d']),
         toggle3d() {
-            if (this.webGlIsSupported) {
+            if (this.webGlIsSupported && !this.showDrawingOverlay) {
                 this.setShowIn3d(!this.isActive)
             }
         },


### PR DESCRIPTION


[Test link](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-3146_fix_drawing_crash/index.html)