### PR TITLE
BGDIINF_SB-3154 : make crosshair URL param dynamic

### DIFF
--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -41,7 +41,7 @@
         <!-- Showing cross hair if needed-->
         <OpenLayersMarker
             v-if="crossHairStyle"
-            :position="initialCenter"
+            :position="crossHairPosition"
             :marker-style="crossHairStyle"
             :z-index="zIndexCrossHair"
         />
@@ -157,8 +157,6 @@ export default {
         return {
             // exposing marker styles to the template
             markerStyles,
-            /** Keeping trace of the starting center in order to place the cross hair */
-            initialCenter: null,
             popoverCoordinates: [],
             animationDuration: IS_TESTING_WITH_CYPRESS ? 0 : 250,
         }
@@ -178,6 +176,7 @@ export default {
             geolocationPosition: (state) => state.geolocation.position,
             geolocationAccuracy: (state) => state.geolocation.accuracy,
             crossHair: (state) => state.position.crossHair,
+            crossHairPosition: (state) => state.position.crossHairPosition,
             isFeatureTooltipInFooter: (state) => !state.ui.floatingTooltip,
             clickInfo: (state) => state.map.clickInfo,
             showDrawingOverlay: (state) => state.ui.showDrawingOverlay,
@@ -315,9 +314,6 @@ export default {
         if (IS_TESTING_WITH_CYPRESS) {
             window.map = this.map
         }
-    },
-    created() {
-        this.initialCenter = [...this.center]
     },
     mounted() {
         // register any custom projection in OpenLayers

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,3 +1,4 @@
+import { IS_TESTING_WITH_CYPRESS } from '@/config'
 import appLoadingManagementRouterPlugin from '@/router/appLoadingManagement.routerPlugin'
 import legacyPermalinkManagementRouterPlugin from '@/router/legacyPermalinkManagement.routerPlugin'
 import storeSyncRouterPlugin from '@/router/storeSync/storeSync.routerPlugin'
@@ -7,6 +8,8 @@ import LoadingView from '@/views/LoadingView.vue'
 import MapView from '@/views/MapView.vue'
 import { createRouter, createWebHashHistory } from 'vue-router'
 
+const history = createWebHashHistory()
+
 /**
  * The Vue Router for this app, see [Vue Router's doc on how to use
  * it]{@link https://router.vuejs.org/guide/}
@@ -14,7 +17,7 @@ import { createRouter, createWebHashHistory } from 'vue-router'
  * @type {Router}
  */
 const router = createRouter({
-    history: createWebHashHistory(),
+    history,
     routes: [
         {
             path: '/',
@@ -42,4 +45,10 @@ appLoadingManagementRouterPlugin(router, store)
 legacyPermalinkManagementRouterPlugin(router, store)
 storeSyncRouterPlugin(router, store)
 
+// exposing the router to Cypress, so that we may change URL param on the fly (without app reload),
+// and this way test app reaction to URL changes
+if (IS_TESTING_WITH_CYPRESS) {
+    window.vueRouterHistory = history
+    window.vueRouter = router
+}
 export default router

--- a/src/router/storeSync/CrossHairParamConfig.class.js
+++ b/src/router/storeSync/CrossHairParamConfig.class.js
@@ -1,0 +1,53 @@
+import AbstractParamConfig from '@/router/storeSync/abstractParamConfig.class'
+import { round } from '@/utils/numberUtils'
+
+function dispatchCrossHairFromUrlIntoStore(store, urlParamValue) {
+    const promisesForAllDispatch = []
+
+    const parts = urlParamValue.split(',')
+    if (parts.length === 1) {
+        promisesForAllDispatch.push(store.dispatch('setCrossHair', { crossHair: urlParamValue }))
+    } else if (parts.length === 3) {
+        const crossHair = parts[0]
+        const crossHairPosition = [parseFloat(parts[1]), parseFloat(parts[2])]
+        promisesForAllDispatch.push(
+            store.dispatch('setCrossHair', { crossHair, crossHairPosition })
+        )
+    }
+    return Promise.all(promisesForAllDispatch)
+}
+
+function generateCrossHairUrlParamFromStoreValues(store) {
+    if (store.state.position.crossHair) {
+        let crossHairParamValue = store.state.position.crossHair
+        const { center, crossHairPosition } = store.state.position
+        if (
+            crossHairPosition &&
+            (center[0] !== crossHairPosition[0] || center[1] !== crossHairPosition[1])
+        ) {
+            crossHairParamValue += `,${crossHairPosition.map((val) => round(val, 2)).join(',')}`
+        }
+        return crossHairParamValue
+    }
+    return null
+}
+
+/**
+ * Concat the crosshair type with its position, if the crosshair's position is not the same as the
+ * current center of the map.
+ *
+ * This enables users to change the crosshair's type and position "on the fly" without reloading the
+ * app
+ */
+export default class CrossHairParamConfig extends AbstractParamConfig {
+    constructor() {
+        super(
+            'crosshair',
+            'setCrossHair,setCrossHairPosition',
+            dispatchCrossHairFromUrlIntoStore,
+            generateCrossHairUrlParamFromStoreValues,
+            false,
+            String
+        )
+    }
+}

--- a/src/router/storeSync/CrossHairParamConfig.class.js
+++ b/src/router/storeSync/CrossHairParamConfig.class.js
@@ -4,6 +4,10 @@ import { round } from '@/utils/numberUtils'
 function dispatchCrossHairFromUrlIntoStore(store, urlParamValue) {
     const promisesForAllDispatch = []
 
+    if (typeof urlParamValue !== 'string') {
+        promisesForAllDispatch.push(store.dispatch('setCrossHair', { crossHair: null }))
+    }
+
     const parts = urlParamValue.split(',')
     if (parts.length === 1) {
         promisesForAllDispatch.push(store.dispatch('setCrossHair', { crossHair: urlParamValue }))

--- a/src/router/storeSync/storeSync.config.js
+++ b/src/router/storeSync/storeSync.config.js
@@ -1,5 +1,6 @@
 import { DEFAULT_PROJECTION } from '@/config'
 import CameraParamConfig from '@/router/storeSync/CameraParamConfig.class'
+import CrossHairParamConfig from '@/router/storeSync/CrossHairParamConfig.class'
 import CustomDispatchUrlParamConfig from '@/router/storeSync/CustomDispatchUrlParamConfig.class'
 import LayerParamConfig from '@/router/storeSync/LayerParamConfig.class'
 import PositionParamConfig from '@/router/storeSync/PositionParamConfig.class'
@@ -101,14 +102,7 @@ const storeSyncConfig = [
         String,
         ''
     ),
-    new SimpleUrlParamConfig(
-        'crosshair',
-        'setCrossHair',
-        'setCrossHair',
-        (store) => store.state.position.crossHair,
-        false,
-        String
-    ),
+    new CrossHairParamConfig(),
     new LayerParamConfig(),
     new SimpleUrlParamConfig(
         'embed',

--- a/src/store/modules/position.store.js
+++ b/src/store/modules/position.store.js
@@ -89,7 +89,8 @@ const state = {
 
     /** @type CrossHairs */
     crossHair: null,
-
+    /** @type Number[] */
+    crossHairPosition: null,
     /**
      * Position of the view when we are in 3D, always expressed in EPSG:3857 (only projection system
      * that works with Cesium)
@@ -229,11 +230,18 @@ const actions = {
     increaseZoom: ({ dispatch, state }) => dispatch('setZoom', Number(state.zoom) + 1),
     decreaseZoom: ({ dispatch, state }) => dispatch('setZoom', Number(state.zoom) - 1),
     /** @param {CrossHairs | String | null} crossHair */
-    setCrossHair: ({ commit }, crossHair) => {
+    setCrossHair: ({ commit, state }, { crossHair, crossHairPosition }) => {
         if (crossHair === null) {
             commit('setCrossHair', crossHair)
         } else if (crossHair in CrossHairs) {
             commit('setCrossHair', CrossHairs[crossHair])
+        }
+        // if a position is defined as param we use it
+        if (crossHairPosition) {
+            commit('setCrossHairPosition', crossHairPosition)
+        } else {
+            // if no position was given, we use the current center of the map as crosshair position
+            commit('setCrossHairPosition', state.center)
         }
     },
     /**
@@ -296,6 +304,13 @@ const actions = {
                 )
             }
 
+            if (state.crossHairPosition) {
+                commit(
+                    'setCrossHairPosition',
+                    proj4(oldProjection.epsg, matchingProjection.epsg, state.crossHairPosition)
+                )
+            }
+
             commit('setProjection', matchingProjection)
         } else {
             log.error('Unsupported projection', projection)
@@ -308,6 +323,8 @@ const mutations = {
     setRotation: (state, rotation) => (state.rotation = rotation),
     setCenter: (state, { x, y }) => (state.center = [x, y]),
     setCrossHair: (state, crossHair) => (state.crossHair = crossHair),
+    setCrossHairPosition: (state, crossHairPosition) =>
+        (state.crossHairPosition = crossHairPosition),
     setCameraPosition: (state, cameraPosition) => (state.camera = cameraPosition),
     setProjection: (state, projection) => (state.projection = projection),
 }

--- a/src/store/modules/position.store.js
+++ b/src/store/modules/position.store.js
@@ -229,19 +229,24 @@ const actions = {
     },
     increaseZoom: ({ dispatch, state }) => dispatch('setZoom', Number(state.zoom) + 1),
     decreaseZoom: ({ dispatch, state }) => dispatch('setZoom', Number(state.zoom) - 1),
-    /** @param {CrossHairs | String | null} crossHair */
+    /**
+     * @param {CrossHairs | String | null} crossHair
+     * @param {Number[] | null} crossHairPosition
+     */
     setCrossHair: ({ commit, state }, { crossHair, crossHairPosition }) => {
         if (crossHair === null) {
-            commit('setCrossHair', crossHair)
+            commit('setCrossHair', null)
+            commit('setCrossHairPosition', null)
         } else if (crossHair in CrossHairs) {
             commit('setCrossHair', CrossHairs[crossHair])
-        }
-        // if a position is defined as param we use it
-        if (crossHairPosition) {
-            commit('setCrossHairPosition', crossHairPosition)
-        } else {
-            // if no position was given, we use the current center of the map as crosshair position
-            commit('setCrossHairPosition', state.center)
+
+            // if a position is defined as param we use it
+            if (crossHairPosition) {
+                commit('setCrossHairPosition', crossHairPosition)
+            } else {
+                // if no position was given, we use the current center of the map as crosshair position
+                commit('setCrossHairPosition', state.center)
+            }
         }
     },
     /**

--- a/tests/e2e-cypress/integration/crosshair.cy.js
+++ b/tests/e2e-cypress/integration/crosshair.cy.js
@@ -1,0 +1,82 @@
+/// <reference types="cypress" />
+
+import { DEFAULT_PROJECTION } from '@/config'
+import { CrossHairs } from '@/store/modules/position.store'
+
+describe('Testing the crosshair URL param', () => {
+    context('At app startup', () => {
+        it('does not add the crosshair by default', () => {
+            cy.goToMapView()
+            cy.readStoreValue('state.position').then((positionStore) => {
+                expect(positionStore.crossHair).to.be.null
+                expect(positionStore.crossHairPosition).to.be.null
+            })
+        })
+        it('adds the crosshair at the center of the map if only the crosshair param is given', () => {
+            cy.goToMapView({
+                crosshair: CrossHairs.point,
+            })
+            cy.readStoreValue('state.position').then((positionStore) => {
+                expect(positionStore.crossHair).to.eq(CrossHairs.point)
+                expect(positionStore.crossHairPosition).to.eql(positionStore.center)
+            })
+        })
+        it('sets the crosshair at the given coordinate if provided in the URL (and not at map center)', () => {
+            const crossHairPosition = DEFAULT_PROJECTION.bounds.center.map((value) => value + 1000)
+            cy.goToMapView({
+                crosshair: `${CrossHairs.bowl},${crossHairPosition.join(',')}`,
+            })
+            cy.readStoreValue('state.position').then((positionStore) => {
+                expect(positionStore.crossHair).to.eq(CrossHairs.bowl)
+                expect(positionStore.crossHairPosition).to.eql(crossHairPosition)
+            })
+        })
+    })
+    context('Changes of URL param value while the app has been loaded', () => {
+        it('Changes the crosshair types correctly if changed after app load', () => {
+            cy.goToMapView({
+                crosshair: CrossHairs.point,
+            })
+            cy.readStoreValue('state.position.crossHair').should('eq', CrossHairs.point)
+            cy.changeUrlParam('crosshair', CrossHairs.marker)
+            cy.readStoreValue('state.position.crossHair').should('eq', CrossHairs.marker)
+        })
+        it('Changes the crosshair position if set after app reload', () => {
+            cy.goToMapView({
+                crosshair: CrossHairs.cross,
+            })
+            cy.readStoreValue('state.position').then((positionStore) => {
+                expect(positionStore.crossHair).to.eq(CrossHairs.cross)
+                expect(positionStore.crossHairPosition).to.eql(positionStore.center)
+            })
+
+            const newCrossHairPosition = DEFAULT_PROJECTION.bounds.center.map(
+                (value) => value - 12345
+            )
+            cy.changeUrlParam(
+                'crosshair',
+                `${CrossHairs.cross},${newCrossHairPosition.join(',')}`,
+                // a change of the crosshair param with position triggers two dispatches: setCrossHair and setCrossHairPosition
+                2
+            )
+            cy.readStoreValue('state.position').then((positionStore) => {
+                expect(positionStore.crossHair).to.eq(CrossHairs.cross)
+                expect(positionStore.crossHairPosition).to.eql(newCrossHairPosition)
+            })
+        })
+        it('removes the crosshair if the URL param is removed (or set to null)', () => {
+            cy.goToMapView({
+                crosshair: CrossHairs.circle,
+            })
+            cy.readStoreValue('state.position').then((positionStore) => {
+                expect(positionStore.crossHair).to.eq(CrossHairs.circle)
+                expect(positionStore.crossHairPosition).to.eql(positionStore.center)
+            })
+            cy.changeUrlParam('crosshair', null, 2)
+            cy.readStoreValue('state.position').then((positionStore) => {
+                expect(positionStore.crossHair).to.be.null
+                expect(positionStore.crossHairPosition).to.be.null
+            })
+        })
+    })
+})


### PR DESCRIPTION
So that it may be changed while the app has been loaded, and moved too (without requiring a complete reload)

Will need to wait for #470 to be merged, and then adapt the crosshair center on a projection change
This fixes #451

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_bgdiinf_sb-3154_dynamic_crosshair/index.html)