### PR TITLE
BGDIINF_SB-3071, BGDIINF_SB-2890: Update import tool to work with lv95 default projection

### DIFF
--- a/src/modules/infobox/components/ImportContent.vue
+++ b/src/modules/infobox/components/ImportContent.vue
@@ -112,6 +112,7 @@ export default {
     computed: {
         ...mapState({
             lang: (state) => state.i18n.lang,
+            projection: (state) => state.position.projection,
         }),
         filteredList() {
             let providers = externalLayerProviders
@@ -213,13 +214,13 @@ export default {
                     }
                 }
                 this.importedLayers = getCap.Capability.Layer.Layer.map((l) =>
-                    getCapWMSLayers(getCap, l)
+                    getCapWMSLayers(getCap, l, this.projection)
                 ).filter((l) => !!l)
             } else if (isWmtsGetCap(fileContent)) {
                 const parser = new WMTSCapabilities()
                 const getCap = parser.read(fileContent)
                 this.importedLayers = getCap.Contents.Layer.map((l) =>
-                    getCapWMTSLayers(url, getCap, l)
+                    getCapWMTSLayers(url, getCap, l, this.projection)
                 ).filter((l) => !!l)
             } else if (isKml(fileContent)) {
                 // todo just for test

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -3,18 +3,20 @@ import ExternalGroupOfLayers from '@/api/layers/ExternalGroupOfLayers.class'
 import { LayerAttribution } from '@/api/layers/AbstractLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
 import proj4 from 'proj4'
-import { WEBMERCATOR, WGS84 } from '@/utils/coordinateSystems'
+import { WGS84 } from '@/utils/coordinates/coordinateSystems'
 
 /**
  * Creates WMS or Group layer config from parsed getCap content
  *
  * @param getCap - Object parsed from WMS getCap XML
  * @param layer - Layer item parsed from WMS getCap XML
- * @param visible
- * @param opacity
+ * @param {CoordinateSystem} projection Projection in which the coordinates of the features should
+ *   be expressed
+ * @param {boolean} visible
+ * @param {number} opacity
  * @returns {ExternalGroupOfLayers | undefined | ExternalWMSLayer}
  */
-export function getCapWMSLayers(getCap, layer, visible = true, opacity = 1) {
+export function getCapWMSLayers(getCap, layer, projection, visible = true, opacity = 1) {
     // If the WMS layer has no name, it can't be displayed
     if (!layer.Name) {
         return undefined
@@ -24,22 +26,22 @@ export function getCapWMSLayers(getCap, layer, visible = true, opacity = 1) {
     if (layer.BoundingBox?.length) {
         const crs = layer.BoundingBox[0].crs
         const extent = layer.BoundingBox[0].extent
-        if (crs === WEBMERCATOR.epsg) {
+        if (crs === projection.epsg) {
             layerExtent = [
                 [extent[0], extent[1]],
                 [extent[2], extent[3]],
             ]
         } else {
             layerExtent = [
-                proj4(crs, WEBMERCATOR.epsg, [extent[0], extent[1]]),
-                proj4(crs, WEBMERCATOR.epsg, [extent[2], extent[3]]),
+                proj4(crs, projection.epsg, [extent[0], extent[1]]),
+                proj4(crs, projection.epsg, [extent[2], extent[3]]),
             ]
         }
     }
 
     // Go through the child to get valid layers
     if (layer.Layer?.length) {
-        const layers = layer.Layer.map((l) => getCapWMSLayers(getCap, l))
+        const layers = layer.Layer.map((l) => getCapWMSLayers(getCap, l, projection))
         return new ExternalGroupOfLayers(layer.Title, wmsUrl, layers, layer.Abstract, layerExtent)
     }
     const attribution = layer.Attribution || getCap.Capability.Layer.Attribution || getCap.Service
@@ -62,11 +64,20 @@ export function getCapWMSLayers(getCap, layer, visible = true, opacity = 1) {
  *
  * @param getCap - Object parsed from WMTS getCap XML
  * @param layer - Layer item parsed from WMTS getCap XML
+ * @param {CoordinateSystem} projection Projection in which the coordinates of the features should
+ *   be expressed
  * @param visible
  * @param opacity
  * @returns {ExternalWMTSLayer}
  */
-export function getCapWMTSLayers(getCapUrl, getCap, layer, visible = true, opacity = 1) {
+export function getCapWMTSLayers(
+    getCapUrl,
+    getCap,
+    layer,
+    projection,
+    visible = true,
+    opacity = 1
+) {
     if (!layer.Identifier) {
         return undefined
     }
@@ -74,8 +85,8 @@ export function getCapWMTSLayers(getCapUrl, getCap, layer, visible = true, opaci
     if (layer.WGS84BoundingBox?.length) {
         const extent = layer.WGS84BoundingBox
         layerExtent = [
-            proj4(WGS84.epsg, WEBMERCATOR.epsg, [extent[0], extent[1]]),
-            proj4(WGS84.epsg, WEBMERCATOR.epsg, [extent[2], extent[3]]),
+            proj4(WGS84.epsg, projection.epsg, [extent[0], extent[1]]),
+            proj4(WGS84.epsg, projection.epsg, [extent[2], extent[3]]),
         ]
     }
 


### PR DESCRIPTION
Now the import tool should work regardless of the projection used.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-3071-import-url-lv95/index.html)