### PR TITLE
BGDIINF_SB-2890: Fixed what3words in popup location

### DIFF
--- a/src/api/what3words.api.js
+++ b/src/api/what3words.api.js
@@ -59,17 +59,20 @@ export const retrieveWhat3WordsLocation = (what3wordsString) => {
  * Sends the location given in param to what3words backend in get the equivalent what3word entry for
  * this coordinate
  *
- * @param location A location expressed in EPSG:3857 projection
- * @param lang The ISO code for the language that should be used to build this w3w
+ * @param {number[]} location A location expressed in the given projection
+ * @param {CoordinateSystem} projection Projection currently in use
+ * @param {string} lang The ISO code for the language that should be used to build this w3w
  * @returns {Promise<String>} The what3words for this location
  */
-export const registerWhat3WordsLocation = (location, lang = 'en') => {
+export const registerWhat3WordsLocation = (location, projection, lang = 'en') => {
     return new Promise((resolve, reject) => {
         if (!Array.isArray(location) && location.length !== 2) {
             reject('Bad location, must be a coordinate array')
         } else {
-            // transforming EPSG:3857 coordinates into EPGS:4326 (WGS84)
-            const [lon, lat] = proj4(WEBMERCATOR.epsg, WGS84.epsg, location)
+            let [lon, lat] = location
+            if (projection.epsg !== WGS84.epsg) {
+                ;[lon, lat] = proj4(projection.epsg, WGS84.epsg, location)
+            }
             axios
                 .get(`${WHAT_3_WORDS_API_BASE_URL}/convert-to-3wa`, {
                     params: {

--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -99,7 +99,6 @@ import { requestHeight } from '@/api/height.api'
 import { generateQrCode } from '@/api/qrcode.api'
 import { createShortLink } from '@/api/shortlink.api'
 import { registerWhat3WordsLocation } from '@/api/what3words.api'
-import { DEFAULT_PROJECTION } from '@/config'
 import LocationPopupCopyInput from '@/modules/map/components/LocationPopupCopyInput.vue'
 import LocationPopupCopySlot from '@/modules/map/components/LocationPopupCopySlot.vue'
 import OpenLayersPopover from '@/modules/map/components/openlayers/OpenLayersPopover.vue'
@@ -110,7 +109,6 @@ import {
     UTMFormat,
     WGS84Format,
 } from '@/utils/coordinates/coordinateFormat'
-import CoordinateSystem from '@/utils/coordinates/CoordinateSystem.class'
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
 import log from '@/utils/logging'
 import { stringifyQuery } from '@/utils/url-router'
@@ -125,12 +123,6 @@ export default {
         LocationPopupCopySlot,
     },
     inject: ['getMap'],
-    props: {
-        projection: {
-            type: CoordinateSystem,
-            default: DEFAULT_PROJECTION,
-        },
-    },
     data() {
         return {
             what3Words: '',
@@ -149,6 +141,7 @@ export default {
             clickInfo: (state) => state.map.clickInfo,
             currentLang: (state) => state.i18n.lang,
             displayLocationPopup: (state) => state.map.displayLocationPopup,
+            projection: (state) => state.position.projection,
         }),
         coordinate() {
             return this.clickInfo?.coordinate
@@ -221,7 +214,11 @@ export default {
         },
         async updateWhat3Word(coordinate, lang) {
             try {
-                this.what3Words = await registerWhat3WordsLocation(coordinate, lang)
+                this.what3Words = await registerWhat3WordsLocation(
+                    coordinate,
+                    this.projection,
+                    lang
+                )
             } catch (error) {
                 log.error(`Failed to retrieve What3Words Location`)
                 this.what3Words = ''

--- a/src/modules/map/components/openlayers/OpenLayersExternalWMTSLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersExternalWMTSLayer.vue
@@ -24,7 +24,7 @@ export default {
         },
         projection: {
             type: CoordinateSystem,
-            default: DEFAULT_PROJECTION,
+            required: true,
         },
         zIndex: {
             type: Number,

--- a/src/modules/map/components/openlayers/OpenLayersGeoJSONLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersGeoJSONLayer.vue
@@ -39,7 +39,7 @@ export default {
         },
         projection: {
             type: CoordinateSystem,
-            default: DEFAULT_PROJECTION,
+            required: true,
         },
         zIndex: {
             type: Number,

--- a/src/modules/map/components/openlayers/OpenLayersHighlightedFeature.vue
+++ b/src/modules/map/components/openlayers/OpenLayersHighlightedFeature.vue
@@ -62,7 +62,7 @@ export default {
         },
         projection: {
             type: CoordinateSystem,
-            default: DEFAULT_PROJECTION,
+            required: true,
         },
         zIndex: {
             type: Number,

--- a/src/modules/map/components/openlayers/OpenLayersInternalLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersInternalLayer.vue
@@ -132,7 +132,7 @@ export default {
         },
         projection: {
             type: CoordinateSystem,
-            default: DEFAULT_PROJECTION,
+            required: true,
         },
         zIndex: {
             type: Number,

--- a/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
@@ -34,7 +34,7 @@ export default {
         },
         projection: {
             type: CoordinateSystem,
-            default: DEFAULT_PROJECTION,
+            required: true,
         },
         zIndex: {
             type: Number,

--- a/src/modules/map/components/openlayers/OpenLayersMouseTracker.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMouseTracker.vue
@@ -12,25 +12,23 @@
     <div ref="mousePosition" class="mouse-position" data-cy="mouse-position"></div>
 </template>
 <script>
-import { DEFAULT_PROJECTION } from '@/config'
 import allFormats, { LV03Format, LV95Format } from '@/utils/coordinates/coordinateFormat'
-import CoordinateSystem from '@/utils/coordinates/CoordinateSystem.class'
 import log from '@/utils/logging'
 import MousePosition from 'ol/control/MousePosition'
+import { mapState } from 'vuex'
 
 export default {
     inject: ['getMap'],
-    props: {
-        projection: {
-            type: CoordinateSystem,
-            default: DEFAULT_PROJECTION,
-        },
-    },
     data() {
         return {
             availableFormats: allFormats,
             displayedFormatId: LV95Format.id,
         }
+    },
+    computed: {
+        ...mapState({
+            projection: (state) => state.position.projection,
+        }),
     },
     created() {
         this.mousePositionControl = new MousePosition({

--- a/src/modules/map/components/openlayers/OpenLayersWMSLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersWMSLayer.vue
@@ -32,7 +32,7 @@ export default {
         },
         projection: {
             type: CoordinateSystem,
-            default: DEFAULT_PROJECTION,
+            required: true,
         },
         zIndex: {
             type: Number,

--- a/src/modules/map/components/openlayers/OpenLayersWMTSLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersWMTSLayer.vue
@@ -29,7 +29,7 @@ export default {
         },
         projection: {
             type: CoordinateSystem,
-            default: DEFAULT_PROJECTION,
+            required: true,
         },
         zIndex: {
             type: Number,


### PR DESCRIPTION
The reprojection for what3words was always done by taking webmercator.

The location popup used only lv95 as projection which was wrong for webmercator

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-2890-default-projection/index.html)