### PR TITLE
BGDIINF_SB-2890: Fixed projection error with external WMS layer

### DIFF
--- a/src/utils/coordinates/CoordinateSystem.class.js
+++ b/src/utils/coordinates/CoordinateSystem.class.js
@@ -27,12 +27,14 @@ export default class CoordinateSystem {
      *   section "Projected bounds" of a projection's page. It is possible to specify a custom
      *   center to these bounds, so that the application starts at this custom center instead of the
      *   natural center (when no coordinates are specified at startup).
+     * @param {string[]} aliases List Alias used for proj4
      */
-    constructor(epsgNumber, label, proj4transformationMatrix, bounds = null) {
+    constructor(epsgNumber, label, proj4transformationMatrix, bounds = null, aliases = []) {
         this.epsgNumber = epsgNumber
         this.label = label
         this.proj4transformationMatrix = proj4transformationMatrix
         this.bounds = bounds
+        this.aliases = aliases
     }
 
     /**

--- a/src/utils/coordinates/WGS84CoordinateSystem.class.js
+++ b/src/utils/coordinates/WGS84CoordinateSystem.class.js
@@ -18,7 +18,8 @@ export default class WGS84CoordinateSystem extends StandardCoordinateSystem {
                 90.0,
                 // center of LV95's extent transformed with epsg.io website
                 [8.239436, 46.832259]
-            )
+            ),
+            ['CRS:84']
         )
     }
 

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -4,6 +4,7 @@ import { LayerAttribution } from '@/api/layers/AbstractLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
 import proj4 from 'proj4'
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
+import log from './logging'
 
 /**
  * Creates WMS or Group layer config from parsed getCap content
@@ -32,10 +33,15 @@ export function getCapWMSLayers(getCap, layer, projection, visible = true, opaci
                 [extent[2], extent[3]],
             ]
         } else {
-            layerExtent = [
-                proj4(crs, projection.epsg, [extent[0], extent[1]]),
-                proj4(crs, projection.epsg, [extent[2], extent[3]]),
-            ]
+            try {
+                layerExtent = [
+                    proj4(crs, projection.epsg, [extent[0], extent[1]]),
+                    proj4(crs, projection.epsg, [extent[2], extent[3]]),
+                ]
+            } catch (error) {
+                log.error(`Failed to re-project ${crs} to ${projection.epsg}: ${error}`)
+                throw error
+            }
         }
     }
 

--- a/src/utils/setupProj4.js
+++ b/src/utils/setupProj4.js
@@ -1,4 +1,4 @@
-import { LV03, LV95, WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
+import allCoordinateSystems from '@/utils/coordinates/coordinateSystems'
 import log from '@/utils/logging'
 import proj4 from 'proj4'
 
@@ -14,7 +14,7 @@ import proj4 from 'proj4'
  *
  * @param {CoordinateSystem[]} projections
  */
-const setupProj4 = (projections = [WEBMERCATOR, LV95, LV03]) => {
+const setupProj4 = (projections = allCoordinateSystems) => {
     // adding projection defining a transformation matrix to proj4 (these projection matrices can be found on the epsg.io website)
     projections
         .filter((projection) => projection.proj4transformationMatrix)
@@ -25,6 +25,14 @@ const setupProj4 = (projections = [WEBMERCATOR, LV95, LV03]) => {
                 log.error('Error while setting up projection in proj4', projection.epsg, err)
                 throw err
             }
+        })
+    // Adding projection alias
+    projections
+        .filter((projection) => projection.aliases)
+        .forEach((projection) => {
+            projection.aliases.forEach((alias) => {
+                proj4.defs(alias, proj4.defs(projection.epsg))
+            })
         })
 }
 


### PR DESCRIPTION
Some external WMS layer may use CRS:84 as CRS instead of ESPG:4326. This would
make the re-project failed.

Now we support the CRS:84 alias.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2890-projection-alias/index.html)