### PR TITLE
Fix result selection bug in import tool

### DIFF
--- a/src/modules/infobox/components/ImportContentResultList.vue
+++ b/src/modules/infobox/components/ImportContentResultList.vue
@@ -105,13 +105,8 @@ export default {
             this.revertSort = !this.revertSort
         },
         onItemClick(layer) {
-            if (this.selectedLayer?.externalLayerId === layer.externalLayerId) {
-                this.selectedLayer = undefined
-                this.description = ''
-            } else {
-                this.selectedLayer = layer
-                this.description = this.selectedLayer.abstract
-            }
+            this.selectedLayer = layer
+            this.description = this.selectedLayer.abstract
         },
         onPreviewStart(layer) {
             this.setPreviewLayer(layer)


### PR DESCRIPTION
In the import tool in the result list clicking on a selected result would deselect
it. From a user perspective this don't make sense to unselect because we can
anyway only select one and it is kind of annoying when clicking twice on a
entry.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-import-tool/index.html)