### PR TITLE
BGDIINF_SB-2890: Removed lightbasemap under pixelkarte in webmercartor

### DIFF
--- a/src/modules/map/components/footer/MapFooterAttributionList.vue
+++ b/src/modules/map/components/footer/MapFooterAttributionList.vue
@@ -28,7 +28,6 @@
 </template>
 
 <script>
-import { VECTOR_LIGHT_BASE_MAP_STYLE_ID } from '@/config'
 import MapFooterAttributionItem from '@/modules/map/components/footer/MapFooterAttributionItem.vue'
 import ThirdPartDisclaimer from '@/utils/ThirdPartDisclaimer.vue'
 import { mapGetters, mapState } from 'vuex'
@@ -40,29 +39,12 @@ export default {
             layersConfig: (state) => state.layers.config,
             currentBackgroundLayer: (state) => state.layers.currentBackgroundLayer,
         }),
-        ...mapGetters(['visibleLayers', 'hasDataDisclaimer', 'isExtentOnlyWithinLV95Bounds']),
+        ...mapGetters(['visibleLayers', 'hasDataDisclaimer']),
         layers() {
             const layers = []
             // when the background is void, we receive `undefined` here
             if (this.currentBackgroundLayer) {
                 layers.push(this.currentBackgroundLayer)
-            }
-            /*
-             Edge case that will be removed as soon as we have a proper VT pixelkarte layer.
-
-             As we are showing LightBaseMap layer behind pixelkarte-farbe whenever we are not
-             covering only Swiss grounds, we need to add the attribution of LightBaseMap depending
-             on the current extent of the app
-             */
-            if (
-                this.currentBackgroundLayer?.getID() === 'ch.swisstopo.pixelkarte-farbe' &&
-                !this.isExtentOnlyWithinLV95Bounds
-            ) {
-                layers.push(
-                    this.layersConfig.find(
-                        (layer) => layer.getID() === VECTOR_LIGHT_BASE_MAP_STYLE_ID
-                    )
-                )
             }
             layers.push(...this.visibleLayers)
             return layers


### PR DESCRIPTION
Both map doesn't fit at all together and it doesn't make sense to use them
as a background.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-2890-background/index.html)