### PR TITLE
BGDIINF_SB-2890: Fixed goelocation e2e tests

### DIFF
--- a/tests/e2e-cypress/integration/geolocation.cy.js
+++ b/tests/e2e-cypress/integration/geolocation.cy.js
@@ -1,5 +1,12 @@
 /// <reference types="cypress" />
 
+import { DEFAULT_PROJECTION } from '@/config'
+import { WGS84 } from '@/utils/coordinates/coordinateSystems'
+import setupProj4 from '@/utils/setupProj4'
+import proj4 from 'proj4'
+
+setupProj4()
+
 const geolocationButtonSelector = '[data-cy="geolocation-button"]'
 
 function getGeolocationButtonAndClickIt() {
@@ -44,8 +51,7 @@ describe('Geolocation cypress', () => {
             const latitude = 47.5
             const longitude = 6.8
             // same position but in EPSG:2056 (default projection of the app)
-            const x = 2551881.86
-            const y = 1261223.97
+            const [x, y] = proj4(WGS84.epsg, DEFAULT_PROJECTION.epsg, [longitude, latitude])
 
             beforeEach(() => {
                 cy.goToMapView({}, false, { latitude, longitude })

--- a/tests/e2e-cypress/integration/geolocation.cy.js
+++ b/tests/e2e-cypress/integration/geolocation.cy.js
@@ -43,9 +43,9 @@ describe('Geolocation cypress', () => {
             // lon/lat to mock up the Geolocation API (see beforeEach)
             const latitude = 47.5
             const longitude = 6.8
-            // same position but in EPSG:3857 (that's what will be stored by our app)
-            const x = 756972.54
-            const y = 6024072.12
+            // same position but in EPSG:2056 (default projection of the app)
+            const x = 2551881.86
+            const y = 1261223.97
 
             beforeEach(() => {
                 cy.goToMapView({}, false, { latitude, longitude })


### PR DESCRIPTION
The map default projection is now LV95 therefore test should be either adapted to use lv95 or set the mercator projection.
[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-2890-geolocation-e2e/index.html)