### PR TITLE
BGDIINF_SB-2890: fix infobox test

### DIFF
--- a/src/modules/menu/MenuModule.vue
+++ b/src/modules/menu/MenuModule.vue
@@ -40,8 +40,8 @@
                 :active="showTimeSlider"
                 @click="showTimeSlider = !showTimeSlider"
             />
-            <DebugToolbar v-if="hasDevSiteWarning" class="position-absolute end-0" />
         </div>
+        <DebugToolbar v-if="hasDevSiteWarning" class="position-absolute end-0 debug-toolbar" />
         <div
             class="menu-tray-container position-absolute w-100 h-100"
             :class="{
@@ -180,6 +180,9 @@ $openCloseButtonHeight: 2.5rem;
         &.dev-disclaimer-present {
             top: $header-height + $dev-disclaimer-height;
         }
+    }
+    .debug-toolbar {
+        top: 66%;
     }
     .menu-tray-container {
         pointer-events: none;

--- a/src/utils/coordinates/coordinateUtils.js
+++ b/src/utils/coordinates/coordinateUtils.js
@@ -62,3 +62,22 @@ export function toRoundedString(coordinate, digits, withThousandsSeparator = tru
         .join(', ')
         .replace(/\B(?=(\d{3})+(?!\d))/g, "'")
 }
+
+/**
+ * Projection of an extent, described as [topLeftX, topLeftY, bottomRightX, bottomRightY]
+ *
+ * @param {CoordinateSystem} fromProj Current projection used to describe the extent
+ * @param {CoordinateSystem} toProj Target projection we want the extent be expressed in
+ * @param {Number[]} extent An extent, described as `[topLeftX, topLeftY, bottomRightX,
+ *   bottomRightY]`
+ * @returns {null | Number[]} The reprojected extent, or null if the given extent is not an array of
+ *   four numbers
+ */
+export function projExtent(fromProj, toProj, extent) {
+    if (extent.length === 4) {
+        const topLeft = proj4(fromProj.epsg, toProj.epsg, [extent[0], extent[1]])
+        const bottomRight = proj4(fromProj.epsg, toProj.epsg, [extent[2], extent[3]])
+        return [...topLeft, ...bottomRight]
+    }
+    return null
+}

--- a/tests/e2e-cypress/integration/infobox.cy.js
+++ b/tests/e2e-cypress/integration/infobox.cy.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { LV95 } from '@/utils/coordinates/coordinateSystems'
+import { LV95, WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
 
 describe('The infobox', () => {
     const generateInfoboxTestsForMapSelector = (mapSelector, with3d = false) => {
@@ -161,7 +161,7 @@ describe('The infobox', () => {
     })
     context('Cesium map', () => {
         beforeEach(() => {
-            cy.goToMapView({ layers: layer, '3d': true })
+            cy.goToMapView({ layers: layer, '3d': true, sr: WEBMERCATOR.epsgNumber })
         })
         generateInfoboxTestsForMapSelector('[data-cy="cesium-map"]', true)
     })


### PR DESCRIPTION
Do not request feature to the backend when we change projection, but only reproject on the fly

Feature API file now only requests feature detail in LV95, and transform/reproject the result into the wanted projection (had some issue with Mercator support in some instances)

Move the debug toolbar a bit down, so that it doesn't cover the middle of the map div. It was failing some tests because of that (Cypress thought something was covering a click on the center of the map)

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_bgdiinf_sb-2890_fix_infobox_test/index.html)