### PR TITLE
BGDIINF_SB-3162, BGDIINF_SB-3163: Fixed background in lv95

### DIFF
--- a/src/modules/map/components/footer/MapFooterBackgroundSelector.vue
+++ b/src/modules/map/components/footer/MapFooterBackgroundSelector.vue
@@ -20,17 +20,14 @@
                 :data-cy="`background-selector-${background.getID()}`"
                 @click="selectBackground(background, $event)"
             >
-                <div class="bg-selector-button-label">
+                <div class="bg-selector-button-label text-wrap">
                     {{ $t(getLayerTranslationLabel(background)) }}
                 </div>
             </button>
         </div>
         <button
             class="bg-selector-trigger"
-            :class="[
-                { 'bigger-pulse': animateMainButton },
-                'bg-ch-swisstopo-leichte-basiskarte-imagery_world-vt',
-            ]"
+            :class="[{ 'bigger-pulse': animateMainButton }]"
             type="button"
             :title="$t('bg_toggle')"
             @click="toggleBackgroundWheel"
@@ -47,7 +44,6 @@
 </template>
 
 <script>
-import { VECTOR_LIGHT_BASE_MAP_STYLE_ID, VECTOR_TILES_IMAGERY_STYLE_ID } from '@/config'
 import { mapActions, mapGetters, mapState } from 'vuex'
 
 const voidLayer = {
@@ -104,11 +100,10 @@ export default {
                     return 'void_layer'
                 case 'ch.swisstopo.pixelkarte-farbe':
                     return 'bg_pixel_color'
+                case 'ch.swisstopo.pixelkarte-grau':
+                    return 'bg_pixel_grey'
                 case 'ch.swisstopo.swissimage':
-                case VECTOR_TILES_IMAGERY_STYLE_ID:
                     return 'bg_luftbild'
-                case VECTOR_LIGHT_BASE_MAP_STYLE_ID:
-                    return 'basis'
                 default:
                     return layer.name || layer.getID()
             }

--- a/src/store/plugins/topic-change-management.plugin.js
+++ b/src/store/plugins/topic-change-management.plugin.js
@@ -1,5 +1,4 @@
 import { loadTopicTreeForTopic } from '@/api/topics.api'
-import { VECTOR_LIGHT_BASE_MAP_STYLE_ID } from '@/config'
 import { CHANGE_TOPIC_MUTATION } from '@/store/modules/topics.store'
 
 let isFirstSetTopic = true
@@ -34,15 +33,7 @@ const topicChangeManagementPlugin = (store) => {
             // we set it anyway if the URL doesn't contain a bgLayer URL param
             if (!isFirstSetTopic || window.location.href.indexOf('bgLayer=') === -1) {
                 if (currentTopic.defaultBackgroundLayer) {
-                    // edge case for pixelkarte-grau, we force LightBaseMap as background instead
-                    if (
-                        currentTopic.defaultBackgroundLayer.getID() ===
-                        'ch.swisstopo.pixelkarte-grau'
-                    ) {
-                        store.dispatch('setBackground', VECTOR_LIGHT_BASE_MAP_STYLE_ID)
-                    } else {
-                        store.dispatch('setBackground', currentTopic.defaultBackgroundLayer.getID())
-                    }
+                    store.dispatch('setBackground', currentTopic.defaultBackgroundLayer.getID())
                 } else {
                     store.dispatch('setBackground', null)
                 }


### PR DESCRIPTION
Now the background are the regular old products, pixelkarte-grau and swissimage
in lv95 projection.

Unfortunately I could not easily add the lightbasemap and the world image
as other options in Web Mercator mode because the current BackgroundSelector
cannot be dynamic, it is made of lots of CSS magics with a hardcoded value
in css on how many background is available. So we cannot have a dynamic number
of available background without reworking the bg selector.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-3162-lightbasemap/index.html)