### PR TITLE
BGDIINF_SB-3168: Fix external layer parsing error (no `layer.name`)

### DIFF
--- a/src/modules/infobox/components/ImportContent.vue
+++ b/src/modules/infobox/components/ImportContent.vue
@@ -3,6 +3,7 @@
         data-infobox="height-reference"
         class="import-overlay-content"
         :class="{ 'with-layers': importedLayers?.length }"
+        data-cy="import-tool-content"
     >
         <div class="input-group d-flex">
             <input
@@ -21,6 +22,7 @@
             <button
                 class="list-switch"
                 :class="{ 'clear-btn-shown': importValue?.length > 0 }"
+                data-cy="import-list-switch-button"
                 @click="toggleProviders"
             >
                 <FontAwesomeIcon :icon="listShown ? 'caret-up' : 'caret-down'" />
@@ -30,13 +32,13 @@
                 id="button-addon1"
                 class="btn btn-outline-group rounded-end"
                 type="button"
-                data-cy="searchbar-clear"
+                data-cy="import-input-clear"
                 @click="clearImportQuery"
             >
                 <FontAwesomeIcon :icon="['fas', 'times-circle']" />
             </button>
             <div v-if="listShown" ref="providers" class="providers-list-container bg-light">
-                <div class="providers-list">
+                <div class="providers-list" data-cy="import-provider-list">
                     <div
                         v-for="(provider, key) in filteredList"
                         :key="provider"
@@ -65,6 +67,7 @@
                 type="button"
                 class="btn btn-outline-secondary connect-btn mt-1"
                 :disabled="isConnectDisabled"
+                data-cy="import-connect-button"
                 @click="onConnect"
             >
                 {{ buttonText }}

--- a/src/modules/infobox/components/ImportContentResultList.vue
+++ b/src/modules/infobox/components/ImportContentResultList.vue
@@ -20,7 +20,7 @@
                         </button>
                     </div>
                 </div>
-                <div class="results-list overflow-y-auto">
+                <div class="results-list overflow-y-auto" data-cy="import-result-list">
                     <ImportContentResultItem
                         v-for="(layer, index) in sortedList"
                         :key="`${index}-${layer.externalLayerId}`"
@@ -49,6 +49,7 @@
                         type="button"
                         class="btn btn-outline-secondary add-btn mt-1 w-100"
                         :disabled="!selectedLayer"
+                        data-cy="import-add-layer-button"
                         @click="onAddLayer"
                     >
                         {{ $t('add_layer') }}

--- a/src/modules/infobox/components/ImportContentResultList.vue
+++ b/src/modules/infobox/components/ImportContentResultList.vue
@@ -64,7 +64,6 @@
 import { mapActions } from 'vuex'
 import ImportContentResultItem from './ImportContentResultItem.vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import MenuTopicTreeItem from '@/modules/menu/components/topics/MenuTopicTreeItem.vue'
 
 export default {
     components: { ImportContentResultItem, FontAwesomeIcon },

--- a/src/modules/infobox/utils/external-provider-parsers.js
+++ b/src/modules/infobox/utils/external-provider-parsers.js
@@ -4,7 +4,7 @@ import { LayerAttribution } from '@/api/layers/AbstractLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
 import proj4 from 'proj4'
 import allCoordinateSystems, { WGS84 } from '@/utils/coordinates/coordinateSystems'
-import log from './logging'
+import log from '@/utils/logging'
 
 /**
  * Creates WMS or Group layer config from parsed getCap content

--- a/src/modules/infobox/utils/external-provider-parsers.js
+++ b/src/modules/infobox/utils/external-provider-parsers.js
@@ -19,7 +19,13 @@ import log from '@/utils/logging'
  */
 export function getCapWMSLayers(getCap, layer, projection, visible = true, opacity = 1) {
     // If the WMS layer has no name, it can't be displayed
-    if (!layer.Name) {
+    let name = layer.name
+    if (!name && layer.Title) {
+        // if we don't have a name use the title as name
+        name = layer.Title
+    }
+    if (!name) {
+        log.error(`No layer and/or title available`, layer)
         return undefined
     }
     const wmsUrl = getCap.Capability.Request.GetMap.DCPType[0].HTTP.Get.OnlineResource
@@ -42,7 +48,7 @@ export function getCapWMSLayers(getCap, layer, projection, visible = true, opaci
                 ]
             } else {
                 log.error(
-                    `No valid bounding box found in GetCapabilities for layer ${layer.title}`,
+                    `No valid bounding box found in GetCapabilities for layer ${name}`,
                     getCap,
                     layer
                 )
@@ -90,6 +96,7 @@ export function getCapWMTSLayers(
     opacity = 1
 ) {
     if (!layer.Identifier) {
+        log.error(`No layer identifier available`, layer)
         return undefined
     }
     let layerExtent = undefined

--- a/src/modules/infobox/utils/external-provider-parsers.js
+++ b/src/modules/infobox/utils/external-provider-parsers.js
@@ -19,7 +19,7 @@ import log from '@/utils/logging'
  */
 export function getCapWMSLayers(getCap, layer, projection, visible = true, opacity = 1) {
     // If the WMS layer has no name, it can't be displayed
-    let name = layer.name
+    let name = layer.Name
     if (!name && layer.Title) {
         // if we don't have a name use the title as name
         name = layer.Title
@@ -67,7 +67,7 @@ export function getCapWMSLayers(getCap, layer, projection, visible = true, opaci
         opacity,
         visible,
         wmsUrl,
-        layer.Name,
+        name,
         [new LayerAttribution(attribution.Title, attribution.OnlineResource)],
         getCap.version,
         'png',

--- a/src/modules/map/components/cesium/CesiumMap.vue
+++ b/src/modules/map/components/cesium/CesiumMap.vue
@@ -262,7 +262,6 @@ export default {
             'setCenter',
         ]),
         async createViewer() {
-            console.log('creating Cesium viewer')
             this.viewer = new Viewer(this.$refs.viewer, {
                 contextOptions: {
                     webgl: {

--- a/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
+++ b/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
@@ -5,6 +5,7 @@
                 class="advanced-tools-title"
                 :class="{ 'text-primary': importOverlay }"
                 :title="$t('import_tooltip')"
+                data-cy="menu-import-tool"
                 @click.stop="onToggleImportOverlay"
                 >{{ $t('import') }}</a
             >

--- a/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
+++ b/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
@@ -3,6 +3,7 @@
         <li class="advanced-tools-item">
             <a
                 class="advanced-tools-title"
+                :class="{ 'text-primary': importOverlay }"
                 :title="$t('import_tooltip')"
                 @click.stop="onToggleImportOverlay"
                 >{{ $t('import') }}</a
@@ -12,9 +13,10 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex'
+import { mapActions, mapState } from 'vuex'
 
 export default {
+    computed: { ...mapState({ importOverlay: (state) => state.ui.importOverlay }) },
     methods: {
         ...mapActions(['toggleImportOverlay']),
         onToggleImportOverlay() {

--- a/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
+++ b/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
@@ -14,14 +14,17 @@
 </template>
 
 <script>
-import { mapActions, mapState } from 'vuex'
+import { mapActions, mapState, mapGetters } from 'vuex'
 
 export default {
-    computed: { ...mapState({ importOverlay: (state) => state.ui.importOverlay }) },
+    computed: {
+        ...mapState({ importOverlay: (state) => state.ui.importOverlay }),
+        ...mapGetters(['isPhoneMode']),
+    },
     methods: {
         ...mapActions(['toggleImportOverlay', 'toggleMenu']),
         onToggleImportOverlay() {
-            if (!this.importOverlay) {
+            if (!this.importOverlay && this.isPhoneMode) {
                 // To avoid the menu overlapping the import overlay after open we automatically
                 // close the menu
                 this.toggleMenu()

--- a/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
+++ b/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
@@ -19,8 +19,13 @@ import { mapActions, mapState } from 'vuex'
 export default {
     computed: { ...mapState({ importOverlay: (state) => state.ui.importOverlay }) },
     methods: {
-        ...mapActions(['toggleImportOverlay']),
+        ...mapActions(['toggleImportOverlay', 'toggleMenu']),
         onToggleImportOverlay() {
+            if (!this.importOverlay) {
+                // To avoid the menu overlapping the import overlay after open we automatically
+                // close the menu
+                this.toggleMenu()
+            }
             this.toggleImportOverlay()
         },
     },

--- a/src/modules/menu/components/menu/MenuTray.vue
+++ b/src/modules/menu/components/menu/MenuTray.vue
@@ -29,6 +29,7 @@
         <MenuSection
             id="toolsSection"
             ref="toolsSection"
+            data-cy="menu-tray-tool-section"
             :title="$t('map_tools')"
             secondary
             @open-menu-section="onOpenMenuSection"

--- a/src/modules/menu/components/menu/MenuTray.vue
+++ b/src/modules/menu/components/menu/MenuTray.vue
@@ -86,7 +86,7 @@ export default {
             /* Please note that if the following 2 arrays are updated, "grid-template-rows" in
             the css section must also be updated. */
             scrollableMenuSections: ['topicsSection', 'activeLayersSection'],
-            nonScrollableMenuSections: ['settingsSection', 'shareSection'],
+            nonScrollableMenuSections: ['settingsSection', 'shareSection', 'toolsSection'],
         }
     },
     computed: {

--- a/tests/e2e-cypress/fixtures/import-tool/wms-geo-admin-get-capabilities.xml
+++ b/tests/e2e-cypress/fixtures/import-tool/wms-geo-admin-get-capabilities.xml
@@ -1,0 +1,328 @@
+<?xml version='1.0' encoding="UTF-8" standalone="no"?>
+<WMS_Capabilities version="1.3.0" xmlns="http://www.opengis.net/wms"
+    xmlns:sld="http://www.opengis.net/sld" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+    xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd
+                        http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd
+                        http://mapserver.gis.umn.edu/mapserver https://wms.geo.admin.ch/?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
+
+    <!-- MapServer version 7.6.5 OUTPUT=PNG OUTPUT=JPEG OUTPUT=KML SUPPORTS=PROJ SUPPORTS=AGG
+    SUPPORTS=FREETYPE SUPPORTS=CAIRO SUPPORTS=SVG_SYMBOLS SUPPORTS=RSVG SUPPORTS=ICONV
+    SUPPORTS=FRIBIDI SUPPORTS=WMS_SERVER SUPPORTS=WMS_CLIENT SUPPORTS=WFS_SERVER SUPPORTS=WFS_CLIENT
+    SUPPORTS=WCS_SERVER SUPPORTS=SOS_SERVER SUPPORTS=FASTCGI SUPPORTS=GEOS SUPPORTS=POINT_Z_M
+    SUPPORTS=PBF INPUT=JPEG INPUT=POSTGIS INPUT=OGR INPUT=GDAL INPUT=SHAPEFILE -->
+
+    <Service>
+        <Name>WMS</Name>
+        <Title>WMS IFDG</Title>
+        <Abstract>Données publiques de l&#39;infrastructure fédérale de données géographiques (IFDG) (Revision: service-wms: 0244b64 mapfile_include: 4ed4106)</Abstract>
+        <KeywordList>
+            <Keyword>BGDI Geodaten</Keyword>
+        </KeywordList>
+        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+            xlink:href="https://wms.geo.admin.ch/?" />
+        <ContactInformation>
+            <ContactPersonPrimary>
+                <ContactPerson>webgis@swisstopo.ch</ContactPerson>
+                <ContactOrganization>Office fédéral de topographie swisstopo</ContactOrganization>
+            </ContactPersonPrimary>
+            <ContactAddress>
+                <AddressType>text/html</AddressType>
+                <Address>Seftigenstrasse 264</Address>
+                <City>Wabern</City>
+                <StateOrProvince>Kanton Bern</StateOrProvince>
+                <PostCode>3084</PostCode>
+                <Country>Schweiz</Country>
+            </ContactAddress>
+            <ContactVoiceTelephone>+41 (0)58 / 469 01 11</ContactVoiceTelephone>
+            <ContactFacsimileTelephone>+41 (0)58 / 469 04 59</ContactFacsimileTelephone>
+        </ContactInformation>
+        <Fees>none</Fees>
+        <MaxWidth>10000</MaxWidth>
+        <MaxHeight>10000</MaxHeight>
+    </Service>
+
+    <Capability>
+        <Request>
+            <GetCapabilities>
+                <Format>text/xml</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://wms.geo.admin.ch/?" />
+                        </Get>
+                        <Post>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://wms.geo.admin.ch/?" />
+                        </Post>
+                    </HTTP>
+                </DCPType>
+            </GetCapabilities>
+            <GetMap>
+                <Format>image/jpeg</Format>
+                <Format>image/png</Format>
+                <Format>image/pnga</Format>
+                <Format>image/png; mode=32bit</Format>
+                <Format>image/png; mode=8bit</Format>
+                <Format>image/tiff</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://wms.geo.admin.ch/?" />
+                        </Get>
+                        <Post>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://wms.geo.admin.ch/?" />
+                        </Post>
+                    </HTTP>
+                </DCPType>
+            </GetMap>
+            <GetFeatureInfo>
+                <Format>application/json</Format>
+                <Format>application/json; subtype=geojson</Format>
+                <Format>application/vnd.ogc.gml</Format>
+                <Format>text/plain</Format>
+                <Format>text/xml</Format>
+                <Format>text/xml; subtype=gml/3.1.1</Format>
+                <Format>text/xml; subtype=gml/3.2.1</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://wms.geo.admin.ch/?" />
+                        </Get>
+                        <Post>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://wms.geo.admin.ch/?" />
+                        </Post>
+                    </HTTP>
+                </DCPType>
+            </GetFeatureInfo>
+            <sld:DescribeLayer>
+                <Format>text/xml</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://wms.geo.admin.ch/?" />
+                        </Get>
+                        <Post>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://wms.geo.admin.ch/?" />
+                        </Post>
+                    </HTTP>
+                </DCPType>
+            </sld:DescribeLayer>
+            <sld:GetLegendGraphic>
+                <Format>image/png</Format>
+                <Format>image/jpeg</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://wms.geo.admin.ch/?" />
+                        </Get>
+                        <Post>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://wms.geo.admin.ch/?" />
+                        </Post>
+                    </HTTP>
+                </DCPType>
+            </sld:GetLegendGraphic>
+            <ms:GetStyles>
+                <Format>text/xml</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://wms.geo.admin.ch/?" />
+                        </Get>
+                        <Post>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://wms.geo.admin.ch/?" />
+                        </Post>
+                    </HTTP>
+                </DCPType>
+            </ms:GetStyles>
+        </Request>
+        <Exception>
+            <Format>XML</Format>
+            <Format>INIMAGE</Format>
+            <Format>BLANK</Format>
+        </Exception>
+        <sld:UserDefinedSymbolization SupportSLD="1" UserLayer="0" UserStyle="1" RemoteWFS="0"
+            InlineFeature="0" RemoteWCS="0" />
+        <Layer>
+            <Title>WMS IFDG</Title>
+            <Abstract>Données publiques de l&#39;infrastructure fédérale de données géographiques (IFDG) (Revision: service-wms: 0244b64 mapfile_include: 4ed4106)</Abstract>
+            <KeywordList>
+                <Keyword>BGDI Geodaten</Keyword>
+            </KeywordList>
+            <CRS>EPSG:2056</CRS>
+            <CRS>EPSG:21781</CRS>
+            <CRS>EPSG:4326</CRS>
+            <CRS>EPSG:3857</CRS>
+            <CRS>EPSG:3034</CRS>
+            <CRS>EPSG:3035</CRS>
+            <CRS>EPSG:4258</CRS>
+            <CRS>EPSG:25832</CRS>
+            <CRS>EPSG:25833</CRS>
+            <CRS>EPSG:31467</CRS>
+            <CRS>EPSG:32632</CRS>
+            <CRS>EPSG:32633</CRS>
+            <CRS>EPSG:900913</CRS>
+            <EX_GeographicBoundingBox>
+                <westBoundLongitude>0.659965</westBoundLongitude>
+                <eastBoundLongitude>10.8344</eastBoundLongitude>
+                <southBoundLatitude>45.4183</southBoundLatitude>
+                <northBoundLatitude>48.7495</northBoundLatitude>
+            </EX_GeographicBoundingBox>
+            <BoundingBox CRS="EPSG:2056"
+                minx="2.1e+06" miny="1.05e+06" maxx="2.85e+06" maxy="1.4e+06" />
+            <Attribution>
+                <Title>Das Geoportal des Bundes</Title>
+                <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                    xlink:href="http://www.geo.admin.ch/" />
+                <LogoURL width="50" height="45">
+                    <Format>image/png</Format>
+                    <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple"
+                        xlink:href="http://wms.geo.admin.ch/medias/ch45x50.png" />
+                </LogoURL>
+            </Attribution>
+            <Layer queryable="1" opaque="0" cascaded="0">
+                <Name>ch.vbs.armee-kriegsdenkmaeler</Name>
+                <Title>Mémoriaux de l`armée et de guerre</Title>
+                <Abstract>L`inventaire des mémoriaux de l`armée et de guerre en Suisse inclut environ 1000 sculptures, pierres et plaques commémoratives, stèles, obélisques ou statues qui ont été érigées au fil des ans en Suisse pour commémorer des événements et des personnages de l`histoire militaire. Elles commémorent d`anciennes batailles suisses, la présence de forces armées étrangères en Suisse, des accidents et des catastrophes, des unités de troupes dissoutes, des personnalités marquantes de l`armée ou les deux services actifs du 20e siècle et sont classées en conséquence. Certains événements relatifs à l`histoire militaire qui ne peuvent être attribués sans aucun doute à ces catégories sont également enregistrés dans une catégorie spéciale.</Abstract>
+                <KeywordList>
+                    <Keyword>ch.vbs.armee-kriegsdenkmaeler.wms_ows_keywordlist</Keyword>
+                </KeywordList>
+                <CRS>EPSG:2056</CRS>
+                <CRS>EPSG:21781</CRS>
+                <CRS>EPSG:4326</CRS>
+                <CRS>EPSG:3857</CRS>
+                <CRS>EPSG:3034</CRS>
+                <CRS>EPSG:3035</CRS>
+                <CRS>EPSG:4258</CRS>
+                <CRS>EPSG:25832</CRS>
+                <CRS>EPSG:25833</CRS>
+                <CRS>EPSG:31467</CRS>
+                <CRS>EPSG:32632</CRS>
+                <CRS>EPSG:32633</CRS>
+                <CRS>EPSG:900913</CRS>
+                <EX_GeographicBoundingBox>
+                    <westBoundLongitude>0.659965</westBoundLongitude>
+                    <eastBoundLongitude>10.8344</eastBoundLongitude>
+                    <southBoundLatitude>45.4183</southBoundLatitude>
+                    <northBoundLatitude>48.7495</northBoundLatitude>
+                </EX_GeographicBoundingBox>
+                <BoundingBox CRS="EPSG:2056"
+                    minx="2.1e+06" miny="1.05e+06" maxx="2.85e+06" maxy="1.4e+06" />
+                <MetadataURL type="TC211">
+                    <Format>text/xml</Format>
+                    <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple"
+                        xlink:href="https://wms.geo.admin.ch/?request=GetMetadata&amp;layer=ch.vbs.armee-kriegsdenkmaeler" />
+                </MetadataURL>
+                <Style>
+                    <Name>default</Name>
+                    <Title>default</Title>
+                    <LegendURL width="203" height="124">
+                        <Format>image/png</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                            xlink:type="simple"
+                            xlink:href="https://wms.geo.admin.ch/?version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=ch.vbs.armee-kriegsdenkmaeler&amp;format=image/png&amp;STYLE=default" />
+                    </LegendURL>
+                </Style>
+            </Layer>
+            <Layer queryable="1" opaque="0" cascaded="0">
+                <Name>ch.vbs.armeelogistikcenter</Name>
+                <Title>Centres logistiques de l`armée CLA</Title>
+                <Abstract>Cinq centres logistiques de l`armée (CLA) veillent à ce que les troupes de l`Armée suisse obtiennent pour l`instruction et l`engagement les prestations logistiques nécessaires.</Abstract>
+                <KeywordList>
+                    <Keyword>ch.vbs.armeelogistikcenter.wms_ows_keywordlist</Keyword>
+                </KeywordList>
+                <CRS>EPSG:2056</CRS>
+                <CRS>EPSG:21781</CRS>
+                <CRS>EPSG:4326</CRS>
+                <CRS>EPSG:3857</CRS>
+                <CRS>EPSG:3034</CRS>
+                <CRS>EPSG:3035</CRS>
+                <CRS>EPSG:4258</CRS>
+                <CRS>EPSG:25832</CRS>
+                <CRS>EPSG:25833</CRS>
+                <CRS>EPSG:31467</CRS>
+                <CRS>EPSG:32632</CRS>
+                <CRS>EPSG:32633</CRS>
+                <CRS>EPSG:900913</CRS>
+                <EX_GeographicBoundingBox>
+                    <westBoundLongitude>0.659965</westBoundLongitude>
+                    <eastBoundLongitude>10.8344</eastBoundLongitude>
+                    <southBoundLatitude>45.4183</southBoundLatitude>
+                    <northBoundLatitude>48.7495</northBoundLatitude>
+                </EX_GeographicBoundingBox>
+                <BoundingBox CRS="EPSG:2056"
+                    minx="2.1e+06" miny="1.05e+06" maxx="2.85e+06" maxy="1.4e+06" />
+                <MetadataURL type="TC211">
+                    <Format>text/xml</Format>
+                    <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple"
+                        xlink:href="https://wms.geo.admin.ch/?request=GetMetadata&amp;layer=ch.vbs.armeelogistikcenter" />
+                </MetadataURL>
+                <Style>
+                    <Name>default</Name>
+                    <Title>default</Title>
+                    <LegendURL width="221" height="22">
+                        <Format>image/png</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                            xlink:type="simple"
+                            xlink:href="https://wms.geo.admin.ch/?version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=ch.vbs.armeelogistikcenter&amp;format=image/png&amp;STYLE=default" />
+                    </LegendURL>
+                </Style>
+            </Layer>
+            <Layer queryable="1" opaque="0" cascaded="0">
+                <Name>ch.vbs.bundestankstellen-bebeco</Name>
+                <Title>Stations-service BEBECO</Title>
+                <Abstract>Emplacements des stations-service de la Confédération BEBECO&lt;br&gt;Indication concernant l`utilisation des stations AdBlue:&lt;br&gt; Les véhicules de tourisme et les véhicules utilitaires légers ne peuvent pas faire le plein à ces stations, Haute pression. Veuillez pour cela vous adresser à votre garage. Lubrifiants et produits d`entretien ne peut être livré que sur commande téléphonique. &lt;br&gt;&lt;br&gt; &lt;b&gt;Remarques concernant le ravitaillement:&lt;/b&gt; &lt;br&gt; Les stations-service sont équipées d`automates permettant de se ravitailler au moyen de la CARD - BEBECO. &lt;br&gt; &lt;br&gt; a) Ravitaillement pendant les heures d`exploitation &lt;ul&gt; &lt;li&gt;Véhicules isolés: sans préavis.&lt;/li&gt; &lt;li&gt;Autres ravitaillements, en particulier pour la troupe: seulement après entente avec la station-service concernée, car les possibilités de distribution sont diverses, voire limitées. &lt;/ul&gt; b) Ravitaillement en dehors des heures d`exploitation &lt;ul&gt; &lt;li&gt;Stations marquées avec 24 h / 7: moyennant BEBECO-CARD, elles offrent la possibilité de se ravitailler en carburant 24 h sur 24, y compris le samedi et le dimanche. Par égard aux riverains, cette possibilité est limitée aux véhicules isolés.&lt;/li&gt; &lt;/ul&gt; &lt;br&gt; &lt;b&gt;Contact&lt;/b&gt; &lt;br&gt; Mail: &lt;a href=&#39;mailto:lba.betrst.dienst@vtg.admin.ch&#39;&gt;lba.betrst.dienst@vtg.admin.ch&lt;/a&gt;</Abstract>
+                <KeywordList>
+                    <Keyword>ch.vbs.bundestankstellen-bebeco.wms_ows_keywordlist</Keyword>
+                </KeywordList>
+                <CRS>EPSG:2056</CRS>
+                <CRS>EPSG:21781</CRS>
+                <CRS>EPSG:4326</CRS>
+                <CRS>EPSG:3857</CRS>
+                <CRS>EPSG:3034</CRS>
+                <CRS>EPSG:3035</CRS>
+                <CRS>EPSG:4258</CRS>
+                <CRS>EPSG:25832</CRS>
+                <CRS>EPSG:25833</CRS>
+                <CRS>EPSG:31467</CRS>
+                <CRS>EPSG:32632</CRS>
+                <CRS>EPSG:32633</CRS>
+                <CRS>EPSG:900913</CRS>
+                <EX_GeographicBoundingBox>
+                    <westBoundLongitude>0.659965</westBoundLongitude>
+                    <eastBoundLongitude>10.8344</eastBoundLongitude>
+                    <southBoundLatitude>45.4183</southBoundLatitude>
+                    <northBoundLatitude>48.7495</northBoundLatitude>
+                </EX_GeographicBoundingBox>
+                <BoundingBox CRS="EPSG:2056"
+                    minx="2.1e+06" miny="1.05e+06" maxx="2.85e+06" maxy="1.4e+06" />
+                <MetadataURL type="TC211">
+                    <Format>text/xml</Format>
+                    <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple"
+                        xlink:href="https://wms.geo.admin.ch/?request=GetMetadata&amp;layer=ch.vbs.bundestankstellen-bebeco" />
+                </MetadataURL>
+                <Style>
+                    <Name>default</Name>
+                    <Title>default</Title>
+                    <LegendURL width="280" height="39">
+                        <Format>image/png</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                            xlink:type="simple"
+                            xlink:href="https://wms.geo.admin.ch/?version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=ch.vbs.bundestankstellen-bebeco&amp;format=image/png&amp;STYLE=default" />
+                    </LegendURL>
+                </Style>
+            </Layer>
+        </Layer>
+    </Capability>
+</WMS_Capabilities>

--- a/tests/e2e-cypress/integration/importTool.cy.js
+++ b/tests/e2e-cypress/integration/importTool.cy.js
@@ -1,0 +1,57 @@
+/// <reference types="cypress" />
+
+describe('The Import Tool', () => {
+    beforeEach(() => {
+        cy.goToMapView({}, true)
+        cy.get('[data-cy="menu-button"]').click()
+    })
+    it('Open and close the infobox import tool', () => {
+        cy.get('[data-cy="menu-tray-tool-section"]').click()
+        cy.get('[data-cy="menu-import-tool"]').click()
+        // the menu should be automatically close on opening import tool box
+        cy.get('[data-cy="menu-tray"]').should('not.be.visible')
+        cy.get('[data-cy="import-tool-content"]').should('be.visible')
+        cy.get('[data-cy="infobox-close"]').click()
+        cy.get('[data-cy="import-tool-content"]').should('not.exist')
+    })
+    it.only('Import external wms layers', () => {
+        cy.intercept(
+            {
+                https: true,
+                hostname: 'wms.geo.admin.ch',
+                query: { REQUEST: 'GetCapabilities' },
+            },
+            { fixture: 'import-tool/wms-geo-admin-get-capabilities.xml' }
+        ).as('wms-get-capabilities')
+        cy.intercept(
+            {
+                https: true,
+                hostname: 'wms.geo.admin.ch',
+                query: { REQUEST: 'GetMap' },
+            },
+            { statusCode: 200 }
+        ).as('wms-get-map')
+        cy.get('[data-cy="menu-tray-tool-section"]').click()
+        cy.get('[data-cy="menu-import-tool"]').click()
+        cy.get('[data-cy="import"]').type('wms.geo.admin')
+        cy.get('[data-cy="import-provider-list"]')
+            .children()
+            .contains('https://wms.geo.admin.ch')
+            .click()
+        cy.get('[data-cy="import-connect-button"]').click()
+        cy.wait('@wms-get-capabilities')
+        cy.get('[data-cy="import-add-layer-button"]').should('be.visible')
+        cy.get('[data-cy="import-result-list"]').children().should('have.length', 3).first().click()
+        cy.wait('@wms-get-map')
+        cy.get('[data-cy="import-add-layer-button"]').click()
+        cy.wait('@wms-get-map')
+        cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
+            expect(activeLayers).to.be.an('Array').length(1)
+            const externalLayer = activeLayers[0]
+            expect(externalLayer.isExternal).to.be.true
+            expect(externalLayer.visible).to.be.true
+            expect(externalLayer.externalLayerId).to.eq('ch.vbs.armeelogistikcenter')
+            expect(externalLayer.name).to.eq('Centres logistiques de l`armée CLA')
+        })
+    })
+})

--- a/tests/e2e-cypress/integration/importTool.cy.js
+++ b/tests/e2e-cypress/integration/importTool.cy.js
@@ -14,7 +14,7 @@ describe('The Import Tool', () => {
         cy.get('[data-cy="infobox-close"]').click()
         cy.get('[data-cy="import-tool-content"]').should('not.exist')
     })
-    it.only('Import external wms layers', () => {
+    it('Import external wms layers', () => {
         cy.intercept(
             {
                 https: true,

--- a/tests/e2e-cypress/integration/importTool.cy.js
+++ b/tests/e2e-cypress/integration/importTool.cy.js
@@ -40,7 +40,8 @@ describe('The Import Tool', () => {
             .click()
         cy.get('[data-cy="import-connect-button"]').click()
         cy.wait('@wms-get-capabilities')
-        cy.get('[data-cy="import-add-layer-button"]').should('be.visible')
+        // TODO uncomment this line when BGDIINF_SB-3169 is done
+        // cy.get('[data-cy="import-add-layer-button"]').should('be.visible')
         cy.get('[data-cy="import-result-list"]').children().should('have.length', 3).first().click()
         cy.wait('@wms-get-map')
         cy.get('[data-cy="import-add-layer-button"]').click()


### PR DESCRIPTION
Some WMS layers don't have a `layer.name` but do have a `layer.title`, like for
instance the https://bio.discomap.eea.europa.eu/arcgis/services/Ecosystem/Ecosystems/MapServer/WMSServer

In this case the import took was successful `Loading OK!` but no result
was displayed and no error was found in the error log !

Now we support also layer without name but with a title and in case the
layer has no title and no name, an error log is printed.
Also when no layers could be imported we also throw an error.

- Also added e2e tests
- Added import tool selection/opened feedback in menu (menu input is now red when the tool is opened
- Automatically close the menu when opening the import tool to avoid overlapping in mobile view
- Close other menu section when opening import tool menu

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-import-tool/index.html)