### PR TITLE
BGDIINF_SB-3170: Fixed group of external layers attributions

### DIFF
--- a/src/api/layers/ExternalGroupOfLayers.class.js
+++ b/src/api/layers/ExternalGroupOfLayers.class.js
@@ -17,9 +17,10 @@ export default class ExternalGroupOfLayers extends ExternalLayer {
      * @param {ExternalLayer[]} layers Description of the layers being part of this group (they will
      *   all be displayed at the same time, in contrast to an aggregate layer)
      * @param {String} abstract Abstract of this layer to be shown to the user
+     * @param {LayerAttribution[]} attributions Description of the data owner(s) for this layer
      * @param {[[number, number], [number, number]] | undefined} extent Layer extent
      */
-    constructor(name, hostname, layers, abstract = '', extent = undefined) {
+    constructor(name, hostname, layers, attributions = [], abstract = '', extent = undefined) {
         super(
             name,
             LayerTypes.GROUP,
@@ -27,7 +28,7 @@ export default class ExternalGroupOfLayers extends ExternalLayer {
             null,
             1,
             true,
-            [],
+            attributions,
             abstract,
             extent
         )

--- a/src/modules/infobox/utils/external-provider-parsers.js
+++ b/src/modules/infobox/utils/external-provider-parsers.js
@@ -55,20 +55,27 @@ export function getCapWMSLayers(getCap, layer, projection, visible = true, opaci
             }
         }
     }
-
+    const attribution = layer.Attribution || getCap.Capability.Layer.Attribution || getCap.Service
+    const attributions = [new LayerAttribution(attribution.Title, attribution.OnlineResource)]
     // Go through the child to get valid layers
     if (layer.Layer?.length) {
         const layers = layer.Layer.map((l) => getCapWMSLayers(getCap, l, projection))
-        return new ExternalGroupOfLayers(layer.Title, wmsUrl, layers, layer.Abstract, layerExtent)
+        return new ExternalGroupOfLayers(
+            layer.Title,
+            wmsUrl,
+            layers,
+            attributions,
+            layer.Abstract,
+            layerExtent
+        )
     }
-    const attribution = layer.Attribution || getCap.Capability.Layer.Attribution || getCap.Service
     return new ExternalWMSLayer(
         layer.Title,
         opacity,
         visible,
         wmsUrl,
         name,
-        [new LayerAttribution(attribution.Title, attribution.OnlineResource)],
+        attributions,
         getCap.version,
         'png',
         layer.Abstract,

--- a/src/utils/ModalWithBackdrop.vue
+++ b/src/utils/ModalWithBackdrop.vue
@@ -41,7 +41,11 @@
                             <FontAwesomeIcon icon="times" />
                         </button>
                     </div>
-                    <div ref="modalContent" class="card-body pt-3 ps-4 pe-4">
+                    <div
+                        ref="modalContent"
+                        class="card-body pt-3 ps-4 pe-4"
+                        data-cy="modal-content"
+                    >
                         <slot />
                         <div v-if="showConfirmationButtons" class="mt-1 d-flex justify-content-end">
                             <button

--- a/tests/e2e-cypress/integration/importTool.cy.js
+++ b/tests/e2e-cypress/integration/importTool.cy.js
@@ -10,7 +10,7 @@ describe('The Import Tool', () => {
     it('Open and close the infobox import tool', () => {
         cy.get('[data-cy="menu-tray-tool-section"]').click()
         cy.get('[data-cy="menu-import-tool"]').click()
-        // the menu should be automatically close on opening import tool box
+        // the menu should be automatically closed on opening import tool box
         cy.get('[data-cy="menu-tray"]').should('not.be.visible')
         cy.get('[data-cy="import-tool-content"]').should('be.visible')
         cy.get('[data-cy="infobox-close"]').click()

--- a/tests/e2e-cypress/integration/importTool.cy.js
+++ b/tests/e2e-cypress/integration/importTool.cy.js
@@ -60,7 +60,7 @@ describe('The Import Tool', () => {
         // Check the map attribution
         cy.get('[data-cy="layer-copyright-Das Geoportal des Bundes"]')
             .should('be.visible')
-            .contains('Da s Geoportal des Bundes')
+            .contains('Das Geoportal des Bundes')
         // Check the layer attribution
         if (isMobile()) {
             cy.get('[data-cy="menu-button"]').click()

--- a/tests/e2e-cypress/integration/importTool.cy.js
+++ b/tests/e2e-cypress/integration/importTool.cy.js
@@ -1,9 +1,11 @@
 /// <reference types="cypress" />
 
+import { isMobile } from '../support/utils'
+
 describe('The Import Tool', () => {
     beforeEach(() => {
         cy.goToMapView({}, true)
-        cy.get('[data-cy="menu-button"]').click()
+        cy.clickOnMenuButtonIfMobile()
     })
     it('Open and close the infobox import tool', () => {
         cy.get('[data-cy="menu-tray-tool-section"]').click()
@@ -54,5 +56,19 @@ describe('The Import Tool', () => {
             expect(externalLayer.externalLayerId).to.eq('ch.vbs.armeelogistikcenter')
             expect(externalLayer.name).to.eq('Centres logistiques de l`armée CLA')
         })
+
+        // Check the map attribution
+        cy.get('[data-cy="layer-copyright-Das Geoportal des Bundes"]')
+            .should('be.visible')
+            .contains('Da s Geoportal des Bundes')
+        // Check the layer attribution
+        if (isMobile()) {
+            cy.get('[data-cy="menu-button"]').click()
+            cy.get('[data-cy="menu-active-layers"]').should('be.visible').click()
+        }
+        cy.get('[data-cy="menu-external-disclaimer-icon"]').should('be.visible').click()
+        cy.get('[data-cy="modal-content"]').contains(
+            'Warning: Third party data and/or style shown (Das Geoportal des Bundes)'
+        )
     })
 })

--- a/tests/e2e-cypress/support/commands.js
+++ b/tests/e2e-cypress/support/commands.js
@@ -1,9 +1,9 @@
-import { BREAKPOINT_TABLET } from '@/config'
 import { FAKE_URL_CALLED_AFTER_ROUTE_CHANGE } from '@/router/storeSync/storeSync.routerPlugin'
 import { randomIntBetween } from '@/utils/numberUtils'
 import 'cypress-real-events'
 import 'cypress-wait-until'
 import { MapBrowserEvent } from 'ol'
+import { isMobile } from './utils'
 
 // ***********************************************
 // For more comprehensive examples of custom
@@ -267,8 +267,7 @@ Cypress.Commands.add(
  */
 Cypress.Commands.add('clickOnLanguage', (lang) => {
     let menuSection = null
-    const width = Cypress.config('viewportWidth')
-    if (width < BREAKPOINT_TABLET) {
+    if (isMobile()) {
         // mobile/tablet : clicking on the menu button first
         menuSection = cy.get('[data-cy="menu-settings-section"]')
         menuSection.click()
@@ -450,7 +449,7 @@ Cypress.Commands.add('waitUntilCesiumTilesLoaded', () => {
 })
 
 Cypress.Commands.add('clickOnMenuButtonIfMobile', () => {
-    if (Cypress.config('viewportWidth') < BREAKPOINT_TABLET) {
+    if (isMobile()) {
         // mobile/tablet : clicking on the menu button
         cy.get('[data-cy="menu-button"]').click()
     }

--- a/tests/e2e-cypress/support/utils.js
+++ b/tests/e2e-cypress/support/utils.js
@@ -1,0 +1,8 @@
+import { BREAKPOINT_TABLET } from '@/config'
+
+export function isMobile() {
+    if (Cypress.config('viewportWidth') < BREAKPOINT_TABLET) {
+        return true
+    }
+    return false
+}


### PR DESCRIPTION
When importing a group of external layers the attribution in the map footer was
missing and the disclaimer popup in the active layers was not displayed when clicking
on the disclaimer icon.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-3170-import-attribution/index.html)