### PR TITLE
BGDIINF_SB-3187: Reduce the number of tests for the search bar

### DIFF
--- a/tests/e2e-cypress/integration/search/coordinates-search.cy.js
+++ b/tests/e2e-cypress/integration/search/coordinates-search.cy.js
@@ -55,9 +55,8 @@ describe('Testing coordinates typing in search bar', () => {
         })
     }
     const standardCheck = (x, y, acceptableDelta = 0.0) => {
-        const searchBar = cy.get(searchbarSelector)
-        searchBar.should('be.visible')
-        searchBar.paste(`${x} ${y}`)
+        cy.get(searchbarSelector).should('be.visible')
+        cy.get(searchbarSelector).paste(`${x} ${y}`)
         checkCenterInStore(acceptableDelta)
         checkZoomLevelInStore()
         checkThatCoordinateAreHighlighted(acceptableDelta)


### PR DESCRIPTION
All possible coordinates formats are already tested in unittest so no need to
test everything here again.

This will speed up e2e tests but also reduce the number of tests result which
are not cheap if we want to run the tests on cypress cloud.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-3187-e2e-tests/index.html)