### PR TITLE
Remove lib ogc-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
                 "jsdom": "^22.1.0",
                 "mime-types": "^2.1.35",
                 "mocha-junit-reporter": "^2.2.1",
-                "ogc-parser": "^1.5.0",
                 "prettier": "^3.0.3",
                 "prettier-plugin-jsdoc": "^1.1.1",
                 "rimraf": "^5.0.1",
@@ -8221,26 +8220,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/ogc-parser": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/ogc-parser/-/ogc-parser-1.5.0.tgz",
-            "integrity": "sha512-JsIKCSmCsET6L2WMqytO1jM9r+dbzUYfGIJr4qq9dy+0DVCGzFSztjFEtUiES/hziqfhG1LgrxPjf/XUwUH9RA==",
-            "dev": true,
-            "dependencies": {
-                "xmldom": "^0.1.27",
-                "xpath": "^0.0.24"
-            }
-        },
-        "node_modules/ogc-parser/node_modules/xmldom": {
-            "version": "0.1.31",
-            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-            "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
-            "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
-            "dev": true,
-            "engines": {
-                "node": ">=0.1"
-            }
-        },
         "node_modules/ol": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/ol/-/ol-8.1.0.tgz",
@@ -11173,15 +11152,6 @@
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true
-        },
-        "node_modules/xpath": {
-            "version": "0.0.24",
-            "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.24.tgz",
-            "integrity": "sha512-xUsra70vEDlxu0T90+qkg/8/KvPPm4KQbh25yMZCpBABBkdQLaOLNsgzRAUax7wlWZt7Ka5Q+itg/TPzzHieVQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.6.0"
-            }
         },
         "node_modules/y18n": {
             "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
         "jsdom": "^22.1.0",
         "mime-types": "^2.1.35",
         "mocha-junit-reporter": "^2.2.1",
-        "ogc-parser": "^1.5.0",
         "prettier": "^3.0.3",
         "prettier-plugin-jsdoc": "^1.1.1",
         "rimraf": "^5.0.1",


### PR DESCRIPTION
While updating libs, I had issues with ogc-parser as it is using very outdated dependencies. After checking the GitHub repo, I saw it was kind of staled, so I replaced it with OpenLayers function. I had to add some browser API equivalent to NodeJS in order to achieve this (see first lines of the file) as this is then used under the hood by OpenLayers to parse XMLs

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_remove_ogc_parser/index.html)