### PR TITLE
Improve mobile navigation in 3D

### DIFF
--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -150,7 +150,7 @@ export default {
             currentLang: (state) => state.i18n.lang,
             displayLocationPopup: (state) => state.map.displayLocationPopup,
             projection: (state) => state.position.projection,
-            showIn3d: (state) => state.ui.showIn3d,
+            showIn3d: (state) => state.cesium.active,
         }),
         mappingFrameworkSpecificPopup() {
             if (this.showIn3d) {

--- a/src/modules/map/components/MapPopover.vue
+++ b/src/modules/map/components/MapPopover.vue
@@ -96,6 +96,7 @@ export default {
     z-index: $zindex-map + 1;
     .card {
         max-width: $overlay-width;
+        min-width: $overlay-width;
         pointer-events: auto;
     }
     .map-popover-content {


### PR DESCRIPTION
I found that most (of not all) Cesium sandcastles (online examples) have this CSS rule to block touch action, it fixes all issues I experienced with panning while on a mobile device!

I also de-activated the location popup (right-click) on mobile, as it wasn't very consistent how to trigger a right click with a touch screen.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_cesium_mobile_nav_improvements/index.html)