### PR TITLE
Temporary remove the advanced tool menu on productive environment

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -183,8 +183,8 @@ export const BASE_URL_3D_TILES = enforceEndingSlashInUrl(import.meta.env.VITE_AP
 export const WMS_TILE_SIZE = 512 // px
 
 /**
- * Map view's mininal resolution Currently set so that OL scalebar displays 10 meters Scalebar about
- * 1" on screen, hence about 100px. So, 10 meters/100px = 0.1 Caveat: setting resolution (mininum
+ * Map view's minimal resolution Currently set so that OL scalebar displays 10 meters Scalebar about
+ * 1" on screen, hence about 100px. So, 10 meters/100px = 0.1 Caveat: setting resolution (minimum
  * and maximum) has the precedence over zoom (minimum/maximum)
  */
 
@@ -250,7 +250,7 @@ export const VECTOR_LIGHT_BASE_MAP_STYLE_ID = 'ch.swisstopo.leichte-basiskarte_w
 export const VECTOR_TILES_IMAGERY_STYLE_ID = 'ch.swisstopo.leichte-basiskarte-imagery_world.vt'
 
 /**
- * Display a big developpment banner on all but these hosts.
+ * Display a big development banner on all but these hosts.
  *
  * @type {String[]}
  */

--- a/src/modules/menu/components/menu/MenuTray.vue
+++ b/src/modules/menu/components/menu/MenuTray.vue
@@ -27,6 +27,7 @@
             />
         </div>
         <MenuSection
+            v-if="hasDevSiteWarning"
             id="toolsSection"
             ref="toolsSection"
             data-cy="menu-tray-tool-section"
@@ -97,7 +98,7 @@ export default {
             lang: (state) => state.i18n.lang,
             is3dMode: (state) => state.cesium.active,
         }),
-        ...mapGetters(['isPhoneMode']),
+        ...mapGetters(['isPhoneMode', 'hasDevSiteWarning']),
         showLayerList() {
             return this.activeLayers.length > 0
         },


### PR DESCRIPTION
Because the advanced tool are not yet ready we remove it on productive
environment.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-remove-advanced-menu/index.html)