### PR TITLE
Activate support for Composition API with i18n module

### DIFF
--- a/src/modules/drawing/components/DrawingTextInteraction.vue
+++ b/src/modules/drawing/components/DrawingTextInteraction.vue
@@ -5,19 +5,24 @@
 <script>
 import { EditableFeatureTypes } from '@/api/features.api'
 import drawingInteractionMixin from '@/modules/drawing/components/drawingInteraction.mixin'
+import { useI18n } from 'vue-i18n'
 
 export default {
     mixins: [drawingInteractionMixin],
+    setup() {
+        const i18n = useI18n()
+        return {
+            i18n,
+        }
+    },
     data() {
         return {
             geometryType: 'Point',
             editableFeatureArgs: {
-                title: this.$i18n.t('draw_new_text'),
+                title: this.i18n.t('draw_new_text'),
                 featureType: EditableFeatureTypes.ANNOTATION,
             },
         }
     },
 }
 </script>
-
-<style lang="scss"></style>

--- a/src/modules/drawing/components/DrawingToolbox.vue
+++ b/src/modules/drawing/components/DrawingToolbox.vue
@@ -122,6 +122,7 @@ import DrawingToolboxButton from '@/modules/drawing/components/DrawingToolboxBut
 import SharePopup from '@/modules/drawing/components/SharePopup.vue'
 import ModalWithBackdrop from '@/utils/ModalWithBackdrop.vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { useI18n } from 'vue-i18n'
 import { mapGetters } from 'vuex'
 import { DrawingState } from '../lib/export-utils'
 import DrawingHeader from './DrawingHeader.vue'
@@ -158,6 +159,12 @@ export default {
         },
     },
     emits: ['close', 'setDrawingMode', 'export', 'clearDrawing', 'deleteLastPoint'],
+    setup() {
+        const i18n = useI18n()
+        return {
+            i18n,
+        }
+    },
     data() {
         return {
             drawingModes: Object.values(EditableFeatureTypes),
@@ -180,13 +187,13 @@ export default {
         drawingStateMessage() {
             switch (this.drawingState) {
                 case DrawingState.SAVING:
-                    return this.$i18n.t('draw_file_saving')
+                    return this.i18n.t('draw_file_saving')
                 case DrawingState.SAVED:
-                    return this.$i18n.t('draw_file_saved')
+                    return this.i18n.t('draw_file_saved')
                 case DrawingState.SAVE_ERROR:
-                    return this.$i18n.t('draw_file_load_error')
+                    return this.i18n.t('draw_file_load_error')
                 case DrawingState.LOAD_ERROR:
-                    return this.$i18n.t('draw_file_save_error')
+                    return this.i18n.t('draw_file_save_error')
                 default:
                     return null
             }

--- a/src/modules/drawing/components/DrawingTooltip.vue
+++ b/src/modules/drawing/components/DrawingTooltip.vue
@@ -9,6 +9,7 @@ import { EditableFeatureTypes } from '@/api/features.api'
 import { DRAWING_HIT_TOLERANCE } from '@/config'
 import { getVertexCoordinates, pointWithinTolerance } from '@/modules/drawing/lib/drawingUtils'
 import Overlay from 'ol/Overlay'
+import { useI18n } from 'vue-i18n'
 
 const cssPointer = 'cursor-pointer'
 const cssGrab = 'cursor-grab'
@@ -29,6 +30,12 @@ export default {
             type: Object,
             default: null,
         },
+    },
+    setup() {
+        const i18n = useI18n()
+        return {
+            i18n,
+        }
     },
     data() {
         return {
@@ -66,7 +73,7 @@ export default {
 
             this.tooltipText = translationKeys
                 .map((key) => key.toLowerCase())
-                .map((key) => this.$i18n.t(key))
+                .map((key) => this.i18n.t(key))
                 .join('<br>')
         },
         onPointerMove(event) {

--- a/src/modules/i18n/README.md
+++ b/src/modules/i18n/README.md
@@ -1,24 +1,43 @@
 # Internationalization (i18n) module
 
-Responsible for loading and serving `vue-i18n` through the `$t` function in templates.
+Responsible for loading and serving `vue-i18n`. This utils can be accessed by linking the result of `useI18n()`
+to a local ref (in Composition API) or in-place with the Option API. As we've deactivated the legacy support,
+it's not possible to use `this.$i18n` anymore, we must now go through the `useI18n()` function to
+get a reference to the utils.
 
-Here's an example how to use this translation :
-
-```html
-<label for="...">{{ $t('a_translation_key') }}</label>
-```
-
-Current locale can be accessed through
-
-```html
-<span>Current locale is {{ $i18n.locale }}</span>
-```
-
-Within your Vue Component javascript code you can access translation like this
+Here's an example of how to use this translation :
 
 ```javascript
-this.$i18n.t('a_translation_key')
+import { useI18n } from 'vue-i18n'
+
+const i18n = useI18n()
 ```
+
+```html
+<label for="...">{{ i18n.t('a_translation_key') }}</label>
+```
+
+Current locale can be accessed through the store
+
+```javascript
+import { useStore } from 'vuex'
+import { computed } from 'vue'
+
+const store = useStore()
+const currentLocal = computed(() => store.state.i18n.lang)
+```
+
+```html
+<span>Current locale is {{ currentLocal }}</span>
+```
+
+Within your Option API Vue Component javascript code, you can access translation like this
+
+```javascript
+useI18n().t('a_translation_key')
+```
+
+Or if you have multiple call to `t(...)`, you can store the reference given by `useI18n()` at some point (do not store it in `data()`)
 
 ## update translations
 

--- a/src/modules/i18n/index.js
+++ b/src/modules/i18n/index.js
@@ -19,6 +19,7 @@ if (navigator.languages) {
 const i18n = createI18n({
     locale: matchedLanguage || 'en', // default locale
     messages: languages,
+    legacy: false,
 })
 
 export default i18n

--- a/src/modules/infobox/components/ImportContent.vue
+++ b/src/modules/infobox/components/ImportContent.vue
@@ -182,27 +182,34 @@
     </div>
 </template>
 <script>
+import KMLLayer from '@/api/layers/KMLLayer.class'
+import { parseWmsCapabilities, parseWmtsCapabilities } from '@/api/layers/layers-external.api'
 import externalLayerProviders from '@/modules/infobox/utils/external-layer-providers.json'
 import {
-    isValidUrl,
+    guessExternalLayerUrl,
     isGpx,
     isKml,
+    isValidUrl,
     isWmsGetCap,
     isWmtsGetCap,
-    guessExternalLayerUrl,
 } from '@/modules/infobox/utils/external-provider'
-import { mapState } from 'vuex'
-import KMLLayer from '@/api/layers/KMLLayer.class'
-import ImportContentResultList from './ImportContentResultList.vue'
 import log from '@/utils/logging'
-import { parseWmsCapabilities, parseWmtsCapabilities } from '@/api/layers/layers-external.api'
 import axios from 'axios'
+import { useI18n } from 'vue-i18n'
+import { mapState } from 'vuex'
+import ImportContentResultList from './ImportContentResultList.vue'
 
 const BTN_RESET_TIMEOUT = 3000
 
 export default {
     components: { ImportContentResultList },
     emits: ['connected'],
+    setup() {
+        const i18n = useI18n()
+        return {
+            i18n,
+        }
+    },
     data() {
         return {
             onlineImportValue: '',
@@ -250,15 +257,15 @@ export default {
         },
         buttonText() {
             if (this.uploadBtnStatus === 'loading') {
-                return this.$i18n.t('parsing_file')
+                return this.i18n.t('parsing_file')
             } else if (this.uploadBtnStatus === 'failed') {
-                return this.$i18n.t('parse_failed')
+                return this.i18n.t('parse_failed')
             } else if (this.uploadBtnStatus === 'succeeded') {
-                return this.$i18n.t('parse_succeeded')
+                return this.i18n.t('parse_succeeded')
             } else if (this.selectedTab === 'local') {
-                return this.$i18n.t('load_local_file')
+                return this.i18n.t('load_local_file')
             }
-            return this.$i18n.t('connect')
+            return this.i18n.t('connect')
         },
     },
     watch: {

--- a/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
+++ b/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
@@ -79,6 +79,7 @@ import DrawingStyleColorSelector from '@/modules/infobox/components/styling/Draw
 import DrawingStyleSizeSelector from '@/modules/infobox/components/styling/DrawingStyleSizeSelector.vue'
 import DropdownButton, { DropdownItem } from '@/utils/DropdownButton.vue'
 import { MEDIUM } from '@/utils/featureStyleUtils'
+import { useI18n } from 'vue-i18n'
 
 export default {
     components: {
@@ -97,6 +98,12 @@ export default {
         },
     },
     emits: ['change', 'change:iconSize', 'change:icon', 'change:iconColor'],
+    setup() {
+        const i18n = useI18n()
+        return {
+            i18n,
+        }
+    },
     data: function () {
         return {
             showAllSymbols: false,
@@ -109,13 +116,13 @@ export default {
     computed: {
         currentIconSetName() {
             return this.currentIconSet
-                ? this.$i18n.t(`modify_icon_category_${this.currentIconSet.name}_label`)
+                ? this.i18n.t(`modify_icon_category_${this.currentIconSet.name}_label`)
                 : ''
         },
         iconSetDropdownItems() {
             return this.iconSets.map((iconSet) => {
                 return new DropdownItem(
-                    this.$i18n.t(`modify_icon_category_${iconSet.name}_label`),
+                    this.i18n.t(`modify_icon_category_${iconSet.name}_label`),
                     iconSet
                 )
             })

--- a/src/modules/infobox/components/styling/DrawingStyleSizeSelector.vue
+++ b/src/modules/infobox/components/styling/DrawingStyleSizeSelector.vue
@@ -17,6 +17,7 @@
 <script>
 import DropdownButton, { DropdownItem } from '@/utils/DropdownButton.vue'
 import { allStylingSizes, FeatureStyleSize } from '@/utils/featureStyleUtils'
+import { useI18n } from 'vue-i18n'
 
 export default {
     components: { DropdownButton },
@@ -27,6 +28,12 @@ export default {
         },
     },
     emits: ['change'],
+    setup() {
+        const i18n = useI18n()
+        return {
+            i18n,
+        }
+    },
     data() {
         return {
             sizes: allStylingSizes,
@@ -41,7 +48,7 @@ export default {
         },
         dropdownItems() {
             return this.sizes.map((size) => {
-                return new DropdownItem(this.$i18n.t(size.label), size)
+                return new DropdownItem(this.i18n.t(size.label), size)
             })
         },
     },

--- a/src/modules/map/components/LocationPopupCopySlot.vue
+++ b/src/modules/map/components/LocationPopupCopySlot.vue
@@ -13,6 +13,7 @@
 <script>
 import log from '@/utils/logging'
 import tippy from 'tippy.js'
+import { useI18n } from 'vue-i18n'
 import { mapState } from 'vuex'
 
 export default {
@@ -21,6 +22,12 @@ export default {
             type: String,
             default: '',
         },
+    },
+    setup() {
+        const i18n = useI18n()
+        return {
+            i18n,
+        }
     },
     computed: {
         ...mapState({
@@ -66,10 +73,10 @@ export default {
         },
         setTooltipContent() {
             this.copyTooltip?.forEach((instance) => {
-                instance.setContent(this.$i18n.t('copy_cta'))
+                instance.setContent(this.i18n.t('copy_cta'))
             })
             this.copiedTooltip?.forEach((instance) => {
-                instance.setContent(this.$i18n.t('copy_done'))
+                instance.setContent(this.i18n.t('copy_done'))
             })
         },
     },

--- a/src/modules/map/components/footer/MapFooterAppCopyright.vue
+++ b/src/modules/map/components/footer/MapFooterAppCopyright.vue
@@ -5,13 +5,18 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 export default {
     computed: {
+        ...mapState({
+            currentLang: (state) => state.i18n.lang,
+        }),
         links() {
             return [
                 {
                     label: 'ech_service_link_label',
-                    url: `https://www.geo.admin.ch/${this.$i18n.locale}/home.html`,
+                    url: `https://www.geo.admin.ch/${this.currentLang}/home.html`,
                 },
                 {
                     label: 'copyright_label',

--- a/src/modules/menu/components/LayerLegendPopup.vue
+++ b/src/modules/menu/components/LayerLegendPopup.vue
@@ -14,6 +14,7 @@
 <script>
 import { getLayerLegend } from '@/api/layers/layers.api'
 import ModalWithBackdrop from '@/utils/ModalWithBackdrop.vue'
+import { mapState } from 'vuex'
 
 export default {
     components: { ModalWithBackdrop },
@@ -29,8 +30,13 @@ export default {
             content: null,
         }
     },
+    computed: {
+        ...mapState({
+            currentLang: (state) => state.i18n.lang,
+        }),
+    },
     async mounted() {
-        this.content = await getLayerLegend(this.$i18n.lang, this.layerId)
+        this.content = await getLayerLegend(this.currentLang, this.layerId)
     },
     methods: {
         onClose() {

--- a/src/modules/menu/components/menu/MenuTray.vue
+++ b/src/modules/menu/components/menu/MenuTray.vue
@@ -65,6 +65,7 @@ import MenuSettings from '@/modules/menu/components/menu/MenuSettings.vue'
 import MenuShareSection from '@/modules/menu/components/share/MenuShareSection.vue'
 import MenuTopicSection from '@/modules/menu/components/topics/MenuTopicSection.vue'
 import tippy, { followCursor } from 'tippy.js'
+import { useI18n } from 'vue-i18n'
 import { mapActions, mapGetters, mapState } from 'vuex'
 
 export default {
@@ -81,6 +82,12 @@ export default {
             type: Boolean,
             default: false,
         },
+    },
+    setup() {
+        const i18n = useI18n()
+        return {
+            i18n,
+        }
     },
     data() {
         return {
@@ -151,7 +158,7 @@ export default {
         },
         setDisableDrawingTooltipContent() {
             this.disableDrawingTooltip?.forEach((instance) => {
-                instance.setContent(this.$i18n.t('legacy_drawing_warning'))
+                instance.setContent(this.i18n.t('legacy_drawing_warning'))
             })
         },
     },

--- a/src/modules/menu/components/share/MenuShareInputCopyButton.vue
+++ b/src/modules/menu/components/share/MenuShareInputCopyButton.vue
@@ -22,6 +22,8 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n'
+
 /** Simple input with a helper button to copy the input value to the clipboard */
 export default {
     props: {
@@ -46,6 +48,12 @@ export default {
             default: null,
         },
     },
+    setup() {
+        const i18n = useI18n()
+        return {
+            i18n,
+        }
+    },
     data() {
         return {
             copiedInClipboard: false,
@@ -54,7 +62,7 @@ export default {
     },
     computed: {
         buttonText() {
-            return this.$i18n
+            return this.i18n
                 .t(this.copiedInClipboard ? this.copiedText : this.copyText)
                 .replace('&nbsp;', '\xa0')
         },

--- a/src/utils/OpenFullAppLink.vue
+++ b/src/utils/OpenFullAppLink.vue
@@ -8,9 +8,16 @@
 </template>
 <script>
 import SwissFlag from '@/modules/menu/components/header/SwissFlag.vue'
+import { useI18n } from 'vue-i18n'
 
 export default {
     components: { SwissFlag },
+    setup() {
+        const i18n = useI18n()
+        return {
+            i18n,
+        }
+    },
     data() {
         return {
             currentHost: window.location.host,
@@ -18,7 +25,7 @@ export default {
     },
     computed: {
         linkMessage() {
-            return this.$i18n.t('view_on_mapgeoadminch_webmapviewer', { url: this.currentHost })
+            return this.i18n.t('view_on_mapgeoadminch_webmapviewer', { url: this.currentHost })
         },
         urlWithoutEmbed() {
             return window.location.href.replace('&embed=true', '').replace('?embed=true&', '?')


### PR DESCRIPTION
meaning legacy : false, and that use of `this.$i18n` is not possible anymore, but it needs to go through `useI18n()` (see i18n/README.md)

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_i18n_composition_api/index.html)