### PR TITLE
Added auto import order and sorting using eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,8 +2,12 @@
 require('@rushstack/eslint-patch/modern-module-resolution')
 
 module.exports = {
+    parserOptions: {
+        sourceType: 'module',
+    },
     root: true,
     ignorePatterns: ['node_modules', '.github', 'dist'],
+    plugins: ['simple-import-sort'],
     extends: [
         'eslint:recommended',
         'plugin:vue/vue3-recommended',
@@ -22,6 +26,8 @@ module.exports = {
                 destructuredArrayIgnorePattern: '^_',
             },
         ],
+        'simple-import-sort/imports': 'error',
+        'simple-import-sort/exports': 'error',
     },
     globals: {
         VITE_ENVIRONMENT: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
                 "eslint-plugin-cypress": "^2.15.1",
                 "eslint-plugin-markdownlint": "^0.5.0",
                 "eslint-plugin-prettier-vue": "^5.0.0",
+                "eslint-plugin-simple-import-sort": "^10.0.0",
                 "eslint-plugin-vue": "^9.18.1",
                 "git-describe": "^4.1.1",
                 "googleapis": "^128.0.0",
@@ -3618,6 +3619,15 @@
             },
             "engines": {
                 "node": ">=16"
+            }
+        },
+        "node_modules/eslint-plugin-simple-import-sort": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-10.0.0.tgz",
+            "integrity": "sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==",
+            "dev": true,
+            "peerDependencies": {
+                "eslint": ">=5.0.0"
             }
         },
         "node_modules/eslint-plugin-vue": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
         "eslint-plugin-cypress": "^2.15.1",
         "eslint-plugin-markdownlint": "^0.5.0",
         "eslint-plugin-prettier-vue": "^5.0.0",
+        "eslint-plugin-simple-import-sort": "^10.0.0",
         "eslint-plugin-vue": "^9.18.1",
         "git-describe": "^4.1.1",
         "googleapis": "^128.0.0",

--- a/scripts/check-external-layers-providers.js
+++ b/scripts/check-external-layers-providers.js
@@ -7,26 +7,27 @@ const dom = new JSDOM()
 global.DOMParser = dom.window.DOMParser
 global.Node = dom.window.Node
 
-import { promises as fs } from 'fs'
 import axios, { AxiosError } from 'axios'
-import writeYamlFile from 'write-yaml-file'
 import axiosRetry from 'axios-retry'
+import { promises as fs } from 'fs'
+import { exit } from 'process'
+import writeYamlFile from 'write-yaml-file'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
-import { exit } from 'process'
+
 import {
-    isWmsGetCap,
-    isWmtsGetCap,
-    isKml,
-    isGpx,
-    guessExternalLayerUrl,
-} from '@/modules/infobox/utils/external-provider'
-import { LV95 } from '@/utils/coordinates/coordinateSystems'
-import {
+    EXTERNAL_SERVER_TIMEOUT,
     parseWmsCapabilities,
     parseWmtsCapabilities,
-    EXTERNAL_SERVER_TIMEOUT,
 } from '@/api/layers/layers-external.api'
+import {
+    guessExternalLayerUrl,
+    isGpx,
+    isKml,
+    isWmsGetCap,
+    isWmtsGetCap,
+} from '@/modules/infobox/utils/external-provider'
+import { LV95 } from '@/utils/coordinates/coordinateSystems'
 
 const SIZE_OF_CONTENT_DISPLAY = 150
 

--- a/src/api/__tests__/features.api.spec.js
+++ b/src/api/__tests__/features.api.spec.js
@@ -1,9 +1,10 @@
-import { EditableFeature, EditableFeatureTypes } from '@/api/features.api'
-import { MEDIUM, RED } from '@/utils/featureStyleUtils'
 import { expect } from 'chai'
-import { describe, it } from 'vitest'
 import Feature from 'ol/Feature.js'
 import Polygon from 'ol/geom/Polygon.js'
+import { describe, it } from 'vitest'
+
+import { EditableFeature, EditableFeatureTypes } from '@/api/features.api'
+import { MEDIUM, RED } from '@/utils/featureStyleUtils'
 
 const stringifiedTestObject = `{"id":"drawing_feature_2",\
 "title":"This is a title",\

--- a/src/api/__tests__/profile.api.spec.js
+++ b/src/api/__tests__/profile.api.spec.js
@@ -1,8 +1,9 @@
+import { expect } from 'chai'
+import { describe, it } from 'vitest'
+
 import ElevationProfile from '@/api/profile/ElevationProfile.class'
 import ElevationProfilePoint from '@/api/profile/ElevationProfilePoint.class'
 import ElevationProfileSegment from '@/api/profile/ElevationProfileSegment.class'
-import { expect } from 'chai'
-import { describe, it } from 'vitest'
 
 const testProfile = new ElevationProfile([
     new ElevationProfileSegment([

--- a/src/api/__tests__/search.api.spec.js
+++ b/src/api/__tests__/search.api.spec.js
@@ -1,6 +1,7 @@
-import { FeatureSearchResult } from '@/api/search.api'
 import { expect } from 'chai'
 import { describe, it } from 'vitest'
+
+import { FeatureSearchResult } from '@/api/search.api'
 
 describe('Builds object by extracting all relevant attributes from the backend', () => {
     describe('FeatureSearchResult.getSimpleTitle', () => {

--- a/src/api/features.api.js
+++ b/src/api/features.api.js
@@ -1,3 +1,7 @@
+import axios from 'axios'
+import { Icon as openlayersIcon } from 'ol/style'
+import proj4 from 'proj4'
+
 import { DrawingIcon } from '@/api/icon.api'
 import { API_BASE_URL } from '@/config'
 import {
@@ -19,9 +23,6 @@ import {
 import { GeodesicGeometries } from '@/utils/geodesicManager'
 import { getEditableFeatureFromLegacyKmlFeature } from '@/utils/legacyKmlUtils'
 import log from '@/utils/logging'
-import axios from 'axios'
-import { Icon as openlayersIcon } from 'ol/style'
-import proj4 from 'proj4'
 
 /**
  * Representation of a feature that can be selected by the user on the map. This feature can be

--- a/src/api/feedback.api.js
+++ b/src/api/feedback.api.js
@@ -1,8 +1,9 @@
+import axios from 'axios'
+
 import { getKmlFromUrl } from '@/api/files.api'
 import { createShortLink } from '@/api/shortlink.api'
 import { API_SERVICES_BASE_URL, APP_VERSION } from '@/config'
 import log from '@/utils/logging'
-import axios from 'axios'
 
 /**
  * @param {String} text Mandatory

--- a/src/api/files.api.js
+++ b/src/api/files.api.js
@@ -1,8 +1,9 @@
-import { API_SERVICE_KML_BASE_URL } from '@/config'
-import log from '@/utils/logging'
 import axios from 'axios'
 import FormData from 'form-data'
 import pako from 'pako'
+
+import { API_SERVICE_KML_BASE_URL } from '@/config'
+import log from '@/utils/logging'
 
 /**
  * KML links

--- a/src/api/height.api.js
+++ b/src/api/height.api.js
@@ -1,9 +1,10 @@
+import axios from 'axios'
+import proj4 from 'proj4'
+
 import { API_SERVICE_ALTI_BASE_URL } from '@/config'
 import { LV95 } from '@/utils/coordinates/coordinateSystems'
 import log from '@/utils/logging'
 import { round } from '@/utils/numberUtils'
-import axios from 'axios'
-import proj4 from 'proj4'
 
 export const meterToFeetFactor = 3.28084
 

--- a/src/api/icon.api.js
+++ b/src/api/icon.api.js
@@ -1,7 +1,8 @@
+import axios from 'axios'
+
 import { API_SERVICES_BASE_URL } from '@/config'
 import { MEDIUM, RED } from '@/utils/featureStyleUtils'
 import log from '@/utils/logging'
-import axios from 'axios'
 
 /**
  * Collection of icons belonging to the same "category" (or set).

--- a/src/api/layers/WMSCapabilitiesParser.class.js
+++ b/src/api/layers/WMSCapabilitiesParser.class.js
@@ -1,11 +1,12 @@
-import { WMS_SUPPORTED_VERSIONS } from '@/config'
-import { LayerAttribution } from '@/api/layers/AbstractLayer.class'
-import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
-import ExternalGroupOfLayers from '@/api/layers/ExternalGroupOfLayers.class'
-import allCoordinateSystems, { WGS84 } from '@/utils/coordinates/coordinateSystems'
-import log from '@/utils/logging'
 import { WMSCapabilities } from 'ol/format'
 import proj4 from 'proj4'
+
+import { LayerAttribution } from '@/api/layers/AbstractLayer.class'
+import ExternalGroupOfLayers from '@/api/layers/ExternalGroupOfLayers.class'
+import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
+import { WMS_SUPPORTED_VERSIONS } from '@/config'
+import allCoordinateSystems, { WGS84 } from '@/utils/coordinates/coordinateSystems'
+import log from '@/utils/logging'
 
 function findLayer(layerId, startFrom, parents) {
     let found = {}

--- a/src/api/layers/WMTSCapabilitiesParser.class.js
+++ b/src/api/layers/WMTSCapabilitiesParser.class.js
@@ -1,9 +1,10 @@
+import WMTSCapabilities from 'ol/format/WMTSCapabilities'
+import proj4 from 'proj4'
+
 import { LayerAttribution } from '@/api/layers/AbstractLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
-import log from '@/utils/logging'
-import WMTSCapabilities from 'ol/format/WMTSCapabilities'
 import allCoordinateSystems, { WGS84 } from '@/utils/coordinates/coordinateSystems'
-import proj4 from 'proj4'
+import log from '@/utils/logging'
 
 function parseCrs(crs) {
     let epsgNumber = crs?.split(':').pop()

--- a/src/api/layers/__tests__/WMSCapabitliesParser.class.spec.js
+++ b/src/api/layers/__tests__/WMSCapabitliesParser.class.spec.js
@@ -1,10 +1,11 @@
-import WMSCapabilitiesParser from '../WMSCapabilitiesParser.class'
+import { readFile } from 'fs/promises'
+import { beforeAll, describe, expect, expectTypeOf, it } from 'vitest'
+
 import ExternalGroupOfLayers from '@/api/layers/ExternalGroupOfLayers.class'
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import { LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 
-import { readFile } from 'fs/promises'
-import { describe, it, expect, beforeAll, expectTypeOf } from 'vitest'
+import WMSCapabilitiesParser from '../WMSCapabilitiesParser.class'
 
 describe('WMSCapabilitiesParser - invalid', () => {
     it('Throw Error on invalid input', () => {

--- a/src/api/layers/__tests__/WMTSCapabitliesParser.class.spec.js
+++ b/src/api/layers/__tests__/WMTSCapabitliesParser.class.spec.js
@@ -1,8 +1,9 @@
-import WMTSCapabilitiesParser from '../WMTSCapabilitiesParser.class'
+import { readFile } from 'fs/promises'
+import { beforeAll, describe, expect, expectTypeOf, it } from 'vitest'
+
 import { LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 
-import { readFile } from 'fs/promises'
-import { describe, it, expect, beforeAll, expectTypeOf } from 'vitest'
+import WMTSCapabilitiesParser from '../WMTSCapabilitiesParser.class'
 
 describe('WMTSCapabilitiesParser of wmts-ogc-sample.xml', () => {
     let capabilities

--- a/src/api/layers/layers-external.api.js
+++ b/src/api/layers/layers-external.api.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+
 import WMSCapabilitiesParser from '@/api/layers/WMSCapabilitiesParser.class'
 import WMTSCapabilitiesParser from '@/api/layers/WMTSCapabilitiesParser.class'
 import log from '@/utils/logging'

--- a/src/api/layers/layers.api.js
+++ b/src/api/layers/layers.api.js
@@ -1,3 +1,5 @@
+import axios from 'axios'
+
 import { LayerAttribution } from '@/api/layers/AbstractLayer.class'
 import GeoAdminAggregateLayer, {
     AggregateSubLayer,
@@ -9,7 +11,6 @@ import LayerTimeConfig from '@/api/layers/LayerTimeConfig.class'
 import LayerTimeConfigEntry from '@/api/layers/LayerTimeConfigEntry.class'
 import { API_BASE_URL, WMTS_BASE_URL } from '@/config'
 import log from '@/utils/logging'
-import axios from 'axios'
 
 // API file that covers the backend endpoint http://api3.geo.admin.ch/rest/services/all/MapServer/layersConfig
 // TODO : implement loading of a cached CloudFront version for MVP

--- a/src/api/profile/profile.api.js
+++ b/src/api/profile/profile.api.js
@@ -1,11 +1,12 @@
+import axios from 'axios'
+import proj4 from 'proj4'
+
 import ElevationProfile from '@/api/profile/ElevationProfile.class'
 import ElevationProfilePoint from '@/api/profile/ElevationProfilePoint.class'
 import ElevationProfileSegment from '@/api/profile/ElevationProfileSegment.class'
 import { API_SERVICE_ALTI_BASE_URL } from '@/config'
 import { LV95 } from '@/utils/coordinates/coordinateSystems'
 import log from '@/utils/logging'
-import axios from 'axios'
-import proj4 from 'proj4'
 
 function parseProfileFromBackendResponse(backendResponse, startingDist, outputProjection) {
     const points = []

--- a/src/api/qrcode.api.js
+++ b/src/api/qrcode.api.js
@@ -1,6 +1,7 @@
+import axios from 'axios'
+
 import { API_SERVICES_BASE_URL } from '@/config'
 import log from '@/utils/logging'
-import axios from 'axios'
 
 /**
  * Generates a QR Code that, when scanned by mobile devices, open the URL given in parameters

--- a/src/api/search.api.js
+++ b/src/api/search.api.js
@@ -1,10 +1,11 @@
+import axios from 'axios'
+import proj4 from 'proj4'
+
 import { API_SERVICE_SEARCH_BASE_URL } from '@/config'
 import { LV95, WGS84 } from '@/utils/coordinates/coordinateSystems'
 import CustomCoordinateSystem from '@/utils/coordinates/CustomCoordinateSystem.class'
 import LV95CoordinateSystem from '@/utils/coordinates/LV95CoordinateSystem.class'
 import log from '@/utils/logging'
-import axios from 'axios'
-import proj4 from 'proj4'
 
 // API file that covers the backend endpoint http://api3.geo.admin.ch/services/sdiservices.html#search
 

--- a/src/api/shortlink.api.js
+++ b/src/api/shortlink.api.js
@@ -1,6 +1,7 @@
+import axios from 'axios'
+
 import { API_SERVICE_SHORTLINK_BASE_URL } from '@/config'
 import log from '@/utils/logging'
-import axios from 'axios'
 
 /**
  * Generates a short link from the given URL

--- a/src/api/topics.api.js
+++ b/src/api/topics.api.js
@@ -1,3 +1,5 @@
+import axios from 'axios'
+
 import GeoAdminGroupOfLayers from '@/api/layers/GeoAdminGroupOfLayers.class'
 import { API_BASE_URL } from '@/config'
 import {
@@ -5,7 +7,6 @@ import {
     getLayersFromLegacyUrlParams,
 } from '@/utils/legacyLayerParamUtils'
 import log from '@/utils/logging'
-import axios from 'axios'
 
 /** Representation of a topic (a subset of layers to be shown to the user) */
 export class Topic {

--- a/src/api/what3words.api.js
+++ b/src/api/what3words.api.js
@@ -1,7 +1,8 @@
-import { WGS84 } from '@/utils/coordinates/coordinateSystems'
-import log from '@/utils/logging'
 import axios from 'axios'
 import proj4 from 'proj4'
+
+import { WGS84 } from '@/utils/coordinates/coordinateSystems'
+import log from '@/utils/logging'
 
 // copied from https://developer.what3words.com/tutorial/detecting-if-text-is-in-the-format-of-a-3-word-address
 const REGEX_WHAT_3_WORDS =

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,14 @@
 // exposing the config in the logs
+// Importing styling CSS libraries
+import 'animate.css'
+// setting up font awesome vue component
+import './setup-fontawesome'
+
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import tippy from 'tippy.js'
+import { createApp } from 'vue'
+import VueSocialSharing from 'vue-social-sharing'
+
 import {
     API_BASE_URL,
     API_SERVICE_ALTI_BASE_URL,
@@ -22,17 +32,7 @@ import store from '@/store'
 import log from '@/utils/logging'
 import setupChartJS from '@/utils/setupChartJS'
 
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-// Importing styling CSS libraries
-import 'animate.css'
-import tippy from 'tippy.js'
-
-import { createApp } from 'vue'
-import VueSocialSharing from 'vue-social-sharing'
-
 import App from './App.vue'
-// setting up font awesome vue component
-import './setup-fontawesome'
 
 log.debug('Config is', {
     ENVIRONMENT,

--- a/src/modules/drawing/components/drawingInteraction.mixin.js
+++ b/src/modules/drawing/components/drawingInteraction.mixin.js
@@ -1,9 +1,10 @@
-import { EditableFeature } from '@/api/features.api'
-import { editingFeatureStyleFunction, featureStyleFunction } from '@/modules/drawing/lib/style'
 import DrawInteraction from 'ol/interaction/Draw'
 import { getUid } from 'ol/util'
-import { wrapXCoordinates } from '@/modules/drawing/lib/drawingUtils'
 import { mapState } from 'vuex'
+
+import { EditableFeature } from '@/api/features.api'
+import { wrapXCoordinates } from '@/modules/drawing/lib/drawingUtils'
+import { editingFeatureStyleFunction, featureStyleFunction } from '@/modules/drawing/lib/style'
 
 /**
  * Vue mixin that will handle the addition or removal of a drawing interaction to the drawing

--- a/src/modules/drawing/lib/__tests__/drawingUtils.spec.js
+++ b/src/modules/drawing/lib/__tests__/drawingUtils.spec.js
@@ -1,3 +1,6 @@
+import { expect } from 'chai'
+import { describe, it } from 'vitest'
+
 import {
     formatMeters,
     formatPointCoordinates,
@@ -6,8 +9,6 @@ import {
     wrapXCoordinates,
 } from '@/modules/drawing/lib/drawingUtils'
 import { LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
-import { expect } from 'chai'
-import { describe, it } from 'vitest'
 
 describe('Unit test functions from drawingUtils.js', () => {
     describe('toLv95(coordinate, "EPSG:4326")', () => {

--- a/src/modules/drawing/lib/drawingUtils.js
+++ b/src/modules/drawing/lib/drawingUtils.js
@@ -1,11 +1,12 @@
-import { LV95, WGS84 } from '@/utils/coordinates/coordinateSystems'
-import { format } from '@/utils/numberUtils'
 import { wrapX } from 'ol/coordinate'
+import KML from 'ol/format/KML'
 import { LineString, Point, Polygon } from 'ol/geom'
 import { get as getProjection } from 'ol/proj'
 import proj4 from 'proj4'
-import KML from 'ol/format/KML'
+
 import { EditableFeature } from '@/api/features.api'
+import { LV95, WGS84 } from '@/utils/coordinates/coordinateSystems'
+import { format } from '@/utils/numberUtils'
 
 export function toLv95(input, epsg) {
     if (Array.isArray(input[0])) {

--- a/src/modules/drawing/lib/export-utils.js
+++ b/src/modules/drawing/lib/export-utils.js
@@ -1,11 +1,12 @@
-import { featureStyleFunction } from '@/modules/drawing/lib/style'
-import i18n from '@/modules/i18n/index'
-import { WGS84 } from '@/utils/coordinates/coordinateSystems'
 import Feature from 'ol/Feature'
 import { GPX, KML } from 'ol/format'
 import { LineString, Polygon } from 'ol/geom'
 import { Circle, Icon } from 'ol/style'
 import Style from 'ol/style/Style'
+
+import { featureStyleFunction } from '@/modules/drawing/lib/style'
+import i18n from '@/modules/i18n/index'
+import { WGS84 } from '@/utils/coordinates/coordinateSystems'
 import log from '@/utils/logging'
 
 const kmlFormat = new KML()

--- a/src/modules/drawing/lib/modifyInteraction.js
+++ b/src/modules/drawing/lib/modifyInteraction.js
@@ -28,24 +28,9 @@
  *
  * @module ol/interaction/Modify
  * */
+import { equals } from "ol/array";
 import Collection from "ol/Collection";
 import CollectionEventType from "ol/CollectionEventType";
-import Event from "ol/events/Event";
-import EventType from "ol/events/EventType";
-import Feature from "ol/Feature";
-import MapBrowserEventType from "ol/MapBrowserEventType";
-import Point from "ol/geom/Point";
-import PointerInteraction from "ol/interaction/Pointer";
-import RBush from "ol/structs/RBush";
-import VectorEventType from "ol/source/VectorEventType";
-import VectorLayer from "ol/layer/Vector";
-import VectorSource from "ol/source/Vector";
-import { altKeyOnly, always, primaryAction, singleClick } from "ol/events/condition";
-import {
-  boundingExtent,
-  buffer as bufferExtent,
-  createOrUpdateFromCoordinate as createExtent,
-} from "ol/extent";
 import { wrapX as wrapXCoordinate } from "ol/coordinate";
 import {
   closestOnSegment,
@@ -54,9 +39,20 @@ import {
   squaredDistance as squaredCoordinateDistance,
   squaredDistanceToSegment,
 } from "ol/coordinate";
-import { createEditingStyle } from "ol/style/Style";
-import { equals } from "ol/array";
+import { altKeyOnly, always, primaryAction, singleClick } from "ol/events/condition";
+import Event from "ol/events/Event";
+import EventType from "ol/events/EventType";
+import {
+  boundingExtent,
+  buffer as bufferExtent,
+  createOrUpdateFromCoordinate as createExtent,
+} from "ol/extent";
+import Feature from "ol/Feature";
+import Point from "ol/geom/Point";
 import { fromCircle } from "ol/geom/Polygon";
+import PointerInteraction from "ol/interaction/Pointer";
+import VectorLayer from "ol/layer/Vector";
+import MapBrowserEventType from "ol/MapBrowserEventType";
 import {
   fromUserCoordinate,
   fromUserExtent,
@@ -64,6 +60,10 @@ import {
   toUserCoordinate,
   toUserExtent,
 } from "ol/proj";
+import VectorSource from "ol/source/Vector";
+import VectorEventType from "ol/source/VectorEventType";
+import RBush from "ol/structs/RBush";
+import { createEditingStyle } from "ol/style/Style";
 import { getUid } from "ol/util";
 
 /**

--- a/src/modules/drawing/lib/style.js
+++ b/src/modules/drawing/lib/style.js
@@ -1,6 +1,7 @@
-import { EditableFeatureTypes } from '@/api/features.api'
-import { LineString, MultiPoint, Polygon, Point } from 'ol/geom'
+import { LineString, MultiPoint, Point, Polygon } from 'ol/geom'
 import { Circle, Fill, Stroke, Style, Text } from 'ol/style'
+
+import { EditableFeatureTypes } from '@/api/features.api'
 
 /* Z-INDICES
 The z indices for the styles are given according to the following table:

--- a/src/modules/i18n/index.js
+++ b/src/modules/i18n/index.js
@@ -1,6 +1,6 @@
 import { createI18n } from 'vue-i18n'
-import de from './locales/de.json'
 
+import de from './locales/de.json'
 import en from './locales/en.json'
 import fr from './locales/fr.json'
 import it from './locales/it.json'

--- a/src/modules/map/components/cesium/utils/addPrimitiveFromOLLayer.mixins.js
+++ b/src/modules/map/components/cesium/utils/addPrimitiveFromOLLayer.mixins.js
@@ -1,9 +1,11 @@
+import { PrimitiveCollection } from 'cesium'
+import { Vector as VectorLayer } from 'ol/layer'
+import FeatureConverter from 'ol-cesium/src/olcs/FeatureConverter'
+
 import { IS_TESTING_WITH_CYPRESS } from '@/config'
 import { PRIMITIVE_DISABLE_DEPTH_TEST_DISTANCE } from '@/modules/map/components/cesium/constants'
 import { updateCollectionProperties } from '@/modules/map/components/cesium/utils/primitiveLayerUtils'
-import { PrimitiveCollection } from 'cesium'
-import FeatureConverter from 'ol-cesium/src/olcs/FeatureConverter'
-import { Vector as VectorLayer } from 'ol/layer'
+
 import addLayerToViewer from './addLayerToViewer-mixins'
 
 const STYLE_RESOLUTION = 20

--- a/src/modules/map/components/cesium/utils/cameraUtils.js
+++ b/src/modules/map/components/cesium/utils/cameraUtils.js
@@ -1,13 +1,13 @@
 import {
     Cartesian2,
     Cartesian3,
-    Matrix4,
     Cartographic,
+    HeadingPitchRange,
+    Math as CesiumMath,
+    Matrix4,
     Ray,
     Rectangle,
     Transforms,
-    HeadingPitchRange,
-    Math as CesiumMath,
 } from 'cesium'
 
 /**

--- a/src/modules/map/components/cesium/utils/highlightUtils.js
+++ b/src/modules/map/components/cesium/utils/highlightUtils.js
@@ -1,6 +1,7 @@
-import { WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 import { Cartesian3, Color, Entity, HeightReference } from 'cesium'
 import proj4 from 'proj4'
+
+import { WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 
 let highlightedEntities = []
 const highlightFill = Color.fromCssColorString('rgba(255, 255, 0, 0.75)')

--- a/src/modules/map/components/cesium/utils/primitiveLayerUtils.js
+++ b/src/modules/map/components/cesium/utils/primitiveLayerUtils.js
@@ -1,4 +1,3 @@
-import log from '@/utils/logging'
 import {
     Billboard,
     BillboardCollection,
@@ -17,6 +16,8 @@ import {
     PrimitiveCollection,
     VerticalOrigin,
 } from 'cesium'
+
+import log from '@/utils/logging'
 
 /**
  * Style to apply to our labels in 3D. It is a complete rip-off of

--- a/src/modules/map/components/common/mouse-click.composable.js
+++ b/src/modules/map/components/common/mouse-click.composable.js
@@ -1,8 +1,9 @@
+import { computed } from 'vue'
+import { useStore } from 'vuex'
+
 import LayerTypes from '@/api/layers/LayerTypes.enum'
 import { ClickInfo, ClickType } from '@/store/modules/map.store'
 import { identifyGeoJSONFeatureAt, identifyKMLFeatureAt } from '@/utils/identifyOnVectorLayer'
-import { computed } from 'vue'
-import { useStore } from 'vuex'
 
 const msBeforeTriggeringLocationPopup = 700
 

--- a/src/modules/map/components/common/z-index.composable.js
+++ b/src/modules/map/components/common/z-index.composable.js
@@ -1,6 +1,7 @@
-import LayerTypes from '@/api/layers/LayerTypes.enum'
 import { computed } from 'vue'
 import { useStore } from 'vuex'
+
+import LayerTypes from '@/api/layers/LayerTypes.enum'
 
 /** Composable that gives utility function to calculate/get layers' and features' z-index */
 export function useLayerZIndexCalculation() {

--- a/src/modules/map/components/openlayers/utils/map-interactions.composable.js
+++ b/src/modules/map/components/openlayers/utils/map-interactions.composable.js
@@ -1,11 +1,12 @@
-import { useMouseOnMap } from '@/modules/map/components/common/mouse-click.composable'
-import { LV95 } from '@/utils/coordinates/coordinateSystems'
 import { platformModifierKeyOnly } from 'ol/events/condition'
 import { defaults as getDefaultInteractions, MouseWheelZoom } from 'ol/interaction'
 import DoubleClickZoomInteraction from 'ol/interaction/DoubleClickZoom'
 import DragRotateInteraction from 'ol/interaction/DragRotate'
 import { computed, onBeforeUnmount, onMounted, watch } from 'vue'
 import { useStore } from 'vuex'
+
+import { useMouseOnMap } from '@/modules/map/components/common/mouse-click.composable'
+import { LV95 } from '@/utils/coordinates/coordinateSystems'
 
 export default function useMapInteractions(map) {
     const { onLeftClickDown, onLeftClickUp, onRightClick, onMouseMove } = useMouseOnMap()

--- a/src/modules/map/components/openlayers/utils/map-views.composable.js
+++ b/src/modules/map/components/openlayers/utils/map-views.composable.js
@@ -1,11 +1,12 @@
+import { View } from 'ol'
+import { computed, onBeforeUnmount, onMounted, watch } from 'vue'
+import { useStore } from 'vuex'
+
 import { IS_TESTING_WITH_CYPRESS, VIEW_MIN_RESOLUTION } from '@/config'
 import { LV95, WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
 import { LV95_RESOLUTIONS } from '@/utils/coordinates/SwissCoordinateSystem.class'
 import log from '@/utils/logging'
 import { round } from '@/utils/numberUtils'
-import { View } from 'ol'
-import { computed, onBeforeUnmount, onMounted, watch } from 'vue'
-import { useStore } from 'vuex'
 
 let animationDuration = 200
 if (IS_TESTING_WITH_CYPRESS) {

--- a/src/modules/map/components/openlayers/utils/markerStyle.js
+++ b/src/modules/map/components/openlayers/utils/markerStyle.js
@@ -1,11 +1,12 @@
+import { Fill, Stroke, Style } from 'ol/style'
+import CircleStyle from 'ol/style/Circle'
+import IconStyle from 'ol/style/Icon'
+
 import bowlImage from '@/modules/map/assets/bowl.png'
 import circleImage from '@/modules/map/assets/circle.png'
 import crossImage from '@/modules/map/assets/cross.png'
 import markerImage from '@/modules/map/assets/marker.png'
 import pointImage from '@/modules/map/assets/point.png'
-import { Fill, Stroke, Style } from 'ol/style'
-import CircleStyle from 'ol/style/Circle'
-import IconStyle from 'ol/style/Icon'
 
 // style for feature highlighting (we export it so that they can be re-used by OpenLayersHighlightedFeature)
 export const highlightedFill = new Fill({

--- a/src/modules/map/components/openlayers/utils/styleFromLiterals.js
+++ b/src/modules/map/components/openlayers/utils/styleFromLiterals.js
@@ -1,8 +1,9 @@
 // copied and adapted from https://github.com/geoadmin/mf-geoadmin3/blob/master/src/components/StylesFromLiteralsService.js
-import log from '@/utils/logging'
-import { isNumber } from '@/utils/numberUtils'
 import { LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon } from 'ol/geom'
 import { Circle, Fill, Icon, RegularShape, Stroke, Style, Text } from 'ol/style'
+
+import log from '@/utils/logging'
+import { isNumber } from '@/utils/numberUtils'
 
 function getOlStyleForPoint(options, shape) {
     if (shape === 'circle') {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,3 +1,5 @@
+import { createRouter, createWebHashHistory } from 'vue-router'
+
 import { IS_TESTING_WITH_CYPRESS } from '@/config'
 import appLoadingManagementRouterPlugin from '@/router/appLoadingManagement.routerPlugin'
 import legacyPermalinkManagementRouterPlugin from '@/router/legacyPermalinkManagement.routerPlugin'
@@ -6,7 +8,6 @@ import store from '@/store'
 import { parseQuery, stringifyQuery } from '@/utils/url-router'
 import LoadingView from '@/views/LoadingView.vue'
 import MapView from '@/views/MapView.vue'
-import { createRouter, createWebHashHistory } from 'vue-router'
 
 const history = createWebHashHistory()
 

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -1,3 +1,5 @@
+import proj4 from 'proj4'
+
 import { transformLayerIntoUrlString } from '@/router/storeSync/LayerParamConfig.class'
 import { LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 import CustomCoordinateSystem from '@/utils/coordinates/CustomCoordinateSystem.class'
@@ -8,7 +10,6 @@ import {
     isLayersUrlParamLegacy,
 } from '@/utils/legacyLayerParamUtils'
 import log from '@/utils/logging'
-import proj4 from 'proj4'
 
 /**
  * @param {String} search

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -1,6 +1,6 @@
+import ExternalGroupOfLayers from '@/api/layers/ExternalGroupOfLayers.class'
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
-import ExternalGroupOfLayers from '@/api/layers/ExternalGroupOfLayers.class'
 import KMLLayer from '@/api/layers/KMLLayer.class'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
 import AbstractParamConfig from '@/router/storeSync/abstractParamConfig.class'

--- a/src/router/storeSync/__tests__/CameraParamConfig.class.spec.js
+++ b/src/router/storeSync/__tests__/CameraParamConfig.class.spec.js
@@ -1,7 +1,8 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import PositionUrlParamConfig, {
     readCameraFromUrlParam,
 } from '@/router/storeSync/CameraParamConfig.class'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('CameraParamConfig class test', () => {
     const testInstance = new PositionUrlParamConfig()

--- a/src/router/storeSync/__tests__/LayerParamConfig.class.spec.js
+++ b/src/router/storeSync/__tests__/LayerParamConfig.class.spec.js
@@ -1,10 +1,11 @@
+import { expect } from 'chai'
+import { describe, it } from 'vitest'
+
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
 import KMLLayer from '@/api/layers/KMLLayer.class'
 import { createLayerObject } from '@/router/storeSync/LayerParamConfig.class'
 import { ActiveLayerConfig } from '@/utils/layerUtils'
-import { expect } from 'chai'
-import { describe, it } from 'vitest'
 
 describe('External layer parsing with createLayerObject', () => {
     it('parses a KML layer correctly', () => {

--- a/src/router/storeSync/__tests__/SimpleUrlParamConfig.class.spec.js
+++ b/src/router/storeSync/__tests__/SimpleUrlParamConfig.class.spec.js
@@ -1,6 +1,7 @@
-import SimpleUrlParamConfig from '@/router/storeSync/SimpleUrlParamConfig.class'
 import { expect } from 'chai'
 import { describe, it } from 'vitest'
+
+import SimpleUrlParamConfig from '@/router/storeSync/SimpleUrlParamConfig.class'
 
 describe('Test all SimpleUrlParamConfig class functionalities', () => {
     const fakeStore = {

--- a/src/router/storeSync/__tests__/abstractParamConfig.class.spec.js
+++ b/src/router/storeSync/__tests__/abstractParamConfig.class.spec.js
@@ -1,6 +1,7 @@
-import AbstractParamConfig from '@/router/storeSync/abstractParamConfig.class'
 import { expect } from 'chai'
 import { describe, it } from 'vitest'
+
+import AbstractParamConfig from '@/router/storeSync/abstractParamConfig.class'
 
 class DummyUrlParamConfig extends AbstractParamConfig {
     constructor(

--- a/src/router/storeSync/__tests__/layersParamParser.spec.js
+++ b/src/router/storeSync/__tests__/layersParamParser.spec.js
@@ -1,6 +1,7 @@
-import layersParamParser from '@/router/storeSync/layersParamParser'
 import { expect } from 'chai'
 import { describe, it } from 'vitest'
+
+import layersParamParser from '@/router/storeSync/layersParamParser'
 
 describe('Testing layersParamParser', () => {
     const checkLayer = (layer, id, visible = true, opacity = undefined, customAttributes = {}) => {

--- a/src/router/storeSync/layersParamParser.js
+++ b/src/router/storeSync/layersParamParser.js
@@ -1,5 +1,5 @@
-import { isNumber } from '@/utils/numberUtils'
 import { ActiveLayerConfig } from '@/utils/layerUtils'
+import { isNumber } from '@/utils/numberUtils'
 
 /**
  * Parses the URL param value for `layers` as described in the ADR :

--- a/src/router/storeSync/storeSync.routerPlugin.js
+++ b/src/router/storeSync/storeSync.routerPlugin.js
@@ -1,7 +1,8 @@
+import axios from 'axios'
+
 import { IS_TESTING_WITH_CYPRESS } from '@/config'
 import storeSyncConfig from '@/router/storeSync/storeSync.config'
 import log from '@/utils/logging'
-import axios from 'axios'
 
 export const FAKE_URL_CALLED_AFTER_ROUTE_CHANGE = '/tell-cypress-route-has-changed'
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,7 +1,9 @@
+import { createStore } from 'vuex'
+
 import from2Dto3Dplugin from '@/store/plugins/2d-to-3d-management.plugin'
 import loadGeojsonStyleAndData from '@/store/plugins/load-geojson-style-and-data.plugin'
 import reprojectSelectedFeaturesOnProjectionChangePlugin from '@/store/plugins/reproject-selected-features-on-projection-change.plugin'
-import { createStore } from 'vuex'
+
 import app from './modules/app.store'
 import cesium from './modules/cesium.store'
 import drawing from './modules/drawing.store'

--- a/src/store/modules/__tests__/layers.store.spec.js
+++ b/src/store/modules/__tests__/layers.store.spec.js
@@ -1,3 +1,6 @@
+import { expect } from 'chai'
+import { beforeEach, describe, it } from 'vitest'
+
 import AbstractLayer from '@/api/layers/AbstractLayer.class'
 import ExternalGroupOfLayers from '@/api/layers/ExternalGroupOfLayers.class'
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
@@ -5,8 +8,6 @@ import GeoAdminWMSLayer from '@/api/layers/GeoAdminWMSLayer.class'
 import GeoAdminWMTSLayer from '@/api/layers/GeoAdminWMTSLayer.class'
 import LayerTimeConfig from '@/api/layers/LayerTimeConfig.class'
 import store from '@/store'
-import { expect } from 'chai'
-import { beforeEach, describe, it } from 'vitest'
 
 const bgLayer = new GeoAdminWMTSLayer(
     'background',

--- a/src/store/modules/__tests__/rotation.store.spec.js
+++ b/src/store/modules/__tests__/rotation.store.spec.js
@@ -1,7 +1,8 @@
-import store from '@/store'
-import { normalizeAngle } from '@/store/modules/position.store'
 import { expect } from 'chai'
 import { describe, it } from 'vitest'
+
+import store from '@/store'
+import { normalizeAngle } from '@/store/modules/position.store'
 
 function validateNormalizeAngle(angle) {
     expect(angle).to.be.lte(Math.PI)

--- a/src/store/modules/__tests__/zoom.store.spec.js
+++ b/src/store/modules/__tests__/zoom.store.spec.js
@@ -1,8 +1,9 @@
-import store from '@/store'
-import { WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 import { expect } from 'chai'
 import proj4 from 'proj4'
 import { beforeEach, describe, it } from 'vitest'
+
+import store from '@/store'
+import { WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 
 describe('Zoom level is calculated correctly in the store when using WebMercator as the projection', () => {
     const screenSize = 100

--- a/src/store/modules/position.store.js
+++ b/src/store/modules/position.store.js
@@ -1,3 +1,5 @@
+import proj4 from 'proj4'
+
 import { DEFAULT_PROJECTION } from '@/config'
 import CoordinateSystem from '@/utils/coordinates/CoordinateSystem.class'
 import allCoordinateSystems, { LV95, WGS84 } from '@/utils/coordinates/coordinateSystems'
@@ -5,7 +7,6 @@ import CustomCoordinateSystem from '@/utils/coordinates/CustomCoordinateSystem.c
 import StandardCoordinateSystem from '@/utils/coordinates/StandardCoordinateSystem.class'
 import log from '@/utils/logging'
 import { round } from '@/utils/numberUtils'
-import proj4 from 'proj4'
 
 /** @enum */
 export const CrossHairs = {

--- a/src/store/plugins/geolocation-management.plugin.js
+++ b/src/store/plugins/geolocation-management.plugin.js
@@ -1,8 +1,9 @@
+import proj4 from 'proj4'
+
 import { IS_TESTING_WITH_CYPRESS } from '@/config'
 import i18n from '@/modules/i18n'
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
 import log from '@/utils/logging'
-import proj4 from 'proj4'
 
 let geolocationWatcher = null
 let firstTimeActivatingGeolocation = true

--- a/src/store/plugins/load-geojson-style-and-data.plugin.js
+++ b/src/store/plugins/load-geojson-style-and-data.plugin.js
@@ -3,9 +3,10 @@
  * it here
  */
 
+import axios from 'axios'
+
 import GeoAdminGeoJsonLayer from '@/api/layers/GeoAdminGeoJsonLayer.class'
 import log from '@/utils/logging'
-import axios from 'axios'
 
 async function load(url) {
     try {

--- a/src/store/plugins/reproject-selected-features-on-projection-change.plugin.js
+++ b/src/store/plugins/reproject-selected-features-on-projection-change.plugin.js
@@ -1,7 +1,8 @@
+import proj4 from 'proj4'
+
 import { EditableFeature, LayerFeature } from '@/api/features.api'
 import { projExtent } from '@/utils/coordinates/coordinateUtils'
 import log from '@/utils/logging'
-import proj4 from 'proj4'
 
 let oldProjection = null
 /**

--- a/src/store/plugins/sync-camera-lonlatzoom.js
+++ b/src/store/plugins/sync-camera-lonlatzoom.js
@@ -1,7 +1,8 @@
+import proj4 from 'proj4'
+
 import { calculateResolution } from '@/modules/map/components/cesium/utils/cameraUtils'
 import { normalizeAngle } from '@/store/modules/position.store'
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
-import proj4 from 'proj4'
 
 /**
  * Plugin to synchronize the 3d camera position and orientation with the center and zoom.

--- a/src/utils/__tests__/geodesicManager.spec.js
+++ b/src/utils/__tests__/geodesicManager.spec.js
@@ -1,10 +1,11 @@
-import { HALFSIZE_WEBMERCATOR, GeodesicGeometries } from '@/utils/geodesicManager'
-import { WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
-import { Feature } from 'ol'
 import { expect } from 'chai'
+import { Feature } from 'ol'
 import { LineString, MultiLineString, MultiPolygon } from 'ol/geom'
-import { describe, it } from 'vitest'
 import { Style } from 'ol/style'
+import { describe, it } from 'vitest'
+
+import { WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
+import { GeodesicGeometries, HALFSIZE_WEBMERCATOR } from '@/utils/geodesicManager'
 
 function constructGeodLineString(...coords) {
     const feature = new Feature(new LineString(coords))

--- a/src/utils/__tests__/legacyKmlUtils.spec.js
+++ b/src/utils/__tests__/legacyKmlUtils.spec.js
@@ -1,5 +1,11 @@
+import { expect } from 'chai'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { beforeEach, describe, it } from 'vitest'
+
 import { EditableFeatureTypes } from '@/api/features.api'
 import { DrawingIcon, DrawingIconSet } from '@/api/icon.api'
+import { parseKml } from '@/modules/drawing/lib/drawingUtils'
 import { WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
 import {
     BLACK,
@@ -13,11 +19,6 @@ import {
     WHITE,
     YELLOW,
 } from '@/utils/featureStyleUtils'
-import { expect } from 'chai'
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
-import { beforeEach, describe, it } from 'vitest'
-import { parseKml } from '@/modules/drawing/lib/drawingUtils'
 
 const fakeDefaultIconSet = new DrawingIconSet(
     'default',

--- a/src/utils/__tests__/legacyLayerParamUtils.spec.js
+++ b/src/utils/__tests__/legacyLayerParamUtils.spec.js
@@ -1,3 +1,6 @@
+import { expect } from 'chai'
+import { describe, it } from 'vitest'
+
 import { LayerAttribution } from '@/api/layers/AbstractLayer.class'
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
@@ -6,8 +9,6 @@ import GeoAdminWMTSLayer from '@/api/layers/GeoAdminWMTSLayer.class'
 import LayerTimeConfig from '@/api/layers/LayerTimeConfig.class'
 import LayerTimeConfigEntry from '@/api/layers/LayerTimeConfigEntry.class'
 import { getLayersFromLegacyUrlParams, isLayersUrlParamLegacy } from '@/utils/legacyLayerParamUtils'
-import { expect } from 'chai'
-import { describe, it } from 'vitest'
 
 describe('Test parsing of legacy URL param into new params', () => {
     describe('test getLayersFromLegacyUrlParams', () => {

--- a/src/utils/__tests__/numberUtils.spec.js
+++ b/src/utils/__tests__/numberUtils.spec.js
@@ -1,6 +1,7 @@
-import { format, formatThousand, isNumber, randomIntBetween, round } from '@/utils/numberUtils'
 import { expect } from 'chai'
 import { describe, it } from 'vitest'
+
+import { format, formatThousand, isNumber, randomIntBetween, round } from '@/utils/numberUtils'
 
 describe('Unit test functions from numberUtils.js', () => {
     describe('round(value, decimals)', () => {

--- a/src/utils/__tests__/urlQuery.spec.js
+++ b/src/utils/__tests__/urlQuery.spec.js
@@ -1,7 +1,7 @@
-import { describe, it } from 'vitest'
 import { expect } from 'chai'
+import { describe, it } from 'vitest'
 
-import { stringifyQuery, parseQuery } from '../url-router'
+import { parseQuery, stringifyQuery } from '../url-router'
 
 describe('Unit test function for parseQuery', () => {
     it('Decode + as space', () => {

--- a/src/utils/coordinates/CoordinateSystem.class.js
+++ b/src/utils/coordinates/CoordinateSystem.class.js
@@ -1,5 +1,6 @@
-import CoordinateSystemBounds from '@/utils/coordinates/CoordinateSystemBounds.class'
 import proj4 from 'proj4'
+
+import CoordinateSystemBounds from '@/utils/coordinates/CoordinateSystemBounds.class'
 
 /**
  * Representation of a coordinate system (or also called projection system) in the context of this

--- a/src/utils/coordinates/WebMercatorCoordinateSystem.class.js
+++ b/src/utils/coordinates/WebMercatorCoordinateSystem.class.js
@@ -1,10 +1,11 @@
+import proj4 from 'proj4'
+
 import CoordinateSystemBounds from '@/utils/coordinates/CoordinateSystemBounds.class'
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
 import StandardCoordinateSystem, {
     PIXEL_LENGTH_IN_KM_AT_ZOOM_ZERO_WITH_256PX_TILES,
 } from '@/utils/coordinates/StandardCoordinateSystem.class'
 import { round } from '@/utils/numberUtils'
-import proj4 from 'proj4'
 
 export default class WebMercatorCoordinateSystem extends StandardCoordinateSystem {
     constructor() {

--- a/src/utils/coordinates/__test__/CoordinateSystem.class.spec.js
+++ b/src/utils/coordinates/__test__/CoordinateSystem.class.spec.js
@@ -1,7 +1,8 @@
+import { describe, expect, it } from 'vitest'
+
 import CoordinateSystemBounds from '@/utils/coordinates/CoordinateSystemBounds.class'
 import { LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 import StandardCoordinateSystem from '@/utils/coordinates/StandardCoordinateSystem.class'
-import { describe, expect, it } from 'vitest'
 
 describe('CoordinateSystem', () => {
     const coordinateSystemWithouBounds = new StandardCoordinateSystem('test', 'test', 1234, null)

--- a/src/utils/coordinates/__test__/CoordinateSystemBounds.class.spec.js
+++ b/src/utils/coordinates/__test__/CoordinateSystemBounds.class.spec.js
@@ -1,6 +1,7 @@
-import CoordinateSystemBounds from '@/utils/coordinates/CoordinateSystemBounds.class'
 import { expect } from 'chai'
 import { beforeEach, describe, it } from 'vitest'
+
+import CoordinateSystemBounds from '@/utils/coordinates/CoordinateSystemBounds.class'
 
 describe('CoordinateSystemBounds', () => {
     describe('splitIfOutOfBounds(coordinates, bounds)', () => {

--- a/src/utils/coordinates/__test__/SwissCoordinateSystem.class.spec.js
+++ b/src/utils/coordinates/__test__/SwissCoordinateSystem.class.spec.js
@@ -1,9 +1,10 @@
+import { describe, expect, it } from 'vitest'
+
 import { LV03, LV95 } from '@/utils/coordinates/coordinateSystems'
 import {
     LV95_RESOLUTIONS,
     swissPyramidZoomToStandardZoomMatrix,
 } from '@/utils/coordinates/SwissCoordinateSystem.class'
-import { describe, expect, it } from 'vitest'
 
 describe('Unit test functions from SwissCoordinateSystem', () => {
     describe('transformCustomZoomLevelToStandard', () => {

--- a/src/utils/coordinates/__test__/coordinateExtractors.spec.js
+++ b/src/utils/coordinates/__test__/coordinateExtractors.spec.js
@@ -1,9 +1,10 @@
-import coordinateFromString from '@/utils/coordinates/coordinateExtractors'
-import { LV03, LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 import { expect } from 'chai'
 import { toStringHDMS } from 'ol/coordinate'
 import proj4 from 'proj4'
 import { describe, it } from 'vitest'
+
+import coordinateFromString from '@/utils/coordinates/coordinateExtractors'
+import { LV03, LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 
 /**
  * Place a separator after each group of 3 digit

--- a/src/utils/coordinates/__test__/coordinateUtils.spec.js
+++ b/src/utils/coordinates/__test__/coordinateUtils.spec.js
@@ -1,8 +1,9 @@
-import { LV03, LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
-import { reprojectUnknownSrsCoordsToWGS84 } from '@/utils/coordinates/coordinateUtils'
 import { expect } from 'chai'
 import proj4 from 'proj4'
 import { describe, it } from 'vitest'
+
+import { LV03, LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
+import { reprojectUnknownSrsCoordsToWGS84 } from '@/utils/coordinates/coordinateUtils'
 
 describe('Unit test functions from coordinateUtils.js', () => {
     describe('reprojectUnknownSrsCoordsToWGS84(x,y)', () => {

--- a/src/utils/coordinates/coordinateExtractors.js
+++ b/src/utils/coordinates/coordinateExtractors.js
@@ -1,7 +1,8 @@
+import proj4 from 'proj4'
+
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
 import { reprojectUnknownSrsCoordsToWGS84 } from '@/utils/coordinates/coordinateUtils'
 import { toPoint as mgrsToWGS84 } from '@/utils/militaryGridProjection'
-import proj4 from 'proj4'
 
 // 47.5 7.5
 const REGEX_WEB_MERCATOR = /^\s*([\d]{1,3}[.\d]+)\s*[ ,/]+\s*([\d]{1,3}[.\d]+)\s*$/i

--- a/src/utils/coordinates/coordinateFormat.js
+++ b/src/utils/coordinates/coordinateFormat.js
@@ -1,9 +1,10 @@
+import { format as formatCoordinate, toStringHDMS } from 'ol/coordinate'
+import proj4 from 'proj4'
+
 import { LV03, LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 import { toRoundedString } from '@/utils/coordinates/coordinateUtils'
 import { latLonToMGRS, latLonToUTM } from '@/utils/militaryGridProjection'
 import { formatThousand } from '@/utils/numberUtils'
-import { format as formatCoordinate, toStringHDMS } from 'ol/coordinate'
-import proj4 from 'proj4'
 
 /** Representation of coordinates in a human-readable format */
 export class CoordinateFormat {

--- a/src/utils/coordinates/coordinateUtils.js
+++ b/src/utils/coordinates/coordinateUtils.js
@@ -1,4 +1,5 @@
 import proj4 from 'proj4'
+
 import log from '../logging'
 import { formatThousand } from '../numberUtils'
 import { LV03, LV95, WEBMERCATOR, WGS84 } from './coordinateSystems'

--- a/src/utils/geoJsonUtils.js
+++ b/src/utils/geoJsonUtils.js
@@ -1,6 +1,7 @@
+import { reproject } from 'reproject'
+
 import CoordinateSystem from '@/utils/coordinates/CoordinateSystem.class'
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
-import { reproject } from 'reproject'
 
 /**
  * Re-projecting the GeoJSON if not in the wanted projection

--- a/src/utils/geodesicManager.js
+++ b/src/utils/geodesicManager.js
@@ -1,6 +1,3 @@
-import log from '@/utils/logging'
-import { formatAngle, formatMeters } from '@/modules/drawing/lib/drawingUtils'
-import { WGS84 } from '@/utils/coordinates/coordinateSystems'
 import { Geodesic, Math as geographicMath, PolygonArea } from 'geographiclib-geodesic'
 import {
     boundingExtent,
@@ -12,6 +9,10 @@ import { LineString, MultiLineString, MultiPolygon, Point, Polygon } from 'ol/ge
 import RBush from 'ol/structs/RBush' /* Warning: private class of openlayers */
 import { Circle, Fill, RegularShape, Stroke, Style, Text } from 'ol/style'
 import proj4 from 'proj4'
+
+import { formatAngle, formatMeters } from '@/modules/drawing/lib/drawingUtils'
+import { WGS84 } from '@/utils/coordinates/coordinateSystems'
+import log from '@/utils/logging'
 
 const geod = Geodesic.WGS84
 

--- a/src/utils/identifyOnVectorLayer.js
+++ b/src/utils/identifyOnVectorLayer.js
@@ -1,10 +1,11 @@
+import distance from '@turf/distance'
+import { point } from '@turf/helpers'
+import proj4 from 'proj4'
+
 import { LayerFeature } from '@/api/features.api'
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
 import reprojectGeoJsonData from '@/utils/geoJsonUtils'
 import log from '@/utils/logging'
-import distance from '@turf/distance'
-import { point } from '@turf/helpers'
-import proj4 from 'proj4'
 
 const pixelToleranceForIdentify = 10
 

--- a/src/utils/legacyKmlUtils.js
+++ b/src/utils/legacyKmlUtils.js
@@ -1,11 +1,12 @@
-import { EditableFeature, EditableFeatureTypes } from '@/api/features.api'
-import { DrawingIcon } from '@/api/icon.api'
-import { allStylingColors, allStylingSizes, MEDIUM, RED, SMALL } from '@/utils/featureStyleUtils'
-import log from '@/utils/logging'
 import Feature from 'ol/Feature'
 import { getDefaultStyle } from 'ol/format/KML'
 import IconStyle from 'ol/style/Icon'
 import Style from 'ol/style/Style'
+
+import { EditableFeature, EditableFeatureTypes } from '@/api/features.api'
+import { DrawingIcon } from '@/api/icon.api'
+import { allStylingColors, allStylingSizes, MEDIUM, RED, SMALL } from '@/utils/featureStyleUtils'
+import log from '@/utils/logging'
 
 /**
  * This is a helper function for {@link deserialize} that generates an editable feature based on the

--- a/src/utils/setupChartJS.js
+++ b/src/utils/setupChartJS.js
@@ -1,5 +1,3 @@
-import dataModel from '@/utils/chartjs-datamodel.plugin'
-import noDataPlugin from '@/utils/chartjs-nodata.plugin'
 import {
     CategoryScale,
     Chart as ChartJS,
@@ -11,6 +9,9 @@ import {
     Tooltip,
 } from 'chart.js'
 import zoomPlugin from 'chartjs-plugin-zoom'
+
+import dataModel from '@/utils/chartjs-datamodel.plugin'
+import noDataPlugin from '@/utils/chartjs-nodata.plugin'
 
 export default function setupChartJS() {
     ChartJS.register(CategoryScale, Filler, Legend, LinearScale, LineElement, PointElement, Tooltip)

--- a/src/utils/setupProj4.js
+++ b/src/utils/setupProj4.js
@@ -1,6 +1,7 @@
+import proj4 from 'proj4'
+
 import { LV03, LV95, WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
 import log from '@/utils/logging'
-import proj4 from 'proj4'
 
 /**
  * Proj4 comes with [EPSG:4326]{@link https://epsg.io/4326} as default projection.

--- a/tests/e2e-cypress/integration/3d/click.cy.js
+++ b/tests/e2e-cypress/integration/3d/click.cy.js
@@ -1,7 +1,8 @@
 /// <reference types="cypress" />
+import proj4 from 'proj4'
+
 import { ClickType } from '@/store/modules/map.store'
 import { WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
-import proj4 from 'proj4'
 
 describe('Testing click', () => {
     it('handles left click on the map', () => {

--- a/tests/e2e-cypress/integration/3d/navigation.cy.js
+++ b/tests/e2e-cypress/integration/3d/navigation.cy.js
@@ -1,12 +1,13 @@
 /// <reference types="cypress" />
+import { Cartesian3 } from 'cesium'
+import proj4 from 'proj4'
+
 import {
     CAMERA_MAX_ZOOM_DISTANCE,
     CAMERA_MIN_ZOOM_DISTANCE,
 } from '@/modules/map/components/cesium/constants'
 import { calculateResolution } from '@/modules/map/components/cesium/utils/cameraUtils'
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
-import { Cartesian3 } from 'cesium'
-import proj4 from 'proj4'
 
 describe('Testing 3D navigation', () => {
     context('camera limits', () => {

--- a/tests/e2e-cypress/integration/3d/transitionTo3d.cy.js
+++ b/tests/e2e-cypress/integration/3d/transitionTo3d.cy.js
@@ -1,9 +1,10 @@
 /// <reference types="cypress" />
 
-import { DEFAULT_PROJECTION } from '@/config'
-import { WGS84 } from '@/utils/coordinates/coordinateSystems'
 import { Math as CesiumMath } from 'cesium'
 import proj4 from 'proj4'
+
+import { DEFAULT_PROJECTION } from '@/config'
+import { WGS84 } from '@/utils/coordinates/coordinateSystems'
 
 describe('Testing transitioning between 2D and 3D', () => {
     context('3D toggle button', () => {

--- a/tests/e2e-cypress/integration/drawing/export.cy.js
+++ b/tests/e2e-cypress/integration/drawing/export.cy.js
@@ -1,7 +1,8 @@
 /// <reference types="cypress" />
 
-import { EditableFeatureTypes } from '@/api/features.api'
 import { recurse } from 'cypress-recurse'
+
+import { EditableFeatureTypes } from '@/api/features.api'
 
 const downloadsFolder = Cypress.config('downloadsFolder')
 

--- a/tests/e2e-cypress/integration/drawing/geodesicDrawing.cy.js
+++ b/tests/e2e-cypress/integration/drawing/geodesicDrawing.cy.js
@@ -1,7 +1,7 @@
 import { EditableFeatureTypes } from '@/api/features.api'
 import { extractOlFeatureCoordinates, wrapXCoordinates } from '@/modules/drawing/lib/drawingUtils'
-import { HALFSIZE_WEBMERCATOR } from '@/utils/geodesicManager'
 import { WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
+import { HALFSIZE_WEBMERCATOR } from '@/utils/geodesicManager'
 
 const olSelector = '.ol-viewport'
 

--- a/tests/e2e-cypress/integration/drawing/kml.cy.js
+++ b/tests/e2e-cypress/integration/drawing/kml.cy.js
@@ -1,9 +1,10 @@
 /// <reference types="cypress" />
+import proj4 from 'proj4'
+
 import { EditableFeatureTypes } from '@/api/features.api'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
 import { DEFAULT_PROJECTION } from '@/config'
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
-import proj4 from 'proj4'
 
 const olSelector = '.ol-viewport'
 

--- a/tests/e2e-cypress/integration/geolocation.cy.js
+++ b/tests/e2e-cypress/integration/geolocation.cy.js
@@ -1,8 +1,9 @@
 /// <reference types="cypress" />
 
+import proj4 from 'proj4'
+
 import { DEFAULT_PROJECTION } from '@/config'
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
-import proj4 from 'proj4'
 
 const geolocationButtonSelector = '[data-cy="geolocation-button"]'
 

--- a/tests/e2e-cypress/integration/legacyParamImport.cy.js
+++ b/tests/e2e-cypress/integration/legacyParamImport.cy.js
@@ -1,8 +1,9 @@
 /// <reference types="cypress" />
 
+import proj4 from 'proj4'
+
 import { DEFAULT_PROJECTION } from '@/config'
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
-import proj4 from 'proj4'
 
 describe('Test on legacy param import', () => {
     context('Coordinates import', () => {

--- a/tests/e2e-cypress/integration/mouseposition.cy.js
+++ b/tests/e2e-cypress/integration/mouseposition.cy.js
@@ -1,5 +1,7 @@
 /// <reference types="cypress" />
 
+import proj4 from 'proj4'
+
 import { BREAKPOINT_TABLET, DEFAULT_PROJECTION } from '@/config'
 import {
     LV03Format,
@@ -9,7 +11,6 @@ import {
     WGS84Format,
 } from '@/utils/coordinates/coordinateFormat'
 import { LV03, LV95, WGS84 } from '@/utils/coordinates/coordinateSystems'
-import proj4 from 'proj4'
 
 /** @param {CoordinateFormat} format */
 function getMousePositionAndSelect(format) {

--- a/tests/e2e-cypress/integration/search/coordinates-search.cy.js
+++ b/tests/e2e-cypress/integration/search/coordinates-search.cy.js
@@ -1,11 +1,12 @@
 /// <reference types="cypress" />
 
+import proj4 from 'proj4'
+
 import { DEFAULT_PROJECTION } from '@/config'
 import { LV03, LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 import CustomCoordinateSystem from '@/utils/coordinates/CustomCoordinateSystem.class'
 import { STANDARD_ZOOM_LEVEL_1_25000_MAP } from '@/utils/coordinates/SwissCoordinateSystem.class'
 import { latLonToMGRS } from '@/utils/militaryGridProjection'
-import proj4 from 'proj4'
 
 const searchbarSelector = '[data-cy="searchbar"]'
 

--- a/tests/e2e-cypress/integration/search/search-results.cy.js
+++ b/tests/e2e-cypress/integration/search/search-results.cy.js
@@ -1,8 +1,9 @@
 /// <reference types="cypress" />
 
+import proj4 from 'proj4'
+
 import { BREAKPOINT_TABLET, DEFAULT_PROJECTION } from '@/config'
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
-import proj4 from 'proj4'
 
 const searchbarSelector = '[data-cy="searchbar"]'
 const locationsSelector = '[data-cy="search-results-locations"]'

--- a/tests/e2e-cypress/support/commands.js
+++ b/tests/e2e-cypress/support/commands.js
@@ -1,8 +1,11 @@
-import { FAKE_URL_CALLED_AFTER_ROUTE_CHANGE } from '@/router/storeSync/storeSync.routerPlugin'
-import { randomIntBetween } from '@/utils/numberUtils'
 import 'cypress-real-events'
 import 'cypress-wait-until'
+
 import { MapBrowserEvent } from 'ol'
+
+import { FAKE_URL_CALLED_AFTER_ROUTE_CHANGE } from '@/router/storeSync/storeSync.routerPlugin'
+import { randomIntBetween } from '@/utils/numberUtils'
+
 import { isMobile } from './utils'
 
 // ***********************************************

--- a/tests/e2e-cypress/support/drawing.js
+++ b/tests/e2e-cypress/support/drawing.js
@@ -1,7 +1,8 @@
+import pako from 'pako'
+
 import { EditableFeatureTypes } from '@/api/features.api'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
 import { BREAKPOINT_PHONE_WIDTH } from '@/config'
-import pako from 'pako'
 
 const olSelector = '.ol-viewport'
 


### PR DESCRIPTION
NOTE: the sorting of the imports as been fully automated with the es-lint plugin.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-sort-import/index.html)