### PR TITLE
Fixed modal windows exit on click outside

### DIFF
--- a/src/utils/ModalWithBackdrop.vue
+++ b/src/utils/ModalWithBackdrop.vue
@@ -3,8 +3,8 @@
         <!-- Must teleport inside main-component in order for dynamic outlines to work and to be
         sure that it is always on top of the reset. -->
         <div>
-            <BlackBackdrop class="modal-view" @click="onClose(false)" />
-            <div class="modal-popup">
+            <BlackBackdrop class="modal-view" @click.stop="onClose(false)" />
+            <div class="modal-popup position-fixed top-50 start-50 translate-middle">
                 <div
                     class="card"
                     :class="{
@@ -122,12 +122,6 @@ export default {
 @import 'src/scss/variables';
 @import 'src/scss/media-query.mixin';
 .modal-popup {
-    position: fixed;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
-    height: 100%;
     z-index: $zindex-modal;
     .card {
         &:not(.modal-popup-fluid) {


### PR DESCRIPTION
When clicking outside a modal window the windows was not closed. This was due
to the fact that the modal window took the whole screen overlaping the black
backdrop.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-modal-exit/index.html)