### PR TITLE
BGDIINF_SB-3212 : force matching of our custom zoom levels

### DIFF
--- a/src/store/modules/position.store.js
+++ b/src/store/modules/position.store.js
@@ -6,7 +6,6 @@ import allCoordinateSystems, { LV95, WGS84 } from '@/utils/coordinates/coordinat
 import CustomCoordinateSystem from '@/utils/coordinates/CustomCoordinateSystem.class'
 import StandardCoordinateSystem from '@/utils/coordinates/StandardCoordinateSystem.class'
 import log from '@/utils/logging'
-import { round } from '@/utils/numberUtils'
 
 /** @enum */
 export const CrossHairs = {
@@ -169,11 +168,11 @@ const getters = {
 }
 
 const actions = {
-    setZoom({ commit }, zoom) {
+    setZoom({ commit, state }, zoom) {
         if (typeof zoom !== 'number' || zoom < 0) {
             return
         }
-        commit('setZoom', round(zoom, 3))
+        commit('setZoom', state.projection.roundZoomLevel(zoom))
     },
     setRotation({ commit }, rotation) {
         if (typeof rotation !== 'number') {

--- a/src/utils/__tests__/numberUtils.spec.js
+++ b/src/utils/__tests__/numberUtils.spec.js
@@ -1,7 +1,14 @@
 import { expect } from 'chai'
 import { describe, it } from 'vitest'
 
-import { format, formatThousand, isNumber, randomIntBetween, round } from '@/utils/numberUtils'
+import {
+    closest,
+    format,
+    formatThousand,
+    isNumber,
+    randomIntBetween,
+    round,
+} from '@/utils/numberUtils'
 
 describe('Unit test functions from numberUtils.js', () => {
     describe('round(value, decimals)', () => {
@@ -37,6 +44,25 @@ describe('Unit test functions from numberUtils.js', () => {
 
         it('rounds a stringified number correctly', () => {
             expect(round('' + numberToRound)).to.eq(123)
+        })
+    })
+
+    describe('closest(value, fromList)', () => {
+        it('returns the given value if the list of value is invalid or empty', () => {
+            const value = 1234.56
+            expect(closest(value)).to.eq(value)
+            expect(closest(value, null)).to.eq(value)
+            expect(closest(value, undefined)).to.eq(value)
+            expect(closest(value, [])).to.eq(value)
+        })
+        it('returns a match', () => {
+            const list = [0, 1, 2]
+            expect(closest(0.5, list)).to.eq(0)
+            // testing numbers between 0.51 and 1.50
+            for (let value = 0.51; value <= 1.5; value += 0.01) {
+                expect(closest(value, list)).to.eq(1)
+            }
+            expect(closest(1.51, list)).to.eq(2)
         })
     })
 
@@ -103,6 +129,7 @@ describe('Unit test functions from numberUtils.js', () => {
             expect(format(123456789.12)).to.eq("123'456'789.12")
         })
     })
+
     describe('formatThousand(num, separator)', () => {
         it('returns a string with the thousands separator', () => {
             expect(formatThousand(1000, "'")).to.eq("1'000")

--- a/src/utils/coordinates/CoordinateSystem.class.js
+++ b/src/utils/coordinates/CoordinateSystem.class.js
@@ -1,6 +1,7 @@
 import proj4 from 'proj4'
 
 import CoordinateSystemBounds from '@/utils/coordinates/CoordinateSystemBounds.class'
+import { round } from '@/utils/numberUtils'
 
 /**
  * Representation of a coordinate system (or also called projection system) in the context of this
@@ -98,6 +99,19 @@ export default class CoordinateSystem {
      */
     getDefaultZoom() {
         throw Error('Not yet implemented')
+    }
+
+    /**
+     * Rounds a zoom level.
+     *
+     * You can, by overwriting this function, add custom zoom level roundings or similar function in
+     * your custom coordinate systems.
+     *
+     * @param {Number} zoom A zoom level in this coordinate system
+     * @returns {Number} The given zoom level after rounding
+     */
+    roundZoomLevel(zoom) {
+        return round(zoom, 3)
     }
 
     /**

--- a/src/utils/coordinates/SwissCoordinateSystem.class.js
+++ b/src/utils/coordinates/SwissCoordinateSystem.class.js
@@ -1,5 +1,5 @@
 import CustomCoordinateSystem from '@/utils/coordinates/CustomCoordinateSystem.class'
-import { round } from '@/utils/numberUtils'
+import { closest, round } from '@/utils/numberUtils'
 
 /**
  * WebMercator zoom level corresponding to the resolution of the 1:25'000 map we provide
@@ -73,6 +73,8 @@ export const swissPyramidZoomToStandardZoomMatrix = [
     20, // 13
     21, // max: 14
 ]
+
+const swisstopoZoomLevels = swissPyramidZoomToStandardZoomMatrix.map((_, index) => index)
 
 /**
  * This specialization will be used to represent LV95 and LV03, that use a custom zoom/resolution
@@ -156,5 +158,15 @@ export default class SwissCoordinateSystem extends CustomCoordinateSystem {
 
     roundCoordinateValue(value) {
         return round(value, 2)
+    }
+
+    /**
+     * Rounding to the closest Swisstopo zoom level
+     *
+     * @param {Number} customZoomLevel A zoom level, that could be a floating number
+     * @returns {Number} A zoom level matching one of our national maps
+     */
+    roundZoomLevel(customZoomLevel) {
+        return closest(customZoomLevel, swisstopoZoomLevels)
     }
 }

--- a/src/utils/numberUtils.js
+++ b/src/utils/numberUtils.js
@@ -23,6 +23,23 @@ export function round(value, decimals = 0, enforcedigit = false) {
 }
 
 /**
+ * @param {Number} value A floating number
+ * @param {Number[]} fromList A list of integer
+ * @returns {Number} The closest value, from the list of integer, matching the floating number (will
+ *   floor or ceil accordingly)
+ */
+export function closest(value, fromList) {
+    if (Array.isArray(fromList) && fromList.length > 2) {
+        const difference = fromList.map((listValue) => Math.abs(value - listValue))
+        const smallestDifference = difference.reduce((diff1, diff2) =>
+            diff1 > diff2 ? diff2 : diff1
+        )
+        return fromList[difference.indexOf(smallestDifference)]
+    }
+    return value
+}
+
+/**
  * Returns true if value represents or is a number (a string containing a valid number will return
  * true)
  *

--- a/tests/e2e-cypress/integration/legacyParamImport.cy.js
+++ b/tests/e2e-cypress/integration/legacyParamImport.cy.js
@@ -18,7 +18,7 @@ describe('Test on legacy param import', () => {
             })
 
             // checking in the store that the position has not changed from what was in the URL
-            cy.readStoreValue('state.position.zoom').should('eq', zoom)
+            cy.readStoreValue('state.position.zoom').should('eq', 10) // zoom should be rounded to the closest Swisstopo zoom level
             cy.readStoreValue('getters.centerEpsg4326').should((center) => {
                 expect(center[0]).to.eq(lon)
                 expect(center[1]).to.eq(lat)


### PR DESCRIPTION
So that a mobile user won't have a floating/non-matching zoom level after a pinch/zoom on the map.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_bgdiinf_sb-3212_constrain_zoom_levels/index.html)