### PR TITLE
BGDIINF_SB-3210 : fix starting geolocation zoom

### DIFF
--- a/src/modules/map/components/openlayers/OpenLayersAccuracyCircle.vue
+++ b/src/modules/map/components/openlayers/OpenLayersAccuracyCircle.vue
@@ -24,8 +24,8 @@ const { zIndex } = toRefs(props)
 
 // mapping relevant store values
 const store = useStore()
-const position = computed(() => store.state.layers.previewYear)
-const accuracy = computed(() => store.state.position.projection)
+const position = computed(() => store.state.geolocation.position)
+const accuracy = computed(() => store.state.geolocation.accuracy)
 
 const accuracyCircle = new Circle(position.value, accuracy.value)
 const accuracyCircleFeature = new Feature({


### PR DESCRIPTION
It was still set as a WebMercator zoom, disregarding the current projection system Also fixing an issue with the accuracy circle component after migration to composition API (wrong store bindings)

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_bgdiinf_sb-3210_zoom_start_geolocation/index.html)