### PR TITLE
BGDIINF_SB-3194: Added click-outside directive

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,7 @@ import {
 import i18n from '@/modules/i18n'
 import router from '@/router'
 import store from '@/store'
+import clickOutside from '@/utils/click-outside'
 import log from '@/utils/logging'
 import setupChartJS from '@/utils/setupChartJS'
 
@@ -62,6 +63,7 @@ app.use(i18n)
 app.use(store)
 app.use(VueSocialSharing)
 
+app.directive('click-outside', clickOutside)
 app.component('FontAwesomeIcon', FontAwesomeIcon)
 
 // if we are testing with Cypress, we expose the store

--- a/src/utils/click-outside.js
+++ b/src/utils/click-outside.js
@@ -1,0 +1,22 @@
+import log from '@/utils/logging'
+
+const clickOutside = {
+    beforeMount: (el, binding) => {
+        el.clickOutsideEvent = (event) => {
+            // here I check that click was outside the el and his children
+            if (!(el == event.target || el.contains(event.target))) {
+                // and if it did, call method provided in attribute value
+                if (typeof binding.value === 'function') {
+                    binding.value()
+                } else {
+                    log.error(`Binding to v-click-outside is not a function`, binding.value)
+                }
+            }
+        }
+        document.addEventListener('click', el.clickOutsideEvent)
+    },
+    unmounted: (el) => {
+        document.removeEventListener('click', el.clickOutsideEvent)
+    },
+}
+export default clickOutside


### PR DESCRIPTION
This allow to register a click outside event to an element.

This will be used by #571 

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-3194-click-oudside/index.html)