### PR TITLE
Fix external WMTS/WMS loading when added through URL params

### DIFF
--- a/src/modules/map/components/openlayers/OpenLayersExternalWMTSLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersExternalWMTSLayer.vue
@@ -4,7 +4,7 @@
 import WMTSCapabilities from 'ol/format/WMTSCapabilities'
 import { Tile as TileLayer } from 'ol/layer'
 import WMTS, { optionsFromCapabilities } from 'ol/source/WMTS'
-import { computed, inject, toRefs, watch } from 'vue'
+import { computed, inject, onMounted, toRefs, watch } from 'vue'
 import { useStore } from 'vuex'
 
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
@@ -32,7 +32,7 @@ const store = useStore()
 const projection = computed(() => store.state.position.projection)
 
 // extracting useful info from what we've linked so far
-const layerId = computed(() => externalWmtsLayerConfig.value.serverLayerId)
+const layerId = computed(() => externalWmtsLayerConfig.value.externalLayerId)
 const opacity = computed(() => parentLayerOpacity.value || externalWmtsLayerConfig.value.opacity)
 const getCapabilitiesUrl = computed(() => externalWmtsLayerConfig.value.getURL())
 
@@ -40,6 +40,16 @@ const wmtsGetCapParser = new WMTSCapabilities()
 const layer = new TileLayer({
     id: layerId.value,
     opacity: opacity.value,
+})
+
+const olMap = inject('olMap', null)
+useAddLayerToMap(layer, olMap, zIndex)
+
+watch(opacity, (newOpacity) => layer.setOpacity(newOpacity))
+watch(projection, setSourceForProjection)
+
+onMounted(() => {
+    setSourceForProjection()
 })
 
 /**
@@ -70,12 +80,8 @@ function setSourceForProjection() {
             }
         })
 }
-
-setSourceForProjection()
-
-const olMap = inject('olMap', null)
-useAddLayerToMap(layer, olMap, zIndex)
-
-watch(opacity, (newOpacity) => layer.setOpacity(newOpacity))
-watch(projection, setSourceForProjection)
 </script>
+
+<template>
+    <slot />
+</template>

--- a/src/store/plugins/external-layers.plugin.js
+++ b/src/store/plugins/external-layers.plugin.js
@@ -22,15 +22,15 @@ export default function loadExternalLayerAttributes(store) {
     store.subscribe((mutation, state) => {
         if (
             mutation.type === 'addLayer' &&
-            mutation.payload.layer instanceof ExternalLayer &&
-            mutation.payload.layer.isLoading
+            mutation.payload instanceof ExternalLayer &&
+            mutation.payload.isLoading
         ) {
             log.debug(
                 `Loading state external layer added, trigger attribute updated`,
                 mutation,
                 state
             )
-            updateExternalLayer(store, mutation.payload.layer, state.position.projection)
+            updateExternalLayer(store, mutation.payload, state.position.projection)
         }
     })
 }


### PR DESCRIPTION
the store plugin was forgotten when the payload of the "addLayer" action/mutation has been changed to only contain the layer (and not an object with other attributes)

Also the ID for the external layer's component wasn't selected correctly.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_external_wmts_not_loading/index.html)