### PR TITLE
Also create test link on PR not based on develop branch

### DIFF
--- a/.github/workflows/add-testlink-to-pr.yml
+++ b/.github/workflows/add-testlink-to-pr.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create/update test link on DEV
-        if: ${{ github.base_ref == 'develop' || startsWith(github.base_ref, 'develop-') }}
+        if: ${{ github.base_ref != 'master' }}
         uses: tzkhan/pr-update-action@v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
When creating a PR based on another PR, a test deployment was already deployed
but no test link in the PR was generated.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-test-link/index.html)