### PR TITLE
BGDIINF_SB-3194: Added support for external layer legend

### DIFF
--- a/src/api/layers/AbstractLayer.class.js
+++ b/src/api/layers/AbstractLayer.class.js
@@ -86,6 +86,9 @@ export default class AbstractLayer {
     }
 
     get hasLegend() {
-        return this.type !== LayerTypes.KML && !this.isExternal
+        if ([LayerTypes.KML, LayerTypes.GPX].includes(this.type)) {
+            return false
+        }
+        return true
     }
 }

--- a/src/api/layers/ExternalGroupOfLayers.class.js
+++ b/src/api/layers/ExternalGroupOfLayers.class.js
@@ -23,6 +23,7 @@ export default class ExternalGroupOfLayers extends ExternalLayer {
      *   layer. When `null` is given it uses the default attribution which is based on the hostname
      *   of the GetCapabilities server.
      * @param {[[number, number], [number, number]] | null} extent Layer extent
+     * @param {[LayerLegend]} legends Layer legends.
      * @param {boolean} isLoading Set to true if some parts of the layer (e.g. metadata) are still
      *   loading
      */
@@ -36,6 +37,7 @@ export default class ExternalGroupOfLayers extends ExternalLayer {
         attributions = null,
         abstract = '',
         extent = null,
+        legends = [],
         isLoading = true
     ) {
         super(
@@ -48,6 +50,7 @@ export default class ExternalGroupOfLayers extends ExternalLayer {
             attributions,
             abstract,
             extent,
+            legends,
             isLoading
         )
         this.layers = [...layers]

--- a/src/api/layers/ExternalLayer.class.js
+++ b/src/api/layers/ExternalLayer.class.js
@@ -11,6 +11,24 @@ export function getDefaultAttribution(baseUrl) {
     return [new LayerAttribution(new URL(baseUrl).hostname)]
 }
 
+/** External Layer Legend */
+export class LayerLegend {
+    /**
+     * @param {String} url Legend URL
+     * @param {String} format Legend MIME type
+     * @param {number | null} width Width of the legend image (in case the format is an image
+     *   format)
+     * @param {number | null} height Height of the legend image (in case the format is an image
+     *   format)
+     */
+    constructor(url, format, width = null, height = null) {
+        this.url = url
+        this.format = format
+        this.width = width
+        this.height = height
+    }
+}
+
 /**
  * Base for all external layers, defining a flag to differentiate them from GeoAdminLayers
  *
@@ -30,6 +48,7 @@ export default class ExternalLayer extends AbstractLayer {
      *   of the GetCapabilities server.
      * @param {String} abstract Abstract of this layer to be shown to the user
      * @param {[[number, number], [number, number]] | null} extent Layer extent
+     * @param {[LayerLegend]} legends Layer legends.
      * @param {boolean} isLoading Set to true if some parts of the layer (e.g. metadata) are still
      *   loading
      */
@@ -43,6 +62,7 @@ export default class ExternalLayer extends AbstractLayer {
         attributions = null,
         abstract = '',
         extent = null,
+        legends = [],
         isLoading = true
     ) {
         super(
@@ -58,10 +78,15 @@ export default class ExternalLayer extends AbstractLayer {
         this.baseURL = baseURL
         this.abstract = abstract
         this.extent = extent
+        this.legends = legends
         this.isLoading = isLoading
     }
 
     getURL() {
         return this.baseURL
+    }
+
+    get hasLegend() {
+        return this.abstract || this.legends.length > 0 || super.hasLegend
     }
 }

--- a/src/api/layers/ExternalWMSLayer.class.js
+++ b/src/api/layers/ExternalWMSLayer.class.js
@@ -16,6 +16,7 @@ export default class ExternalWMSLayer extends ExternalLayer {
      * @param {String} format Image format for this layer, default is PNG
      * @param {String} abstract Abstract of this layer to be shown to the user
      * @param {[[number, number], [number, number]] | null} extent Layer extent
+     * @param {[LayerLegend]} legends Layer legends.
      * @param {boolean} isLoading Set to true if some parts of the layer (e.g. metadata) are still
      *   loading
      */
@@ -30,6 +31,7 @@ export default class ExternalWMSLayer extends ExternalLayer {
         format = 'png',
         abstract = '',
         extent = null,
+        legends = [],
         isLoading = true
     ) {
         super(
@@ -42,6 +44,7 @@ export default class ExternalWMSLayer extends ExternalLayer {
             attributions,
             abstract,
             extent,
+            legends,
             isLoading
         )
         this.wmsVersion = wmsVersion

--- a/src/api/layers/ExternalWMTSLayer.class.js
+++ b/src/api/layers/ExternalWMTSLayer.class.js
@@ -17,6 +17,7 @@ export default class ExternalWMTSLayer extends ExternalLayer {
      *   of the GetCapabilities server.
      * @param {String} abstract Abstract of this layer to be shown to the user
      * @param {[[number, number], [number, number]] | null} extent Layer extent
+     * @param {[LayerLegend]} legends Layer legends.
      * @param {boolean} isLoading Set to true if some parts of the layer (e.g. metadata) are still
      *   loading
      */
@@ -29,6 +30,7 @@ export default class ExternalWMTSLayer extends ExternalLayer {
         attributions = null,
         abstract = '',
         extent = null,
+        legends = [],
         isLoading = true
     ) {
         super(
@@ -41,6 +43,7 @@ export default class ExternalWMTSLayer extends ExternalLayer {
             attributions,
             abstract,
             extent,
+            legends,
             isLoading
         )
     }

--- a/src/api/layers/LayerTypes.enum.js
+++ b/src/api/layers/LayerTypes.enum.js
@@ -8,6 +8,7 @@ const LayerTypes = {
     GEOJSON: 'geojson',
     AGGREGATE: 'aggregate',
     KML: 'kml',
+    GPX: 'gpx',
     VECTOR: 'vector',
     GROUP: 'group',
 }

--- a/src/api/layers/WMTSCapabilitiesParser.class.js
+++ b/src/api/layers/WMTSCapabilitiesParser.class.js
@@ -2,6 +2,7 @@ import WMTSCapabilities from 'ol/format/WMTSCapabilities'
 import proj4 from 'proj4'
 
 import { LayerAttribution } from '@/api/layers/AbstractLayer.class'
+import { LayerLegend } from '@/api/layers/ExternalLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
 import allCoordinateSystems, { WGS84 } from '@/utils/coordinates/coordinateSystems'
 import log from '@/utils/logging'
@@ -106,6 +107,7 @@ export default class WMTSCapabilitiesParser {
             attributes.attributions,
             attributes.abstract,
             attributes.extent,
+            attributes.legends,
             false
         )
     }
@@ -133,6 +135,7 @@ export default class WMTSCapabilitiesParser {
             abstract: layer.Abstract,
             attributions: this._getLayerAttribution(layerId),
             extent: this._getLayerExtent(layerId, layer, projection, ignoreError),
+            legends: this._getLegends(layerId, layer),
         }
     }
 
@@ -233,5 +236,14 @@ export default class WMTSCapabilitiesParser {
             title = new URL(this.originUrl).hostname
         }
         return [new LayerAttribution(title, url)]
+    }
+
+    _getLegends(layerId, layer) {
+        const styles = layer.Style?.filter((s) => s.LegendURL?.length > 0) ?? []
+        return styles
+            .map((style) =>
+                style.LegendURL.map((legend) => new LayerLegend(legend.href, legend.format))
+            )
+            .flat()
     }
 }

--- a/src/api/layers/__tests__/WMSCapabitliesParser.class.spec.js
+++ b/src/api/layers/__tests__/WMSCapabitliesParser.class.spec.js
@@ -2,10 +2,10 @@ import { readFile } from 'fs/promises'
 import { beforeAll, describe, expect, expectTypeOf, it } from 'vitest'
 
 import ExternalGroupOfLayers from '@/api/layers/ExternalGroupOfLayers.class'
+import { LayerLegend } from '@/api/layers/ExternalLayer.class'
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
+import WMSCapabilitiesParser from '@/api/layers/WMSCapabilitiesParser.class'
 import { LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
-
-import WMSCapabilitiesParser from '../WMSCapabilitiesParser.class'
 
 describe('WMSCapabilitiesParser - invalid', () => {
     it('Throw Error on invalid input', () => {
@@ -87,6 +87,24 @@ describe('WMSCapabilitiesParser of wms-geoadmin-sample.xml', () => {
         expect(externalLayers[1].extent[0][1]).toBeCloseTo(expected[0][1], 1)
         expect(externalLayers[1].extent[1][0]).toBeCloseTo(expected[1][0], 1)
         expect(externalLayers[1].extent[1][1]).toBeCloseTo(expected[1][1], 1)
+    })
+    it('Parse layer legend', () => {
+        // General layer
+        let layer = capabilities.getExternalLayerObject('ch.swisstopo-vd.official-survey', WGS84)
+        expect(layer.externalLayerId).toBe('ch.swisstopo-vd.official-survey')
+        expect(layer.legends.length).toBe(0)
+
+        // Layer without .Name
+        layer = capabilities.getExternalLayerObject('Periodic-Tracking', WGS84)
+        expect(layer.externalLayerId).toBe('Periodic-Tracking')
+        expect(layer.legends.length).toBe(1)
+        expect(layer.legends[0]).toBeInstanceOf(LayerLegend)
+        expect(layer.legends[0].url).toBe(
+            'https://wms.geo.admin.ch/?version=1.3.0&service=WMS&request=GetLegendGraphic&sld_version=1.1.0&layer=ch.swisstopo-vd.geometa-periodische_nachfuehrung&format=image/png&STYLE=default'
+        )
+        expect(layer.legends[0].format).toBe('image/png')
+        expect(layer.legends[0].width).toBe(168)
+        expect(layer.legends[0].height).toBe(22)
     })
 })
 

--- a/src/api/layers/__tests__/WMTSCapabitliesParser.class.spec.js
+++ b/src/api/layers/__tests__/WMTSCapabitliesParser.class.spec.js
@@ -1,9 +1,9 @@
 import { readFile } from 'fs/promises'
 import { beforeAll, describe, expect, expectTypeOf, it } from 'vitest'
 
+import { LayerLegend } from '@/api/layers/ExternalLayer.class'
+import WMTSCapabilitiesParser from '@/api/layers/WMTSCapabilitiesParser.class'
 import { LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
-
-import WMTSCapabilitiesParser from '../WMTSCapabilitiesParser.class'
 
 describe('WMTSCapabilitiesParser of wmts-ogc-sample.xml', () => {
     let capabilities
@@ -219,5 +219,17 @@ describe('WMTSCapabilitiesParser of wmts-ogc-sample.xml', () => {
             [6.81, 47.12],
             [7.56, 47.55],
         ])
+    })
+    it('Parse layer legend', () => {
+        // General layer
+        let layer = capabilities.getExternalLayerObject('BlueMarbleSecondGenerationAG', WGS84)
+        expect(layer.externalLayerId).toBe('BlueMarbleSecondGenerationAG')
+        expectTypeOf(layer.legends).toBeArray()
+        expect(layer.legends.length).toBe(1)
+        expect(layer.legends[0]).toBeInstanceOf(LayerLegend)
+        expect(layer.legends[0].url).toBe(
+            'http://www.miramon.uab.es/wmts/Coastlines/coastlines_darkBlue.png'
+        )
+        expect(layer.legends[0].format).toBe('image/png')
     })
 })

--- a/src/modules/menu/components/LayerCatalogueItem.vue
+++ b/src/modules/menu/components/LayerCatalogueItem.vue
@@ -42,7 +42,7 @@ const activeLayers = computed(() => store.state.layers.activeLayers)
 const openThemesIds = computed(() => store.state.topics.openedTreeThemesIds)
 
 const hasChildren = computed(() => item?.layers?.length > 0)
-const hasLegend = computed(() => canBeAddedToTheMap.value && (!item.isExternal || item.abstract))
+const hasLegend = computed(() => canBeAddedToTheMap.value && item?.hasLegend)
 
 /**
  * Flag telling if this layer can be added to the map (so if the UI should include the necessary

--- a/src/modules/menu/components/LayerLegendPopup.vue
+++ b/src/modules/menu/components/LayerLegendPopup.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, ref, toRefs, watch } from 'vue'
 import { onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 
 import AbstractLayer from '@/api/layers/AbstractLayer.class'
@@ -23,6 +24,7 @@ const props = defineProps({
 })
 const emit = defineEmits(['close'])
 const store = useStore()
+const i18n = useI18n()
 
 const { layer, layerId, layerName } = toRefs(props)
 const htmlContent = ref('')
@@ -34,6 +36,7 @@ const body = computed(() => layer.value?.abstract ?? '')
 const attributionName = computed(() => layer.value?.attributions[0].name ?? '')
 const attributionUrl = computed(() => layer.value?.attributions[0].url ?? '')
 const isExternal = computed(() => layer.value?.isExternal ?? false)
+const legends = computed(() => layer.value?.legends ?? [])
 
 watch(layer, async (newLayer) => {
     htmlContent.value = await getLayerLegend(currentLang.value, newLayer.getID())
@@ -59,7 +62,17 @@ onMounted(async () => {
                 <font-awesome-icon spin :icon="['fa', 'spinner']" />
             </h4>
             <div v-else-if="isExternal">
+                <h6>{{ i18n.t('description') }}</h6>
                 <div>{{ body }}</div>
+                <div v-if="legends.length" class="mt-4">
+                    <h6>{{ i18n.t('legend') }}</h6>
+                    <div v-for="legend in legends" :key="legend.url">
+                        <img v-if="legend.format.startsWith('image/')" :src="legend.url" />
+                        <iframe v-else-if="legend.format === 'text/html'" :src="legend.url" />
+                        <a v-else :href="legend.url" target="_blank">{{ legend.url }}</a>
+                    </div>
+                </div>
+
                 <div class="mt-2 text-primary text-end">
                     <span class="me-1">{{ $t('copyright_data') }}</span>
                     <a v-if="attributionUrl" :href="attributionUrl" target="_blank">{{


### PR DESCRIPTION
Now in the external layer catalogue the legends are also displayed if available.
Also adding the info button on the active layers for external layer.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-bgdiinf_sb-3194-import-tool-ui-legend/index.html)