### PR TITLE
BGDIINF_SB-3211: Fix zoom after going back to 2D

### DIFF
--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -10,13 +10,11 @@ import DrawingToolbox from '@/modules/drawing/components/DrawingToolbox.vue'
 import DrawingTooltip from '@/modules/drawing/components/DrawingTooltip.vue'
 import { DrawingState } from '@/modules/drawing/lib/export-utils'
 import useKmlDataManagement from '@/modules/drawing/useKmlDataManagement.composable'
-import BlackBackdrop from '@/modules/menu/components/BlackBackdrop.vue'
 import log from '@/utils/logging'
 
 const olMap = inject('olMap')
 
 const drawingInteractions = ref(null)
-const isClosing = ref(false)
 const isNewDrawing = ref(true)
 
 const store = useStore()
@@ -119,7 +117,7 @@ function removeLastPointOnDeleteKeyUp(event) {
 }
 
 async function closeDrawing() {
-    isClosing.value = true
+    await store.dispatch('setShowLoadingBar', true)
 
     log.debug(
         `Closing drawing menu: isModified=${isDrawingModified.value}, isNew=${isNewDrawing.value}, isEmpty=${isDrawingEmpty.value}`
@@ -135,13 +133,13 @@ async function closeDrawing() {
         await saveDrawing(false)
     }
 
-    store.dispatch('toggleDrawingOverlay')
+    await store.dispatch('toggleDrawingOverlay')
+    await store.dispatch('setShowLoadingBar', false)
 }
 </script>
 
 <template>
     <div>
-        <BlackBackdrop v-if="isClosing" with-spinner place-for-modal />
         <DrawingToolbox @remove-last-point="removeLastPoint" @close-drawing="closeDrawing" />
         <DrawingTooltip />
         <DrawingInteractions ref="drawingInteractions" />

--- a/src/modules/drawing/components/DrawingHeader.vue
+++ b/src/modules/drawing/components/DrawingHeader.vue
@@ -1,17 +1,32 @@
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const emits = defineEmits(['close'])
 
+const isClosing = ref(false)
+
 const i18n = useI18n()
+
+function onClose() {
+    isClosing.value = true
+    emits('close')
+}
 </script>
 
 <template>
     <div class="drawing-header">
-        <button class="drawing-header-close-button btn btn-dark" @click="emits('close')">
-            <FontAwesomeIcon class="icon me-2" :icon="['fas', 'arrow-left']" />
-            {{ i18n.t('draw_back') }}
+        <button
+            class="drawing-header-close-button btn btn-dark"
+            :disabled="isClosing"
+            @click="onClose"
+        >
+            <FontAwesomeIcon v-if="isClosing" icon="spinner" spin />
+            <span v-else>
+                <FontAwesomeIcon class="icon me-2" :icon="['fas', 'arrow-left']" />
+                {{ i18n.t('draw_back') }}
+            </span>
         </button>
         <h1 class="drawing-header-title">{{ i18n.t('draw_mode_title') }}</h1>
     </div>

--- a/src/modules/drawing/components/DrawingHeader.vue
+++ b/src/modules/drawing/components/DrawingHeader.vue
@@ -22,9 +22,11 @@ function onClose() {
             :disabled="isClosing"
             @click="onClose"
         >
-            <FontAwesomeIcon v-if="isClosing" icon="spinner" spin />
+            <FontAwesomeIcon class="icon me-2" :icon="['fas', 'arrow-left']" />
+            <span v-if="isClosing">
+                {{ i18n.t('draw_file_saving') }}
+            </span>
             <span v-else>
-                <FontAwesomeIcon class="icon me-2" :icon="['fas', 'arrow-left']" />
                 {{ i18n.t('draw_back') }}
             </span>
         </button>

--- a/src/modules/map/MapModule.vue
+++ b/src/modules/map/MapModule.vue
@@ -1,3 +1,29 @@
+<script setup>
+import { computed, defineAsyncComponent } from 'vue'
+import { useStore } from 'vuex'
+
+import OpenLayersCompassButton from '@/modules/map/components/openlayers/OpenLayersCompassButton.vue'
+import OpenLayersMouseTracker from '@/modules/map/components/openlayers/OpenLayersMouseTracker.vue'
+import OpenLayersScale from '@/modules/map/components/openlayers/OpenLayersScale.vue'
+import { UIModes } from '@/store/modules/ui.store'
+
+import LocationPopup from './components/LocationPopup.vue'
+import WarningRibbon from './components/WarningRibbon.vue'
+
+const CesiumMap = defineAsyncComponent(() => import('./components/cesium/CesiumMap.vue'))
+const OpenLayersMap = defineAsyncComponent(
+    () => import('./components/openlayers/OpenLayersMap.vue')
+)
+
+const store = useStore()
+
+const is3DActive = computed(() => store.state.cesium.active)
+const uiMode = computed(() => store.state.ui.mode)
+const displayLocationPopup = computed(() => store.state.map.displayLocationPopup)
+
+const isPhoneMode = computed(() => uiMode.value === UIModes.PHONE)
+</script>
+
 <template>
     <div class="full-screen-map" data-cy="map">
         <CesiumMap v-if="is3DActive">
@@ -22,43 +48,6 @@
         <WarningRibbon />
     </div>
 </template>
-
-<script>
-import { defineAsyncComponent } from 'vue'
-import { mapState } from 'vuex'
-
-import OpenLayersCompassButton from '@/modules/map/components/openlayers/OpenLayersCompassButton.vue'
-import OpenLayersMouseTracker from '@/modules/map/components/openlayers/OpenLayersMouseTracker.vue'
-import OpenLayersScale from '@/modules/map/components/openlayers/OpenLayersScale.vue'
-import { UIModes } from '@/store/modules/ui.store'
-
-import LocationPopup from './components/LocationPopup.vue'
-import WarningRibbon from './components/WarningRibbon.vue'
-
-export default {
-    components: {
-        OpenLayersCompassButton,
-        OpenLayersMouseTracker,
-        OpenLayersScale,
-        LocationPopup,
-        WarningRibbon,
-        OpenLayersMap: defineAsyncComponent(
-            () => import('./components/openlayers/OpenLayersMap.vue')
-        ),
-        CesiumMap: defineAsyncComponent(() => import('./components/cesium/CesiumMap.vue')),
-    },
-    computed: {
-        ...mapState({
-            is3DActive: (state) => state.cesium.active,
-            uiMode: (state) => state.ui.mode,
-            displayLocationPopup: (state) => state.map.displayLocationPopup,
-        }),
-        isPhoneMode() {
-            return this.uiMode === UIModes.PHONE
-        },
-    },
-}
-</script>
 
 <style lang="scss" scoped>
 @import 'src/scss/webmapviewer-bootstrap-theme';

--- a/src/modules/map/components/common/mouse-click.composable.js
+++ b/src/modules/map/components/common/mouse-click.composable.js
@@ -23,6 +23,9 @@ export function useMouseOnMap() {
     )
     const currentMapResolution = computed(() => store.getters.resolution)
     const currentProjection = computed(() => store.state.position.projection)
+    const isCurrentlyTrackingGeoLocation = computed(
+        () => store.state.geolocation.active && store.state.geolocation.tracking
+    )
 
     /**
      * @param {[Number, Number]} screenPosition
@@ -83,6 +86,10 @@ export function useMouseOnMap() {
     function onMouseMove() {
         if (isPointerDown) {
             isStillOnStartingPosition = false
+        }
+        if (isCurrentlyTrackingGeoLocation.value) {
+            // stop tracking the user geolocation to the center of the view as soon as the map is dragged
+            store.dispatch('setGeolocationTracking', false)
         }
     }
 

--- a/src/modules/map/components/openlayers/utils/map-views.composable.js
+++ b/src/modules/map/components/openlayers/utils/map-views.composable.js
@@ -69,6 +69,7 @@ export default function useViewBasedOnProjection(map) {
         const viewForProjection = viewsForProjection[projection.value.epsg]
         if (viewForProjection) {
             viewForProjection.setCenter(center.value)
+            viewForProjection.setZoom(zoom.value)
             map.setView(viewForProjection)
         } else {
             log.error('View for projection was not found', projection.value)

--- a/src/store/modules/map.store.js
+++ b/src/store/modules/map.store.js
@@ -37,25 +37,32 @@ export class ClickInfo {
 export default {
     state: {
         /**
-         * @type Boolean Whether the map is being dragged right now or not (if the mouse/touch is
-         *   down and cursor moving)
+         * Information about the last click that has occurred on the map
+         *
+         * @type ClickInfo
          */
-        isBeingDragged: false,
-        /** @type ClickInfo Information about the last click that has occurred on the map */
         clickInfo: null,
         /**
-         * @type Array<Number> Coordinate of the dropped pin on the map, expressed in EPSG:3857. If
-         *   null, no pin will be shown.
+         * Coordinate of the dropped pin on the map. If null, no pin will be shown.
+         *
+         * @type Array<Number>
          */
         pinnedLocation: null,
         /**
-         * @type Array<Number> Same thing as pinnedLocation, will be used to show location of search
-         *   entries when they are hovered. If we use the same pinned location as the one above, the
-         *   pinned location is lost as soon as another one is hovered (meaning that the search bar
-         *   is still filled with a search query, but no pinned location is present anymore)
+         * Will be used to show the location of search entries when they are hovered. If we use the
+         * same pinned location as the one above, the pinned location is lost as soon as another one
+         * is hovered. Meaning that the search bar is still filled with a search query, but no
+         * pinned location is present anymore.
+         *
+         * @type Array<Number>
          */
         previewedPinnedLocation: null,
-
+        /**
+         * Flags telling if the location popup (information about a set of coordinates) must be
+         * shown at the location of the last click (using clickInfo above).
+         *
+         * @type Boolean
+         */
         displayLocationPopup: false,
     },
     actions: {
@@ -67,8 +74,6 @@ export default {
          */
         click: ({ commit }, clickInfo) => commit('setClickInfo', clickInfo),
         clearClick: ({ commit }) => commit('setClickInfo', null),
-        mapStartBeingDragged: ({ commit }) => commit('mapStartBeingDragged'),
-        mapStoppedBeingDragged: ({ commit }) => commit('mapStoppedBeingDragged'),
         /**
          * Sets the dropped pin on the map, if coordinates are null the dropped pin is removed
          *
@@ -105,8 +110,6 @@ export default {
     },
     mutations: {
         setClickInfo: (state, clickInfo) => (state.clickInfo = clickInfo),
-        mapStartBeingDragged: (state) => (state.isBeingDragged = true),
-        mapStoppedBeingDragged: (state) => (state.isBeingDragged = false),
         setPinnedLocation: (state, coordinates) => (state.pinnedLocation = coordinates),
         setPreviewedPinnedLocation: (state, coordinate) =>
             (state.previewedPinnedLocation = coordinate),

--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -190,6 +190,9 @@ export default {
         setEmbeddedMode({ commit }, isEmbedded) {
             commit('setEmbeddedMode', !!isEmbedded)
         },
+        setShowLoadingBar({ commit }, value) {
+            commit('setShowLoadingBar', !!value)
+        },
         toggleLoadingBar({ commit, state }) {
             commit('setShowLoadingBar', !state.showLoadingBar)
         },

--- a/src/store/plugins/2d-to-3d-management.plugin.js
+++ b/src/store/plugins/2d-to-3d-management.plugin.js
@@ -24,19 +24,15 @@ export default function from2Dto3Dplugin(store) {
                     ).find(([_, layerId3d]) => {
                         return layerId3d === state.layers.currentBackgroundLayer?.getID()
                     })
-                    if (matching2dBackgroundId.length > 0) {
+                    if (matching2dBackgroundId?.length > 0) {
                         store.dispatch('setBackground', matching2dBackgroundId[0])
                     }
-                } else {
+                } else if (state.layers.currentBackgroundLayer) {
                     // when going 3D, as we are before the action
-                    if (state.layers.currentBackgroundLayer) {
-                        const matching3dBackgroundId =
-                            backgroundMatriceBetween2dAnd3d[
-                                state.layers.currentBackgroundLayer.getID()
-                            ]
-                        if (matching3dBackgroundId) {
-                            store.dispatch('setBackground', matching3dBackgroundId)
-                        }
+                    const matching3dBackgroundId =
+                        backgroundMatriceBetween2dAnd3d[state.layers.currentBackgroundLayer.getID()]
+                    if (matching3dBackgroundId) {
+                        store.dispatch('setBackground', matching3dBackgroundId)
                     }
                 }
             }

--- a/src/store/plugins/geolocation-management.plugin.js
+++ b/src/store/plugins/geolocation-management.plugin.js
@@ -59,11 +59,6 @@ const handlePositionError = (error, store) => {
  */
 const geolocationManagementPlugin = (store) => {
     store.subscribe((mutation, state) => {
-        // we listen to the mutation that is triggered when the map is starting being dragged in order to stop
-        // tracking the user geolocation to the center of the view
-        if (state.geolocation.active && mutation.type === 'mapStartBeingDragged') {
-            store.dispatch('setGeolocationTracking', false)
-        }
         // listening to the start/stop of geolocation
         if (mutation.type === 'setGeolocationActive') {
             if (state.geolocation.active) {


### PR DESCRIPTION
Also removing/simplifying the geolocation tracking/untracking when the map is dragged. As we now have a central composable that handles all map interaction, this state isMapBeingDragged was not necessary anymore, it could be handle in the mouse click composable.

The zoom level was not set properly when the view (dependent on the projection) was changed in the OL composable.

I also removed the spinner backdrop from the drawing module when it closes, replacing it by a spinner inside the close button (to give the user a feedback something is happening anyway)


[Test link](https://sys-map.dev.bgdi.ch/preview/bug_bgdiinf_sb-3211_fix_zoom_after_going_back_2d/index.html)