### PR TITLE
BGDIINF_SB-3194: Fixed external layer

### DIFF
--- a/src/api/layers/ExternalGroupOfLayers.class.js
+++ b/src/api/layers/ExternalGroupOfLayers.class.js
@@ -58,7 +58,9 @@ export default class ExternalGroupOfLayers extends ExternalLayer {
 
     getID() {
         // format coming from https://github.com/geoadmin/web-mapviewer/blob/develop/adr/2021_03_16_url_param_structure.md
-        return `GRP|${this.baseURL}|${this.externalLayerId}`
+        // NOTE we don't differentiate between group of layers and regular WMS layer. This differentiation was not
+        // done the legacy parameter and is not required.
+        return `WMS|${this.baseURL}|${this.externalLayerId}`
     }
     clone() {
         let clone = super.clone()

--- a/src/api/layers/WMSCapabilitiesParser.class.js
+++ b/src/api/layers/WMSCapabilitiesParser.class.js
@@ -35,7 +35,7 @@ export default class WMSCapabilitiesParser {
             throw new Error(`Failed to parse WMTS Capabilities: invalid content: ${error}`)
         }
 
-        this.originUrl = originUrl
+        this.originUrl = new URL(originUrl)
     }
 
     /**
@@ -66,7 +66,7 @@ export default class WMSCapabilitiesParser {
     getExternalLayerObject(layerId, projection, opacity = 1, visible = true, ignoreError = true) {
         const { layer, parents } = this.findLayer(layerId)
         if (!layer) {
-            const msg = `No WMS layer ${layerId} found in Capabilities ${this.originUrl}`
+            const msg = `No WMS layer ${layerId} found in Capabilities ${this.originUrl.toString()}`
             log.error(msg)
             if (ignoreError) {
                 return null
@@ -167,7 +167,7 @@ export default class WMSCapabilitiesParser {
         }
         if (!layerId) {
             // Without layerID we cannot use the layer in our viewer
-            const msg = `No layerId found in WMS capabilities for layer in ${this.originUrl}`
+            const msg = `No layerId found in WMS capabilities for layer in ${this.originUrl.toString()}`
             log.error(msg, layer)
             if (ignoreError) {
                 return {}
@@ -178,9 +178,9 @@ export default class WMSCapabilitiesParser {
         if (!this.version || !WMS_SUPPORTED_VERSIONS.includes(this.version)) {
             let msg = ''
             if (!this.version) {
-                msg = `No WMS version found in Capabilities of ${this.originUrl}`
+                msg = `No WMS version found in Capabilities of ${this.originUrl.toString()}`
             } else {
-                msg = `WMS version ${this.version} of ${this.originUrl} not supported`
+                msg = `WMS version ${this.version} of ${this.originUrl.toString()} not supported`
             }
             log.error(msg, layer)
             if (ignoreError) {
@@ -192,7 +192,9 @@ export default class WMSCapabilitiesParser {
         return {
             layerId: layerId,
             title: layer.Title,
-            url: this.originUrl,
+            url:
+                this.Capability?.Request?.GetMap?.DCPType[0]?.HTTP?.Get?.OnlineResource ||
+                this.originUrl.toString(),
             version: this.version,
             abstract: layer.Abstract,
             attributions: this._getLayerAttribution(layerId, layer, ignoreError),
@@ -250,7 +252,7 @@ export default class WMSCapabilitiesParser {
         }
 
         if (!layerExtent) {
-            const msg = `No layer extent found for ${layerId} in ${this.originUrl}`
+            const msg = `No layer extent found for ${layerId} in ${this.originUrl.toString()}`
             log.error(msg, layer, parents)
             if (!ignoreError) {
                 throw Error(msg)

--- a/src/api/layers/__tests__/WMSCapabitliesParser.class.spec.js
+++ b/src/api/layers/__tests__/WMSCapabitliesParser.class.spec.js
@@ -27,7 +27,8 @@ describe('WMSCapabilitiesParser of wms-geoadmin-sample.xml', () => {
         expect(capabilities.version).toBe('1.3.0')
         expect(capabilities.Capability).toBeTypeOf('object')
         expect(capabilities.Service).toBeTypeOf('object')
-        expect(capabilities.originUrl).toBe('https://wms.geo.admin.ch')
+        expect(capabilities.originUrl).toBeInstanceOf(URL)
+        expect(capabilities.originUrl.toString()).toBe('https://wms.geo.admin.ch/')
     })
     it('Parse layer attributes', () => {
         // General layer
@@ -35,14 +36,14 @@ describe('WMSCapabilitiesParser of wms-geoadmin-sample.xml', () => {
         expect(layer.externalLayerId).toBe('ch.swisstopo-vd.official-survey')
         expect(layer.name).toBe('OpenData-AV')
         expect(layer.abstract).toBe('The official survey (AV).')
-        expect(layer.baseURL).toBe('https://wms.geo.admin.ch')
+        expect(layer.baseURL).toBe('https://wms.geo.admin.ch/?')
 
         // Layer without .Name
         layer = capabilities.getExternalLayerObject('Periodic-Tracking', WGS84)
         expect(layer.externalLayerId).toBe('Periodic-Tracking')
         expect(layer.name).toBe('Periodic-Tracking')
         expect(layer.abstract).toBe('Layer without Name element should use the Title')
-        expect(layer.baseURL).toBe('https://wms.geo.admin.ch')
+        expect(layer.baseURL).toBe('https://wms.geo.admin.ch/?')
     })
     it('Parse layer attribution', () => {
         // Attribution in root layer
@@ -126,7 +127,7 @@ describe('WMSCapabilitiesParser - layer attributes', () => {
         `
         let capabilities = new WMSCapabilitiesParser(content, 'https://wms.geo.admin.ch')
         let layer = capabilities.getExternalLayerObject('ch.swisstopo-vd.official-survey', WGS84)
-        expect(layer.baseURL).toBe('https://wms.geo.admin.ch')
+        expect(layer.baseURL).toBe('https://wms.geo.admin.ch/')
 
         // URL from Capability
         content = `<?xml version='1.0' encoding="UTF-8" standalone="no"?>
@@ -157,7 +158,7 @@ describe('WMSCapabilitiesParser - layer attributes', () => {
         `
         capabilities = new WMSCapabilitiesParser(content, 'https://wms.geo.admin.ch')
         layer = capabilities.getExternalLayerObject('ch.swisstopo-vd.official-survey', WGS84)
-        expect(layer.baseURL).toBe('https://wms.geo.admin.ch')
+        expect(layer.baseURL).toBe('https://wms.geo.admin.ch/map?')
     })
 })
 

--- a/src/api/layers/__tests__/WMTSCapabitliesParser.class.spec.js
+++ b/src/api/layers/__tests__/WMTSCapabitliesParser.class.spec.js
@@ -24,7 +24,8 @@ describe('WMTSCapabilitiesParser of wmts-ogc-sample.xml', () => {
         expect(capabilities.OperationsMetadata).toBeTypeOf('object')
         expect(capabilities.ServiceIdentification).toBeTypeOf('object')
         expect(capabilities.ServiceProvider).toBeTypeOf('object')
-        expect(capabilities.originUrl).toBe('https://example.com')
+        expect(capabilities.originUrl).toBeInstanceOf(URL)
+        expect(capabilities.originUrl.toString()).toBe('https://example.com/')
     })
     it('Parse layer attributes', () => {
         // General layer
@@ -32,14 +33,14 @@ describe('WMTSCapabilitiesParser of wmts-ogc-sample.xml', () => {
         expect(layer.externalLayerId).toBe('BlueMarbleSecondGenerationAG')
         expect(layer.name).toBe('Blue Marble Second Generation - AG')
         expect(layer.abstract).toBe('Blue Marble Second Generation Canton Aargau Product')
-        expect(layer.baseURL).toBe('https://example.com')
+        expect(layer.baseURL).toBe('http://maps.example.com/cgi-bin/map.cgi?')
 
         // Layer without .Identifier
         layer = capabilities.getExternalLayerObject('BlueMarbleThirdGenerationZH', WGS84)
         expect(layer.externalLayerId).toBe('BlueMarbleThirdGenerationZH')
         expect(layer.name).toBe('BlueMarbleThirdGenerationZH')
         expect(layer.abstract).toBe('Blue Marble Third Generation Canton Zürich Product')
-        expect(layer.baseURL).toBe('https://example.com')
+        expect(layer.baseURL).toBe('http://maps.example.com/cgi-bin/map.cgi?')
     })
     it('Parse layer attribution', () => {
         // General layer

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -1,4 +1,3 @@
-import ExternalGroupOfLayers from '@/api/layers/ExternalGroupOfLayers.class'
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
 import KMLLayer from '@/api/layers/KMLLayer.class'
@@ -76,23 +75,14 @@ export function createLayerObject(parsedLayer) {
     // format is : WMS|BASE_URL|LAYER_ID
     else if (parsedLayer.id.startsWith('WMS|')) {
         const [_externalLayerType, wmsServerBaseURL, wmsLayerId] = parsedLayer.id.split('|')
+        // here we assume that is a regular WMS layer, upon parsing of the WMS get capabilities
+        // the layer might be updated to an external group of layers if needed.
         layer = new ExternalWMSLayer(
             wmsLayerId,
             parsedLayer.opacity,
             parsedLayer.visible,
             wmsServerBaseURL,
             wmsLayerId
-        )
-    }
-    // format is : GRP|BASE_URL|LAYER_ID
-    else if (parsedLayer.id.startsWith('GRP|')) {
-        const [_externalLayerType, serverBaseURL, layerId] = parsedLayer.id.split('|')
-        layer = new ExternalGroupOfLayers(
-            layerId,
-            parsedLayer.opacity,
-            parsedLayer.visible,
-            serverBaseURL,
-            layerId
         )
     }
     return layer

--- a/src/store/plugins/external-layers.plugin.js
+++ b/src/store/plugins/external-layers.plugin.js
@@ -50,20 +50,7 @@ async function updateExternalLayer(store, externalLayer, projection) {
         }
 
         updatedExternalLayer.isLoading = false
-        // Hack for legacy group of external layers, in this case the URL was with WMS|| and
-        // in the legacy parameters plugin we have no possibility to differentiate between
-        // group of layers and regular WMS layer, therefore if we don't find the layer in the
-        // active layers try to find it using the legacy group of layer type
-        const legacyGroupOfLayerId = updatedExternalLayer.getID().replace('GRP|', 'WMS|')
-        if (store.getters.getActiveLayerById(updatedExternalLayer.getID())) {
-            store.dispatch('updateLayer', updatedExternalLayer)
-        } else if (store.getters.getActiveLayerById(legacyGroupOfLayerId)) {
-            // This is a legacy group of wms layer
-            store.dispatch('removeLayer', legacyGroupOfLayerId)
-            store.dispatch('addLayer', updatedExternalLayer)
-        } else {
-            throw new Error(`Layer ${updatedExternalLayer.getID()} not found`)
-        }
+        store.dispatch('updateLayer', updatedExternalLayer)
     } catch (error) {
         log.error(`Failed to update external layer: `, error)
     }

--- a/tests/e2e-cypress/fixtures/external-wms-getcap.fixture.xml
+++ b/tests/e2e-cypress/fixtures/external-wms-getcap.fixture.xml
@@ -44,11 +44,11 @@
                     <HTTP>
                         <Get>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://wms.geo.admin.ch/?" />
+                                xlink:href="https://fake.wms.base.url/?" />
                         </Get>
                         <Post>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://wms.geo.admin.ch/?" />
+                                xlink:href="https://fake.wms.base.url/?" />
                         </Post>
                     </HTTP>
                 </DCPType>
@@ -64,11 +64,11 @@
                     <HTTP>
                         <Get>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://wms.geo.admin.ch/?" />
+                                xlink:href="https://fake.wms.base.url/?" />
                         </Get>
                         <Post>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://wms.geo.admin.ch/?" />
+                                xlink:href="https://fake.wms.base.url/?" />
                         </Post>
                     </HTTP>
                 </DCPType>
@@ -85,11 +85,11 @@
                     <HTTP>
                         <Get>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://wms.geo.admin.ch/?" />
+                                xlink:href="https://fake.wms.base.url/?" />
                         </Get>
                         <Post>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://wms.geo.admin.ch/?" />
+                                xlink:href="https://fake.wms.base.url/?" />
                         </Post>
                     </HTTP>
                 </DCPType>
@@ -100,11 +100,11 @@
                     <HTTP>
                         <Get>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://wms.geo.admin.ch/?" />
+                                xlink:href="https://fake.wms.base.url/?" />
                         </Get>
                         <Post>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://wms.geo.admin.ch/?" />
+                                xlink:href="https://fake.wms.base.url/?" />
                         </Post>
                     </HTTP>
                 </DCPType>
@@ -116,11 +116,11 @@
                     <HTTP>
                         <Get>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://wms.geo.admin.ch/?" />
+                                xlink:href="https://fake.wms.base.url/?" />
                         </Get>
                         <Post>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://wms.geo.admin.ch/?" />
+                                xlink:href="https://fake.wms.base.url/?" />
                         </Post>
                     </HTTP>
                 </DCPType>
@@ -131,11 +131,11 @@
                     <HTTP>
                         <Get>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://wms.geo.admin.ch/?" />
+                                xlink:href="https://fake.wms.base.url/?" />
                         </Get>
                         <Post>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://wms.geo.admin.ch/?" />
+                                xlink:href="https://fake.wms.base.url/?" />
                         </Post>
                     </HTTP>
                 </DCPType>

--- a/tests/e2e-cypress/integration/layers.cy.js
+++ b/tests/e2e-cypress/integration/layers.cy.js
@@ -127,7 +127,7 @@ describe('Test of layer handling', () => {
                     .get('[data-cy="menu-external-disclaimer-icon"]')
                     .should('be.visible')
             })
-            it.only('reads and adds an external WMTS correctly', () => {
+            it('reads and adds an external WMTS correctly', () => {
                 const fakeGetCapUrl = 'https://fake.wmts.getcap.url/WMTSGetCapabilities.xml'
                 const fakeLayerId = 'TestExternalWMTS'
                 // format is WMTS|GET_CAPABILITIES_URL|LAYER_ID

--- a/tests/e2e-cypress/integration/layers.cy.js
+++ b/tests/e2e-cypress/integration/layers.cy.js
@@ -85,20 +85,20 @@ describe('Test of layer handling', () => {
         })
         context('External layers', () => {
             it('reads and adds an external WMS correctly', () => {
-                const fakeWmsBaseUrl = 'https://fake.wms.base.url'
+                const fakeWmsBaseUrl = 'https://fake.wms.base.url/?'
                 const fakeLayerId = 'ch.swisstopo-vd.official-survey'
                 // format is WMS|BASE_URL|LAYER_IDS
                 const fakeLayerUrlId = `WMS|${fakeWmsBaseUrl}|${fakeLayerId}`
 
                 // intercepting call to our fake WMS
                 cy.intercept(
-                    { url: `${fakeWmsBaseUrl}/**`, query: { REQUEST: 'GetMap' } },
+                    { url: `${fakeWmsBaseUrl}**`, query: { REQUEST: 'GetMap' } },
                     {
                         fixture: '256.png',
                     }
                 ).as('externalWMSGetMap')
                 cy.intercept(
-                    { url: `${fakeWmsBaseUrl}/**`, query: { REQUEST: 'GetCapabilities' } },
+                    { url: `${fakeWmsBaseUrl}**`, query: { REQUEST: 'GetCapabilities' } },
                     { fixture: 'external-wms-getcap.fixture.xml' }
                 ).as('externalWMSGetCap')
 
@@ -127,7 +127,7 @@ describe('Test of layer handling', () => {
                     .get('[data-cy="menu-external-disclaimer-icon"]')
                     .should('be.visible')
             })
-            it('reads and adds an external WMTS correctly', () => {
+            it.only('reads and adds an external WMTS correctly', () => {
                 const fakeGetCapUrl = 'https://fake.wmts.getcap.url/WMTSGetCapabilities.xml'
                 const fakeLayerId = 'TestExternalWMTS'
                 // format is WMTS|GET_CAPABILITIES_URL|LAYER_ID

--- a/tests/e2e-cypress/integration/legacyParamImport.cy.js
+++ b/tests/e2e-cypress/integration/legacyParamImport.cy.js
@@ -203,15 +203,15 @@ describe('Test on legacy param import', () => {
         it('External WMS layer', () => {
             const layerName = 'OpenData-AV'
             const layerId = 'ch.swisstopo-vd.official-survey'
-            const url = 'http://wms-test.url/'
+            const url = 'https://fake.wms.base.url/?'
             cy.intercept(
-                { url: `${url}/**`, query: { REQUEST: 'GetMap' } },
+                { url: `${url}**`, query: { REQUEST: 'GetMap' } },
                 {
                     fixture: '256.png',
                 }
             ).as('externalWMSGetMap')
             cy.intercept(
-                { url: `${url}/**`, query: { REQUEST: 'GetCapabilities' } },
+                { url: `${url}**`, query: { REQUEST: 'GetCapabilities' } },
                 { fixture: 'external-wms-getcap.fixture.xml' }
             ).as('externalWMSGetCap')
 


### PR DESCRIPTION
This reverts commit 6a3ec3d1714e0561b1ed2d13e4a889cc8d797fd5.

Some external provider original URL return a 302 and are not value for the GetMap.

Therefore keep the URL provided by the GetCapabilities as base URL.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-bgdiinf_sb-3194-external-layer/index.html)