### PR TITLE
PB-88: Import tool/Geo Catalogue checkbox action changed to add/remove layer

### DIFF
--- a/src/modules/menu/components/LayerCatalogueItem.vue
+++ b/src/modules/menu/components/LayerCatalogueItem.vue
@@ -58,11 +58,6 @@ const canBeAddedToTheMap = computed(() => {
 const isPresentInActiveLayers = computed(() =>
     activeLayers.value.find((layer) => layer.getID() === item.getID())
 )
-const isCurrentlyHidden = computed(
-    () =>
-        isPresentInActiveLayers.value &&
-        activeLayers.value.find((layer) => layer.getID() === item.getID() && !layer.visible)
-)
 
 // reacting to topic changes (some categories might need some auto-opening)
 watch(openThemesIds, (newValue) => {
@@ -80,11 +75,11 @@ function startLayerPreview() {
     }
 }
 
-function addLayer() {
+function addRemoveLayer() {
     // if this is a group of a layer then simply add it to the map
     const matchingActiveLayer = store.getters.getActiveLayerById(item.getID())
     if (matchingActiveLayer) {
-        store.dispatch('toggleLayerVisibility', matchingActiveLayer)
+        store.dispatch('removeLayer', matchingActiveLayer)
     } else if (item.isExternal) {
         store.dispatch('addLayer', item)
     } else {
@@ -94,7 +89,7 @@ function addLayer() {
 
 function onItemClick() {
     if (canBeAddedToTheMap.value) {
-        addLayer()
+        addRemoveLayer()
     } else if (hasChildren.value) {
         showChildren.value = !showChildren.value
     }
@@ -147,24 +142,20 @@ function zoomToLayer() {
                 v-if="canBeAddedToTheMap"
                 class="btn"
                 :class="{
-                    'text-primary': isPresentInActiveLayers || isCurrentlyHidden,
+                    'text-primary': isPresentInActiveLayers,
                     'btn-lg': !compact,
                 }"
-                @click.stop="addLayer()"
+                @click.stop="addRemoveLayer()"
             >
                 <FontAwesomeIcon
-                    :icon="`far ${
-                        isPresentInActiveLayers && !isCurrentlyHidden
-                            ? 'fa-check-square'
-                            : 'fa-square'
-                    }`"
+                    :icon="`far ${isPresentInActiveLayers ? 'fa-check-square' : 'fa-square'}`"
                 />
             </button>
             <button
                 v-if="hasChildren"
                 class="btn btn-rounded"
                 :class="{
-                    'text-primary': isPresentInActiveLayers || isCurrentlyHidden,
+                    'text-primary': isPresentInActiveLayers,
                     'btn-lg': !compact,
                 }"
                 @click.stop="onCollapseClick"
@@ -175,7 +166,7 @@ function zoomToLayer() {
 
             <span
                 class="menu-catalogue-item-name"
-                :class="{ 'text-primary': isPresentInActiveLayers || isCurrentlyHidden }"
+                :class="{ 'text-primary': isPresentInActiveLayers }"
                 >{{ item.name }}</span
             >
             <button v-if="item.extent?.length" class="btn" @click.stop="zoomToLayer">

--- a/tests/e2e-cypress/integration/legacyParamImport.cy.js
+++ b/tests/e2e-cypress/integration/legacyParamImport.cy.js
@@ -76,8 +76,8 @@ describe('Test on legacy param import', () => {
         const kmlServiceFilePath = `${kmlServiceBasePath}/files/${kmlId}`
         beforeEach(() => {
             // serving a dummy KML so that we don't get a 404
-            cy.intercept(`**/${kmlServiceFilePath}`, '<kml />').as('get-kml')
-            cy.intercept(`**/${kmlServiceAdminPath}?admin_id=${adminId}`, (request) => {
+            cy.intercept(`**${kmlServiceFilePath}`, '<kml />').as('get-kml')
+            cy.intercept(`**${kmlServiceAdminPath}?admin_id=${adminId}`, (request) => {
                 request.reply({
                     id: kmlId,
                     admin_id: adminId,
@@ -89,7 +89,7 @@ describe('Test on legacy param import', () => {
                     updated: '',
                 })
             }).as('get-kml-metada-by-admin-id')
-            cy.intercept(`**/${kmlServiceAdminPath}/${kmlId}`, (request) => {
+            cy.intercept(`**${kmlServiceAdminPath}/${kmlId}`, (request) => {
                 request.reply({
                     id: kmlId,
                     links: {
@@ -191,14 +191,27 @@ describe('Test on legacy param import', () => {
             })
         })
         it("doesn't show encoding in the search bar when serving a swisssearch legacy url", () => {
+            cy.intercept('**/rest/services/ech/SearchServer*?type=layers*', {
+                body: { results: [] },
+            }).as('search-layers')
+            cy.intercept('**/rest/services/ech/SearchServer*?type=locations*', {
+                body: {
+                    results: [
+                        {
+                            attrs: {
+                                detail: '1530 payerne 5822 payerne ch vd',
+                                label: '  <b>1530 Payerne</b>',
+                            },
+                        },
+                    ],
+                },
+            }).as('search-locations')
             cy.goToMapView({
                 swisssearch: '1530 Payerne',
             })
             cy.readStoreValue('state.search.query').should('eq', '1530 Payerne')
             cy.url().should('include', 'swisssearch=1530+Payerne')
-            cy.get('[data-cy="search-result-entry-location"]', { timeout: 8000 }).should(
-                'be.visible'
-            )
+            cy.get('[data-cy="search-result-entry-location"]').should('be.visible')
         })
         it('External WMS layer', () => {
             const layerName = 'OpenData-AV'


### PR DESCRIPTION
The checkbox in the geo catalogue and import tool has been change to add/remove
layer in active layers. Previously it did add the layer if it was not in active
layers and was toggling the layer visibility.

In order to keep a clean and intuitive user interface, the layer config is kept
in one place, which means in active layer, where the visibility, opacity and timestamp
can be configured. In the catalogue we can define which layer can be added or removed.

This also allow click on wrong layer to be removed from the same view which was
previously not possible.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-88-import-improvement/index.html)