### PR TITLE
Improve import catalogue provider url size

### DIFF
--- a/src/modules/menu/components/LayerCatalogue.vue
+++ b/src/modules/menu/components/LayerCatalogue.vue
@@ -55,7 +55,7 @@ function clearSearchText() {
 
 <template>
     <div @mouseleave="clearPreviewLayer">
-        <div v-if="showSearchBar" class="input-group input-group-sm d-flex p-1">
+        <div v-if="showSearchBar" class="input-group input-group-sm d-flex pb-1">
             <span id="searchCatalogueIcon" class="input-group-text">
                 <FontAwesomeIcon :icon="['fas', 'search']" />
             </span>

--- a/src/modules/menu/components/advancedTools/ImportCatalogue/ImportCatalogue.vue
+++ b/src/modules/menu/components/advancedTools/ImportCatalogue/ImportCatalogue.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { ref, toRefs } from 'vue'
+import { computed, ref, toRefs } from 'vue'
+import { useStore } from 'vuex'
 
 import ProviderUrl from '@/modules/menu/components/advancedTools/ImportCatalogue/ProviderUrl.vue'
 import LayerCatalogue from '@/modules/menu/components/LayerCatalogue.vue'
@@ -15,6 +16,10 @@ const props = defineProps({
 const { compact } = toRefs(props)
 const capabilities = ref([])
 
+const store = useStore()
+
+const isDesktopMode = computed(() => store.getters.isDesktopMode)
+
 function onNewCapabilities(newCapabilities) {
     log.debug(`New capabilities`, newCapabilities)
     capabilities.value = newCapabilities.sort((layerA, layerB) =>
@@ -28,7 +33,11 @@ function onClear() {
 </script>
 
 <template>
-    <div class="ps-2" data-cy="import-catalog-content">
+    <div
+        class="import-catalogue ps-2"
+        :class="{ 'desktop-mode': isDesktopMode, 'me-2': !isDesktopMode }"
+        data-cy="import-catalog-content"
+    >
         <ProviderUrl @capabilities:parsed="onNewCapabilities" @capabilities:cleared="onClear" />
         <LayerCatalogue
             class="mb-2"
@@ -39,4 +48,16 @@ function onClear() {
     </div>
 </template>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+@import 'src/scss/media-query.mixin';
+@import 'src/scss/variables';
+
+.import-catalogue {
+    &.desktop-mode {
+        // Here we need to set the max-width with a buffer of 32px to avoid changing the width
+        // of the input due the scrollbar that could appears when toggling the dropdown of the
+        // input element of ProviderUrl
+        max-width: calc($menu-tray-width - 32px);
+    }
+}
+</style>

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -16,7 +16,7 @@ body {
 input,
 p,
 li {
-    // whitelisting inputs, so that they may be selected by iOS (otherewise, link copy is a bit weird without
+    // whitelisting inputs, so that they may be selected by iOS (otherwise, link copy is a bit weird without
     // having selected the text first)
     @extend .clear-no-ios-long-press;
 }


### PR DESCRIPTION
The provider url size changed when the scrollbar appeared. This was quite
disturbing when toggling the provider list, which could trigger the scrollbar
based on the size of the window.

This has been simply fixed by setting a max size of the import tool.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-import-catalogue/index.html)