### PR TITLE
PB-100: Manage camera and 3D parameter from the legacy parameters

### DIFF
--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -178,7 +178,7 @@ const handleLegacyParams = (legacyParams, store, to, next) => {
             cameraPosition
         )
     })
-    if (cameraPosition.length === 5) {
+    if (cameraPosition.length >= 3) {
         cameraPosition.push('')
         newQuery['camera'] = cameraPosition.join(',')
         newQuery['3d'] = true

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -51,7 +51,8 @@ const handleLegacyParam = (
     store,
     newQuery,
     latlongCoordinates,
-    legacyCoordinates
+    legacyCoordinates,
+    cameraPosition
 ) => {
     const { projection } = store.state.position
     let newValue
@@ -83,9 +84,11 @@ const handleLegacyParam = (
 
         case 'lon':
             latlongCoordinates[0] = Number(legacyValue)
+            cameraPosition[0] = Number(legacyValue)
             break
         case 'lat':
             latlongCoordinates[1] = Number(legacyValue)
+            cameraPosition[1] = Number(legacyValue)
             break
 
         // taking all layers related param aside so that they can be processed later (see below)
@@ -123,6 +126,18 @@ const handleLegacyParam = (
             newValue = legacyValue
             break
 
+        case 'elevation':
+            cameraPosition[2] = Number(legacyValue)
+            break
+
+        case 'pitch':
+            cameraPosition[3] = Number(legacyValue)
+            break
+
+        case 'heading':
+            cameraPosition[4] = Number(legacyValue)
+            break
+
         // if no special work to do, we just copy past legacy params to the new viewer
         default:
             newValue = legacyValue
@@ -145,6 +160,7 @@ const handleLegacyParams = (legacyParams, store, to, next) => {
     const { projection } = store.state.position
     let legacyCoordinates = []
     let latlongCoordinates = []
+    let cameraPosition = []
     // TODO BGDIINF_SB-2685: remove once legacy prod is decommissioned
     const isOnDevelopmentHost = DISABLE_DRAWING_MENU_FOR_LEGACY_ON_HOSTNAMES.some(
         (hostname) => hostname === store.state.ui.hostname
@@ -157,9 +173,16 @@ const handleLegacyParams = (legacyParams, store, to, next) => {
             store,
             newQuery,
             latlongCoordinates,
-            legacyCoordinates
+            legacyCoordinates,
+            cameraPosition
         )
     })
+    if (cameraPosition.length === 5) {
+        cameraPosition.push('')
+        newQuery['camera'] = cameraPosition.join(',')
+        newQuery['3d'] = true
+        newQuery['sr'] = WEBMERCATOR.epsgNumber
+    }
 
     // Convert legacies coordinates if needed
     if (latlongCoordinates.length === 2) {
@@ -241,7 +264,6 @@ const legacyPermalinkManagementRouterPlugin = (router, store) => {
     // to.query only parse the query after the /#? and legacy params are at the root /?
     const legacyParams =
         window.location && window.location.search ? parseLegacyParams(window.location.search) : null
-
     router.beforeEach((to, from, next) => {
         // Waiting for the app to enter the MapView before dealing with legacy param, otherwise
         // the storeSync plugin might overwrite some parameters. To handle legacy param we also

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -2,6 +2,7 @@ import proj4 from 'proj4'
 
 import { DISABLE_DRAWING_MENU_FOR_LEGACY_ON_HOSTNAMES } from '@/config'
 import { transformLayerIntoUrlString } from '@/router/storeSync/LayerParamConfig.class'
+import { backgroundMatriceBetween2dAnd3d as backgroundMatriceBetweenLegacyAndNew } from '@/store/plugins/2d-to-3d-management.plugin'
 import { LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 import CustomCoordinateSystem from '@/utils/coordinates/CustomCoordinateSystem.class'
 import SwissCoordinateSystem from '@/utils/coordinates/SwissCoordinateSystem.class'
@@ -182,6 +183,14 @@ const handleLegacyParams = (legacyParams, store, to, next) => {
         newQuery['camera'] = cameraPosition.join(',')
         newQuery['3d'] = true
         newQuery['sr'] = WEBMERCATOR.epsgNumber
+
+        // Handle different backrgound layer from legacy 3D parameter
+        if (newQuery['bgLayer']) {
+            const newBackgroundLayer = backgroundMatriceBetweenLegacyAndNew[newQuery['bgLayer']]
+            if (newBackgroundLayer) {
+                newQuery['bgLayer'] = newBackgroundLayer
+            }
+        }
     }
 
     // Convert legacies coordinates if needed

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -184,7 +184,7 @@ const handleLegacyParams = (legacyParams, store, to, next) => {
         newQuery['3d'] = true
         newQuery['sr'] = WEBMERCATOR.epsgNumber
 
-        // Handle different backrgound layer from legacy 3D parameter
+        // Handle different background layer from legacy 3D parameter
         if (newQuery['bgLayer']) {
             const newBackgroundLayer = backgroundMatriceBetweenLegacyAndNew[newQuery['bgLayer']]
             if (newBackgroundLayer) {

--- a/src/store/plugins/2d-to-3d-management.plugin.js
+++ b/src/store/plugins/2d-to-3d-management.plugin.js
@@ -1,7 +1,7 @@
 import { DEFAULT_PROJECTION } from '@/config'
 import { WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
 
-const backgroundMatriceBetween2dAnd3d = {
+export const backgroundMatriceBetween2dAnd3d = {
     'ch.swisstopo.pixelkarte-farbe': 'ch.swisstopo.swisstlm3d-karte-farbe_3d',
     'ch.swisstopo.pixelkarte-grau': 'ch.swisstopo.swisstlm3d-karte-grau_3d',
     'ch.swisstopo.swissimage': 'ch.swisstopo.swissimage_3d',

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -215,8 +215,9 @@ Cypress.Commands.add(
             }
         )
 
-        // In the legacy URL, 3d is not found. We check is the map in 3d or not by checking the pitch and heading
-        const isLegacy3d = 'pitch' in queryParams || 'heading' in queryParams
+        // In the legacy URL, 3d is not found. We check is the map in 3d or not by checking the pitch, heading, and elevation
+        const isLegacy3d =
+            'pitch' in queryParams || 'heading' in queryParams || 'elevation' in queryParams
         const is3d = '3d' in queryParams && queryParams['3d'] === true
 
         if (is3d || isLegacy3d) {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -215,7 +215,7 @@ Cypress.Commands.add(
             }
         )
 
-        // In the legacy URL, 3d is not found. We check is the map in 3d or not by checking the pitch, heading, and elevation
+        // In the legacy URL, 3d is not found. We check if the map in 3d or not by checking the pitch, heading, and elevation
         const isLegacy3d =
             'pitch' in queryParams || 'heading' in queryParams || 'elevation' in queryParams
         const is3d = '3d' in queryParams && queryParams['3d'] === true

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -214,7 +214,12 @@ Cypress.Commands.add(
                 errorMsg: 'Timeout waiting for all layers to be loaded',
             }
         )
-        if ('3d' in queryParams && queryParams['3d'] === true) {
+
+        // In the legacy URL, 3d is not found. We check is the map in 3d or not by checking the pitch and heading
+        const isLegacy3d = 'pitch' in queryParams || 'heading' in queryParams
+        const is3d = '3d' in queryParams && queryParams['3d'] === true
+
+        if (is3d || isLegacy3d) {
             cy.get('[data-cy="cesium-map"]').should('be.visible')
         } else {
             cy.get('[data-cy="ol-map"]', { timeout: 10000 }).should('be.visible')

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -304,7 +304,6 @@ describe('Test on legacy param import', () => {
                 elevation,
                 heading,
                 pitch,
-                '3d': true, // this should be removed
             })
 
             // checking in the store that the parameters have been converted into the new 3D parameters

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -341,5 +341,28 @@ describe('Test on legacy param import', () => {
             // EPSG is set to 3857
             cy.readStoreValue('state.position.projection.epsgNumber').should('eq', 3857)
         })
+
+        it('transfers camera parameter from legacy URL to the new URL only elevation', () => {
+            cy.goToMapView({
+                lat,
+                lon,
+                elevation,
+            })
+
+            // checking in the store that the parameters have been converted into the new 3D parameters
+            cy.readStoreValue('state.cesium.active').should('eq', true) // cesium should be active
+
+            // Checking camera position
+            // x, y, and z seems recalculated when there is only elevation, so I just check that they are not null
+            cy.readStoreValue('state.position.camera.x').should('not.be.null')
+            cy.readStoreValue('state.position.camera.y').should('not.be.null')
+            cy.readStoreValue('state.position.camera.z').should('not.be.null')
+            cy.readStoreValue('state.position.camera.heading').should('eq', 360)
+            cy.readStoreValue('state.position.camera.pitch').should('eq', -90)
+            cy.readStoreValue('state.position.camera.roll').should('eq', 0)
+
+            // EPSG is set to 3857
+            cy.readStoreValue('state.position.projection.epsgNumber').should('eq', 3857)
+        })
     })
 })

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -290,14 +290,13 @@ describe('Test on legacy param import', () => {
     })
 
     context('3D import', () => {
-        it('transfers camera parameter from legacy URL to the new URL', () => {
-            const lat = 47.3
-            const lon = 7.3
-            const elevation = 215370
-            const heading = 318
-            const pitch = -45
+        const lat = 47.3
+        const lon = 7.3
+        const elevation = 215370
+        const heading = 318
+        const pitch = -45
 
-            const defaultRoll = 360
+        it('transfers camera parameter from legacy URL to the new URL', () => {
             cy.goToMapView({
                 lat,
                 lon,
@@ -315,7 +314,29 @@ describe('Test on legacy param import', () => {
             cy.readStoreValue('state.position.camera.z').should('eq', elevation)
             cy.readStoreValue('state.position.camera.heading').should('eq', heading)
             cy.readStoreValue('state.position.camera.pitch').should('eq', pitch)
-            cy.readStoreValue('state.position.camera.roll').should('eq', defaultRoll)
+            cy.readStoreValue('state.position.camera.roll').should('eq', 360)
+
+            // EPSG is set to 3857
+            cy.readStoreValue('state.position.projection.epsgNumber').should('eq', 3857)
+        })
+
+        it('transfers camera parameter from legacy URL to the new URL only heading', () => {
+            cy.goToMapView({
+                lat,
+                lon,
+                heading,
+            })
+
+            // checking in the store that the parameters have been converted into the new 3D parameters
+            cy.readStoreValue('state.cesium.active').should('eq', true) // cesium should be active
+
+            // Checking camera position
+            cy.readStoreValue('state.position.camera.x').should('eq', lon)
+            cy.readStoreValue('state.position.camera.y').should('eq', lat)
+            cy.readStoreValue('state.position.camera.z').should('eq', 0)
+            cy.readStoreValue('state.position.camera.heading').should('eq', heading)
+            cy.readStoreValue('state.position.camera.pitch').should('eq', 0)
+            cy.readStoreValue('state.position.camera.roll').should('eq', 360)
 
             // EPSG is set to 3857
             cy.readStoreValue('state.position.projection.epsgNumber').should('eq', 3857)

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -288,4 +288,38 @@ describe('Test on legacy param import', () => {
             })
         })
     })
+
+    context('3D import', () => {
+        it('transfers camera parameter from legacy URL to the new URL', () => {
+            const lat = 47.3
+            const lon = 7.3
+            const elevation = 215370
+            const heading = 318
+            const pitch = -45
+
+            const defaultRoll = 360
+            cy.goToMapView({
+                lat,
+                lon,
+                elevation,
+                heading,
+                pitch,
+                '3d': true, // this should be removed
+            })
+
+            // checking in the store that the parameters have been converted into the new 3D parameters
+            cy.readStoreValue('state.cesium.active').should('eq', true) // cesium should be active
+
+            // Checking camera position
+            cy.readStoreValue('state.position.camera.x').should('eq', lon)
+            cy.readStoreValue('state.position.camera.y').should('eq', lat)
+            cy.readStoreValue('state.position.camera.z').should('eq', elevation)
+            cy.readStoreValue('state.position.camera.heading').should('eq', heading)
+            cy.readStoreValue('state.position.camera.pitch').should('eq', pitch)
+            cy.readStoreValue('state.position.camera.roll').should('eq', defaultRoll)
+
+            // EPSG is set to 3857
+            cy.readStoreValue('state.position.projection.epsgNumber').should('eq', 3857)
+        })
+    })
 })


### PR DESCRIPTION
Transferring legacy parameters for 3D maps including:

- `lon`, `lat`, `elevation`, `pitch`, `heading` into camera position
- Set the `3d` to true
- Set the `sr` to WEBMERCATOR
- Convert the `bgLayer` to use the 3D one

Example of old geoadmin: https://map.geo.admin.ch/?lang=en&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,ch.swisstopo.swissnames3d&layers_visibility=false,false,false,true,false&layers_timestamp=18641231,,,,&layers_opacity=1,1,1,0.8,1&lon=10.14968&lat=45.51136&elevation=215370&heading=317.946&pitch=-45.394
![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/a2facc73-b4d3-453c-bef7-93fcc7713f09)



Example of new geoadmin with old parameter: https://sys-map.dev.bgdi.ch/preview/feat-pb-100-manage-3d-parameters/index.html?lang=en&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,ch.swisstopo.swissnames3d&layers_visibility=false,false,false,true,false&layers_timestamp=18641231,,,,&layers_opacity=1,1,1,0.8,1&lon=10.14968&lat=45.51136&elevation=215370&heading=317.946&pitch=-45.394
![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/9a92b940-acce-4a49-b0a8-7bab7cf00018)



[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-100-manage-3d-parameters/index.html)