### PR TITLE
PB-95: Add zoom to KML extent in import file

### DIFF
--- a/src/api/files.api.js
+++ b/src/api/files.api.js
@@ -313,14 +313,21 @@ export function loadKmlData(kmlLayer) {
                 )
             )
         }
-        axios.get(kmlLayer.kmlFileUrl).then((response) => {
-            if (response.status === 200 && response.data) {
-                resolve(response.data)
-            } else {
-                const msg = `Incorrect response while getting KML file data for layer ${kmlLayer.getID()}`
-                log.error(msg, response)
+        axios
+            .get(kmlLayer.kmlFileUrl)
+            .then((response) => {
+                if (response.status === 200 && response.data) {
+                    resolve(response.data)
+                } else {
+                    const msg = `Incorrect response while getting KML file data for layer ${kmlLayer.getID()}`
+                    log.error(msg, response)
+                    reject(new Error(msg))
+                }
+            })
+            .catch((error) => {
+                const msg = `Failed to load KML data: ${error}`
+                log.error(msg)
                 reject(new Error(msg))
-            }
-        })
+            })
     })
 }

--- a/src/api/layers/AbstractLayer.class.js
+++ b/src/api/layers/AbstractLayer.class.js
@@ -77,6 +77,8 @@ export default class AbstractLayer {
         } else {
             this.hasLegend = true
         }
+        this.errorKey = null
+        this.hasError = false
     }
 
     /**

--- a/src/api/layers/ExternalLayer.class.js
+++ b/src/api/layers/ExternalLayer.class.js
@@ -97,8 +97,6 @@ export default class ExternalLayer extends AbstractLayer {
         this.extent = extent
         this.legends = legends
         this.isLoading = isLoading
-        this.errorKey = null
-        this.hasError = false
         this.hasLegend = this.abstract || this.legends?.length > 0
     }
 

--- a/src/api/layers/KMLLayer.class.js
+++ b/src/api/layers/KMLLayer.class.js
@@ -66,6 +66,8 @@ export default class KMLLayer extends AbstractLayer {
             this.isLoading = true
         }
         this.kmlData = kmlData
+        this.errorKey = null
+        this.hasError = false
     }
 
     getID() {

--- a/src/api/layers/KMLLayer.class.js
+++ b/src/api/layers/KMLLayer.class.js
@@ -66,8 +66,6 @@ export default class KMLLayer extends AbstractLayer {
             this.isLoading = true
         }
         this.kmlData = kmlData
-        this.errorKey = null
-        this.hasError = false
     }
 
     getID() {

--- a/src/api/layers/WMSCapabilitiesParser.class.js
+++ b/src/api/layers/WMSCapabilitiesParser.class.js
@@ -208,6 +208,15 @@ export default class WMSCapabilitiesParser {
     }
 
     _getLayerExtent(layerId, layer, parents, projection) {
+        // TODO PB-243 handling of extent out of projection bound (currently not properly handled)
+        // - extent totally out of projection bounds
+        //    => return null and set outOfBounds flag to true
+        // - extent totally inside of projection bounds
+        //   => crop extent and set outOfBounds flag to true
+        // - extent partially inside projection bounds
+        //   => take intersect extent and set outOfBounds flag to true
+        // - no extent
+        //   => return null and set the outOfBounds flag to false (we don't know)
         let layerExtent = null
         const matchedBbox = layer.BoundingBox?.find((bbox) => bbox.crs === projection.epsg)
         // First try to find a matching extent from the BoundingBox

--- a/src/api/layers/WMTSCapabilitiesParser.class.js
+++ b/src/api/layers/WMTSCapabilitiesParser.class.js
@@ -162,6 +162,7 @@ export default class WMTSCapabilitiesParser {
     }
 
     _getLayerExtent(layerId, layer, projection) {
+        // TODO PB-243 handling of extent out of projection bound (currently not properly handled)
         let layerExtent = null
         let extentEpsg = null
         // First try to get the extent from the default bounding box

--- a/src/modules/drawing/useKmlDataManagement.composable.js
+++ b/src/modules/drawing/useKmlDataManagement.composable.js
@@ -6,7 +6,6 @@ import KMLLayer from '@/api/layers/KMLLayer.class'
 import { IS_TESTING_WITH_CYPRESS } from '@/config'
 import { parseKml } from '@/modules/drawing/lib/drawingUtils'
 import { DrawingState, generateKmlString } from '@/modules/drawing/lib/export-utils'
-import { updateKmlActiveLayer } from '@/utils/kmlUtils'
 import log from '@/utils/logging'
 
 // ref/variables outside useSaveKmlOnChange function so that they may be shared between all usages of the usaSaveKmlOnChange
@@ -81,7 +80,11 @@ export default function useSaveKmlOnChange(drawingLayerDirectReference) {
                     activeKmlLayer.value.adminId,
                     kmlData
                 )
-                await updateKmlActiveLayer(store, activeKmlLayer.value, kmlData, kmlMetadata)
+                await store.dispatch('updateKmlLayer', {
+                    layerId: activeKmlLayer.value.getID(),
+                    kmlData: kmlData,
+                    kmlMetadata: kmlMetadata,
+                })
                 saveState.value = DrawingState.SAVED
             }
         } catch (e) {

--- a/src/modules/i18n/locales/de.json
+++ b/src/modules/i18n/locales/de.json
@@ -648,6 +648,6 @@
     "no_result": "Kein Ergebnis",
     "loading": "Laden",
     "search_in_catalogue_placeholder": "Suche in importierten Karten",
-    "kml_name": "Name der KML",
-    "name_too_long": "Name ist zu lang"
+    "kml_gpx_file_out_of_bounds": "Der Dateiinhalt liegt außerhalb der Projektionsgrenzen",
+    "kml_gpx_file_empty": "Die KML/GPX-Datei ist leer"
 }

--- a/src/modules/i18n/locales/en.json
+++ b/src/modules/i18n/locales/en.json
@@ -648,6 +648,6 @@
     "no_result": "No result",
     "loading": "Loading",
     "search_in_catalogue_placeholder": "Search in imported maps",
-    "kml_name": "Name of the KML",
-    "name_too_long": "Name is too long"
+    "kml_gpx_file_out_of_bounds": "File content is out of projection bounds",
+    "kml_gpx_file_empty": "KML/GPX file is empty"
 }

--- a/src/modules/i18n/locales/fr.json
+++ b/src/modules/i18n/locales/fr.json
@@ -648,6 +648,6 @@
     "no_result": "Pas de résultat",
     "loading": "Chargement",
     "search_in_catalogue_placeholder": "Rechercher dans les cartes importées",
-    "kml_name": "Nom du KML",
-    "name_too_long": "Le nom est trop long"
+    "kml_gpx_file_out_of_bounds": "Le contenu du fichier est hors des limites de projection",
+    "kml_gpx_file_empty": "Le fichier KML/GPX est vide"
 }

--- a/src/modules/i18n/locales/it.json
+++ b/src/modules/i18n/locales/it.json
@@ -648,6 +648,6 @@
     "no_result": "Nessun risultato",
     "loading": "Caricamento",
     "search_in_catalogue_placeholder": "Cerca nelle mappe importate",
-    "kml_name": "Nome del KML",
-    "name_too_long": "Il nome è troppo lungo"
+    "kml_gpx_file_out_of_bounds": "Il contenuto del file è fuori dai limiti della proiezione",
+    "kml_gpx_file_empty": "Il file KML/GPX è vuoto"
 }

--- a/src/modules/i18n/locales/rm.json
+++ b/src/modules/i18n/locales/rm.json
@@ -646,6 +646,6 @@
     "no_result": "Nagut resultat",
     "loading": "Chargiada",
     "search_in_catalogue_placeholder": "Cercar en mapas importads",
-    "kml_name": "Num da la KML",
-    "name_too_long": "Il num è massa lung"
+    "kml_gpx_file_out_of_bounds": "Il contetn dal file è en furma da las limitas da projezziun",
+    "kml_gpx_file_empty": "La datoteca KML/GPX è vegnida empruva"
 }

--- a/src/modules/menu/components/LayerCatalogueItem.vue
+++ b/src/modules/menu/components/LayerCatalogueItem.vue
@@ -151,6 +151,16 @@ function transformExtentIntoPolygon(flattenExtent) {
 
 const lv95Extent = [LV95.bounds.bottomLeft, LV95.bounds.topRight]
 function zoomToLayer() {
+    // TODO PB-243 better handling of layers extent errors
+    // - extent totally out of projection bounds
+    //    => layer should be marked as out of bounds and disabled, no zoom to layer icon
+    //       but an error icon with reason
+    // - extent totally inside of projection bounds
+    //   => current behavior, maybe add a warning icon about partial layer display
+    // - extent partially inside projection bounds
+    //   => take intersection as extent, maybe add a warning icon about partial layer display
+    // - no extent
+    //   => add a warning that the layer might be out of bound
     log.debug(`Zoom to layer ${item.value.name}`, item.value.extent)
     // Only zooming to layer's extent if its extent is entirely within LV95 extent.
     // If part (or all) of the extent is outside LV95 extent, we zoom to LV95 extent instead.

--- a/src/modules/menu/components/advancedTools/ImportFile/ImportFileLocalTab.vue
+++ b/src/modules/menu/components/advancedTools/ImportFile/ImportFileLocalTab.vue
@@ -6,6 +6,8 @@ import { useStore } from 'vuex'
 import ImportFileButtons from '@/modules/menu/components/advancedTools/ImportFile/ImportFileButtons.vue'
 import { handleFileContent } from '@/modules/menu/components/advancedTools/ImportFile/utils'
 import { useImportButton } from '@/modules/menu/components/advancedTools/useImportButton'
+import { OutOfBoundsError } from '@/utils/coordinates/coordinateUtils'
+import { EmptyKMLError } from '@/utils/kmlUtils'
 import log from '@/utils/logging'
 
 const LOCAL_UPLOAD_ACCEPT = '.kml,.KML,.gpx,.GPX'
@@ -72,8 +74,14 @@ async function loadFile() {
             handleFileContent(store, content, selectedFile.value.name)
             layerAdded.value = true
         } catch (error) {
-            errorMessage.value = 'invalid_kml_gpx_file_error'
-            log.error(`Failed to load file`, error)
+            if (error instanceof OutOfBoundsError) {
+                errorMessage.value = 'kml_gpx_file_out_of_bounds'
+            } else if (error instanceof EmptyKMLError) {
+                errorMessage.value = 'kml_gpx_file_empty'
+            } else {
+                errorMessage.value = 'invalid_kml_gpx_file_error'
+                log.error(`Failed to load file`, error)
+            }
         }
     }
 

--- a/src/modules/menu/components/advancedTools/ImportFile/ImportFileOnlineTab.vue
+++ b/src/modules/menu/components/advancedTools/ImportFile/ImportFileOnlineTab.vue
@@ -6,6 +6,8 @@ import { useStore } from 'vuex'
 import ImportFileButtons from '@/modules/menu/components/advancedTools/ImportFile/ImportFileButtons.vue'
 import { handleFileContent } from '@/modules/menu/components/advancedTools/ImportFile/utils'
 import TextInput from '@/utils/components/TextInput.vue'
+import { OutOfBoundsError } from '@/utils/coordinates/coordinateUtils'
+import { EmptyKMLError } from '@/utils/kmlUtils'
 import log from '@/utils/logging'
 import { isValidUrl } from '@/utils/utils'
 
@@ -74,6 +76,10 @@ async function loadFile() {
         if (error instanceof AxiosError || /fetch/.test(error.message)) {
             log.error(`Failed to load file from url ${fileUrl.value}`, error)
             urlError.value = 'loading_error_network_failure'
+        } else if (error instanceof OutOfBoundsError) {
+            urlError.value = 'kml_gpx_file_out_of_bounds'
+        } else if (error instanceof EmptyKMLError) {
+            urlError.value = 'kml_gpx_file_empty'
         } else {
             log.error(`Failed to parse file from url ${fileUrl.value}`, error)
             urlError.value = 'invalid_kml_gpx_file_error'

--- a/src/store/plugins/external-layers.plugin.js
+++ b/src/store/plugins/external-layers.plugin.js
@@ -53,12 +53,10 @@ async function updateExternalLayer(store, externalLayer, projection) {
         store.dispatch('updateLayer', updatedExternalLayer)
     } catch (error) {
         log.error(`Failed to update external layer: `, error)
-        const erroredLayer = {
-            id: externalLayer.getID(),
+        store.dispatch('setLayerErrorKey', {
+            layerId: externalLayer.getID(),
             errorKey: error.key ? error.key : 'error',
-            hasError: true,
-        }
-        store.dispatch('updateLayer', erroredLayer)
+        })
     }
 }
 

--- a/src/store/plugins/load-kml-data.plugin.js
+++ b/src/store/plugins/load-kml-data.plugin.js
@@ -5,7 +5,6 @@
 
 import { loadKmlData, loadKmlMetadata } from '@/api/files.api'
 import KMLLayer from '@/api/layers/KMLLayer.class'
-import { updateKmlActiveLayer } from '@/utils/kmlUtils'
 import log from '@/utils/logging'
 
 /**
@@ -17,7 +16,7 @@ async function loadMetadata(store, kmlLayer) {
     log.debug(`Loading metadata for added KML layer`, kmlLayer)
     try {
         const metadata = await loadKmlMetadata(kmlLayer)
-        updateKmlActiveLayer(store, kmlLayer, null, metadata)
+        store.dispatch('updateKmlLayer', { layerId: kmlLayer?.getID(), kmlMetadata: metadata })
     } catch (error) {
         log.error(`Error while fetching KML metadata for layer ${kmlLayer?.getID()}`)
     }
@@ -32,9 +31,13 @@ async function loadData(store, kmlLayer) {
     log.debug(`Loading data for added KML layer`, kmlLayer)
     try {
         const data = await loadKmlData(kmlLayer)
-        updateKmlActiveLayer(store, kmlLayer, data)
+        store.dispatch('updateKmlLayer', { layerId: kmlLayer?.getID(), kmlData: data })
     } catch (error) {
-        log.error(`Error while fetching KML data for layer ${kmlLayer?.getID()}`)
+        log.error(`Error while fetching KML data for layer ${kmlLayer?.getID()}: ${error}`)
+        store.dispatch('setLayerErrorKey', {
+            layerId: kmlLayer.getID(),
+            errorKey: `loading_error_network_failure`,
+        })
     }
 }
 

--- a/src/utils/__tests__/kmlUtils.spec.js
+++ b/src/utils/__tests__/kmlUtils.spec.js
@@ -1,0 +1,206 @@
+import { expect } from 'chai'
+import { describe, it } from 'vitest'
+
+import { LV95 } from '@/utils/coordinates/coordinateSystems'
+import { getKmlExtent, getKmlExtentForProjection } from '@/utils/kmlUtils'
+
+describe('Test KML utils', () => {
+    describe('get KML Extent', () => {
+        it('get extent of a single feature', () => {
+            const content = `<?xml version="1.0" encoding="UTF-8"?>
+            <kml xmlns="http://www.opengis.net/kml/2.2">
+                <Document>
+                    <Placemark>
+                        <name>Sample Placemark</name>
+                        <description>This is a sample KML Placemark.</description>
+                        <Point>
+                        <coordinates>8.117189,46.852375</coordinates>
+                        </Point>
+                    </Placemark>
+                </Document>
+            </kml>
+            `
+            const extent = getKmlExtent(content)
+
+            expect(extent).to.deep.equal([8.117189, 46.852375, 8.117189, 46.852375])
+        })
+        it('get extent of a single line feature crossing europe', () => {
+            const content = `<?xml version="1.0" encoding="UTF-8"?>
+            <kml xmlns="http://www.opengis.net/kml/2.2">
+                <Document>
+                    <Placemark>
+                        <name>Line accross europe and switzerland</name>
+                        <description>This is a sample KML Placemark.</description>
+                        <LineString>
+                            <coordinates>
+                                -0.771255570521181,47.49354012712542,0
+                                2.274382135396515,47.72412908565185,0
+                                4.437570870313552,46.75086073673278,0
+                                6.524331142187565,46.85471653404525,0
+                                7.977505534554298,46.45920177484218,0
+                                8.377161172051387,46.87625449359594,0
+                                10.28654975787117,46.54805193225931,0
+                                13.85851000860247,47.33184853266135,0
+                                15.69760034017345,47.60792210418662,0
+                            </coordinates>
+                        </LineString>
+                    </Placemark>
+                </Document>
+            </kml>
+            `
+            const extent = getKmlExtent(content)
+
+            expect(extent).to.deep.equal([
+                -0.771255570521181, 46.45920177484218, 15.69760034017345, 47.72412908565185,
+            ])
+        })
+        it('get extent of multiples features (marker, line, polygone)', () => {
+            const content = `<?xml version="1.0" encoding="UTF-8"?>
+            <kml xmlns="http://www.opengis.net/kml/2.2">
+                <Document>
+                    <Placemark>
+                        <name>My Marker</name>
+                        <Point>
+                            <coordinates>7.659940678339698,46.95427014117109,843.3989330301123</coordinates>
+                        </Point>
+                    </Placemark>
+                    <Placemark>
+                        <name>No title</name>
+                        <Point>
+                            <coordinates>7.84495931692009,46.92430731160568,801.1875341365708</coordinates>
+                        </Point>
+                    </Placemark>
+                    <Placemark>
+                        <name>Polygone sans titre</name>
+                        <Polygon>
+                            <outerBoundaryIs>
+                                <LinearRing>
+                                    <coordinates>
+                                        7.736857178846723,46.82670125209653,0 8.06124136917296,46.75405886506746,0 8.092263503513564,46.88254009447432,0 7.674984953448975,46.90741897412888,0 7.736857178846723,46.82670125209653,0
+                                    </coordinates>
+                                </LinearRing>
+                            </outerBoundaryIs>
+                        </Polygon>
+                    </Placemark>
+                    <Placemark>
+                        <name>This is a line</name>
+                        <LineString>
+                            <coordinates>
+                                7.661326190900879,46.9229765613044,0 7.736317332421581,46.95310606597951,0 7.783350668405761,46.96964910688379,0 7.819080121407933,46.95554156911379,0 7.895270534105141,46.9409704077278,0
+                            </coordinates>
+                        </LineString>
+                    </Placemark>
+                </Document>
+            </kml>
+            `
+            const extent = getKmlExtent(content)
+
+            expect(extent).to.deep.equal([
+                7.659940678339698, 46.75405886506746, 8.092263503513564, 46.96964910688379,
+            ])
+        })
+    })
+    describe('get KML Extent within projection bounds', () => {
+        it('get extent of a single feature', () => {
+            const content = `<?xml version="1.0" encoding="UTF-8"?>
+            <kml xmlns="http://www.opengis.net/kml/2.2">
+                <Document>
+                    <Placemark>
+                        <name>Sample Placemark</name>
+                        <description>This is a sample KML Placemark.</description>
+                        <Point>
+                        <coordinates>8.117189,46.852375</coordinates>
+                        </Point>
+                    </Placemark>
+                </Document>
+            </kml>
+            `
+            const extent = getKmlExtent(content)
+            const projectedExtent = getKmlExtentForProjection(LV95, extent)
+
+            expect(projectedExtent).to.deep.equal([
+                [2651749.9748876626, 1189249.9890369223],
+                [2651749.9748876626, 1189249.9890369223],
+            ])
+        })
+        it('get extent of a single line feature crossing europe', () => {
+            const content = `<?xml version="1.0" encoding="UTF-8"?>
+            <kml xmlns="http://www.opengis.net/kml/2.2">
+                <Document>
+                    <Placemark>
+                        <name>Line accross europe and switzerland</name>
+                        <description>This is a sample KML Placemark.</description>
+                        <LineString>
+                            <coordinates>
+                                -0.771255570521181,47.49354012712542,0
+                                2.274382135396515,47.72412908565185,0
+                                4.437570870313552,46.75086073673278,0
+                                6.524331142187565,46.85471653404525,0
+                                7.977505534554298,46.45920177484218,0
+                                8.377161172051387,46.87625449359594,0
+                                10.28654975787117,46.54805193225931,0
+                                13.85851000860247,47.33184853266135,0
+                                15.69760034017345,47.60792210418662,0
+                            </coordinates>
+                        </LineString>
+                    </Placemark>
+                </Document>
+            </kml>
+            `
+            const extent = getKmlExtent(content)
+            const projectedExtent = getKmlExtentForProjection(LV95, extent)
+
+            expect(projectedExtent).to.deep.equal([
+                [2423458.972383674, 1147908.7345235168],
+                [2902899.0399873387, 1293747.491178336],
+            ])
+        })
+        it('get extent of multiples features (marker, line, polygone)', () => {
+            const content = `<?xml version="1.0" encoding="UTF-8"?>
+            <kml xmlns="http://www.opengis.net/kml/2.2">
+                <Document>
+                    <Placemark>
+                        <name>My Marker</name>
+                        <Point>
+                            <coordinates>7.659940678339698,46.95427014117109,843.3989330301123</coordinates>
+                        </Point>
+                    </Placemark>
+                    <Placemark>
+                        <name>No title</name>
+                        <Point>
+                            <coordinates>7.84495931692009,46.92430731160568,801.1875341365708</coordinates>
+                        </Point>
+                    </Placemark>
+                    <Placemark>
+                        <name>Polygone sans titre</name>
+                        <Polygon>
+                            <outerBoundaryIs>
+                                <LinearRing>
+                                    <coordinates>
+                                        7.736857178846723,46.82670125209653,0 8.06124136917296,46.75405886506746,0 8.092263503513564,46.88254009447432,0 7.674984953448975,46.90741897412888,0 7.736857178846723,46.82670125209653,0
+                                    </coordinates>
+                                </LinearRing>
+                            </outerBoundaryIs>
+                        </Polygon>
+                    </Placemark>
+                    <Placemark>
+                        <name>This is a line</name>
+                        <LineString>
+                            <coordinates>
+                                7.661326190900879,46.9229765613044,0 7.736317332421581,46.95310606597951,0 7.783350668405761,46.96964910688379,0 7.819080121407933,46.95554156911379,0 7.895270534105141,46.9409704077278,0
+                            </coordinates>
+                        </LineString>
+                    </Placemark>
+                </Document>
+            </kml>
+            `
+            const extent = getKmlExtent(content)
+            const projectedExtent = getKmlExtentForProjection(LV95, extent)
+
+            expect(projectedExtent).to.deep.equal([
+                [2616908.846006978, 1178120.7002258834],
+                [2649740.5472833975, +1202270.7737464283],
+            ])
+        })
+    })
+})

--- a/src/utils/components/ErrorButton.vue
+++ b/src/utils/components/ErrorButton.vue
@@ -34,6 +34,12 @@ onMounted(() => {
         placement: 'top',
         touch: false,
         hideOnClick: false,
+        onCreate: (instance) => {
+            const dataCy = instance.reference.getAttribute('data-cy')
+            if (dataCy) {
+                instance.popper.setAttribute('data-cy', `tippy-${dataCy}`)
+            }
+        },
     })
 })
 

--- a/src/utils/coordinates/__test__/coordinateUtils.spec.js
+++ b/src/utils/coordinates/__test__/coordinateUtils.spec.js
@@ -3,7 +3,11 @@ import proj4 from 'proj4'
 import { describe, it } from 'vitest'
 
 import { LV03, LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
-import { reprojectUnknownSrsCoordsToWGS84 } from '@/utils/coordinates/coordinateUtils'
+import {
+    flattenExtent,
+    normalizeExtent,
+    reprojectUnknownSrsCoordsToWGS84,
+} from '@/utils/coordinates/coordinateUtils'
 
 describe('Unit test functions from coordinateUtils.js', () => {
     describe('reprojectUnknownSrsCoordsToWGS84(x,y)', () => {
@@ -73,6 +77,30 @@ describe('Unit test functions from coordinateUtils.js', () => {
                 reprojectUnknownSrsCoordsToWGS84(coordinatesWGS84[1], coordinatesWGS84[0]),
                 coordinatesWGS84
             )
+        })
+        it('normalize an extent', () => {
+            const flatExtent = [1, 2, 3, 4]
+            const result = normalizeExtent(flatExtent)
+            expect(result).to.have.length(2)
+            expect(result[0]).to.have.length(2)
+            expect(result[1]).to.have.length(2)
+            expect(result[0][0]).to.equal(1)
+            expect(result[0][1]).to.equal(2)
+            expect(result[1][0]).to.equal(3)
+            expect(result[1][1]).to.equal(4)
+
+            expect(normalizeExtent(result)).to.deep.equal(result)
+        })
+        it('flattern an extent', () => {
+            const normalizedExtent = [
+                [1, 2],
+                [3, 4],
+            ]
+            const flatExtent = flattenExtent(normalizedExtent)
+            expect(flatExtent).to.have.length(4)
+            expect(flatExtent).to.deep.equal([1, 2, 3, 4])
+
+            expect(flattenExtent(flatExtent)).to.deep.equal([1, 2, 3, 4])
         })
     })
 })

--- a/src/utils/coordinates/coordinateUtils.js
+++ b/src/utils/coordinates/coordinateUtils.js
@@ -82,3 +82,47 @@ export function projExtent(fromProj, toProj, extent) {
     }
     return null
 }
+
+/**
+ * Return an extent normalized to [[x, y], [x, y]] from a flat extent
+ *
+ * @param {Array} extent Extent to normalize
+ * @returns {Array} Extent in the form [[x, y], [x, y]]
+ */
+export function normalizeExtent(extent) {
+    let extentNormalized = extent
+    if (extent?.length === 4) {
+        // convert to the flat extent to [[x, y], [x, y]]
+        extentNormalized = [
+            [extent[0], extent[1]],
+            [extent[2], extent[3]],
+        ]
+    } else if (extent?.length !== 2) {
+        throw new Error(`Invalid extent: ${extent}`)
+    }
+    return extentNormalized
+}
+
+/**
+ * Flatten extent
+ *
+ * @param {Array} extent Extent to flatten
+ * @returns {Array} Flatten extent in from [minx, miny, maxx, maxy]
+ */
+export function flattenExtent(extent) {
+    let flattenExtent = extent
+    if (extent?.length === 2) {
+        flattenExtent = [...extent[0], ...extent[1]]
+    } else if (extent?.length !== 4) {
+        throw new Error(`Invalid extent: ${extent}`)
+    }
+    return flattenExtent
+}
+
+/** Coordinates or extent out of bounds error */
+export class OutOfBoundsError extends Error {
+    constructor(message) {
+        super(message)
+        this.name = 'OutOfBoundsError'
+    }
+}

--- a/src/utils/kmlUtils.js
+++ b/src/utils/kmlUtils.js
@@ -1,4 +1,14 @@
+import {
+    createEmpty as emptyExtent,
+    extend as extendExtent,
+    getIntersection as getExtentIntersection,
+    isEmpty as isExtentEmpty,
+} from 'ol/extent'
 import KML from 'ol/format/KML'
+
+import { WGS84 } from '@/utils/coordinates/coordinateSystems'
+import { normalizeExtent, projExtent } from '@/utils/coordinates/coordinateUtils'
+import log from '@/utils/logging'
 
 /**
  * Read the KML name
@@ -13,24 +23,47 @@ export function parseKmlName(content) {
 }
 
 /**
- * Update a KML Active Layer
+ * Get KML extent
  *
- * @param {Store} store
- * @param {KMLLayer} kmlLayer KML Layer object to update
- * @param {string | null} data KML data as string
- * @param {JSON | null} metadata KML metadata as JSON (only for geoadmin KML)
+ * @param {string} conetnt KML content
+ * @returns {ol/extent|null} KML layer extent in WGS84 projection or null if the KML has no features
  */
-export async function updateKmlActiveLayer(store, kmlLayer, data = null, metadata = null) {
-    if (data || metadata) {
-        const updateObj = { id: kmlLayer.getID() }
-        if (data) {
-            updateObj.kmlData = data
-            updateObj.name = parseKmlName(data)
-            updateObj.isLoading = false
-        }
-        if (metadata) {
-            updateObj.kmlMetadata = metadata
-        }
-        await store.dispatch('updateLayer', updateObj)
+export function getKmlExtent(content) {
+    const kml = new KML()
+    const features = kml.readFeatures(content, {
+        dataProjection: WGS84.epsg, // KML files should always be in WGS84
+        featureProjection: WGS84.epsg,
+    })
+    const extent = emptyExtent()
+    features.forEach((feature) => {
+        extendExtent(extent, feature.getGeometry().getExtent())
+    })
+    if (isExtentEmpty(extent)) {
+        return null
     }
+    return extent
 }
+
+/**
+ * Get KML extent for the projection bounds.
+ *
+ * @param {CoordinateSystem} projection Projection in which to get the KML extent
+ * @param {[minx, miny, maxx, maxy]} kmlExtent KML extent in WGS84
+ * @returns {null | [[minx, miny], [maxx, maxy]]} Return null if the KML is out of projection bounds
+ *   or the intersect extent between KML and projection bounds. The return extent is re-projected to
+ *   the projection
+ */
+export function getKmlExtentForProjection(projection, extent) {
+    const projectionBounds = projection.getBoundsAs(WGS84).flatten
+    let intersectExtent = getExtentIntersection(projectionBounds, extent)
+    log.debug(
+        `Get KML extent for projection ${projection.epsg}, ` +
+            `kmlExtent=${extent}, projectionBounds=${projectionBounds}, intersectExtent=${intersectExtent}`
+    )
+    if (!isExtentEmpty(intersectExtent)) {
+        return normalizeExtent(projExtent(WGS84, projection, intersectExtent))
+    }
+    return null
+}
+
+export class EmptyKMLError extends Error {}

--- a/tests/cypress/fixtures/import-tool/empty.kml
+++ b/tests/cypress/fixtures/import-tool/empty.kml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Document>
+	<name>Empty KML</name>
+</Document>
+</kml>

--- a/tests/cypress/fixtures/import-tool/external-kml-file.kml
+++ b/tests/cypress/fixtures/import-tool/external-kml-file.kml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <kml xmlns="http://www.opengis.net/kml/2.2">
-  <Placemark>
-    <name>Sample Placemark</name>
-    <description>This is a sample KML Placemark.</description>
-    <Point>
-      <coordinates>8.117189,46.852375</coordinates>
-    </Point>
-  </Placemark>
+  <Document>
+    <Placemark>
+      <name>Sample Placemark</name>
+      <description>This is a sample KML Placemark.</description>
+      <Point>
+        <coordinates>9.749210,46.707841</coordinates>
+      </Point>
+    </Placemark>
+  </Document>
 </kml>

--- a/tests/cypress/fixtures/import-tool/line-accross-eu.kml
+++ b/tests/cypress/fixtures/import-tool/line-accross-eu.kml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2"
+	xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+	<Document>
+		<name>Line accross europe</name>
+		<gx:CascadingStyle kml:id="__managed_style_28D420FFB62E52351BDC">
+			<Style>
+				<IconStyle>
+					<scale>1.2</scale>
+					<Icon>
+						<href>
+							https://earth.google.com/earth/rpc/cc/icon?color=1976d2&amp;id=2000&amp;scale=4</href>
+					</Icon>
+					<hotSpot x="64" y="128" xunits="pixels" yunits="insetPixels" />
+				</IconStyle>
+				<LabelStyle>
+				</LabelStyle>
+				<LineStyle>
+					<color>ff2dc0fb</color>
+					<width>6</width>
+				</LineStyle>
+				<PolyStyle>
+					<color>40ffffff</color>
+				</PolyStyle>
+				<BalloonStyle>
+					<displayMode>hide</displayMode>
+				</BalloonStyle>
+			</Style>
+		</gx:CascadingStyle>
+		<gx:CascadingStyle kml:id="__managed_style_187D6D7EAC2E52351BDC">
+			<Style>
+				<IconStyle>
+					<Icon>
+						<href>
+							https://earth.google.com/earth/rpc/cc/icon?color=1976d2&amp;id=2000&amp;scale=4</href>
+					</Icon>
+					<hotSpot x="64" y="128" xunits="pixels" yunits="insetPixels" />
+				</IconStyle>
+				<LabelStyle>
+				</LabelStyle>
+				<LineStyle>
+					<color>ff2dc0fb</color>
+					<width>4</width>
+				</LineStyle>
+				<PolyStyle>
+					<color>40ffffff</color>
+				</PolyStyle>
+				<BalloonStyle>
+					<displayMode>hide</displayMode>
+				</BalloonStyle>
+			</Style>
+		</gx:CascadingStyle>
+		<StyleMap id="__managed_style_051666CBF82E52351BDC">
+			<Pair>
+				<key>normal</key>
+				<styleUrl>#__managed_style_187D6D7EAC2E52351BDC</styleUrl>
+			</Pair>
+			<Pair>
+				<key>highlight</key>
+				<styleUrl>#__managed_style_28D420FFB62E52351BDC</styleUrl>
+			</Pair>
+		</StyleMap>
+		<Placemark id="0658EB55B12E52351BDB">
+			<name>Across Switzerland</name>
+			<LookAt>
+				<longitude>7.861238525263361</longitude>
+				<latitude>44.92129093460304</latitude>
+				<altitude>640.3042845829615</altitude>
+				<heading>0</heading>
+				<tilt>0</tilt>
+				<gx:fovy>30.00079335</gx:fovy>
+				<range>4255783.305492997</range>
+				<altitudeMode>absolute</altitudeMode>
+			</LookAt>
+			<styleUrl>#__managed_style_051666CBF82E52351BDC</styleUrl>
+			<LineString>
+				<coordinates>
+					-0.771255570521181,47.49354012712542,0 2.274382135396515,47.72412908565185,0
+					4.437570870313552,46.75086073673278,0 6.524331142187565,46.85471653404525,0
+					7.977505534554298,46.45920177484218,0 8.377161172051387,46.87625449359594,0
+					10.28654975787117,46.54805193225931,0 13.85851000860247,47.33184853266135,0
+					15.69760034017345,47.60792210418662,0
+				</coordinates>
+			</LineString>
+		</Placemark>
+	</Document>
+</kml>

--- a/tests/cypress/fixtures/import-tool/paris.kml
+++ b/tests/cypress/fixtures/import-tool/paris.kml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Document>
+	<name>paris</name>
+	<gx:CascadingStyle kml:id="__managed_style_235D90EB2C2E51D74FB5">
+		<Style>
+			<IconStyle>
+				<scale>1.2</scale>
+				<Icon>
+					<href>https://earth.google.com/earth/rpc/cc/icon?color=1976d2&amp;id=2000&amp;scale=4</href>
+				</Icon>
+				<hotSpot x="64" y="128" xunits="pixels" yunits="insetPixels"/>
+			</IconStyle>
+			<LabelStyle>
+			</LabelStyle>
+			<LineStyle>
+				<color>ff2dc0fb</color>
+				<width>6</width>
+			</LineStyle>
+			<PolyStyle>
+				<color>40ffffff</color>
+			</PolyStyle>
+			<BalloonStyle>
+				<displayMode>hide</displayMode>
+			</BalloonStyle>
+		</Style>
+	</gx:CascadingStyle>
+	<gx:CascadingStyle kml:id="__managed_style_10EB57D7D62E51D74FB5">
+		<Style>
+			<IconStyle>
+				<Icon>
+					<href>https://earth.google.com/earth/rpc/cc/icon?color=1976d2&amp;id=2000&amp;scale=4</href>
+				</Icon>
+				<hotSpot x="64" y="128" xunits="pixels" yunits="insetPixels"/>
+			</IconStyle>
+			<LabelStyle>
+			</LabelStyle>
+			<LineStyle>
+				<color>ff2dc0fb</color>
+				<width>4</width>
+			</LineStyle>
+			<PolyStyle>
+				<color>40ffffff</color>
+			</PolyStyle>
+			<BalloonStyle>
+				<displayMode>hide</displayMode>
+			</BalloonStyle>
+		</Style>
+	</gx:CascadingStyle>
+	<StyleMap id="__managed_style_00B43DF4652E51D74FB5">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#__managed_style_10EB57D7D62E51D74FB5</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#__managed_style_235D90EB2C2E51D74FB5</styleUrl>
+		</Pair>
+	</StyleMap>
+	<Placemark id="0D61C19A612E51D74FB3">
+		<name>Paris</name>
+		<LookAt>
+			<longitude>1.63099469494228</longitude>
+			<latitude>47.72434808355845</latitude>
+			<altitude>289.1190974965373</altitude>
+			<heading>0</heading>
+			<tilt>0</tilt>
+			<gx:fovy>30.00079335</gx:fovy>
+			<range>1337806.490011364</range>
+			<altitudeMode>absolute</altitudeMode>
+		</LookAt>
+		<styleUrl>#__managed_style_00B43DF4652E51D74FB5</styleUrl>
+		<Point>
+			<coordinates>2.357910202352023,48.77107906667177,63.6427936441105</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark id="08279583952E51D7ABB3">
+		<name>Around Paris</name>
+		<LookAt>
+			<longitude>1.63099469494228</longitude>
+			<latitude>47.72434808355845</latitude>
+			<altitude>289.1190974965373</altitude>
+			<heading>0</heading>
+			<tilt>0</tilt>
+			<gx:fovy>30.00079335</gx:fovy>
+			<range>1337806.490011364</range>
+			<altitudeMode>absolute</altitudeMode>
+		</LookAt>
+		<styleUrl>#__managed_style_00B43DF4652E51D74FB5</styleUrl>
+		<Polygon>
+			<outerBoundaryIs>
+				<LinearRing>
+					<coordinates>
+						0.5094097468560621,48.631658237171,0 3.317001783239044,48.37794428096584,0 3.466861284145009,49.09399373713251,0 2.26901763217032,49.53081236749633,0 0.5094097468560621,48.631658237171,0 
+					</coordinates>
+				</LinearRing>
+			</outerBoundaryIs>
+		</Polygon>
+	</Placemark>
+</Document>
+</kml>


### PR DESCRIPTION
Now when importing a KML file we automatically zoom to its extent

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-95-kml-zoom-to-extent/index.html)