### PR TITLE
PB-95: add an animation when we open the import file popup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
                 "file-saver": "^2.0.5",
                 "form-data": "^4.0.0",
                 "geographiclib-geodesic": "^2.0.0",
+                "gsap": "^3.12.5",
                 "hammerjs": "^2.0.8",
                 "jquery": "^3.7.1",
                 "liang-barsky": "^1.0.5",
@@ -5102,6 +5103,11 @@
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true
+        },
+        "node_modules/gsap": {
+            "version": "3.12.5",
+            "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.12.5.tgz",
+            "integrity": "sha512-srBfnk4n+Oe/ZnMIOXt3gT605BX9x5+rh/prT2F1SsNJsU1XuMiP0E2aptW481OnonOGACZWBqseH5Z7csHxhQ=="
         },
         "node_modules/gtoken": {
             "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "file-saver": "^2.0.5",
         "form-data": "^4.0.0",
         "geographiclib-geodesic": "^2.0.0",
+        "gsap": "^3.12.5",
         "hammerjs": "^2.0.8",
         "jquery": "^3.7.1",
         "liang-barsky": "^1.0.5",

--- a/src/modules/menu/components/advancedTools/ImportFile/ImportFile.vue
+++ b/src/modules/menu/components/advancedTools/ImportFile/ImportFile.vue
@@ -45,11 +45,21 @@ function onEnter(el, done) {
         onComplete: done,
     })
 }
+
+function onAfterEnter() {
+    // for iOs devices, we need to scroll down to the bottom so that the import popup is not covered by the keyboard
+    window.scrollBy(0, window.innerHeight)
+}
 </script>
 
 <template>
     <teleport to="#map-footer-middle-1">
-        <Transition :css="false" @before-enter="onBeforeEnter" @enter="onEnter">
+        <Transition
+            :css="false"
+            @before-enter="onBeforeEnter"
+            @enter="onEnter"
+            @after-enter="onAfterEnter"
+        >
             <SimpleWindow
                 v-if="debounceAnimate"
                 title="import_file"

--- a/src/modules/menu/components/advancedTools/ImportFile/ImportFile.vue
+++ b/src/modules/menu/components/advancedTools/ImportFile/ImportFile.vue
@@ -1,66 +1,105 @@
 <script setup>
-import { ref } from 'vue'
+import gsap from 'gsap'
+import { nextTick, onMounted, ref } from 'vue'
 import { useStore } from 'vuex'
 
 import ImportFileLocalTab from '@/modules/menu/components/advancedTools/ImportFile/ImportFileLocalTab.vue'
 import ImportFileOnlineTab from '@/modules/menu/components/advancedTools/ImportFile/ImportFileOnlineTab.vue'
 import SimpleWindow from '@/utils/components/SimpleWindow.vue'
 
+const debounceAnimate = ref(false)
 const selectedTab = ref('online')
 
 const store = useStore()
+
+onMounted(() => {
+    // using a boolean and a v-if to trigger the Vue Transition
+    // starting with our element hidden (not added to the DOM)
+    debounceAnimate.value = false
+    // after a tick of Vue's lifecycle, add the element to the DOM
+    // this will trigger the animation from the Transition
+    nextTick(() => {
+        debounceAnimate.value = true
+    })
+})
+
+function onBeforeEnter(el) {
+    // setting the import popup minimized, outside the screen (on the top-left position, behind the menu)
+    gsap.set(el, {
+        x: `-100vw`,
+        y: `-100vh`,
+        scaleX: 0,
+        scaleY: 0,
+    })
+}
+
+function onEnter(el, done) {
+    // moving the import popup back where it naturally sits
+    gsap.to(el, {
+        // no duration set, default is 0.5sec
+        x: 0,
+        y: 0,
+        scaleX: 1,
+        scaleY: 1,
+        // important : call the done() callback to tell the Transition we are done
+        onComplete: done,
+    })
+}
 </script>
 
 <template>
     <teleport to="#map-footer-middle-1">
-        <SimpleWindow
-            title="import_file"
-            class="rounded-0"
-            @close="store.dispatch('toggleImportFile')"
-        >
-            <div data-cy="import-file-content" class="container">
-                <ul class="nav nav-tabs" role="tablist">
-                    <li class="nav-item" role="presentation">
-                        <button
-                            class="nav-link py-1"
-                            :class="{
-                                active: selectedTab === 'online',
-                            }"
-                            type="button"
-                            role="tab"
-                            aria-controls="nav-online"
-                            :aria-selected="selectedTab === 'online'"
-                            data-cy="import-file-online-btn"
-                            @click="selectedTab = 'online'"
-                        >
-                            Online
-                        </button>
-                    </li>
-                    <li class="nav-item" role="presentation">
-                        <button
-                            class="nav-link py-1"
-                            :class="{
-                                active: selectedTab === 'local',
-                            }"
-                            type="button"
-                            role="tab"
-                            aria-controls="nav-local"
-                            :aria-selected="selectedTab === 'local'"
-                            data-cy="import-file-local-btn"
-                            @click="selectedTab = 'local'"
-                        >
-                            Local
-                        </button>
-                    </li>
-                </ul>
-                <div class="tab-content mt-2">
-                    <!-- Online Tab -->
-                    <ImportFileOnlineTab :active="selectedTab === 'online'" />
-                    <!-- Local tab -->
-                    <ImportFileLocalTab :active="selectedTab === 'local'" />
+        <Transition :css="false" @before-enter="onBeforeEnter" @enter="onEnter">
+            <SimpleWindow
+                v-if="debounceAnimate"
+                title="import_file"
+                class="rounded-0"
+                @close="store.dispatch('toggleImportFile')"
+            >
+                <div data-cy="import-file-content" class="container">
+                    <ul class="nav nav-tabs" role="tablist">
+                        <li class="nav-item" role="presentation">
+                            <button
+                                class="nav-link py-1"
+                                :class="{
+                                    active: selectedTab === 'online',
+                                }"
+                                type="button"
+                                role="tab"
+                                aria-controls="nav-online"
+                                :aria-selected="selectedTab === 'online'"
+                                data-cy="import-file-online-btn"
+                                @click="selectedTab = 'online'"
+                            >
+                                Online
+                            </button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button
+                                class="nav-link py-1"
+                                :class="{
+                                    active: selectedTab === 'local',
+                                }"
+                                type="button"
+                                role="tab"
+                                aria-controls="nav-local"
+                                :aria-selected="selectedTab === 'local'"
+                                data-cy="import-file-local-btn"
+                                @click="selectedTab = 'local'"
+                            >
+                                Local
+                            </button>
+                        </li>
+                    </ul>
+                    <div class="tab-content mt-2">
+                        <!-- Online Tab -->
+                        <ImportFileOnlineTab :active="selectedTab === 'online'" />
+                        <!-- Local tab -->
+                        <ImportFileLocalTab :active="selectedTab === 'local'" />
+                    </div>
                 </div>
-            </div>
-        </SimpleWindow>
+            </SimpleWindow>
+        </Transition>
     </teleport>
 </template>
 


### PR DESCRIPTION
using GSAP to achieve this, as it is much easier to set multiple CSS properties this way, and it has a built-in animation engine when changing the CSS style.

I couldn't find an easy solution to place this element on top of its parent (the menu "Import file") so I resorted to place it behind the menu when it opens up.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_pb-95_animate_import_file_open/index.html)