### PR TITLE
PB-105: Remove menu share spinner and make embed ui similar to import maps

### DIFF
--- a/src/modules/drawing/components/DrawingToolbox.vue
+++ b/src/modules/drawing/components/DrawingToolbox.vue
@@ -82,7 +82,9 @@ function onDeleteLastPoint() {
     <teleport to=".drawing-toolbox-in-menu">
         <DrawingHeader v-if="isDesktopMode" @close="closeDrawing" />
         <div :class="[{ 'drawing-toolbox-closed': !drawMenuOpen }, 'drawing-toolbox']">
-            <div class="card text-center drawing-toolbox-content rounded-0">
+            <div
+                class="card text-center drawing-toolbox-content shadow-lg rounded-bottom rounded-top-0 rounded-start-0"
+            >
                 <div class="card-body position-relative container">
                     <div
                         class="row justify-content-start g-2"

--- a/src/modules/menu/MenuModule.vue
+++ b/src/modules/menu/MenuModule.vue
@@ -125,7 +125,11 @@ function toggleMenu() {
                 >
                     <MenuTray
                         class="menu-tray-content"
-                        :class="{ 'shadow-lg': isDesktopMode, 'rounded-bottom': isDesktopMode }"
+                        :class="{
+                            'shadow-lg': isDesktopMode,
+                            'rounded-bottom': isDesktopMode,
+                            'rounded-start-0': isDesktopMode,
+                        }"
                         :compact="isDesktopMode"
                     />
                     <button

--- a/src/modules/menu/components/LayerCatalogueItem.vue
+++ b/src/modules/menu/components/LayerCatalogueItem.vue
@@ -286,8 +286,8 @@ function containsLayer(layers, searchText) {
         }
     }
 }
-.menu-catalogue-item-title:hover {
-    background-color: $list-item-hover-bg-color;
+.menu-catalogue-item-title {
+    @extend .menu-item;
 }
 .menu-catalogue-item-name {
     @extend .menu-name;

--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
@@ -265,6 +265,7 @@ export default {
 }
 
 .menu-layer-item {
+    @extend .menu-item;
     border-bottom: 1px solid $gray-400;
 }
 .menu-layer-item-title {

--- a/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
+++ b/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="advanced-tools-list px-2 py-1">
+    <div class="advanced-tools-list">
         <MenuAdvancedToolsListItem
             :is-selected="showImportCatalogue"
             title="import_maps"
@@ -8,7 +8,7 @@
             data-cy="menu-advanced-tools-import-catalogue"
             @toggle-menu="onToggleImportCatalogue"
         >
-            <ImportCatalogue v-show="showImportCatalogue" :compact="compact" />
+            <ImportCatalogue v-show="showImportCatalogue" class="py-2" :compact="compact" />
         </MenuAdvancedToolsListItem>
         <MenuAdvancedToolsListItem
             :is-selected="showImportFile"

--- a/src/modules/menu/components/advancedTools/MenuAdvancedToolsListItem.vue
+++ b/src/modules/menu/components/advancedTools/MenuAdvancedToolsListItem.vue
@@ -74,15 +74,16 @@ onUnmounted(() => {
 
 <style lang="scss" scoped>
 @import 'src/scss/webmapviewer-bootstrap-theme';
+@import 'src/modules/menu/scss/menu-items';
 .advanced-tools-item {
     .advanced-tools-title {
+        // Here we add the menu-item styling to the title only to avoid hover
+        // on the content once the item has been opened
+        @extend .menu-item;
+
         cursor: pointer;
         height: 2.75em;
         line-height: 2.75em;
-    }
-    .advanced-tools-title:hover,
-    .advanced-tools-title:focus {
-        color: $list-item-hover-text-color !important;
     }
 }
 </style>

--- a/src/modules/menu/components/advancedTools/MenuAdvancedToolsListItem.vue
+++ b/src/modules/menu/components/advancedTools/MenuAdvancedToolsListItem.vue
@@ -56,13 +56,13 @@ onUnmounted(() => {
 <template>
     <div class="advanced-tools-item border-bottom">
         <a
-            class="d-flex align-items-center advanced-tools-title text-decoration-none"
+            class="d-flex align-items-center advanced-tools-title text-decoration-none ps-2"
             :class="{ 'text-primary': isSelected, 'text-black': !isSelected }"
             :data-cy="`menu-advanced-tools-${title}`"
             @click="emit('toggleMenu')"
         >
             <FontAwesomeIcon
-                class="me-2"
+                class="dropdown-icon me-2"
                 :class="{ invisible: !dropdownMenu }"
                 :icon="`caret-${isSelected ? 'down' : 'right'}`"
             />
@@ -76,6 +76,11 @@ onUnmounted(() => {
 @import 'src/scss/webmapviewer-bootstrap-theme';
 @import 'src/modules/menu/scss/menu-items';
 .advanced-tools-item {
+    .dropdown-icon {
+        // The min-width here is to avoid size changes when toggling the dropdown, the caret-down
+        // icon is wider than the caret right
+        min-width: 8.5px;
+    }
     .advanced-tools-title {
         // Here we add the menu-item styling to the title only to avoid hover
         // on the content once the item has been opened

--- a/src/modules/menu/components/share/MenuShareEmbed.vue
+++ b/src/modules/menu/components/share/MenuShareEmbed.vue
@@ -1,15 +1,16 @@
 <template>
     <div class="menu-share-embed">
-        <button
-            class="btn btn-light btn-sm embedded-button"
+        <a
+            class="embed-btn d-flex align-items-center text-decoration-none ps-3 p-2"
+            :class="{ 'text-primary': isSelected, 'text-black': !isSelected }"
             data-cy="menu-share-embed-button"
             @click="toggleEmbedSharing"
         >
             <FontAwesomeIcon :icon="`caret-${showEmbedSharing ? 'down' : 'right'}`" />
             <span class="ms-2">{{ $t('share_more') }}</span>
-        </button>
+        </a>
         <CollapseTransition :duration="200">
-            <div v-show="showEmbedSharing" class="p-2 card border-light bg-light">
+            <div v-show="showEmbedSharing" class="p-2 ps-4 card border-light">
                 <div class="input-group input-group-sm">
                     <input
                         ref="embedInput"
@@ -29,7 +30,7 @@
                     </button>
                 </div>
                 <!-- eslint-disable vue/no-v-html-->
-                <div v-html="$t('share_disclaimer')"></div>
+                <div class="py-2" v-html="$t('share_disclaimer')"></div>
                 <!-- eslint-enable vue/no-v-html-->
             </div>
         </CollapseTransition>
@@ -253,6 +254,13 @@ export default {
 
 <style lang="scss" scoped>
 @import 'src/scss/media-query.mixin';
+@import 'src/scss/webmapviewer-bootstrap-theme';
+.embed-btn {
+    &:hover {
+        background-color: $list-item-hover-bg-color !important;
+        cursor: pointer;
+    }
+}
 
 .menu-share-embed {
     display: none;

--- a/src/modules/menu/components/share/MenuShareSection.vue
+++ b/src/modules/menu/components/share/MenuShareSection.vue
@@ -8,18 +8,17 @@
         @click:header="toggleShareMenu"
         @open-menu-section="(id) => $emit('openMenuSection', id)"
     >
-        <FontAwesomeIcon v-if="!shortLink" icon="spinner" spin size="2x" class="p-2" />
-        <div v-if="shortLink" class="p-2">
-            <MenuShareSocialNetworks :short-link="shortLink" class="pt-1" />
+        <div class="p-2">
+            <MenuShareSocialNetworks :short-link="shortLink" />
             <MenuShareInputCopyButton
                 :input-text="shortLink"
                 :label-text="'share_link'"
                 :copy-text="'copy_url'"
                 :copied-text="'copy_success'"
-                class="px-2 py-3"
+                class="p-2"
             />
-            <MenuShareEmbed :short-link="embeddedShortLink" class="pb-1" />
         </div>
+        <MenuShareEmbed :short-link="embeddedShortLink" class="menu-share-embed border-top" />
     </MenuSection>
 </template>
 

--- a/src/modules/menu/components/share/MenuShareSocialNetworks.vue
+++ b/src/modules/menu/components/share/MenuShareSocialNetworks.vue
@@ -6,7 +6,7 @@
             :network="network.id"
             :url="shortLink"
             title=""
-            class="btn btn-light share-network-button"
+            class="btn btn-sm btn-light share-network-button"
             :options="shareNetworkOptions"
             :data-cy="`share-shortlink-${network.id}`"
         >

--- a/src/modules/menu/scss/menu-items.scss
+++ b/src/modules/menu/scss/menu-items.scss
@@ -1,7 +1,15 @@
+@import 'src/scss/webmapviewer-bootstrap-theme';
+
 .menu-list {
     list-style: none;
     padding: 0;
     margin: 0;
+}
+
+.menu-item {
+    &:hover {
+        background-color: $list-item-hover-bg-color !important;
+    }
 }
 
 .menu-title {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -34,10 +34,6 @@ export default defineConfig(({ mode }) => {
                         isCustomElement: (tag) => tag === 'cesium-compass',
                     },
                 },
-                script: {
-                    // TODO remove this once updated vue to 3.4
-                    defineModel: true,
-                },
             }),
             generateBuildInfo(appVersion),
             // CesiumJS requires static files from the following 4 folders to be included in the build


### PR DESCRIPTION
Also did several menu styling improvements

- add the same hover for each menu items
- Improved import maps padding
- Improved import maps caret icon

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-menu-hover/index.html)