### PR TITLE
PB-203: Debounce edit text dispatch

### DIFF
--- a/src/modules/infobox/components/styling/FeatureStyleEdit.vue
+++ b/src/modules/infobox/components/styling/FeatureStyleEdit.vue
@@ -34,14 +34,14 @@ const description = ref(feature.value.description)
 
 // Update the UI when the feature changes
 watch(
-    () => feature.title,
+    () => feature.value.title,
     (newTitle) => {
         title.value = newTitle
     }
 )
 
 watch(
-    () => feature.description,
+    () => feature.value.description,
     (newDescription) => {
         description.value = newDescription
     }
@@ -61,13 +61,16 @@ watch(description, (newDescription) => {
 
 function updateFeatureTitle(previousTitle) {
     if (previousTitle === title.value) {
-        store.dispatch('changeFeatureTitle', { feature, title: title.value })
+        store.dispatch('changeFeatureTitle', { feature: feature.value, title: title.value })
     }
 }
 
 function updateFeatureDecription(previousDescription) {
     if (previousDescription === description.value) {
-        store.dispatch('changeFeatureDescription', { feature, description: description.value })
+        store.dispatch('changeFeatureDescription', {
+            feature: feature.value,
+            description: description.value,
+        })
     }
 }
 

--- a/src/modules/infobox/components/styling/FeatureStyleEdit.vue
+++ b/src/modules/infobox/components/styling/FeatureStyleEdit.vue
@@ -32,6 +32,21 @@ const { feature, readOnly } = toRefs(props)
 const title = ref(feature.value.title)
 const description = ref(feature.value.description)
 
+// Update the UI when the feature changes
+watch(
+    () => feature.title,
+    (newTitle) => {
+        title.value = newTitle
+    }
+)
+
+watch(
+    () => feature.description,
+    (newDescription) => {
+        description.value = newDescription
+    }
+)
+
 // The idea is watching the title and the description.
 // Put a debounce on the update of the feature so that we can compare with the current UI state
 // If the value is the same as in the UI, we can update the feature

--- a/src/modules/infobox/components/styling/FeatureStyleEdit.vue
+++ b/src/modules/infobox/components/styling/FeatureStyleEdit.vue
@@ -50,28 +50,29 @@ watch(
 // The idea is watching the title and the description.
 // Put a debounce on the update of the feature so that we can compare with the current UI state
 // If the value is the same as in the UI, we can update the feature
-watch(title, (newTitle) => {
-    const debounceTitleUpdate = debounce(updateFeatureTitle, 300)
-    debounceTitleUpdate(newTitle)
+watch(title, () => {
+    debounceTitleUpdate(store)
 })
-watch(description, (newDescription) => {
-    const debounceDescriptionUpdate = debounce(updateFeatureDecription, 300)
-    debounceDescriptionUpdate(newDescription)
+watch(description, () => {
+    debounceDescriptionUpdate(store)
 })
 
-function updateFeatureTitle(previousTitle) {
-    if (previousTitle === title.value) {
-        store.dispatch('changeFeatureTitle', { feature: feature.value, title: title.value })
-    }
+// Here we need to declare the debounce method globally otherwise it does not work (it is based
+// on closure which will not work if the debounce mehtod is defined in a watcher)
+// The title debounce needs to be quick in order to be displayed on the map
+const debounceTitleUpdate = debounce(updateFeatureTitle, 100)
+// The description don't need a quick debounce as it is not displayed on the map
+const debounceDescriptionUpdate = debounce(updateFeatureDescription, 300)
+
+function updateFeatureTitle() {
+    store.dispatch('changeFeatureTitle', { feature: feature.value, title: title.value })
 }
 
-function updateFeatureDecription(previousDescription) {
-    if (previousDescription === description.value) {
-        store.dispatch('changeFeatureDescription', {
-            feature: feature.value,
-            description: description.value,
-        })
-    }
+function updateFeatureDescription() {
+    store.dispatch('changeFeatureDescription', {
+        feature: feature.value,
+        description: description.value,
+    })
 }
 
 /**

--- a/src/modules/infobox/components/styling/FeatureStyleEdit.vue
+++ b/src/modules/infobox/components/styling/FeatureStyleEdit.vue
@@ -14,6 +14,7 @@ import DrawingStylePopoverButton from '@/modules/infobox/components/styling/Draw
 import DrawingStyleSizeSelector from '@/modules/infobox/components/styling/DrawingStyleSizeSelector.vue'
 import DrawingStyleTextColorSelector from '@/modules/infobox/components/styling/DrawingStyleTextColorSelector.vue'
 import SelectedFeatureProfile from '@/modules/infobox/components/styling/SelectedFeatureProfile.vue'
+import debounce from '@/utils/debounce'
 import { round } from '@/utils/numberUtils'
 
 const props = defineProps({
@@ -33,7 +34,8 @@ const description = computed({
         return feature.value.description
     },
     set(value) {
-        store.dispatch('changeFeatureDescription', { feature: feature.value, description: value })
+        this.description = value
+        debounce(store.dispatch('changeFeatureDescription', { feature, description: value }), 3000)
     },
 })
 const text = computed({
@@ -41,7 +43,8 @@ const text = computed({
         return feature.value.title
     },
     set(value) {
-        store.dispatch('changeFeatureTitle', { feature: feature.value, title: value })
+        this.text = value
+        debounce(store.dispatch('changeFeatureTitle', { feature, title: value }), 3000)
     },
 })
 /**

--- a/src/modules/infobox/components/styling/FeatureStyleEdit.vue
+++ b/src/modules/infobox/components/styling/FeatureStyleEdit.vue
@@ -29,17 +29,32 @@ const props = defineProps({
 })
 const { feature, readOnly } = toRefs(props)
 
-const descriptionValue = ref(feature.value.description)
-const textValue = ref(feature.value.title)
+const title = ref(feature.value.title)
+const description = ref(feature.value.description)
 
-watch(textValue, (newTextValue) => {
-    const dispatch = debounce(store.dispatch, 3000)
-    dispatch('changeFeatureTitle', { feature, title: newTextValue })
+// The idea is watching the title and the description.
+// Put a debounce on the update of the feature so that we can compare with the current UI state
+// If the value is the same as in the UI, we can update the feature
+watch(title, (newTitle) => {
+    const debounceTitleUpdate = debounce(updateFeatureTitle, 300)
+    debounceTitleUpdate(newTitle)
 })
-watch(descriptionValue, (newDescriptionValue) => {
-    const dispatch = debounce(store.dispatch, 3000)
-    dispatch('changeFeatureDescription', { feature, description: newDescriptionValue })
+watch(description, (newDescription) => {
+    const debounceDescriptionUpdate = debounce(updateFeatureDecription, 300)
+    debounceDescriptionUpdate(newDescription)
 })
+
+function updateFeatureTitle(previousTitle) {
+    if (previousTitle === title.value) {
+        store.dispatch('changeFeatureTitle', { feature, title: title.value })
+    }
+}
+
+function updateFeatureDecription(previousDescription) {
+    if (previousDescription === description.value) {
+        store.dispatch('changeFeatureDescription', { feature, description: description.value })
+    }
+}
 
 /**
  * OpenLayers polygons coordinates are in a triple array. The first array is the "ring", the second
@@ -135,7 +150,7 @@ function onDelete() {
             </label>
             <textarea
                 id="drawing-style-feature-title"
-                v-model="textValue"
+                v-model="title"
                 :readonly="readOnly"
                 data-cy="drawing-style-feature-title"
                 class="feature-title form-control"
@@ -151,7 +166,7 @@ function onDelete() {
             </label>
             <textarea
                 id="drawing-style-feature-description"
-                v-model="descriptionValue"
+                v-model="description"
                 :readonly="readOnly"
                 data-cy="drawing-style-feature-description"
                 class="feature-description form-control"

--- a/src/modules/infobox/components/styling/FeatureStyleEdit.vue
+++ b/src/modules/infobox/components/styling/FeatureStyleEdit.vue
@@ -4,7 +4,7 @@
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { Polygon } from 'ol/geom'
 import { getLength } from 'ol/sphere'
-import { computed, toRefs } from 'vue'
+import { computed, ref, toRefs, watch } from 'vue'
 import { useStore } from 'vuex'
 
 import { EditableFeature, EditableFeatureTypes } from '@/api/features.api'
@@ -29,24 +29,18 @@ const props = defineProps({
 })
 const { feature, readOnly } = toRefs(props)
 
-const description = computed({
-    get() {
-        return feature.value.description
-    },
-    set(value) {
-        this.description = value
-        debounce(store.dispatch('changeFeatureDescription', { feature, description: value }), 3000)
-    },
+const descriptionValue = ref(feature.value.description)
+const textValue = ref(feature.value.title)
+
+watch(textValue, (newTextValue) => {
+    const dispatch = debounce(store.dispatch, 3000)
+    dispatch('changeFeatureTitle', { feature, title: newTextValue })
 })
-const text = computed({
-    get() {
-        return feature.value.title
-    },
-    set(value) {
-        this.text = value
-        debounce(store.dispatch('changeFeatureTitle', { feature, title: value }), 3000)
-    },
+watch(descriptionValue, (newDescriptionValue) => {
+    const dispatch = debounce(store.dispatch, 3000)
+    dispatch('changeFeatureDescription', { feature, description: newDescriptionValue })
 })
+
 /**
  * OpenLayers polygons coordinates are in a triple array. The first array is the "ring", the second
  * is to hold the coordinates, which are in an array themselves. We don't have rings in this case,
@@ -141,7 +135,7 @@ function onDelete() {
             </label>
             <textarea
                 id="drawing-style-feature-title"
-                v-model="text"
+                v-model="textValue"
                 :readonly="readOnly"
                 data-cy="drawing-style-feature-title"
                 class="feature-title form-control"
@@ -157,7 +151,7 @@ function onDelete() {
             </label>
             <textarea
                 id="drawing-style-feature-description"
-                v-model="description"
+                v-model="descriptionValue"
                 :readonly="readOnly"
                 data-cy="drawing-style-feature-description"
                 class="feature-description form-control"

--- a/tests/cypress/fixtures/3d/terrain-3d-layer.json
+++ b/tests/cypress/fixtures/3d/terrain-3d-layer.json
@@ -1,0 +1,30 @@
+{
+    "attribution": "Put something there",
+    "available": [
+        [
+            {
+                "endX": 1,
+                "endY": 0,
+                "startX": 0,
+                "startY": 0
+            }
+        ],
+        [
+            {
+                "endX": 3,
+                "endY": 1,
+                "startX": 0,
+                "startY": 0
+            }
+        ]
+    ],
+    "bounds": [-180, -90, 180, 90],
+    "description": "Nice terrains",
+    "format": "quantized-mesh-1.0",
+    "minzoom": 0,
+    "projection": "EPSG:4326",
+    "scheme": "tms",
+    "tilejson": "2.1.0",
+    "tiles": ["20201203/{z}/{x}/{y}.terrain?v={version}"],
+    "version": "3924.0.0"
+}

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -122,6 +122,9 @@ const addCesiumTilesetIntercepts = () => {
     cy.intercept('**/*.terrain**', {
         fixture: '3d/tile.terrain',
     }).as('cesiumTerrainTile')
+    cy.intercept('**/ch.swisstopo.terrain.3d/*/layer.json', {
+        fixture: '3d/terrain-3d-layer.json',
+    }).as('terrain-3d-layer')
 }
 
 export function getDefaultFixturesAndIntercepts() {

--- a/tests/cypress/tests-e2e/3d/layers.cy.js
+++ b/tests/cypress/tests-e2e/3d/layers.cy.js
@@ -189,6 +189,8 @@ describe('Test of layer handling in 3D', () => {
             expect(mainCollection.length).to.eq(1)
             const layerCollection = mainCollection.get(0)
             // should be 3 (line, icon, text) but ol-cesium creates additional empty collection
+            // eslint-disable-next-line cypress/no-unnecessary-waiting
+            cy.wait(500)
             expect(layerCollection.length).to.eq(4)
         })
     })

--- a/tests/cypress/tests-e2e/3d/layers.cy.js
+++ b/tests/cypress/tests-e2e/3d/layers.cy.js
@@ -184,13 +184,12 @@ describe('Test of layer handling in 3D', () => {
         cy.clickOnMenuButtonIfMobile()
         cy.get('[data-cy="3d-button"]').click()
         cy.waitUntilCesiumTilesLoaded()
+        cy.wait('@terrain-3d-layer')
         cy.readWindowValue('cesiumViewer').then((viewer) => {
             const mainCollection = viewer.scene.primitives.get(0)
             expect(mainCollection.length).to.eq(1)
             const layerCollection = mainCollection.get(0)
             // should be 3 (line, icon, text) but ol-cesium creates additional empty collection
-            // eslint-disable-next-line cypress/no-unnecessary-waiting
-            cy.wait(500)
             expect(layerCollection.length).to.eq(4)
         })
     })

--- a/tests/cypress/tests-e2e/3d/layers.cy.js
+++ b/tests/cypress/tests-e2e/3d/layers.cy.js
@@ -184,13 +184,15 @@ describe('Test of layer handling in 3D', () => {
         cy.clickOnMenuButtonIfMobile()
         cy.get('[data-cy="3d-button"]').click()
         cy.waitUntilCesiumTilesLoaded()
-        cy.wait('@terrain-3d-layer')
         cy.readWindowValue('cesiumViewer').then((viewer) => {
-            const mainCollection = viewer.scene.primitives.get(0)
-            expect(mainCollection.length).to.eq(1)
-            const layerCollection = mainCollection.get(0)
+            // main collection
+            cy.wrap(viewer.scene.primitives.get(0)).should('have.length', 1)
+            // layer collection
             // should be 3 (line, icon, text) but ol-cesium creates additional empty collection
-            expect(layerCollection.length).to.eq(4)
+            cy.wrap(viewer.scene.primitives.get(0).get(0), { timeout: 10000 }).should(
+                'have.length',
+                4
+            )
         })
     })
 })

--- a/tests/cypress/tests-e2e/drawing.cy.js
+++ b/tests/cypress/tests-e2e/drawing.cy.js
@@ -41,9 +41,11 @@ describe('Drawing module tests', () => {
             const title = `This is a random title ${randomIntBetween(1000, 9999)}`
             cy.get('[data-cy="drawing-style-feature-title"]').clear()
             cy.get('[data-cy="drawing-style-feature-title"]').type(title)
+            cy.get('[data-cy="drawing-style-feature-title"]').should('have.value', title)
             cy.wait('@update-kml').then((interception) =>
                 cy.checkKMLRequest(interception, [new RegExp(`<name>${title}</name>`)])
             )
+            cy.readStoreValue('state.features.selectedFeatures[0].title').should('eq', title)
         }
 
         beforeEach(() => {
@@ -185,10 +187,18 @@ describe('Drawing module tests', () => {
             // changing/editing the description of this marker
             const description = 'A description for this marker'
             cy.get('[data-cy="drawing-style-feature-description"]').type(description)
+            cy.get('[data-cy="drawing-style-feature-description"]').should(
+                'have.value',
+                description
+            )
             cy.wait('@update-kml').then((interception) =>
                 cy.checkKMLRequest(interception, [
                     new RegExp(`<description>${description}</description>`),
                 ])
+            )
+            cy.readStoreValue('state.features.selectedFeatures[0].description').should(
+                'eq',
+                description
             )
 
             //  moving the marker by drag&drop on the map


### PR DESCRIPTION
In the drawing feature, when changing a text the store got updated after every keystroke, and with this a request was sent.

In this PR a debounce function for ~3~ 0.3 seconds after a keystroke was used to delay the update on the store and minimize the amount of requests being sent.

Ismail: I set the delay to 0.3 seconds since 3 seconds is too long.

Example of the delay:
![Peek 2024-02-05 14-59](https://github.com/geoadmin/web-mapviewer/assets/1421861/4945a0b9-afce-4961-ae2e-a0fa9a5aced4)


[Test link](https://sys-map.dev.bgdi.ch/preview/bugfix-pb-203-debounce-drawing-feat-text-edit/index.html)