### PR TITLE
PB-246: bugfix legacy timestamps parameters not taken into account

### DIFF
--- a/src/api/layers/GeoAdminWMSLayer.class.js
+++ b/src/api/layers/GeoAdminWMSLayer.class.js
@@ -79,6 +79,12 @@ export default class GeoAdminWMSLayer extends GeoAdminLayer {
         this.wmsVersion = wmsVersion
     }
 
+    clone() {
+        const clone = super.clone()
+        clone.timeConfig = this.timeConfig ? this.timeConfig.clone() : null
+        return clone
+    }
+
     getURL() {
         return this.baseURL ?? WMS_BASE_URL
     }

--- a/src/api/layers/GeoAdminWMSLayer.class.js
+++ b/src/api/layers/GeoAdminWMSLayer.class.js
@@ -81,7 +81,7 @@ export default class GeoAdminWMSLayer extends GeoAdminLayer {
 
     clone() {
         const clone = super.clone()
-        clone.timeConfig = this.timeConfig ? this.timeConfig.clone() : null
+        clone.timeConfig = this.timeConfig?.clone() ?? null
         return clone
     }
 

--- a/src/api/layers/GeoAdminWMTSLayer.class.js
+++ b/src/api/layers/GeoAdminWMTSLayer.class.js
@@ -68,6 +68,12 @@ export default class GeoAdminWMTSLayer extends GeoAdminLayer {
         this.hasMultipleTimestamps = this.timeConfig?.timeEntries?.length > 1
     }
 
+    clone() {
+        const clone = super.clone()
+        clone.timeConfig = this.timeConfig ? this.timeConfig.clone() : null
+        return clone
+    }
+
     /**
      * @param {Number} epsgNumber The EPSG number of the projection system to use (for instance,
      *   EPSG:2056 will require an input of 2056)

--- a/src/api/layers/GeoAdminWMTSLayer.class.js
+++ b/src/api/layers/GeoAdminWMTSLayer.class.js
@@ -70,7 +70,7 @@ export default class GeoAdminWMTSLayer extends GeoAdminLayer {
 
     clone() {
         const clone = super.clone()
-        clone.timeConfig = this.timeConfig ? this.timeConfig.clone() : null
+        clone.timeConfig = this.timeConfig?.clone() ?? null
         return clone
     }
 

--- a/src/api/topics.api.js
+++ b/src/api/topics.api.js
@@ -142,8 +142,15 @@ const loadTopicsFromBackend = (layersConfig) => {
                                     (layer) => layer.getID() === defaultBackgroundLayerId
                                 )
                             }
+                            const params = new URLSearchParams(legacyUrlParams)
                             const layersToActivate = [
-                                ...getLayersFromLegacyUrlParams(layersConfig, legacyUrlParams),
+                                ...getLayersFromLegacyUrlParams(
+                                    layersConfig,
+                                    params.get('layers'),
+                                    params.get('layers_visibility'),
+                                    params.get('layers_opacity'),
+                                    params.get('layers_timestamp')
+                                ),
                             ]
                             if (
                                 Array.isArray(rawTopic.activatedLayers) &&

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -117,8 +117,9 @@ const handleLegacyParam = (
         case 'layers_opacity':
         case 'layers_visibility':
         case 'layers_timestamp':
-            // we ignore those params as they are now obsolete
-            // see adr/2021_03_16_url_param_structure.md
+            // Those are checked within the `isLayersUrlParamLegacy` function, which is
+            // called under the `layers` case. We simply ensure here that they're not called
+            // multiple times for nothing
             break
 
         case '3d':

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -151,11 +151,11 @@ const handleLegacyParams = (legacyParams, store, to, next) => {
     let latlongCoordinates = []
     let cameraPosition = []
 
-    Object.keys(legacyParams).forEach((param) => {
+    legacyParams.forEach((param_value, param_key) => {
         handleLegacyParam(
             legacyParams,
-            param,
-            legacyParams[param],
+            param_key,
+            param_value,
             store,
             newQuery,
             latlongCoordinates,

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -94,10 +94,6 @@ const handleLegacyParam = (
         // taking all layers related param aside so that they can be processed later (see below)
         // this only occurs if the syntax is recognized as a mf-geoadmin3 syntax (or legacy)
         case 'layers':
-            console.log('----------------------------')
-            console.log(legacyValue)
-            console.log(isLayersUrlParamLegacy(legacyValue))
-            console.log('----------------------------')
             if (isLayersUrlParamLegacy(legacyValue)) {
                 // for legacy layers param, we need to give the whole search query
                 // as it needs to look for layers, layers_visibility, layers_opacity and

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -14,7 +14,7 @@ import log from '@/utils/logging'
 
 const handleLegacyKmlAdminIdParam = async (legacyParams, newQuery) => {
     log.debug('Transforming legacy kml adminId, get KML ID from adminId...')
-    const kmlLayer = await getKmlLayerFromLegacyAdminIdParam(legacyParams['adminId'])
+    const kmlLayer = await getKmlLayerFromLegacyAdminIdParam(legacyParams.get('adminId'))
     log.debug('Adding KML layer from legacy kml adminId')
     if (newQuery.layers) {
         newQuery.layers = `${newQuery.layers};${kmlLayer.getID()}@adminId=${kmlLayer.adminId}`
@@ -198,8 +198,7 @@ const handleLegacyParams = (legacyParams, store, to, next) => {
     // removing old query part (new ones will be added by vue-router after the /# part of the URL)
     const urlWithoutQueryParam = window.location.href.substr(0, window.location.href.indexOf('?'))
     window.history.replaceState(window.history.state, document.title, urlWithoutQueryParam)
-
-    if ('adminId' in legacyParams) {
+    if (legacyParams.get('adminId')) {
         // adminId legacy param cannot be handle above in the loop because it needs to add a layer
         // to the layers param, thats why we do handle after.
         handleLegacyKmlAdminIdParam(legacyParams, newQuery)

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -45,6 +45,7 @@ const handleLegacyKmlAdminIdParam = async (legacyParams, newQuery) => {
 }
 
 const handleLegacyParam = (
+    params,
     param,
     legacyValue,
     store,
@@ -96,11 +97,12 @@ const handleLegacyParam = (
             // for legacy layers param, we need to give the whole search query
             // as it needs to look for layers, layers_visibility, layers_opacity and
             // layers_timestamp param altogether
-
-            // HERE : use params to get visibility, opacity, timestamps
             newValue = getLayersFromLegacyUrlParams(
                 store.state.layers.config,
-                window.location.search
+                legacyValue,
+                params['layers_visibility'],
+                params['layers_opacity'],
+                params['layers_timestamp']
             )
                 .map((layer) => transformLayerIntoUrlString(layer))
                 .join(';')
@@ -167,6 +169,7 @@ const handleLegacyParams = (legacyParams, store, to, next) => {
 
     Object.keys(legacyParams).forEach((param) => {
         handleLegacyParam(
+            legacyParams,
             param,
             legacyParams[param],
             store,

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -75,12 +75,10 @@ const handleLegacyParam = (
             cameraPosition[1] = Number(legacyValue)
             break
 
-        // taking all layers related param aside so that they can be processed later (see below)
-        // this only occurs if the syntax is recognized as a mf-geoadmin3 syntax (or legacy)
         case 'layers':
-            // for legacy layers param, we need to give the whole search query
-            // as it needs to look for layers, layers_visibility, layers_opacity and
-            // layers_timestamp param altogether
+            // for legacy layers param, we need to give the layers visibility, opacity and timestamps,
+            // as they are combined into one value with the layer in the current 'layers' parameter
+            // implementation
             newValue = getLayersFromLegacyUrlParams(
                 store.state.layers.config,
                 legacyValue,

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -8,7 +8,6 @@ import SwissCoordinateSystem from '@/utils/coordinates/SwissCoordinateSystem.cla
 import {
     getKmlLayerFromLegacyAdminIdParam,
     getLayersFromLegacyUrlParams,
-    isLayersUrlParamLegacy,
 } from '@/utils/legacyLayerParamUtils'
 import log from '@/utils/logging'
 
@@ -94,20 +93,19 @@ const handleLegacyParam = (
         // taking all layers related param aside so that they can be processed later (see below)
         // this only occurs if the syntax is recognized as a mf-geoadmin3 syntax (or legacy)
         case 'layers':
-            if (isLayersUrlParamLegacy(legacyValue)) {
-                // for legacy layers param, we need to give the whole search query
-                // as it needs to look for layers, layers_visibility, layers_opacity and
-                // layers_timestamp param altogether
-                const layers = getLayersFromLegacyUrlParams(
-                    store.state.layers.config,
-                    window.location.search
-                )
-                newValue = layers.map((layer) => transformLayerIntoUrlString(layer)).join(';')
-                log.debug('Importing legacy layers as', newValue)
-            } else {
-                // if not legacy, we let it go as it is
-                newValue = legacyValue
-            }
+            // for legacy layers param, we need to give the whole search query
+            // as it needs to look for layers, layers_visibility, layers_opacity and
+            // layers_timestamp param altogether
+
+            // HERE : use params to get visibility, opacity, timestamps
+            newValue = getLayersFromLegacyUrlParams(
+                store.state.layers.config,
+                window.location.search
+            )
+                .map((layer) => transformLayerIntoUrlString(layer))
+                .join(';')
+            log.debug('Importing legacy layers as', newValue)
+
             break
         // Setting the position of the compare slider
         case 'swipe_ratio':
@@ -117,9 +115,8 @@ const handleLegacyParam = (
         case 'layers_opacity':
         case 'layers_visibility':
         case 'layers_timestamp':
-            // Those are checked within the `isLayersUrlParamLegacy` function, which is
-            // called under the `layers` case. We simply ensure here that they're not called
-            // multiple times for nothing
+            // Those are combined with the layers case. We simply ensure here that
+            // they're not called multiple times for nothing
             break
 
         case '3d':

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -94,6 +94,10 @@ const handleLegacyParam = (
         // taking all layers related param aside so that they can be processed later (see below)
         // this only occurs if the syntax is recognized as a mf-geoadmin3 syntax (or legacy)
         case 'layers':
+            console.log('----------------------------')
+            console.log(legacyValue)
+            console.log(isLayersUrlParamLegacy(legacyValue))
+            console.log('----------------------------')
             if (isLayersUrlParamLegacy(legacyValue)) {
                 // for legacy layers param, we need to give the whole search query
                 // as it needs to look for layers, layers_visibility, layers_opacity and

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -8,33 +8,9 @@ import SwissCoordinateSystem from '@/utils/coordinates/SwissCoordinateSystem.cla
 import {
     getKmlLayerFromLegacyAdminIdParam,
     getLayersFromLegacyUrlParams,
+    isLegacyParams,
 } from '@/utils/legacyLayerParamUtils'
 import log from '@/utils/logging'
-
-/**
- * @param {String} search The query made to the mapviewer
- * @returns True if the query starts with ? or /?
- */
-const isLegacyParams = (search) => {
-    const parts = search.match(/^(\?|\/).*$/g)
-    return parts && Array.isArray(parts)
-}
-
-/**
- * @param {String} search
- * @returns {any}
- */
-const parseLegacyParams = (search) => {
-    const params = {}
-    const parts = search.match(/(\?|&)([^=]+)=([^&]+)/g)
-    parts?.forEach((part) => {
-        const equalSignIndex = part.indexOf('=')
-        const paramName = part.substr(1, equalSignIndex - 1)
-        params[paramName] = part.substr(equalSignIndex + 1)
-    })
-
-    return params
-}
 
 const handleLegacyKmlAdminIdParam = async (legacyParams, newQuery) => {
     log.debug('Transforming legacy kml adminId, get KML ID from adminId...')
@@ -108,9 +84,9 @@ const handleLegacyParam = (
             newValue = getLayersFromLegacyUrlParams(
                 store.state.layers.config,
                 legacyValue,
-                params['layers_visibility'],
-                params['layers_opacity'],
-                params['layers_timestamp']
+                params.get('layers_visibility'),
+                params.get('layers_opacity'),
+                params.get('layers_timestamp')
             )
                 .map((layer) => transformLayerIntoUrlString(layer))
                 .join(';')
@@ -279,7 +255,7 @@ const legacyPermalinkManagementRouterPlugin = (router, store) => {
     // to.query only parse the query after the /#? and legacy params are at the root /?
     const legacyParams =
         window.location && window.location.search && isLegacyParams(window.location.search)
-            ? parseLegacyParams(window.location.search)
+            ? new URLSearchParams(window.location.search)
             : null
     router.beforeEach((to, from, next) => {
         // Waiting for the app to enter the MapView before dealing with legacy param, otherwise

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -375,49 +375,6 @@ const actions = {
             log.error('Failed to set layer year, invalid payload', layerId, year)
         }
     },
-    setLegacyTimeLayerYear({ commit }, { layer, year }) {
-        /*
-            Legacy Parameters are added to layers that might not yet be active, but
-            timeSeries still require them to go through mutations. So we need to be
-            able to add a time series to a layer without it being active
-        */
-        if (layer && year) {
-            if (layer.timeConfig) {
-                // checking that the year exists in this timeConfig
-                const timeEntryForYear = layer.timeConfig.getTimeEntryForYear(year)
-                if (timeEntryForYear) {
-                    commit('setLegacyLayerYear', {
-                        timedLayer: layer,
-                        year: year,
-                    })
-                } else {
-                    log.error('timestamp for year not found, ignoring change', layer, year)
-                }
-            } else {
-                log.error(
-                    'Failed to set layer year, layer has no time config',
-                    layer?.layerId,
-                    layer
-                )
-            }
-        } else {
-            log.error('Failed to set layer year, invalid payload', layer, year)
-        }
-    },
-    moveActiveLayerBack({ commit, state, getters }, layerId) {
-        const activeLayer = getters.getActiveLayerById(layerId)
-        if (activeLayer) {
-            // checking if the layer can be put one step back
-            const currentIndex = state.activeLayers.indexOf(activeLayer)
-            if (currentIndex > 0) {
-                commit('moveActiveLayerFromIndexToIndex', {
-                    layer: activeLayer,
-                    startingIndex: currentIndex,
-                    endingIndex: currentIndex - 1,
-                })
-            }
-        }
-    },
     moveActiveLayerFront({ commit, state, getters }, layerId) {
         const activeLayer = getters.getActiveLayerById(layerId)
         if (activeLayer) {
@@ -576,11 +533,6 @@ const mutations = {
     },
     setLayerYear(state, { layerId, year }) {
         const timedLayer = getActiveLayerById(state, layerId)
-        timedLayer.timeConfig.updateCurrentTimeEntry(
-            timedLayer.timeConfig.getTimeEntryForYear(year)
-        )
-    },
-    setLegacyLayerYear(state, { timedLayer, year }) {
         timedLayer.timeConfig.updateCurrentTimeEntry(
             timedLayer.timeConfig.getTimeEntryForYear(year)
         )

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -375,6 +375,20 @@ const actions = {
             log.error('Failed to set layer year, invalid payload', layerId, year)
         }
     },
+    moveActiveLayerBack({ commit, state, getters }, layerId) {
+        const activeLayer = getters.getActiveLayerById(layerId)
+        if (activeLayer) {
+            // checking if the layer can be put one step back
+            const currentIndex = state.activeLayers.indexOf(activeLayer)
+            if (currentIndex > 0) {
+                commit('moveActiveLayerFromIndexToIndex', {
+                    layer: activeLayer,
+                    startingIndex: currentIndex,
+                    endingIndex: currentIndex - 1,
+                })
+            }
+        }
+    },
     moveActiveLayerFront({ commit, state, getters }, layerId) {
         const activeLayer = getters.getActiveLayerById(layerId)
         if (activeLayer) {

--- a/src/utils/__tests__/legacyLayerParamUtils.spec.js
+++ b/src/utils/__tests__/legacyLayerParamUtils.spec.js
@@ -213,8 +213,9 @@ describe('Test parsing of legacy URL param into new params', () => {
     })
     describe('test isLayersUrlParamLegacy', () => {
         it('recognize a valid new layers param as such', () => {
-            expect(isLayersUrlParamLegacy('layer.id')).to.be.false
             expect(isLayersUrlParamLegacy('layer.id@time=123')).to.be.false
+            expect(isLayersUrlParamLegacy('layer.id-layer-name-extension@time=123')).to.be.false
+            expect(isLayersUrlParamLegacy('layer.id_layername_extension@time=123')).to.be.false
             expect(isLayersUrlParamLegacy('layer.id,f')).to.be.false
             expect(isLayersUrlParamLegacy('layer.id@time=123,f')).to.be.false
             expect(isLayersUrlParamLegacy('layer.id,,0.5')).to.be.false
@@ -227,8 +228,14 @@ describe('Test parsing of legacy URL param into new params', () => {
                 )
             ).to.be.false
         })
-        it('detects old layers syntax with many layers as legacy', () => {
-            expect(isLayersUrlParamLegacy('layer.id,layer.id')).to.be.true
+        it('detects single layers without any parameter as legacy', () => {
+            expect(isLayersUrlParamLegacy('layer.id')).to.be.true
+            expect(isLayersUrlParamLegacy('layer.id.finish.with.t')).to.be.true
+            expect(isLayersUrlParamLegacy('layer.id-layer-name-extension')).to.be.true
+            expect(isLayersUrlParamLegacy('layer.id_layer_name_extension')).to.be.true
+        })
+        it('detects old layers syntax with any number of layers as legacy', () => {
+            expect(isLayersUrlParamLegacy('layer.id,layer.id.2,layer.id_3')).to.be.true
         })
         it('detects legacy external URL structure correctly', () => {
             expect(

--- a/src/utils/__tests__/legacyLayerParamUtils.spec.js
+++ b/src/utils/__tests__/legacyLayerParamUtils.spec.js
@@ -8,18 +8,12 @@ import GeoAdminWMSLayer from '@/api/layers/GeoAdminWMSLayer.class'
 import GeoAdminWMTSLayer from '@/api/layers/GeoAdminWMTSLayer.class'
 import LayerTimeConfig from '@/api/layers/LayerTimeConfig.class'
 import LayerTimeConfigEntry from '@/api/layers/LayerTimeConfigEntry.class'
-import { getLayersFromLegacyUrlParams } from '@/utils/legacyLayerParamUtils'
+import {
+    getLayersFromLegacyUrlParams,
+    isLegacyParams,
+    parseOpacity,
+} from '@/utils/legacyLayerParamUtils'
 
-// TODO HERE : GET NEW SYNTAX FOR ALL TESTS
-/*
-newValue = getLayersFromLegacyUrlParams(
-                store.state.layers.config,
-                legacyValue,
-                params['layers_visibility'],
-                params['layers_opacity'],
-                params['layers_timestamp']
-            )
-            */
 describe('Test parsing of legacy URL param into new params', () => {
     describe('test getLayersFromLegacyUrlParams', () => {
         const fakeLayerConfig = [
@@ -258,6 +252,28 @@ describe('Test parsing of legacy URL param into new params', () => {
                     undefined
                 )
                 expect(wmsResult).to.be.an('Array').empty
+            })
+            describe('utility functions for legacy Parameter Handling', () => {
+                it('ensure the parseOpacity Function always returns a valid value', () => {
+                    const correct_opacity = parseOpacity(0.321)
+                    expect(correct_opacity).to.equal(0.321)
+                    const opacity_too_low = parseOpacity(-0.2)
+                    expect(opacity_too_low).to.equal(0)
+                    const opacity_too_high = parseOpacity(1.45)
+                    expect(opacity_too_high).to.equal(1)
+                    const opacity_NaN = parseOpacity('test')
+                    expect(opacity_NaN).to.equal(1)
+                })
+                it('Makes sure the isLegacyParams function recognize a legacy URL', () => {
+                    const result_true_no_slash = isLegacyParams('?test=true')
+                    expect(result_true_no_slash).to.equal(true)
+                    const result_true_slash = isLegacyParams('/?test=true')
+                    expect(result_true_slash).to.equal(true)
+                    const result_false_no_slash = isLegacyParams('#?test=false')
+                    expect(result_false_no_slash).to.equal(false)
+                    const result_false_slash = isLegacyParams('#/?test=false')
+                    expect(result_false_slash).to.equal(false)
+                })
             })
         })
     })

--- a/src/utils/__tests__/legacyLayerParamUtils.spec.js
+++ b/src/utils/__tests__/legacyLayerParamUtils.spec.js
@@ -88,7 +88,7 @@ describe('Test parsing of legacy URL param into new params', () => {
             const checkOneLayerTimestamps = (timestamp) => {
                 const result = getLayersFromLegacyUrlParams(
                     fakeLayerConfig,
-                    `layers=test.timed.wmts.layer&layers_timestamps=${timestamp}`
+                    `layers=test.timed.wmts.layer&layers_timestamp=${timestamp}`
                 )
                 expect(result).to.be.an('Array').length(1)
                 const [firstLayer] = result
@@ -102,7 +102,7 @@ describe('Test parsing of legacy URL param into new params', () => {
         it('Parses multiples layers with all params set', () => {
             const result = getLayersFromLegacyUrlParams(
                 fakeLayerConfig,
-                'layers=test.wmts.layer,test.wms.layer,test.timed.wmts.layer&layers_opacity=0.6,0.5,0.8&layers_visibility=false,true,false&layers_timestamps=,,456'
+                'layers=test.wmts.layer,test.wms.layer,test.timed.wmts.layer&layers_opacity=0.6,0.5,0.8&layers_visibility=false,true,false&layers_timestamp=,,456'
             )
             expect(result).to.be.an('Array').length(3)
             const [wmtsLayer, wmsLayer, timedWmtsLayer] = result

--- a/src/utils/__tests__/legacyLayerParamUtils.spec.js
+++ b/src/utils/__tests__/legacyLayerParamUtils.spec.js
@@ -8,7 +8,7 @@ import GeoAdminWMSLayer from '@/api/layers/GeoAdminWMSLayer.class'
 import GeoAdminWMTSLayer from '@/api/layers/GeoAdminWMTSLayer.class'
 import LayerTimeConfig from '@/api/layers/LayerTimeConfig.class'
 import LayerTimeConfigEntry from '@/api/layers/LayerTimeConfigEntry.class'
-import { getLayersFromLegacyUrlParams, isLayersUrlParamLegacy } from '@/utils/legacyLayerParamUtils'
+import { getLayersFromLegacyUrlParams } from '@/utils/legacyLayerParamUtils'
 
 describe('Test parsing of legacy URL param into new params', () => {
     describe('test getLayersFromLegacyUrlParams', () => {
@@ -209,61 +209,6 @@ describe('Test parsing of legacy URL param into new params', () => {
                 )
                 expect(wmsResult).to.be.an('Array').empty
             })
-        })
-    })
-    describe('test isLayersUrlParamLegacy', () => {
-        it('recognize a valid new layers param as such', () => {
-            expect(isLayersUrlParamLegacy('layer.id@time=123')).to.be.false
-            expect(isLayersUrlParamLegacy('layer.id-layer-name-extension@time=123')).to.be.false
-            expect(isLayersUrlParamLegacy('layer.id_layername_extension@time=123')).to.be.false
-            expect(isLayersUrlParamLegacy('layer.id,f')).to.be.false
-            expect(isLayersUrlParamLegacy('layer.id@time=123,f')).to.be.false
-            expect(isLayersUrlParamLegacy('layer.id,,0.5')).to.be.false
-            expect(isLayersUrlParamLegacy('layer.id@time=123,,0.5')).to.be.false
-        })
-        it('recognize many layers with the new syntax as non legacy', () => {
-            expect(
-                isLayersUrlParamLegacy(
-                    'layer.id,,0.5;layer.id.2;layer.id.3,f;layer.id.4@time=123,,0.5'
-                )
-            ).to.be.false
-        })
-        it('detects single layers without any parameter as legacy', () => {
-            expect(isLayersUrlParamLegacy('layer.id')).to.be.true
-            expect(isLayersUrlParamLegacy('layer.id.finish.with.t')).to.be.true
-            expect(isLayersUrlParamLegacy('layer.id-layer-name-extension')).to.be.true
-            expect(isLayersUrlParamLegacy('layer.id_layer_name_extension')).to.be.true
-        })
-        it('detects old layers syntax with any number of layers as legacy', () => {
-            expect(isLayersUrlParamLegacy('layer.id,layer.id.2,layer.id_3')).to.be.true
-        })
-        it('detects legacy external URL structure correctly', () => {
-            expect(
-                isLayersUrlParamLegacy(
-                    encodeURIComponent(
-                        'WMTS||fake.layer.id||https://fake.get.cap.url/WMTSGetCapabilities.xml'
-                    )
-                )
-            ).to.be.true
-            expect(
-                isLayersUrlParamLegacy(
-                    encodeURIComponent(
-                        'WMS||fake layer name||https://fake.wms.server/||fake.wms.layer_id||0.0.0'
-                    )
-                )
-            ).to.be.true
-        })
-        it("doesn't detect the new external layer format as legacy", () => {
-            expect(
-                isLayersUrlParamLegacy(
-                    'WMTS|https://fake.get.cap.url/WMTSGetCapabilities.xml|fake.layer.id|Layer name'
-                )
-            ).to.be.false
-            expect(
-                isLayersUrlParamLegacy(
-                    'WMS|https://base.url/|wms.layer_id|2.2.2|External layer name'
-                )
-            ).to.be.false
         })
     })
 })

--- a/src/utils/__tests__/legacyLayerParamUtils.spec.js
+++ b/src/utils/__tests__/legacyLayerParamUtils.spec.js
@@ -10,6 +10,16 @@ import LayerTimeConfig from '@/api/layers/LayerTimeConfig.class'
 import LayerTimeConfigEntry from '@/api/layers/LayerTimeConfigEntry.class'
 import { getLayersFromLegacyUrlParams } from '@/utils/legacyLayerParamUtils'
 
+// TODO HERE : GET NEW SYNTAX FOR ALL TESTS
+/*
+newValue = getLayersFromLegacyUrlParams(
+                store.state.layers.config,
+                legacyValue,
+                params['layers_visibility'],
+                params['layers_opacity'],
+                params['layers_timestamp']
+            )
+            */
 describe('Test parsing of legacy URL param into new params', () => {
     describe('test getLayersFromLegacyUrlParams', () => {
         const fakeLayerConfig = [
@@ -41,7 +51,13 @@ describe('Test parsing of legacy URL param into new params', () => {
             ),
         ]
         it('Parses layers IDs and pass them along', () => {
-            const result = getLayersFromLegacyUrlParams(fakeLayerConfig, 'layers=test.wms.layer')
+            const result = getLayersFromLegacyUrlParams(
+                fakeLayerConfig,
+                'test.wms.layer',
+                undefined,
+                undefined,
+                undefined
+            )
             expect(result).to.be.an('Array').length(1)
             const [firstLayer] = result
             expect(firstLayer.getID()).to.eq('test.wms.layer')
@@ -50,7 +66,10 @@ describe('Test parsing of legacy URL param into new params', () => {
             const checkOneLayerVisibility = (flagValue) => {
                 const result = getLayersFromLegacyUrlParams(
                     fakeLayerConfig,
-                    `layers=test.wms.layer&layers_visibility=${flagValue}`
+                    `test.wms.layer`,
+                    `${flagValue}`,
+                    undefined,
+                    undefined
                 )
                 expect(result).to.be.an('Array').length(1)
                 const [firstLayer] = result
@@ -64,7 +83,13 @@ describe('Test parsing of legacy URL param into new params', () => {
             checkOneLayerVisibility(false)
         })
         it('sets visibility to true when layers_visibility is not present', () => {
-            const result = getLayersFromLegacyUrlParams(fakeLayerConfig, 'layers=test.wms.layer')
+            const result = getLayersFromLegacyUrlParams(
+                fakeLayerConfig,
+                'test.wms.layer',
+                undefined,
+                undefined,
+                undefined
+            )
             expect(result).to.be.an('Array').length(1)
             const [firstLayer] = result
             expect(firstLayer.visible).to.be.true
@@ -73,7 +98,10 @@ describe('Test parsing of legacy URL param into new params', () => {
             const checkOneLayerOpacity = (opacity) => {
                 const result = getLayersFromLegacyUrlParams(
                     fakeLayerConfig,
-                    `layers=test.wms.layer&layers_opacity=${opacity}`
+                    `test.wms.layer`,
+                    undefined,
+                    `${opacity}`,
+                    undefined
                 )
                 expect(result).to.be.an('Array').length(1)
                 const [firstLayer] = result
@@ -88,7 +116,10 @@ describe('Test parsing of legacy URL param into new params', () => {
             const checkOneLayerTimestamps = (timestamp) => {
                 const result = getLayersFromLegacyUrlParams(
                     fakeLayerConfig,
-                    `layers=test.timed.wmts.layer&layers_timestamp=${timestamp}`
+                    `test.timed.wmts.layer`,
+                    undefined,
+                    undefined,
+                    `${timestamp}`
                 )
                 expect(result).to.be.an('Array').length(1)
                 const [firstLayer] = result
@@ -102,7 +133,10 @@ describe('Test parsing of legacy URL param into new params', () => {
         it('Parses multiples layers with all params set', () => {
             const result = getLayersFromLegacyUrlParams(
                 fakeLayerConfig,
-                'layers=test.wmts.layer,test.wms.layer,test.timed.wmts.layer&layers_opacity=0.6,0.5,0.8&layers_visibility=false,true,false&layers_timestamp=,,456'
+                'test.wmts.layer,test.wms.layer,test.timed.wmts.layer',
+                'false,true,false',
+                '0.6,0.5,0.8',
+                ',,456'
             )
             expect(result).to.be.an('Array').length(3)
             const [wmtsLayer, wmsLayer, timedWmtsLayer] = result
@@ -132,7 +166,10 @@ describe('Test parsing of legacy URL param into new params', () => {
                 const kmlFileUrl = 'https://public.geo.admin.ch/super-legit-file-id'
                 const result = getLayersFromLegacyUrlParams(
                     fakeLayerConfig,
-                    `layers=KML||${kmlFileUrl}`
+                    `KML||${kmlFileUrl}`,
+                    undefined,
+                    undefined,
+                    undefined
                 )
                 expect(result).to.be.an('Array').length(1)
                 const [kmlLayer] = result
@@ -142,7 +179,10 @@ describe('Test parsing of legacy URL param into new params', () => {
             it('Handles opacity/visibility correctly with external layers', () => {
                 const result = getLayersFromLegacyUrlParams(
                     fakeLayerConfig,
-                    'layers=KML||https://we-dont-care-about-this-url&layers_opacity=0.65&layers_visibility=true'
+                    'KML||https://we-dont-care-about-this-url',
+                    'true',
+                    '0.65',
+                    undefined
                 )
                 expect(result).to.be.an('Array').length(1)
                 const [kmlLayer] = result
@@ -158,9 +198,10 @@ describe('Test parsing of legacy URL param into new params', () => {
 
                 const result = getLayersFromLegacyUrlParams(
                     fakeLayerConfig,
-                    `layers=${encodeURIComponent(
-                        legacyLayerUrlString
-                    )}&layers_opacity=0.45&layers_visibility=true`
+                    `${encodeURIComponent(legacyLayerUrlString)}`,
+                    `true`,
+                    `0.45`,
+                    undefined
                 )
                 expect(result).to.be.an('Array').length(1)
                 const [externalWmsLayer] = result
@@ -182,7 +223,10 @@ describe('Test parsing of legacy URL param into new params', () => {
                 )
                 const result = getLayersFromLegacyUrlParams(
                     fakeLayerConfig,
-                    `layers=${legacyLayerUrlString}&layers_opacity=0.77&layers_visibility=false`
+                    `${legacyLayerUrlString}`,
+                    `false`,
+                    `0.77`,
+                    undefined
                 )
                 expect(result).to.be.an('Array').length(1)
                 const [externalWmtsLayer] = result
@@ -200,12 +244,18 @@ describe('Test parsing of legacy URL param into new params', () => {
             it('does not parse an external layer if it is in the current format', () => {
                 const wmtsResult = getLayersFromLegacyUrlParams(
                     fakeLayerConfig,
-                    'WMTS|https://url.to.wmts.server|layer.id|LayerName'
+                    'WMTS|https://url.to.wmts.server|layer.id|LayerName',
+                    undefined,
+                    undefined,
+                    undefined
                 )
                 expect(wmtsResult).to.be.an('Array').empty
                 const wmsResult = getLayersFromLegacyUrlParams(
                     fakeLayerConfig,
-                    `WMS|${'https://wms.server.url?PARAM1=x&'}|layer.id|5.4.3|LayerName`
+                    `WMS|${'https://wms.server.url?PARAM1=x&'}|layer.id|5.4.3|LayerName`,
+                    undefined,
+                    undefined,
+                    undefined
                 )
                 expect(wmsResult).to.be.an('Array').empty
             })

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -2,6 +2,8 @@ import { getKmlMetadataByAdminId } from '@/api/files.api'
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
 import KMLLayer from '@/api/layers/KMLLayer.class'
+import log from '@/utils/logging'
+
 function readUrlParamValue(url, paramName) {
     if (url && paramName && url.indexOf(paramName) !== -1) {
         const urlStartingAtParamDeclaration = url.substr(url.indexOf(paramName) + 1)
@@ -14,6 +16,24 @@ function readUrlParamValue(url, paramName) {
     return undefined
 }
 
+/**
+ * Ensure opacity is within its bounds (0 and 1). Also assign a default value of 1 should the
+ * parameter be something unexpected
+ *
+ * @param {String} value
+ * @returns
+ */
+function parseOpacity(value) {
+    try {
+        if (isNaN(Number(value))) {
+            throw new Error()
+        }
+        return Math.max(Math.min(Number(value), 1), 0)
+    } catch (error) {
+        log.error(`failed to parse opacity value : ${value}, default to 1`)
+        return 1
+    }
+}
 /**
  * Reads URL params :
  *
@@ -28,92 +48,76 @@ function readUrlParamValue(url, paramName) {
  * set according to the legacyLayersParam)
  *
  * @param {GeoAdminLayer[]} layersConfig
- * @param {String} legacyLayersParam
+ * @param {String} layers A string containing all layers ids
+ * @param {String} legacyVisibilities A string containing the visibility value for each layer
+ * @param {String} legacyOpacities A string containing the opacity value for each layer
+ * @param {String} legacyTimestamp A string containing the timestamp or year for each time enabled
+ *   layer
  * @returns {AbstractLayer[]}
  */
-export function getLayersFromLegacyUrlParams(layersConfig, legacyLayersParam) {
+export function getLayersFromLegacyUrlParams(
+    layersConfig,
+    layers,
+    legacyVisibilities,
+    legacyOpacities,
+    legacyTimestamp
+) {
     const layersToBeActivated = []
-    if (legacyLayersParam) {
-        const layerIdsUrlParam = readUrlParamValue(legacyLayersParam, 'layers')
-        const layerVisibilityParam = readUrlParamValue(legacyLayersParam, 'layers_visibility')
-        const layerOpacityParam = readUrlParamValue(legacyLayersParam, 'layers_opacity')
-        const layerTimestampsParam = readUrlParamValue(legacyLayersParam, 'layers_timestamp')
-        const layerVisibilities = []
+    // In the case these parameters are not defined, we ensure we have empty arrays rather than
+    // 'undefined' elements. Since the function is also called in `topics.api.js`, it can be called
+    // with a completely empty string.
+    const layersIds = layers?.split(',').map(decodeURIComponent) ?? []
 
-        if (layerVisibilityParam) {
-            layerVisibilities.push(...layerVisibilityParam.split(','))
+    const layerOpacities = legacyOpacities?.split(',').map(parseOpacity) ?? []
+    const layerVisibilities = legacyVisibilities?.split(',') ?? []
+    const layerTimestamps = legacyTimestamp?.split(',') ?? []
+    layersIds.forEach((layerId, index) => {
+        let layer = layersConfig.find((layer) => layer.getID() === layerId)
+        // if this layer can be found in the list of GeoAdminLayers (from the config), we use that as the basis
+        // to add it to the map
+        if (layer) {
+            // we can't modify "layer" straight because it comes from the Vuex state, so we deep copy it
+            // in order to alter it before returning it
+            layer = layer.clone()
         }
-
-        const layerOpacities = []
-        if (layerOpacityParam) {
-            layerOpacities.push(...layerOpacityParam.split(','))
+        if (layerId.startsWith('KML||')) {
+            const [_layerType, url] = layerId.split('||')
+            layer = new KMLLayer(url, true /* visible */)
         }
-        const layerTimestamps = []
-        if (layerTimestampsParam) {
-            layerTimestamps.push(...layerTimestampsParam.split(','))
+        if (layerId.startsWith('WMTS||')) {
+            const [_layerType, id, url] = layerId.split('||')
+            if (layerId && url) {
+                layer = new ExternalWMTSLayer(id, 1.0, true, url, id)
+            }
         }
-
-        if (layerIdsUrlParam) {
-            layerIdsUrlParam
-                .split(',')
-                .map(decodeURIComponent)
-                .forEach((layerId, index) => {
-                    let layer = layersConfig.find((layer) => layer.getID() === layerId)
-                    // if this layer can be found in the list of GeoAdminLayers (from the config), we use that as the basis
-                    // to add it to the map
-                    if (layer) {
-                        // we can't modify "layer" straight because it comes from the Vuex state, so we deep copy it
-                        // in order to alter it before returning it
-                        layer = layer.clone()
-                    }
-                    if (layerId.startsWith('KML||')) {
-                        const [_layerType, url] = layerId.split('||')
-                        layer = new KMLLayer(url, true /* visible */)
-                    }
-                    if (layerId.startsWith('WMTS||')) {
-                        const [_layerType, id, url] = layerId.split('||')
-                        if (layerId && url) {
-                            layer = new ExternalWMTSLayer(id, 1.0, true, url, id)
-                        }
-                    }
-                    if (layerId.startsWith('WMS||')) {
-                        const [_layerType, name, url, id, version] = layerId.split('||')
-                        // we only decode if we have enough material
-                        if (url && id) {
-                            layer = new ExternalWMSLayer(
-                                name ? name : id,
-                                1.0,
-                                true,
-                                url,
-                                id,
-                                null,
-                                version
-                            )
-                        }
-                    }
-                    if (layer) {
-                        // checking if visibility is set in URL
-                        if (layerVisibilities.length > index) {
-                            layer.visible = layerVisibilities[index] === 'true'
-                        } else {
-                            // if param layers_visibility is not present, it means all layers are visible
-                            layer.visible = true
-                        }
-                        // checking if opacity is set in the URL
-                        if (layerOpacities.length > index) {
-                            layer.opacity = Number(layerOpacities[index])
-                        }
-                        // checking if a timestamp is defined for this layer
-                        if (layerTimestamps.length > index && layerTimestamps[index]) {
-                            layer.timeConfig.updateCurrentTimeEntry(
-                                layer.timeConfig.getTimeEntryForTimestamp(layerTimestamps[index])
-                            )
-                        }
-                        layersToBeActivated.push(layer)
-                    }
-                })
+        if (layerId.startsWith('WMS||')) {
+            const [_layerType, name, url, id, version] = layerId.split('||')
+            // we only decode if we have enough material
+            if (url && id) {
+                layer = new ExternalWMSLayer(name ? name : id, 1.0, true, url, id, null, version)
+            }
         }
-    }
+        if (layer) {
+            // checking if visibility is set in URL
+            if (layerVisibilities.length > index) {
+                layer.visible = layerVisibilities[index] === 'true'
+            } else {
+                // if param layers_visibility is not present, it means all layers are visible
+                layer.visible = true
+            }
+            // checking if opacity is set in the URL
+            if (layerOpacities.length > index) {
+                layer.opacity = Number(layerOpacities[index])
+            }
+            // checking if a timestamp is defined for this layer
+            if (layerTimestamps.length > index && layerTimestamps[index]) {
+                layer.timeConfig.updateCurrentTimeEntry(
+                    layer.timeConfig.getTimeEntryForTimestamp(layerTimestamps[index])
+                )
+            }
+            layersToBeActivated.push(layer)
+        }
+    })
     return layersToBeActivated
 }
 

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -1,9 +1,9 @@
+import { useStore } from 'vuex'
+
 import { getKmlMetadataByAdminId } from '@/api/files.api'
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
 import KMLLayer from '@/api/layers/KMLLayer.class'
-import { useStore } from 'vuex'
-
 function readUrlParamValue(url, paramName) {
     if (url && paramName && url.indexOf(paramName) !== -1) {
         const urlStartingAtParamDeclaration = url.substr(url.indexOf(paramName) + 1)
@@ -126,9 +126,6 @@ export function getLayersFromLegacyUrlParams(layersConfig, legacyLayersParam) {
                         }
                         // checking if a timestamp is defined for this layer
                         if (layerTimestamps.length > index && layerTimestamps[index]) {
-                            // TODO : the commit doesn't work on the swissimage product, apparently
-                            // it doesn't have a time series
-                            // gives the following error 'Failed to set layer year, layer not found or has no time config',
                             let year = layerTimestamps[index]
                             if (
                                 layer.timeConfig.getTimeEntryForTimestamp(layerTimestamps[index])
@@ -138,10 +135,8 @@ export function getLayersFromLegacyUrlParams(layersConfig, legacyLayersParam) {
                                     layerTimestamps[index]
                                 ).year
                             }
-                            console.log(layerId)
-                            console.log(year)
-                            store.dispatch('setTimedLayerCurrentYear', {
-                                layerId: layerId,
+                            store.dispatch('setLegacyTimeLayerYear', {
+                                layer: layer,
                                 year: year,
                             })
                         }

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -17,6 +17,15 @@ function readUrlParamValue(url, paramName) {
 }
 
 /**
+ * @param {String} search The query made to the mapviewer
+ * @returns True if the query starts with ? or /?
+ */
+export const isLegacyParams = (search) => {
+    const parts = search?.match(/^(\?|\/\?).*$/g) ?? null
+    return parts && Array.isArray(parts)
+}
+
+/**
  * Ensure opacity is within its bounds (0 and 1). Also assign a default value of 1 should the
  * parameter be something unexpected
  *
@@ -67,7 +76,6 @@ export function getLayersFromLegacyUrlParams(
     // 'undefined' elements. Since the function is also called in `topics.api.js`, it can be called
     // with a completely empty string.
     const layersIds = layers?.split(',').map(decodeURIComponent) ?? []
-
     const layerOpacities = legacyOpacities?.split(',').map(parseOpacity) ?? []
     const layerVisibilities = legacyVisibilities?.split(',') ?? []
     const layerTimestamps = legacyTimestamp?.split(',') ?? []

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -135,10 +135,19 @@ export function getLayersFromLegacyUrlParams(layersConfig, legacyLayersParam) {
                                     layerTimestamps[index]
                                 ).year
                             }
-                            store.dispatch('setLegacyTimeLayerYear', {
-                                layer: layer,
-                                year: year,
-                            })
+                            if (store) {
+                                store.dispatch('setLegacyTimeLayerYear', {
+                                    layer: layer,
+                                    year: year,
+                                })
+                            } else {
+                                // this does tell us that the changes have been taken into account
+                                // and would be updated, without using a store that is not active
+                                // during unit tests
+                                layer.timeConfig.updateCurrentTimeEntry(
+                                    layer.timeConfig.getTimeEntryForYear(year)
+                                )
+                            }
                         }
                         layersToBeActivated.push(layer)
                     }

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -130,17 +130,8 @@ export function getLayersFromLegacyUrlParams(layersConfig, legacyLayersParam) {
                         }
                         // checking if a timestamp is defined for this layer
                         if (layerTimestamps.length > index && layerTimestamps[index]) {
-                            let year = layerTimestamps[index]
-                            if (
-                                layer.timeConfig.getTimeEntryForTimestamp(layerTimestamps[index])
-                                    .year
-                            ) {
-                                year = layer.timeConfig.getTimeEntryForTimestamp(
-                                    layerTimestamps[index]
-                                ).year
-                            }
                             layer.timeConfig.updateCurrentTimeEntry(
-                                layer.timeConfig.getTimeEntryForYear(year)
+                                layer.timeConfig.getTimeEntryForTimestamp(layerTimestamps[index])
                             )
                         }
                         layersToBeActivated.push(layer)

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -18,11 +18,10 @@ function readUrlParamValue(url, paramName) {
 
 /**
  * @param {String} search The query made to the mapviewer
- * @returns True if the query starts with ? or /?
+ * @returns {Boolean} True if the query starts with ? or /?
  */
 export const isLegacyParams = (search) => {
-    const parts = search?.match(/^(\?|\/\?).*$/g) ?? null
-    return parts && Array.isArray(parts)
+    return !!search?.match(/^(\?|\/\?).*$/g) ?? false
 }
 
 /**
@@ -30,9 +29,9 @@ export const isLegacyParams = (search) => {
  * parameter be something unexpected
  *
  * @param {String} value
- * @returns
+ * @returns {Number} A float between 0 and 1
  */
-function parseOpacity(value) {
+export function parseOpacity(value) {
     try {
         if (isNaN(Number(value))) {
             throw new Error()
@@ -115,7 +114,7 @@ export function getLayersFromLegacyUrlParams(
             }
             // checking if opacity is set in the URL
             if (layerOpacities.length > index) {
-                layer.opacity = Number(layerOpacities[index])
+                layer.opacity = layerOpacities[index]
             }
             // checking if a timestamp is defined for this layer
             if (layerTimestamps.length > index && layerTimestamps[index]) {

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -14,31 +14,6 @@ function readUrlParamValue(url, paramName) {
     return undefined
 }
 
-/*
- Return true if the layer is a layer WITH a specified non legacy parameter.
- Layers without parameters will return false
- */
-const newLayerParamRegex =
-    /^([\w.-]+)((@[\w=\d]+)+(,[ft,]+)*([,\d.]+)*|(@[\w=\d]+)*(,[ft,]+)+([,\d.]+)*|(@[\w=\d]+)*(,[ft,]+)*([,\d.]+)+)$/
-function isExternalLayer(layerId) {
-    return (
-        layerId &&
-        (layerId.startsWith('WMS|') || layerId.startsWith('WMTS|')) &&
-        layerId.indexOf('||') === -1
-    )
-}
-
-export function isLayersUrlParamLegacy(layersParamValue) {
-    // current error : layers thich finish in f/t are recognized as problematic
-    if (layersParamValue.split(';').length > 1) {
-        // if layers are separated by ;, this means we are not having legacy layers
-        return false
-    }
-    return !layersParamValue.split(';').some((layer) => {
-        return isExternalLayer(layer) || newLayerParamRegex.test(layer)
-    })
-}
-
 /**
  * Reads URL params :
  *

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -155,7 +155,7 @@ Cypress.Commands.add(
     'goToMapView',
     (
         queryParams = {},
-        withHash = false,
+        withHash = true,
         geolocationMockupOptions = { latitude: 47, longitude: 7 },
         fixturesAndIntercepts = {}
     ) => {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -4,6 +4,7 @@ import 'cypress-wait-until'
 import { MapBrowserEvent } from 'ol'
 
 import { FAKE_URL_CALLED_AFTER_ROUTE_CHANGE } from '@/router/storeSync/storeSync.routerPlugin'
+import { WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
 import log from '@/utils/logging'
 import { randomIntBetween } from '@/utils/numberUtils'
 
@@ -177,8 +178,9 @@ Cypress.Commands.add(
         if (!('center' in queryParams) && !('3d' in queryParams)) {
             // "old" MAP_CENTER constant re-projected in LV95
             queryParams.center = '2660013.5,1185172'
+        } else if ('3d' in queryParams && !('sr' in queryParams)) {
+            queryParams.sr = WEBMERCATOR.epsgNumber
         }
-
         let flattenedQueryParams = ''
         Object.entries(queryParams).forEach(([key, value]) => {
             if (typeof value === Boolean && value === true) {

--- a/tests/cypress/support/drawing.js
+++ b/tests/cypress/support/drawing.js
@@ -102,7 +102,7 @@ const addFileAPIFixtureAndIntercept = () => {
     }).as('get-kml')
 }
 
-Cypress.Commands.add('goToDrawing', (queryParams = {}, withHash = false) => {
+Cypress.Commands.add('goToDrawing', (queryParams = {}, withHash = true) => {
     addIconFixtureAndIntercept()
     addProfileFixtureAndIntercept()
     addFileAPIFixtureAndIntercept()

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -11,11 +11,14 @@ describe('Test on legacy param import', () => {
             const lat = 47.3
             const lon = 7.3
             const zoom = 10.4
-            cy.goToMapView({
-                lat,
-                lon,
-                z: zoom,
-            })
+            cy.goToMapView(
+                {
+                    lat,
+                    lon,
+                    z: zoom,
+                },
+                false
+            )
 
             // checking in the store that the position has not changed from what was in the URL
             cy.readStoreValue('state.position.zoom').should('eq', 10) // zoom should be rounded to the closest Swisstopo zoom level
@@ -49,11 +52,14 @@ describe('Test on legacy param import', () => {
             const E = 2660000
             const N = 1200000
             const lv95zoom = 8
-            cy.goToMapView({
-                E,
-                N,
-                zoom: lv95zoom,
-            })
+            cy.goToMapView(
+                {
+                    E,
+                    N,
+                    zoom: lv95zoom,
+                },
+                false
+            )
 
             cy.readStoreValue('state.position.zoom').should('eq', lv95zoom)
 
@@ -103,11 +109,14 @@ describe('Test on legacy param import', () => {
         })
 
         it('Combines all old layers_*** params into the new one', () => {
-            cy.goToMapView({
-                layers: 'test.wms.layer,test.wmts.layer',
-                layers_opacity: '0.6,0.5',
-                layers_visibility: 'true,false',
-            })
+            cy.goToMapView(
+                {
+                    layers: 'test.wms.layer,test.wmts.layer',
+                    layers_opacity: '0.6,0.5',
+                    layers_visibility: 'true,false',
+                },
+                false
+            )
             cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
                 expect(activeLayers).to.be.an('Array').length(2)
                 const [wmsLayer, wmtsLayer] = activeLayers
@@ -120,11 +129,14 @@ describe('Test on legacy param import', () => {
             })
         })
         it('is able to import an external KML from a legacy param', () => {
-            cy.goToMapView({
-                layers: `KML||${kmlServiceBaseUrl}${kmlServiceFilePath}`,
-                layers_opacity: '0.6',
-                layers_visibility: 'true',
-            })
+            cy.goToMapView(
+                {
+                    layers: `KML||${kmlServiceBaseUrl}${kmlServiceFilePath}`,
+                    layers_opacity: '0.6',
+                    layers_visibility: 'true',
+                },
+                false
+            )
             cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
                 expect(activeLayers).to.be.an('Array').length(1)
                 const [kmlLayer] = activeLayers
@@ -135,9 +147,12 @@ describe('Test on legacy param import', () => {
         })
         // TODO BGDIINF_SB-2685: re-activate
         it.skip('is able to import an external KML from a legacy adminId query param', () => {
-            cy.goToMapView({
-                adminId: adminId,
-            })
+            cy.goToMapView(
+                {
+                    adminId: adminId,
+                },
+                false
+            )
             cy.wait('@get-kml-metada-by-admin-id')
             cy.wait('@get-kml')
             cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
@@ -151,9 +166,12 @@ describe('Test on legacy param import', () => {
         })
         // TODO BGDIINF_SB-2685: re-activate
         it.skip("don't keep KML adminId in URL after import", () => {
-            cy.goToMapView({
-                adminId: adminId,
-            })
+            cy.goToMapView(
+                {
+                    adminId: adminId,
+                },
+                false
+            )
             cy.wait('@get-kml-metada-by-admin-id')
             cy.wait('@get-kml')
             cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
@@ -168,12 +186,15 @@ describe('Test on legacy param import', () => {
         })
         // TODO BGDIINF_SB-2685: re-activate
         it.skip('is able to import an external KML from a legacy adminId query param with other layers', () => {
-            cy.goToMapView({
-                adminId: adminId,
-                layers: 'test.wms.layer,test.wmts.layer',
-                layers_opacity: '0.6,0.5',
-                layers_visibility: 'true,false',
-            })
+            cy.goToMapView(
+                {
+                    adminId: adminId,
+                    layers: 'test.wms.layer,test.wmts.layer',
+                    layers_opacity: '0.6,0.5',
+                    layers_visibility: 'true,false',
+                },
+                false
+            )
             cy.wait('@get-kml-metada-by-admin-id')
             cy.wait('@get-kml')
             cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
@@ -206,9 +227,12 @@ describe('Test on legacy param import', () => {
                     ],
                 },
             }).as('search-locations')
-            cy.goToMapView({
-                swisssearch: '1530 Payerne',
-            })
+            cy.goToMapView(
+                {
+                    swisssearch: '1530 Payerne',
+                },
+                false
+            )
             cy.readStoreValue('state.search.query').should('eq', '1530 Payerne')
             cy.url().should('include', 'swisssearch=1530+Payerne')
             cy.get('[data-cy="search-result-entry-location"]').should('be.visible')
@@ -228,12 +252,15 @@ describe('Test on legacy param import', () => {
                 { fixture: 'external-wms-getcap.fixture.xml' }
             ).as('externalWMSGetCap')
 
-            cy.goToMapView({
-                layers: `test.wms.layer,WMS||${layerName}||${url}||${layerId}||1.3.0`,
-                layers_opacity: '1,1',
-                layers_visibility: 'false,true',
-                layers_timestam: ',',
-            })
+            cy.goToMapView(
+                {
+                    layers: `test.wms.layer,WMS||${layerName}||${url}||${layerId}||1.3.0`,
+                    layers_opacity: '1,1',
+                    layers_visibility: 'false,true',
+                    layers_timestam: ',',
+                },
+                false
+            )
             cy.wait('@externalWMSGetCap')
             cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
                 expect(activeLayers).to.be.an('Array').length(2)
@@ -264,12 +291,15 @@ describe('Test on legacy param import', () => {
             const layerId = 'TestExternalWMTS'
             const layerName = 'Test External WMTS'
             const url = 'http://wmts-test.url/'
-            cy.goToMapView({
-                layers: `test.wmts.layer,WMTS||${layerId}||${url}`,
-                layers_opacity: '1,1',
-                layers_visibility: 'false,true',
-                layers_timestam: ',',
-            })
+            cy.goToMapView(
+                {
+                    layers: `test.wmts.layer,WMTS||${layerId}||${url}`,
+                    layers_opacity: '1,1',
+                    layers_visibility: 'false,true',
+                    layers_timestam: ',',
+                },
+                false
+            )
             cy.wait('@externalWMTSGetCap')
             cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
                 expect(activeLayers).to.be.an('Array').length(2)
@@ -297,13 +327,16 @@ describe('Test on legacy param import', () => {
         const pitch = -45
 
         it('transfers camera parameter from legacy URL to the new URL', () => {
-            cy.goToMapView({
-                lat,
-                lon,
-                elevation,
-                heading,
-                pitch,
-            })
+            cy.goToMapView(
+                {
+                    lat,
+                    lon,
+                    elevation,
+                    heading,
+                    pitch,
+                },
+                false
+            )
 
             // checking in the store that the parameters have been converted into the new 3D parameters
             cy.readStoreValue('state.cesium.active').should('eq', true) // cesium should be active
@@ -321,11 +354,14 @@ describe('Test on legacy param import', () => {
         })
 
         it('transfers camera parameter from legacy URL to the new URL only heading', () => {
-            cy.goToMapView({
-                lat,
-                lon,
-                heading,
-            })
+            cy.goToMapView(
+                {
+                    lat,
+                    lon,
+                    heading,
+                },
+                false
+            )
 
             // checking in the store that the parameters have been converted into the new 3D parameters
             cy.readStoreValue('state.cesium.active').should('eq', true) // cesium should be active
@@ -343,11 +379,14 @@ describe('Test on legacy param import', () => {
         })
 
         it('transfers camera parameter from legacy URL to the new URL only elevation', () => {
-            cy.goToMapView({
-                lat,
-                lon,
-                elevation,
-            })
+            cy.goToMapView(
+                {
+                    lat,
+                    lon,
+                    elevation,
+                },
+                false
+            )
 
             // checking in the store that the parameters have been converted into the new 3D parameters
             cy.readStoreValue('state.cesium.active').should('eq', true) // cesium should be active


### PR DESCRIPTION
Issue : When using legacy parameters with timestamps on time enabled layers, those parameters were not taken into account on the new mapviewer.

Fix: A typographical error stopped the timestamps parameters from being populated, and then we never entered the condition to apply those parameters to the layers. Once this was solved, it appeared we were trying to assign value to a protected element outside a mutation, thus we added a new setter to apply these changes to the layers, even if they're not active yet.
[Test link with legacy timeseries parameters](https://sys-map.dev.bgdi.ch/preview/pb-246-bugfix-legacy-timestamps/index.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.swisstopo.swissimage-product&layers_timestamp=19951231,2002&lang=en&layers_opacity=0.45,0.7&layers_visibility=false,true)
[Test link](https://sys-map.dev.bgdi.ch/preview/pb-246-bugfix-legacy-timestamps/index.html)