### PR TITLE
PB-114: Made KML retro compatible with mf-geoadmin3

### DIFF
--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -55,6 +55,7 @@ watch(featureIds, (next, last) => {
     }
 })
 
+let unsubscribe = null
 onMounted(() => {
     // if icons have not yet been loaded, we do so
     if (availableIconSets.value.length === 0) {
@@ -79,6 +80,21 @@ onMounted(() => {
     document.addEventListener('keyup', removeLastPointOnDeleteKeyUp, { passive: true })
     document.addEventListener('contextmenu', removeLastPoint, { passive: true })
 
+    log.debug(`subscribe for feature mutation`)
+    unsubscribe = store.subscribe((mutation) => {
+        // The title description of an editable feature are only set in the editable feature
+        // however in the KML standard they should be set in the name and description tags.
+        // To do this we need to set them on the ol feature as properties.
+        if (mutation.type === 'changeFeatureTitle') {
+            const feature = drawingLayer.getSource().getFeatureById(mutation.payload.feature.id)
+            feature?.set('name', mutation.payload.title)
+        }
+        if (mutation.type === 'changeFeatureDescription') {
+            const feature = drawingLayer.getSource().getFeatureById(mutation.payload.feature.id)
+            feature?.set('description', mutation.payload.description)
+        }
+    })
+
     if (IS_TESTING_WITH_CYPRESS) {
         window.drawingLayer = drawingLayer
     }
@@ -92,6 +108,9 @@ onBeforeUnmount(async () => {
 
     document.removeEventListener('contextmenu', removeLastPoint)
     document.removeEventListener('keyup', removeLastPointOnDeleteKeyUp)
+
+    log.debug(`unsubscribe feature mutation`)
+    unsubscribe()
 
     if (IS_TESTING_WITH_CYPRESS) {
         delete window.drawingLayer

--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -55,7 +55,6 @@ watch(featureIds, (next, last) => {
     }
 })
 
-let unsubscribe = null
 onMounted(() => {
     // if icons have not yet been loaded, we do so
     if (availableIconSets.value.length === 0) {
@@ -80,21 +79,6 @@ onMounted(() => {
     document.addEventListener('keyup', removeLastPointOnDeleteKeyUp, { passive: true })
     document.addEventListener('contextmenu', removeLastPoint, { passive: true })
 
-    log.debug(`subscribe for feature mutation`)
-    unsubscribe = store.subscribe((mutation) => {
-        // The title description of an editable feature are only set in the editable feature
-        // however in the KML standard they should be set in the name and description tags.
-        // To do this we need to set them on the ol feature as properties.
-        if (mutation.type === 'changeFeatureTitle') {
-            const feature = drawingLayer.getSource().getFeatureById(mutation.payload.feature.id)
-            feature?.set('name', mutation.payload.title)
-        }
-        if (mutation.type === 'changeFeatureDescription') {
-            const feature = drawingLayer.getSource().getFeatureById(mutation.payload.feature.id)
-            feature?.set('description', mutation.payload.description)
-        }
-    })
-
     if (IS_TESTING_WITH_CYPRESS) {
         window.drawingLayer = drawingLayer
     }
@@ -110,7 +94,6 @@ onBeforeUnmount(async () => {
     document.removeEventListener('keyup', removeLastPointOnDeleteKeyUp)
 
     log.debug(`unsubscribe feature mutation`)
-    unsubscribe()
 
     if (IS_TESTING_WITH_CYPRESS) {
         delete window.drawingLayer

--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -93,8 +93,6 @@ onBeforeUnmount(async () => {
     document.removeEventListener('contextmenu', removeLastPoint)
     document.removeEventListener('keyup', removeLastPointOnDeleteKeyUp)
 
-    log.debug(`unsubscribe feature mutation`)
-
     if (IS_TESTING_WITH_CYPRESS) {
         delete window.drawingLayer
     }

--- a/src/modules/drawing/components/DrawingSelectInteraction.vue
+++ b/src/modules/drawing/components/DrawingSelectInteraction.vue
@@ -84,7 +84,12 @@ function onSelectChange(event) {
         currentlySelectedFeature.value = null
     }
 }
-function onFeatureChange() {
+function onFeatureChange(editableFeature) {
+    // The title and description of an editable feature are only set in the editable feature
+    // however in the KML standard they should be set in the name and description tags.
+    // To do this we need to set them on the ol feature as properties.
+    currentlySelectedFeature.value?.set('name', editableFeature.title)
+    currentlySelectedFeature.value?.set('description', editableFeature.description)
     currentlySelectedFeature.value?.changed()
     debounceSaveDrawing()
 }

--- a/src/modules/drawing/components/useDrawingModeInteraction.composable.js
+++ b/src/modules/drawing/components/useDrawingModeInteraction.composable.js
@@ -113,6 +113,9 @@ export default function useDrawingModeInteraction({
             update must be triggered manually.*/
             feature.setProperties({
                 editableFeature: EditableFeature.newFeature(args),
+                // For backward compatibility with the legacy mf-geoadmin3 viewer we need to add the
+                // feature type as proprietary property
+                type: args.featureType.toLowerCase(),
             })
         }
     }

--- a/src/modules/drawing/lib/export-utils.js
+++ b/src/modules/drawing/lib/export-utils.js
@@ -65,10 +65,9 @@ export function generateGpxString(projection, features = []) {
  *
  * @param {CoordinateSystem} projection Coordinate system of the features
  * @param features {Feature[]} Features (OpenLayers) to be converted to KML format
- * @param styleFunction
  * @returns {string}
  */
-export function generateKmlString(projection, features = [], styleFunction = null) {
+export function generateKmlString(projection, features = []) {
     if (!projection) {
         log.error('Cannot generate KML string without projection')
         return ''
@@ -79,8 +78,7 @@ export function generateKmlString(projection, features = [], styleFunction = nul
         const clone = f.clone()
         clone.setId(f.getId())
         clone.getGeometry().setProperties(f.getGeometry().getProperties())
-        let styles = styleFunction || featureStyleFunction
-        styles = styles(clone)
+        const styles = featureStyleFunction(clone)
         const newStyle = {
             fill: styles[0].getFill(),
             stroke: styles[0].getStroke(),

--- a/src/modules/drawing/lib/export-utils.js
+++ b/src/modules/drawing/lib/export-utils.js
@@ -100,6 +100,14 @@ export function generateKmlString(projection, features = []) {
 
         const myStyle = new Style(newStyle)
         clone.setStyle(myStyle)
+
+        // The description of an editable feature is only set in the editable feature
+        // however in the KML standard the description should be set in the <description> tag
+        // to do this we need to set the description on the ol feature.
+        const editableFeature = clone.get('editableFeature')
+        if (editableFeature?.description) {
+            clone.set('description', editableFeature.description)
+        }
         exportFeatures.push(clone)
     })
 

--- a/src/modules/drawing/lib/export-utils.js
+++ b/src/modules/drawing/lib/export-utils.js
@@ -101,19 +101,6 @@ export function generateKmlString(projection, features = []) {
         const myStyle = new Style(newStyle)
         clone.setStyle(myStyle)
 
-        const editableFeature = clone.get('editableFeature')
-        // For backward compatibility with the legacy mf-geoadmin3 viewer we need to add the
-        // feature type as proprietary property
-        if (editableFeature?.featureType) {
-            clone.set('type', editableFeature.featureType.toLowerCase())
-        }
-
-        // The description of an editable feature is only set in the editable feature
-        // however in the KML standard the description should be set in the <description> tag
-        // to do this we need to set the description on the ol feature.
-        if (editableFeature?.description) {
-            clone.set('description', editableFeature.description)
-        }
         exportFeatures.push(clone)
     })
 

--- a/src/modules/drawing/lib/export-utils.js
+++ b/src/modules/drawing/lib/export-utils.js
@@ -101,10 +101,16 @@ export function generateKmlString(projection, features = []) {
         const myStyle = new Style(newStyle)
         clone.setStyle(myStyle)
 
+        const editableFeature = clone.get('editableFeature')
+        // For backward compatibility with the legacy mf-geoadmin3 viewer we need to add the
+        // feature type as proprietary property
+        if (editableFeature?.featureType) {
+            clone.set('type', editableFeature.featureType.toLowerCase())
+        }
+
         // The description of an editable feature is only set in the editable feature
         // however in the KML standard the description should be set in the <description> tag
         // to do this we need to set the description on the ol feature.
-        const editableFeature = clone.get('editableFeature')
         if (editableFeature?.description) {
             clone.set('description', editableFeature.description)
         }

--- a/src/utils/components/TextInput.vue
+++ b/src/utils/components/TextInput.vue
@@ -11,7 +11,7 @@ import { useI18n } from 'vue-i18n'
 const clearButtonId = `button-addon-clear-${components}`
 components = components + 1
 
-const model = defineModel()
+const model = defineModel({ type: String })
 
 const props = defineProps({
     /**


### PR DESCRIPTION
Now the KML are retro compatible with mf-geadmin3, see test link below which import a KML created by web-mapviewer into mf-geoadmin3
- KML file generated by web-mapviewer: https://sys-public.dev.bgdi.ch/api/kml/files/UguLO2B4RqKGqLosIGOsxA
- Link to mf-geoadmin3 using the file above: https://map.geo.admin.ch/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=KML%7C%7Chttps:%2F%2Fsys-public.dev.bgdi.ch%2Fapi%2Fkml%2Ffiles%2FUguLO2B4RqKGqLosIGOsxA&E=2623716.62&N=1232091.54&zoom=4

In theory the KML are aslo compatible with other KML viewer, but for this it requires first PB-264 to be done.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-114-kml/index.html)