### PR TITLE
PB-267: Removed adminId guard on non prod hosts

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -253,18 +253,6 @@ export const NO_WARNING_BANNER_HOSTNAMES = ['test.map.geo.admin.ch', 'map.geo.ad
 export const WARNING_RIBBON_HOSTNAMES = ['test.map.geo.admin.ch']
 
 /**
- * To avoid breaking legacy KML drawing during an MVP (test phases) we disable the drawing menu for
- * those ones on test.map.geo.admin.ch
- *
- * @type {String[]}
- */
-export const DISABLE_DRAWING_MENU_FOR_LEGACY_ON_HOSTNAMES = [
-    'test.map.geo.admin.ch',
-    'sys-map.dev.bgdi.ch',
-    'localhost',
-]
-
-/**
  * WMS supported versions list
  *
  * @type {String[]}

--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -62,7 +62,10 @@ watch(availableIconSets, () => {
     // did not have any numbered prefix. This means that without this workaround the icon preselection
     // from the set will not work and when modifying the drawing you might end up with a brocken
     // drawing.
-    log.debug('New iconsets available update all drawing features')
+    log.debug(
+        'New iconsets available update all drawing features',
+        drawingLayer.getSource().getFeatures()
+    )
     featureIds.value.forEach((featureId) => {
         const feature = drawingLayer.getSource()?.getFeatureById(featureId)?.get('editableFeature')
         if (feature?.icon) {

--- a/src/modules/menu/components/menu/MenuTray.vue
+++ b/src/modules/menu/components/menu/MenuTray.vue
@@ -25,7 +25,6 @@
                 id="drawSection"
                 :title="$t('draw_panel_title')"
                 secondary
-                :disabled="disableDrawing"
                 :show-content="showDrawingOverlay"
                 data-cy="menu-tray-drawing-section"
                 @click:header="toggleDrawingOverlay()"
@@ -66,11 +65,9 @@
 </template>
 
 <script>
-import tippy, { followCursor } from 'tippy.js'
 import { useI18n } from 'vue-i18n'
 import { mapActions, mapGetters, mapState } from 'vuex'
 
-import { DISABLE_DRAWING_MENU_FOR_LEGACY_ON_HOSTNAMES } from '@/config'
 import MenuActiveLayersList from '@/modules/menu/components/activeLayers/MenuActiveLayersList.vue'
 import MenuAdvancedToolsList from '@/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue'
 import MenuSection from '@/modules/menu/components/menu/MenuSection.vue'
@@ -127,43 +124,8 @@ export default {
             showDrawingOverlay: (state) => state.ui.showDrawingOverlay,
         }),
         ...mapGetters(['isPhoneMode', 'hasDevSiteWarning']),
-        disableDrawing() {
-            // TODO BGDIINF_SB-2685: remove this protection once on prod
-            if (
-                DISABLE_DRAWING_MENU_FOR_LEGACY_ON_HOSTNAMES.some(
-                    (hostname) => hostname === this.hostname
-                )
-            ) {
-                if (this.activeKmlLayer?.adminId && this.activeKmlLayer?.isLegacy()) {
-                    return true
-                }
-            }
-            return false
-        },
     },
     watch: {
-        disableDrawing(disableDrawing) {
-            if (disableDrawing) {
-                this.disableDrawingTooltip = tippy('#drawSectionTooltip', {
-                    theme: 'danger',
-                    arrow: true,
-                    followCursor: 'initial',
-                    plugins: [followCursor],
-                    hideOnClick: false,
-                    delay: 500,
-                    offset: [15, 15],
-                })
-                this.setDisableDrawingTooltipContent()
-            } else {
-                if (this.disableDrawingTooltip) {
-                    this.disableDrawingTooltip.forEach((tooltip) => tooltip.destroy())
-                    this.disableDrawingTooltip = null
-                }
-            }
-        },
-        lang() {
-            this.setDisableDrawingTooltipContent()
-        },
         showImportFile(show) {
             if (show) {
                 this.$refs['activeLayersSection'].open()
@@ -183,11 +145,6 @@ export default {
             if (['drawSection', 'toolsSection'].includes(id)) {
                 this.$refs['activeLayersSection'].open()
             }
-        },
-        setDisableDrawingTooltipContent() {
-            this.disableDrawingTooltip?.forEach((instance) => {
-                instance.setContent(this.i18n.t('legacy_drawing_warning'))
-            })
         },
     },
 }

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -1,6 +1,5 @@
 import proj4 from 'proj4'
 
-import { DISABLE_DRAWING_MENU_FOR_LEGACY_ON_HOSTNAMES } from '@/config'
 import { transformLayerIntoUrlString } from '@/router/storeSync/LayerParamConfig.class'
 import { backgroundMatriceBetween2dAnd3d as backgroundMatriceBetweenLegacyAndNew } from '@/store/plugins/2d-to-3d-management.plugin'
 import { LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
@@ -162,10 +161,6 @@ const handleLegacyParams = (legacyParams, store, to, next) => {
     let legacyCoordinates = []
     let latlongCoordinates = []
     let cameraPosition = []
-    // TODO BGDIINF_SB-2685: remove once legacy prod is decommissioned
-    const isOnDevelopmentHost = DISABLE_DRAWING_MENU_FOR_LEGACY_ON_HOSTNAMES.some(
-        (hostname) => hostname === store.state.ui.hostname
-    )
 
     Object.keys(legacyParams).forEach((param) => {
         handleLegacyParam(
@@ -214,10 +209,7 @@ const handleLegacyParams = (legacyParams, store, to, next) => {
     const urlWithoutQueryParam = window.location.href.substr(0, window.location.href.indexOf('?'))
     window.history.replaceState(window.history.state, document.title, urlWithoutQueryParam)
 
-    // TODO BGDIINF_SB-2685: remove dev host check when map.geo.admin.ch hosts web-mapviewer's code
-    //  we cannot let adminId get through right now (on our dev envs) because legacy KML will be broken by the
-    //  new viewer if edited (broken in a sense that they will not be usable by mf-geoadmin3 anymore)
-    if (!isOnDevelopmentHost && 'adminId' in legacyParams) {
+    if ('adminId' in legacyParams) {
         // adminId legacy param cannot be handle above in the loop because it needs to add a layer
         // to the layers param, thats why we do handle after.
         handleLegacyKmlAdminIdParam(legacyParams, newQuery)

--- a/src/utils/kmlUtils.js
+++ b/src/utils/kmlUtils.js
@@ -206,7 +206,7 @@ export function parseIconUrl(url) {
     // babs set := /images/{set_name}/{image}
     const legacyDefaultMatch =
         /color\/(?<r>\d+),(?<g>\d+),(?<b>\d+)\/(?<name>[^/]+)-\d+@(?<scale>\d+)x\.png$/.exec(url)
-    const legacySetMatch = new RegExp('images/(?<set>\\w+)/(?<name>[^/]+)\\.png$').exec(url)
+    const legacySetMatch = /images\/(?<set>\w+)\/(?<name>[^/]+)\.png$/.exec(url)
 
     // new icon urls pattern
     // /api/icons/sets/{set_name}/icons/{icon_name}.png

--- a/tests/cypress/fixtures/service-icons/set-default.fixture.json
+++ b/tests/cypress/fixtures/service-icons/set-default.fixture.json
@@ -14,8 +14,8 @@
         },
         {
             "icon_set": "default",
-            "name": "003-placeholder",
-            "url": "http://localhost:8080/api/icons/sets/default/icons/003-placeholder-255,0,0.png",
+            "name": "003-square",
+            "url": "http://localhost:8080/api/icons/sets/default/icons/003-square-255,0,0.png",
             "template_url": "http://localhost:8080/api/icons/sets/{icon_set_name}/icons/{icon_name}@{icon_scale}-{r},{g},{b}.png"
         },
         {

--- a/tests/cypress/fixtures/service-kml/legacy-mf-geoadmin3.kml
+++ b/tests/cypress/fixtures/service-kml/legacy-mf-geoadmin3.kml
@@ -1,0 +1,77 @@
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd">
+    <Document>
+        <name>Dessin</name>
+        <Placemark id="marker_1706796360725">
+            <ExtendedData>
+                <Data name="type">
+                    <value>marker</value>
+                </Data>
+            </ExtendedData>
+            <name></name>
+            <description></description>
+            <Style>
+                <IconStyle>
+                    <Icon>
+                        <href>https://sys-api3.dev.bgdi.ch/color/255,0,0/marker-24@2x.png</href>
+                        <gx:w>48</gx:w>
+                        <gx:h>48</gx:h>
+                    </Icon>
+                    <hotSpot x="24" y="4.799999999999997" xunits="pixels" yunits="pixels" />
+                </IconStyle>
+            </Style>
+            <Point>
+                <tessellate>1</tessellate>
+                <altitudeMode>clampToGround</altitudeMode>
+                <coordinates>7.886303547206525,47.07614428012044</coordinates>
+            </Point>
+        </Placemark>
+        <Placemark id="marker_1706796371472">
+            <ExtendedData>
+                <Data name="type">
+                    <value>marker</value>
+                </Data>
+            </ExtendedData>
+            <name></name>
+            <description></description>
+            <Style>
+                <IconStyle>
+                    <Icon>
+                        <href>https://sys-api3.dev.bgdi.ch/color/255,0,0/square-24@2x.png</href>
+                        <gx:w>48</gx:w>
+                        <gx:h>48</gx:h>
+                    </Icon>
+                </IconStyle>
+            </Style>
+            <Point>
+                <tessellate>1</tessellate>
+                <altitudeMode>clampToGround</altitudeMode>
+                <coordinates>7.248686789953856,46.80250110087888</coordinates>
+            </Point>
+        </Placemark>
+        <Placemark id="annotation_1706796378213">
+            <ExtendedData>
+                <Data name="type">
+                    <value>annotation</value>
+                </Data>
+            </ExtendedData>
+            <name>legacy mf-geoadmin3 drawing</name>
+            <description></description>
+            <Style>
+                <IconStyle>
+                    <scale>0</scale>
+                </IconStyle>
+                <LabelStyle>
+                    <color>ff0000ff</color>
+                    <scale>2</scale>
+                </LabelStyle>
+            </Style>
+            <Point>
+                <tessellate>1</tessellate>
+                <altitudeMode>clampToGround</altitudeMode>
+                <coordinates>8.13513639008518,47.47967404695217</coordinates>
+            </Point>
+        </Placemark>
+    </Document>
+</kml>

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -4,6 +4,7 @@ import 'cypress-wait-until'
 import { MapBrowserEvent } from 'ol'
 
 import { FAKE_URL_CALLED_AFTER_ROUTE_CHANGE } from '@/router/storeSync/storeSync.routerPlugin'
+import log from '@/utils/logging'
 import { randomIntBetween } from '@/utils/numberUtils'
 
 import { isMobile } from './utils'
@@ -206,7 +207,7 @@ Cypress.Commands.add(
             onBeforeLoad: (win) => mockGeolocation(win, geolocationMockupOptions),
         })
         // waiting for the app to load and layers to be configured.
-        cy.waitUntilState((state) => state.app.isMapReady, { timeout: 10000 })
+        cy.waitUntilState((state) => state.app.isMapReady, { timeout: 15000 })
         cy.waitUntilState(
             (state) => {
                 const active = state.layers.activeLayers.length
@@ -557,6 +558,9 @@ Cypress.Commands.add('checkOlLayer', (args = null) => {
         const olLayers = map.getAllLayers()
 
         layers.forEach((layer) => {
+            log.debug(
+                `Cypress test if layer is present in layers=${olLayers.map((l) => l.get('id')).join(',')}`
+            )
             const olLayer = olLayers.find((l) => l.get('id') === layer.id)
             if (layer.visible) {
                 expect(olLayer, `[${layer.id}] layer`).not.to.be.null

--- a/tests/cypress/support/drawing.js
+++ b/tests/cypress/support/drawing.js
@@ -4,13 +4,24 @@ import { EditableFeatureTypes } from '@/api/features.api'
 import { BREAKPOINT_PHONE_WIDTH } from '@/config'
 import { randomIntBetween } from '@/utils/numberUtils'
 
-const addIconFixtureAndIntercept = () => {
-    cy.intercept(`**/api/icons/sets/default/icons/**@1x-255,0,0.png`, {
+export const addIconFixtureAndIntercept = () => {
+    cy.intercept(`**/api/icons/sets/default/icons/*@*.png`, {
         fixture: 'service-icons/placeholder.png',
     }).as('icon-default')
-    cy.intercept(`**/api/icons/sets/babs/icons/**@1x.png`, {
+    cy.intercept(`**/api/icons/sets/babs/icons/*@*.png`, {
         fixture: 'service-icons/placeholder.png',
     }).as('icon-babs')
+}
+
+export const addLegacyIconFixtureAndIntercept = () => {
+    // /color/{r},{g},{b}/{image}-{size}@{scale}x.png
+    cy.intercept(`**/color/*,*,*/*@*.png`, {
+        fixture: 'service-icons/placeholder.png',
+    }).as('legacy-icon-default')
+    //  /images/{set_name}/{image}
+    cy.intercept(`**/images/*.png`, {
+        fixture: 'service-icons/placeholder.png',
+    }).as('legacy-icon-babs')
 }
 
 const addProfileFixtureAndIntercept = () => {

--- a/tests/cypress/tests-e2e/drawing.cy.js
+++ b/tests/cypress/tests-e2e/drawing.cy.js
@@ -2,7 +2,12 @@
 
 import { recurse } from 'cypress-recurse'
 import proj4 from 'proj4'
-import { getKmlAdminIdFromRequest, kmlMetadataTemplate } from 'tests/cypress/support/drawing'
+import {
+    addIconFixtureAndIntercept,
+    addLegacyIconFixtureAndIntercept,
+    getKmlAdminIdFromRequest,
+    kmlMetadataTemplate,
+} from 'tests/cypress/support/drawing'
 
 import { EditableFeatureTypes } from '@/api/features.api'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
@@ -538,7 +543,8 @@ describe('Drawing module tests', () => {
                 updated: '2024-02-01T13:52:10.988+00:00',
             }
 
-            // Here we overwrite the previous intercept for kml admin id set in support/drawing.js
+            addIconFixtureAndIntercept()
+            addLegacyIconFixtureAndIntercept()
             cy.intercept('GET', `**/api/kml/admin?admin_id=*`, {
                 body: kmlMetadata,
                 statusCode: 200,


### PR DESCRIPTION
This is not needed anymore as KML are fully backward compatible. This safety
guards was to prevent modifying prod KML on test.map.geo.admin.ch that would
not work on map.geo.admin.ch, but since PB-114 this is not needed anymore.

[Test link with legacy admin ID](https://sys-map.dev.bgdi.ch/preview/bug-267-kml-admin-id/index.html?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,ch.astra.wanderland-sperrungen_umleitungen&layers_opacity=1,1,1,0.8,0.8,1&layers_visibility=false,false,false,false,false,true&layers_timestamp=18641231,,,,,&adminId=egfQtn61TpeBnrZSvwVH_w
)

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-267-kml-admin-id/index.html)