### PR TITLE
PB-101 : add support for GPX reloading and e2e tests

### DIFF
--- a/src/modules/drawing/useKmlDataManagement.composable.js
+++ b/src/modules/drawing/useKmlDataManagement.composable.js
@@ -80,10 +80,10 @@ export default function useSaveKmlOnChange(drawingLayerDirectReference) {
                     activeKmlLayer.value.adminId,
                     kmlData
                 )
-                await store.dispatch('updateKmlLayer', {
+                await store.dispatch('updateKmlGpxLayer', {
                     layerId: activeKmlLayer.value.getID(),
-                    kmlData: kmlData,
-                    kmlMetadata: kmlMetadata,
+                    data: kmlData,
+                    metadata: kmlMetadata,
                 })
                 saveState.value = DrawingState.SAVED
             }

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -1,5 +1,6 @@
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
+import GPXLayer from '@/api/layers/GPXLayer.class.js'
 import KMLLayer from '@/api/layers/KMLLayer.class'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
 import AbstractParamConfig from '@/router/storeSync/abstractParamConfig.class'
@@ -55,6 +56,15 @@ export function createLayerObject(parsedLayer) {
         } else {
             // If the url does not start with http, then it is a local file and we don't add it
             // to the layer list upon start as we cannot load it anymore.
+            layer = null
+        }
+    }
+    // format is GPX|FILE_URL
+    if (layerType === 'GPX') {
+        if (url.startsWith('http')) {
+            layer = new GPXLayer(url, parsedLayer.visible, parsedLayer.opacity)
+        } else {
+            // we can't re-load GPX files loaded through a file import; this GPX file is ignored
             layer = null
         }
     }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -21,6 +21,7 @@ import clickOnMapManagementPlugin from '@/store/plugins/click-on-map-management.
 import loadExternalLayerAttributes from '@/store/plugins/external-layers.plugin'
 import geolocationManagementPlugin from '@/store/plugins/geolocation-management.plugin'
 import loadGeojsonStyleAndData from '@/store/plugins/load-geojson-style-and-data.plugin'
+import loadGpxDataAndMetadata from '@/store/plugins/load-gpx-data.plugin'
 import loadKmlDataAndMetadata from '@/store/plugins/load-kml-data.plugin'
 import loadLayersConfigOnLangChange from '@/store/plugins/load-layersconfig-on-lang-change'
 import loadingBarManagementPlugin from '@/store/plugins/loading-bar-management.plugin'
@@ -48,6 +49,7 @@ const store = createStore({
         loadExternalLayerAttributes,
         loadGeojsonStyleAndData,
         loadKmlDataAndMetadata,
+        loadGpxDataAndMetadata,
     ],
     modules: {
         app,

--- a/src/store/plugins/load-kml-data.plugin.js
+++ b/src/store/plugins/load-kml-data.plugin.js
@@ -16,7 +16,7 @@ async function loadMetadata(store, kmlLayer) {
     log.debug(`Loading metadata for added KML layer`, kmlLayer)
     try {
         const metadata = await loadKmlMetadata(kmlLayer)
-        store.dispatch('updateKmlLayer', { layerId: kmlLayer?.getID(), kmlMetadata: metadata })
+        store.dispatch('updateKmlGpxLayer', { layerId: kmlLayer?.getID(), metadata })
     } catch (error) {
         log.error(`Error while fetching KML metadata for layer ${kmlLayer?.getID()}`)
     }
@@ -31,7 +31,7 @@ async function loadData(store, kmlLayer) {
     log.debug(`Loading data for added KML layer`, kmlLayer)
     try {
         const data = await loadKmlData(kmlLayer)
-        store.dispatch('updateKmlLayer', { layerId: kmlLayer?.getID(), kmlData: data })
+        store.dispatch('updateKmlGpxLayer', { layerId: kmlLayer?.getID(), data })
     } catch (error) {
         log.error(`Error while fetching KML data for layer ${kmlLayer?.getID()}: ${error}`)
         store.dispatch('setLayerErrorKey', {

--- a/src/utils/gpxUtils.js
+++ b/src/utils/gpxUtils.js
@@ -1,7 +1,28 @@
-import CoordinateSystem from '@/utils/coordinates/CoordinateSystem.class.js'
+import { gpx as gpxToGeoJSON } from '@mapbox/togeojson'
+import bbox from '@turf/bbox'
+import { isEmpty as isExtentEmpty } from 'ol/extent'
+
+import CoordinateSystem from '@/utils/coordinates/CoordinateSystem.class'
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
 import GPX from '@/utils/GPX'
 import { gpxStyle } from '@/utils/styleUtils'
+
+/**
+ * Parse the GPX extent from the GPX tracks or features
+ *
+ * Will return null if the extent is not parsable.
+ *
+ * @param {String} content GPX content as a string
+ * @returns {[number, number, number, number] | null}
+ */
+export function getGpxExtent(content) {
+    const parseGpx = new DOMParser().parseFromString(content, 'text/xml')
+    const extent = bbox(gpxToGeoJSON(parseGpx))
+    if (isExtentEmpty(extent)) {
+        return null
+    }
+    return extent
+}
 
 /**
  * Parses a GPX's data into OL Features, including deserialization of features

--- a/tests/cypress/fixtures/import-tool/external-gpx-file.gpx
+++ b/tests/cypress/fixtures/import-tool/external-gpx-file.gpx
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd http://www.topografix.com/GPX/gpx_style/0/2 http://www.topografix.com/GPX/gpx_style/0/2/gpx_style.xsd" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns:gpx_style="http://www.topografix.com/GPX/gpx_style/0/2" version="1.1" creator="https://www.crossingswitzerland.com">
+    <metadata>
+        <name>geoadmin cypress test</name>
+        <author>
+            <name>Geoadmin</name>
+            <link href="https://map.geo.admin.ch" />
+        </author>
+    </metadata>
+    <trk>
+        <name>Test track</name>
+        <type>Testing</type>
+        <trkseg>
+            <trkpt lat="47.0" lon="7.5">
+                <ele>1000.0</ele>
+            </trkpt>
+            <trkpt lat="47.1" lon="7.5">
+                <ele>1200.0</ele>
+            </trkpt>
+        </trkseg>
+    </trk>
+</gpx>


### PR DESCRIPTION
Reworking the KML loading pipeline, which is nearly identical to GPX, to also support this new format
Moving the metadata/data loading parts from the import utils to a dedicated store plugin, so that these things can be loaded on app reload when the layer is added through the URL directly
Add e2e test to cover GPX support

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_pb-101_e2e_test_and_url_support/index.html)