### PR TITLE
PB-276 : bugfix missing compare slider tooltip

### DIFF
--- a/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
+++ b/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, toRefs } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 
 import ImportCatalogue from '@/modules/menu/components/advancedTools/ImportCatalogue/ImportCatalogue.vue'
@@ -14,6 +15,7 @@ const props = defineProps({
 })
 const { compact } = toRefs(props)
 const store = useStore()
+const i18n = useI18n()
 const showImportCatalogue = computed(() => store.state.ui.importCatalogue)
 const showImportFile = computed(() => store.state.ui.importFile)
 const storeCompareRatio = computed(() => store.state.ui.compareRatio)
@@ -62,7 +64,7 @@ function onToggleImportFile() {
         >
             <ModalWithBackdrop
                 v-if="showImportFile"
-                title="import_file"
+                :title="i18n.t('import_file')"
                 top
                 @close="onToggleImportFile"
             >

--- a/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
+++ b/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { computed, toRefs } from 'vue'
-import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 
 import ImportCatalogue from '@/modules/menu/components/advancedTools/ImportCatalogue/ImportCatalogue.vue'
@@ -15,7 +14,6 @@ const props = defineProps({
 })
 const { compact } = toRefs(props)
 const store = useStore()
-const i18n = useI18n()
 const showImportCatalogue = computed(() => store.state.ui.importCatalogue)
 const showImportFile = computed(() => store.state.ui.importFile)
 const storeCompareRatio = computed(() => store.state.ui.compareRatio)
@@ -64,7 +62,7 @@ function onToggleImportFile() {
         >
             <ModalWithBackdrop
                 v-if="showImportFile"
-                :title="i18n.t('import_file')"
+                title="import_file"
                 top
                 @close="onToggleImportFile"
             >
@@ -74,7 +72,8 @@ function onToggleImportFile() {
         <MenuAdvancedToolsListItem
             v-if="!is3dActive"
             :is-selected="isCompareSliderActive"
-            :title="i18n.t('compare')"
+            title="compare"
+            tooltip="swipe_tooltip"
             @click.stop="onToggleCompareSlider"
         >
         </MenuAdvancedToolsListItem>

--- a/tests/cypress/tests-e2e/compareSlider.cy.js
+++ b/tests/cypress/tests-e2e/compareSlider.cy.js
@@ -248,7 +248,7 @@ describe('Testing of the compare slider', () => {
                     cy.goToMapView({}, true)
                     cy.clickOnMenuButtonIfMobile()
                     cy.get('[data-cy="menu-tray-tool-section"]').click()
-                    cy.get('[data-cy="menu-advanced-tools-Compare"]').click()
+                    cy.get('[data-cy="menu-advanced-tools-compare"]').click()
                     cy.readStoreValue('state.ui.compareRatio').then((compareRatio) => {
                         expect(compareRatio).to.eq(0.5)
                     })
@@ -294,7 +294,7 @@ describe('Testing of the compare slider', () => {
                     cy.get('[data-cy="compare_slider"]').should('be.visible')
                     cy.clickOnMenuButtonIfMobile()
                     cy.get('[data-cy="menu-tray-tool-section"]').click()
-                    cy.get('[data-cy="menu-advanced-tools-Compare"]').should('be.visible')
+                    cy.get('[data-cy="menu-advanced-tools-compare"]').should('be.visible')
                     cy.readStoreValue('state.ui.compareRatio').then((compareRatio) => {
                         expect(compareRatio).to.eq(0.3)
                     })
@@ -303,7 +303,7 @@ describe('Testing of the compare slider', () => {
                         expect(isSliderActive).to.eq(true)
                     })
 
-                    cy.get('[data-cy="menu-advanced-tools-Compare"]').click()
+                    cy.get('[data-cy="menu-advanced-tools-compare"]').click()
                     cy.readStoreValue('state.ui.compareRatio').then((compareRatio) => {
                         expect(compareRatio).to.eq(0.3)
                     })
@@ -313,7 +313,7 @@ describe('Testing of the compare slider', () => {
                     })
                     cy.get('[data-cy="compare_slider"]').should('not.exist')
 
-                    cy.get('[data-cy="menu-advanced-tools-Compare"]').click()
+                    cy.get('[data-cy="menu-advanced-tools-compare"]').click()
                     cy.readStoreValue('state.ui.compareRatio').then((compareRatio) => {
                         expect(compareRatio).to.eq(0.3)
                     })
@@ -353,14 +353,14 @@ describe('The compare Slider and the menu elements should not be available in 3d
             )
             cy.clickOnMenuButtonIfMobile()
             cy.get('[data-cy="menu-tray-tool-section"]').click()
-            cy.get('[data-cy="menu-advanced-tools-Compare"]').should('be.visible')
+            cy.get('[data-cy="menu-advanced-tools-compare"]').should('be.visible')
             cy.clickOnMenuButtonIfMobile()
 
             cy.get('[data-cy="3d-button"]').click()
 
             cy.clickOnMenuButtonIfMobile()
 
-            cy.get('[data-cy="menu-advanced-tools-Compare"]').should('not.exist')
+            cy.get('[data-cy="menu-advanced-tools-compare"]').should('not.exist')
         })
     })
 })


### PR DESCRIPTION
Issue : tooltip was missing from compare Slider menu component

fix : we now have a tooltip. We also use the same method across the advanced menu to ask for translations, rather than a mix of ways.

[Test link](https://sys-map.dev.bgdi.ch/preview/pb-278-bugfix-missing-compare-slider-tooltip/index.html)