### PR TITLE
PB-266: Corrected KML icons size

### DIFF
--- a/src/api/features.api.js
+++ b/src/api/features.api.js
@@ -270,9 +270,11 @@ export class EditableFeature extends SelectableFeature {
 
     /** @returns {String} */
     get iconUrl() {
-        // TODO PB-266 use a fix size for icon from the backend and uses the icon style scale instead
-        return this._icon?.generateURL(this.iconSize, this.fillColor)
-        // return this._icon?.generateURL(LARGE, this.fillColor)
+        // For simplification and backward compatibility with the old viewer
+        // as well as to use browser cache more efficiently we get all the
+        // icons at the default scale of 1 (48x48px) and do the scaling
+        // on the client
+        return this._icon?.generateURL(this.fillColor)
     }
 
     generateOpenlayersIcon() {
@@ -281,7 +283,6 @@ export class EditableFeature extends SelectableFeature {
                   src: this.iconUrl,
                   crossOrigin: 'Anonymous',
                   anchor: this.icon.anchor,
-                  // TODO PB-266 use the icon style scale instead of the icon scaled size from backend
                   scale: this.iconSizeScale,
               })
             : null

--- a/src/api/icon.api.js
+++ b/src/api/icon.api.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 import { API_SERVICES_BASE_URL } from '@/config'
-import { MEDIUM, RED } from '@/utils/featureStyleUtils'
+import { RED } from '@/utils/featureStyleUtils'
 import log from '@/utils/logging'
 
 /**
@@ -131,20 +131,20 @@ export class DrawingIcon {
     }
 
     /**
-     * Generate an icon URL from its template. If no iconSize is given, medium scale will be
+     * Generate an icon URL from its template. If no iconScale is given, default scale 1 will be
      * applied. If no iconColor is given, red will be applied (if applicable, as non-colorable icons
      * will not have {r}, {g}, {b} part of their template URL)
      *
-     * @param {FeatureStyleSize} iconSize The size (or scale) to use for this icon's URL
      * @param {FeatureStyleColor} iconColor The color to use for this icon's URL
+     * @param {Number} iconScale The scale to use for this icon's URL
      * @returns {String} A full URL to this icon on the service-icons backend
      */
-    generateURL(iconSize = MEDIUM, iconColor = RED) {
+    generateURL(iconColor = RED, iconScale = 1) {
         const rgb = iconColor.rgb.slice(0, 3)
         return this._imageTemplateURL
             .replace('{icon_set_name}', this._iconSetName)
             .replace('{icon_name}', this._name)
-            .replace('{icon_scale}', iconSize.iconScale + 'x')
+            .replace('{icon_scale}', iconScale + 'x')
             .replace('{r}', `${rgb[0]}`)
             .replace('{g}', `${rgb[1]}`)
             .replace('{b}', `${rgb[2]}`)

--- a/src/modules/i18n/locales/de.json
+++ b/src/modules/i18n/locales/de.json
@@ -649,5 +649,7 @@
     "loading": "Laden",
     "search_in_catalogue_placeholder": "Suche in importierten Karten",
     "kml_gpx_file_out_of_bounds": "Der Dateiinhalt liegt außerhalb der Projektionsgrenzen",
-    "kml_gpx_file_empty": "Die KML/GPX-Datei ist leer"
+    "kml_gpx_file_empty": "Die KML/GPX-Datei ist leer",
+    "large_size": "Gross",
+    "extra_large_size": "Extra Gross"
 }

--- a/src/modules/i18n/locales/en.json
+++ b/src/modules/i18n/locales/en.json
@@ -617,7 +617,7 @@
     "profile_no_data": "No data",
     "view_on_mapgeoadminch_webmapviewer": "View on {url}",
     "full_width": "Full width",
-    "georessourcen": "Geo-resources",
+    "georessourcen": "Georesources",
     "georessourcen_service_link_label": "More information",
     "georessourcen_service_link_href": "https://www.swisstopo.admin.ch/en/knowledge-facts/geology/geo-resources.html",
     "topic_georessourcen_tooltip": "Geo-resources",
@@ -649,5 +649,7 @@
     "loading": "Loading",
     "search_in_catalogue_placeholder": "Search in imported maps",
     "kml_gpx_file_out_of_bounds": "File content is out of projection bounds",
-    "kml_gpx_file_empty": "KML/GPX file is empty"
+    "kml_gpx_file_empty": "KML/GPX file is empty",
+    "large_size": "Large",
+    "extra_large_size": "Extra Large"
 }

--- a/src/modules/i18n/locales/fr.json
+++ b/src/modules/i18n/locales/fr.json
@@ -649,5 +649,7 @@
     "loading": "Chargement",
     "search_in_catalogue_placeholder": "Rechercher dans les cartes importées",
     "kml_gpx_file_out_of_bounds": "Le contenu du fichier est hors des limites de projection",
-    "kml_gpx_file_empty": "Le fichier KML/GPX est vide"
+    "kml_gpx_file_empty": "Le fichier KML/GPX est vide",
+    "large_size": "Grande",
+    "extra_large_size": "Très Grande"
 }

--- a/src/modules/i18n/locales/it.json
+++ b/src/modules/i18n/locales/it.json
@@ -649,5 +649,7 @@
     "loading": "Caricamento",
     "search_in_catalogue_placeholder": "Cerca nelle mappe importate",
     "kml_gpx_file_out_of_bounds": "Il contenuto del file è fuori dai limiti della proiezione",
-    "kml_gpx_file_empty": "Il file KML/GPX è vuoto"
+    "kml_gpx_file_empty": "Il file KML/GPX è vuoto",
+    "large_size": "Grande",
+    "extra_large_size": "Extra Grande"
 }

--- a/src/modules/i18n/locales/rm.json
+++ b/src/modules/i18n/locales/rm.json
@@ -647,5 +647,7 @@
     "loading": "Chargiada",
     "search_in_catalogue_placeholder": "Cercar en mapas importads",
     "kml_gpx_file_out_of_bounds": "Il contetn dal file è en furma da las limitas da projezziun",
-    "kml_gpx_file_empty": "La datoteca KML/GPX è vegnida empruva"
+    "kml_gpx_file_empty": "La datoteca KML/GPX è vegnida empruva",
+    "large_size": "Grond",
+    "extra_large_size": "Extra Grond"
 }

--- a/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
+++ b/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
@@ -143,7 +143,7 @@ export default {
          * @returns {String} An icon URL
          */
         generateColorizedURL(icon) {
-            return icon.generateURL(MEDIUM, this.feature.fillColor)
+            return icon.generateURL(this.feature.fillColor)
         },
         onCurrentIconColorChange(color) {
             this.$emit('change:iconColor', color)

--- a/src/utils/__tests__/kmlUtils.spec.js
+++ b/src/utils/__tests__/kmlUtils.spec.js
@@ -3,7 +3,7 @@ import IconStyle from 'ol/style/Icon'
 import { describe, it } from 'vitest'
 
 import { DrawingIcon, DrawingIconSet } from '@/api/icon.api'
-import { BLUE, LARGE } from '@/utils/featureStyleUtils'
+import { BLUE } from '@/utils/featureStyleUtils'
 import { getIcon, getKmlExtent, parseIconUrl } from '@/utils/kmlUtils'
 
 describe('Test KML utils', () => {
@@ -121,7 +121,6 @@ describe('Test KML utils', () => {
             expect(args).to.be.not.null.and.to.be.not.undefined
             expect(args.set).to.be.equal('default')
             expect(args.name).to.be.equal('001-marker')
-            expect(args.scale).to.be.equal(1.5)
             expect(args.color).to.be.not.null.and.to.be.not.undefined
             expect(args.color.r).to.be.equal(0)
             expect(args.color.g).to.be.equal(128)
@@ -135,7 +134,6 @@ describe('Test KML utils', () => {
             expect(args).to.be.not.null.and.to.be.not.undefined
             expect(args.set).to.be.equal('default')
             expect(args.name).to.be.equal('001-marker')
-            expect(args.scale).to.be.equal(4)
             expect(args.color).to.be.not.null.and.to.be.not.undefined
             expect(args.color.r).to.be.equal(0)
             expect(args.color.g).to.be.equal(255)
@@ -155,7 +153,6 @@ describe('Test KML utils', () => {
             expect(args).to.be.not.null.and.to.be.not.undefined
             expect(args.set).to.be.equal('babs')
             expect(args.name).to.be.equal('babs-100')
-            expect(args.scale).to.be.equal(1)
             expect(args.color).to.be.not.null.and.to.be.not.undefined
             expect(args.color.r).to.be.equal(255)
             expect(args.color.g).to.be.equal(128)
@@ -185,7 +182,6 @@ describe('Test KML utils', () => {
             expect(args).to.be.not.null.and.to.be.not.undefined
             expect(args.set).to.be.equal('default')
             expect(args.name).to.be.equal('star')
-            expect(args.scale).to.be.equal(2)
             expect(args.color).to.be.not.null.and.to.be.not.undefined
             expect(args.color.r).to.be.equal(45)
             expect(args.color.g).to.be.equal(128)
@@ -197,7 +193,6 @@ describe('Test KML utils', () => {
             expect(args).to.be.not.null.and.to.be.not.undefined
             expect(args.set).to.be.equal('default')
             expect(args.name).to.be.equal('star')
-            expect(args.scale).to.be.equal(2)
             expect(args.color).to.be.not.null.and.to.be.not.undefined
             expect(args.color.r).to.be.equal(45)
             // invalid color fallback to 255
@@ -215,7 +210,6 @@ describe('Test KML utils', () => {
             expect(args.set).to.be.equal('babs')
             expect(args.name).to.be.equal('babs-76')
             // expect default scale and color
-            expect(args.scale).to.be.equal(1)
             expect(args.color.r).to.be.equal(255)
             expect(args.color.g).to.be.equal(0)
             expect(args.color.b).to.be.equal(0)
@@ -299,7 +293,7 @@ describe('Test KML utils', () => {
             expect(icon).to.be.not.null.and.not.undefined
             expect(icon.name).to.be.equal('001-marker')
             expect(icon.iconSetName).to.be.equal('default')
-            expect(icon.generateURL(LARGE, BLUE)).to.be.equal(
+            expect(icon.generateURL(BLUE, 1.5)).to.be.equal(
                 'https://fake.image.url/api/icons/sets/default/icons/001-marker@1.5x-0,0,255.png'
             )
         })

--- a/src/utils/__tests__/legacyKmlUtils.spec.js
+++ b/src/utils/__tests__/legacyKmlUtils.spec.js
@@ -14,7 +14,6 @@ import {
     MEDIUM,
     RED,
     SMALL,
-    VERY_SMALL,
     WHITE,
     YELLOW,
 } from '@/utils/featureStyleUtils'
@@ -124,9 +123,6 @@ describe('Validate deserialization of the mf-geoadmin3 viewer kml format', () =>
             performStandardChecks(icon, EditableFeatureTypes.MARKER, 'icon 1', 'desc 1')
             expect(icon.icon.name).to.be.equal('001-marker')
             expect(icon.fillColor).to.be.equal(BLUE)
-            // TODO PB-266
-            // old KMLs were using scales 0.5, 0.75 and 1.0, we are now having an extra 1.5 scale
-            // so legacy SMALL size has become VERY_SMALL
             expect(icon.iconSize).to.be.equal(SMALL)
         })
         it('parses a marker with a small scale and grey fill color correctly', () => {
@@ -134,8 +130,7 @@ describe('Validate deserialization of the mf-geoadmin3 viewer kml format', () =>
             performStandardChecks(icon, EditableFeatureTypes.MARKER, 'icon 2', 'desc 2')
             expect(icon.icon.name).to.be.equal('002-circle')
             expect(icon.fillColor).to.be.equal(GRAY)
-            // TODO PB-266
-            expect(icon.iconSize).to.be.equal(VERY_SMALL)
+            expect(icon.iconSize).to.be.equal(MEDIUM)
             expect(icon.textColor).to.be.equal(WHITE)
         })
         it('parses a marker with a big BABS icon correctly', () => {
@@ -144,8 +139,7 @@ describe('Validate deserialization of the mf-geoadmin3 viewer kml format', () =>
             expect(icon.icon).to.be.not.null.and.not.undefined
             expect(icon.icon.name).to.be.equal('babs-3')
             expect(icon.fillColor).to.be.equal(RED) // default should be red
-            // TODO PB-266
-            expect(icon.iconSize).to.be.equal(SMALL)
+            expect(icon.iconSize).to.be.equal(LARGE)
             expect(icon.textColor).to.be.equal(RED)
         })
     })
@@ -154,7 +148,7 @@ describe('Validate deserialization of the mf-geoadmin3 viewer kml format', () =>
             const standardText = findFeatureWithId('annotation_1668530699494')
             performStandardChecks(standardText, EditableFeatureTypes.ANNOTATION, 'text 1', '')
             expect(standardText.textColor).to.be.equal(BLACK)
-            expect(standardText.textSize).to.be.equal(VERY_SMALL)
+            expect(standardText.textSize).to.be.equal(SMALL)
             expect(standardText.fillColor).to.be.equal(RED) // default should be RED even if no icon is defined
             expect(standardText.iconSize).to.be.null
             expect(standardText.icon).to.be.null

--- a/src/utils/featureStyleUtils.js
+++ b/src/utils/featureStyleUtils.js
@@ -72,7 +72,9 @@ export const allStylingColors = [BLACK, BLUE, GRAY, GREEN, ORANGE, RED, WHITE, Y
 /**
  * Representation of a size for feature style
  *
- * Scale values (that are to apply to the KML/GeoJSON) are different for text and icon
+ * Scale values (that are to apply to the KML/GeoJSON) are different for text and icon. For icon the
+ * scale is the one used by open layer and is scaled up by the factor icon_size/32, see
+ * https://github.com/openlayers/openlayers/issues/12670
  */
 export class FeatureStyleSize {
     /**
@@ -118,17 +120,22 @@ export class FeatureStyleSize {
     }
 }
 
-export const VERY_SMALL = new FeatureStyleSize('very_small_size', 1.0, 0.5)
-export const SMALL = new FeatureStyleSize('small_size', 1.25, 0.75)
-export const MEDIUM = new FeatureStyleSize('medium_size', 1.5, 1.0)
-export const LARGE = new FeatureStyleSize('big_size', 2.0, 1.5)
+/**
+ * NOTE: Here below the icons scale is the one used by openlayer, not the final scale put in the KML
+ * file. In the kml the scale will be set with a factor icon_size/32 => 48/32 => 1.5. The text scale
+ * is unchanged and the scale in openlayer match the KML scale.
+ */
+export const SMALL = new FeatureStyleSize('small_size', 1, 0.5)
+export const MEDIUM = new FeatureStyleSize('medium_size', 1.5, 0.75)
+export const LARGE = new FeatureStyleSize('large_size', 2.0, 1)
+export const EXTRA_LARGE = new FeatureStyleSize('extra_large_size', 2.5, 1.25)
 
 /**
  * List of all available sizes for drawing style
  *
  * @type {FeatureStyleSize[]}
  */
-export const allStylingSizes = [VERY_SMALL, SMALL, MEDIUM, LARGE]
+export const allStylingSizes = [SMALL, MEDIUM, LARGE, EXTRA_LARGE]
 
 /**
  * Get Feature style from feature

--- a/src/utils/kmlUtils.js
+++ b/src/utils/kmlUtils.js
@@ -26,6 +26,15 @@ import { GeodesicGeometries } from '@/utils/geodesicManager'
 import log from '@/utils/logging'
 import { parseRGBColor } from '@/utils/utils'
 
+// On the legacy drawing, openlayer used the scale from xml as is, but since openlayer
+// version 6.7, the scale has been normalized to 32 pixels, therefore we need to add the
+// 32 pixel scale factor below
+// scale_factor := iconStyle.getSize()[0] / 32
+// iconStyle.getSize()[0] = 48 (always 48 pixel on old viewer)
+// scale_factor = 48/32 => 1.5
+// See https://github.com/openlayers/openlayers/pull/12695
+export const LEGACY_ICON_XML_SCALE_FACTOR = 1.5
+
 /**
  * Read the KML name
  *
@@ -409,7 +418,7 @@ export function getEditableFeatureFromKmlFeature(kmlFeature, availableIconSets) 
         // scale_factor := iconStyle.getSize()[0] / 32
         // iconStyle.getSize()[0] = 48 (always 48 pixel on old viewer)
         // scale_factor = 48/32 => 1.5
-        iconStyle.setScale(iconStyle.getScale() * 1.5)
+        iconStyle.setScale(iconStyle.getScale() * LEGACY_ICON_XML_SCALE_FACTOR)
     }
     const icon = iconArgs ? getIcon(iconArgs, iconStyle, availableIconSets) : null
     const iconSize = iconStyle ? getIconSize(iconStyle) : null

--- a/tests/cypress/tests-e2e/drawing.cy.js
+++ b/tests/cypress/tests-e2e/drawing.cy.js
@@ -23,6 +23,7 @@ import {
     RED,
     SMALL,
 } from '@/utils/featureStyleUtils'
+import { LEGACY_ICON_XML_SCALE_FACTOR } from '@/utils/kmlUtils'
 import { randomIntBetween } from '@/utils/numberUtils'
 
 const isNonEmptyArray = (value) => {
@@ -34,10 +35,6 @@ const isNonEmptyArray = (value) => {
 // NOTE: alpha is for opacity
 const KML_STYLE_RED = 'ff0000ff'
 const KML_STYLE_BLACK = 'ff000000'
-
-// Openlayer correct the KML scale up to a factor, see https://github.com/openlayers/openlayers/pull/12695
-// This factor is define as := icon_size / 32, because our icons are always 48px we use the factor 48/32 = 1.5
-const ICON_XML_SCALE_FACTOR = 1.5
 
 const DEFAULT_ICON_URL_SCALE = '1x'
 
@@ -147,7 +144,7 @@ describe('Drawing module tests', () => {
             cy.wait('@update-kml').then((interception) => {
                 cy.checkKMLRequest(interception, [
                     new RegExp(
-                        `<IconStyle><scale>${LARGE.iconScale * ICON_XML_SCALE_FACTOR}</scale>`
+                        `<IconStyle><scale>${LARGE.iconScale * LEGACY_ICON_XML_SCALE_FACTOR}</scale>`
                     ),
                     new RegExp(
                         `<href>https?://.*/api/icons/sets/default/icons/001-marker@${DEFAULT_ICON_URL_SCALE}-${GREEN.rgbString}.png</href>`


### PR DESCRIPTION
Now the KML icon size and text size is retro compatible with the old kml adding a new `extra large` size.
The icon scaling is a bit tricky due to a factor to normalize icons to 32 pixel introduced by open layer in version 6.7 (old viewer used an older openlayer version, see https://github.com/openlayers/openlayers/pull/12695).

Relates to #628 

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-266-icon-size/index.html)