### PR TITLE
PB-190: Implementing bod layer Id

### DIFF
--- a/src/modules/map/components/cesium/CesiumMap.vue
+++ b/src/modules/map/components/cesium/CesiumMap.vue
@@ -168,7 +168,6 @@ export default {
             uiMode: (state) => state.ui.mode,
             previewYear: (state) => state.layers.previewYear,
             isFeatureTooltipInFooter: (state) => !state.ui.floatingTooltip,
-            showToolTip: (state) => state.ui.showTooltip,
             selectedFeatures: (state) => state.features.selectedFeatures,
             projection: (state) => state.position.projection,
             isFullScreenMode: (state) => state.ui.fullscreenMode,
@@ -197,11 +196,7 @@ export default {
             )
         },
         showFeaturesPopover() {
-            return (
-                this.showToolTip &&
-                !this.isFeatureTooltipInFooter &&
-                this.selectedFeatures.length > 0
-            )
+            return !this.isFeatureTooltipInFooter && this.selectedFeatures.length > 0
         },
         editFeature() {
             return this.selectedFeatures.find((feature) => feature.isEditable)

--- a/src/modules/map/components/cesium/CesiumMap.vue
+++ b/src/modules/map/components/cesium/CesiumMap.vue
@@ -168,6 +168,7 @@ export default {
             uiMode: (state) => state.ui.mode,
             previewYear: (state) => state.layers.previewYear,
             isFeatureTooltipInFooter: (state) => !state.ui.floatingTooltip,
+            showToolTip: (state) => state.ui.showTooltip,
             selectedFeatures: (state) => state.features.selectedFeatures,
             projection: (state) => state.position.projection,
             isFullScreenMode: (state) => state.ui.fullscreenMode,
@@ -196,7 +197,11 @@ export default {
             )
         },
         showFeaturesPopover() {
-            return !this.isFeatureTooltipInFooter && this.selectedFeatures.length > 0
+            return (
+                this.showToolTip &&
+                !this.isFeatureTooltipInFooter &&
+                this.selectedFeatures.length > 0
+            )
         },
         editFeature() {
             return this.selectedFeatures.find((feature) => feature.isEditable)

--- a/src/modules/map/components/openlayers/OpenLayersHighlightedFeatures.vue
+++ b/src/modules/map/components/openlayers/OpenLayersHighlightedFeatures.vue
@@ -30,7 +30,7 @@ const isCurrentlyDrawing = computed(() => store.state.ui.showDrawingOverlay)
 const isFloatingTooltip = computed(() => store.state.ui.floatingTooltip)
 const projection = computed(() => store.state.position.projection)
 const highlightedFeatureId = computed(() => store.state.features.highlightedFeatureId)
-
+const showToolTip = computed(() => store.state.ui.showToolTip)
 const editableFeatures = computed(() =>
     selectedFeatures.value.filter((feature) => feature.isEditable)
 )
@@ -116,7 +116,7 @@ function toggleFloatingTooltip() {
 
 <template>
     <OpenLayersPopover
-        v-if="isFloatingTooltip && selectedFeatures.length > 0"
+        v-if="showToolTip && isFloatingTooltip && selectedFeatures.length > 0"
         :coordinates="popoverCoordinate"
         authorize-print
         :use-content-padding="editableFeatures.length > 0"

--- a/src/modules/map/components/openlayers/OpenLayersHighlightedFeatures.vue
+++ b/src/modules/map/components/openlayers/OpenLayersHighlightedFeatures.vue
@@ -30,7 +30,6 @@ const isCurrentlyDrawing = computed(() => store.state.ui.showDrawingOverlay)
 const isFloatingTooltip = computed(() => store.state.ui.floatingTooltip)
 const projection = computed(() => store.state.position.projection)
 const highlightedFeatureId = computed(() => store.state.features.highlightedFeatureId)
-const showToolTip = computed(() => store.state.ui.showToolTip)
 const editableFeatures = computed(() =>
     selectedFeatures.value.filter((feature) => feature.isEditable)
 )
@@ -116,7 +115,7 @@ function toggleFloatingTooltip() {
 
 <template>
     <OpenLayersPopover
-        v-if="showToolTip && isFloatingTooltip && selectedFeatures.length > 0"
+        v-if="isFloatingTooltip && selectedFeatures.length > 0"
         :coordinates="popoverCoordinate"
         authorize-print
         :use-content-padding="editableFeatures.length > 0"

--- a/src/modules/menu/components/LayerCatalogueItem.vue
+++ b/src/modules/menu/components/LayerCatalogueItem.vue
@@ -182,9 +182,15 @@ function zoomToLayer() {
             transformExtentIntoPolygon(item.value.extent.flat())
         )
     ) {
-        store.dispatch('zoomToExtent', item.value.extent)
+        store.dispatch('zoomToExtent', {
+            extent: item.value.extent,
+            dispatcher: STORE_DISPATCHER_LAYER_CATALOGUE_ITEM,
+        })
     } else {
-        store.dispatch('zoomToExtent', lv95Extent)
+        store.dispatch('zoomToExtent', {
+            extent: lv95Extent,
+            dispatcher: STORE_DISPATCHER_LAYER_CATALOGUE_ITEM,
+        })
     }
     if (isPhoneMode.value) {
         // On mobile phone we close the menu so that the user can see the zoom to extent

--- a/src/modules/menu/components/advancedTools/ImportFile/utils.js
+++ b/src/modules/menu/components/advancedTools/ImportFile/utils.js
@@ -47,7 +47,7 @@ export function handleFileContent(store, content, source) {
         if (!projectedExtent) {
             throw new OutOfBoundsError(`KML out of projection bounds: ${extent}`)
         }
-        store.dispatch('zoomToExtent', projectedExtent)
+        store.dispatch('zoomToExtent', { extent: projectedExtent })
         store.dispatch('addLayer', { layer, dispatcher: 'ImportFile.vue/kml' })
     } else if (isGpx(content)) {
         const gpxParser = new GPX()
@@ -61,7 +61,7 @@ export function handleFileContent(store, content, source) {
         if (!projectedExtent) {
             throw new OutOfBoundsError(`GPX out of projection bounds: ${extent}`)
         }
-        store.dispatch('zoomToExtent', projectedExtent)
+        store.dispatch('zoomToExtent', { extent: projectedExtent })
         store.dispatch('addLayer', { layer, dispacther: 'ImportFile.vue/gpx' })
     } else {
         throw new Error(`Unsupported file ${source} content`)

--- a/src/router/BodLayerId.routerPlugin.js
+++ b/src/router/BodLayerId.routerPlugin.js
@@ -1,0 +1,105 @@
+import layersStore from '@/store/modules/layers.store'
+
+import storeSyncConfig from './storeSync/storeSync.config'
+
+const standardsParams = storeSyncConfig.map((param) => {
+    param.urlParamName
+})
+standardsParams.push('showToolTip')
+
+function parseBodLayerParamsFromQuery(query) {
+    if (!query) {
+        return undefined
+    }
+    const urlParams = new URLSearchParams(query)
+    // This will be set to True if all params given are standard parameters
+    const noExtraParams = urlParams.keys().every((param) => standardsParams.includes(param))
+    if (noExtraParams) {
+        return undefined
+    }
+    const layerIds = layersStore.state.config.map((layer) => layer.geoAdminID)
+    const val = {}
+    urlParams.forEach((value, key) => {
+        if (!standardsParams.includes(key) && layerIds.includes(key)) {
+            val.layer = key
+            val.features = value
+            val.showToolTip = !!urlParams.get('showToolTip')
+            return null // we get out at the first instance of a bod layer id found
+        }
+    })
+    return val
+}
+
+/**
+ * This function checks the layers param in the URL and either ensure an already activated layer is
+ * visible, or add the layer in `bodIdParams.layer` to the layers param. It also dispatch the
+ * highlighted features to the store.
+ *
+ * @param {Object} bodIdParams All the bod-layer-id parameters needed
+ * @param {Store} store
+ * @param {any} to
+ * @param {any} next
+ */
+function handleBodIdParams(bodIdParams, store, to, next) {
+    const newQuery = { ...to.query }
+    /* // QUESTION TO pascal : do we allow the bod layer id param to have the same parameters as the other layers ?
+    // in my opinion : no
+    if (newQuery.layers?.includes(bodIdParams.layer)) {
+        const regex = new RegExp(bodIdParams.layer + ',[a-zA-Z]+')
+        // this will replace the `{layer-id},{visibility}` parameter by `{layer-id},`
+        // forcing the layer to be visible
+        newQuery.layers = newQuery.layers.replace(regex, `${bodIdParams.layer},`)
+    } else {
+        // the parameter given was not part of the layers, or there was no active layers
+        newQuery.layers = `${newQuery.layers ? newQuery.layers + ';' : ''}${bodIdParams.layer}`
+    }
+    */
+    delete newQuery[bodIdParams.layer]
+    delete newQuery?.showToolTip
+    dispatchBodIdParamsToStore(bodIdParams, store)
+
+    next({
+        name: 'MapView',
+        query: newQuery,
+    })
+}
+
+async function dispatchBodIdParamsToStore(bodIdParams, store) {
+    await store.dispatch('addLayer', { layer: bodIdParams.layer, visibility: true })
+    store.dispatch('setPreSelectedFeatures', bodIdParams)
+}
+
+/**
+ * Parse the URL for bod-layer-id parameters (with or without the showToolTip parameter), remove the
+ * parameter for the URL while dispatching what is needed to the store
+ *
+ * Example:
+ *
+ * - `http://localhost:8080/#/?geolocation=true&some.layer_id=213,234` =>
+ *   `http://localhost:8080/#/?geolocation=true&layers=some.layer_id`
+ *
+ * @param {Router} router
+ * @param {Store} store
+ */
+const bodLayerIdRouterPlugin = (router, store) => {
+    const bodIdParams = window.location?.search
+        ? parseBodLayerParamsFromQuery(window.location.search)
+        : null
+    router.beforeEach((to, from, next) => {
+        /**
+         * We need to ensure the startup is finished to handle the bod layer Id, as we need some
+         * data to be defined (most importantly : the layers config)
+         */
+        if (to.name === 'MapView') {
+            if (bodIdParams) {
+                handleBodIdParams(bodIdParams, store, to, next)
+            } else {
+                next()
+            }
+        } else {
+            next()
+        }
+    })
+}
+
+export default bodLayerIdRouterPlugin

--- a/src/router/BodLayerId.routerPlugin.js
+++ b/src/router/BodLayerId.routerPlugin.js
@@ -1,4 +1,4 @@
-import getFeature from '@/api/features.api'
+import getFeature from '@/api/features/features.api'
 import log from '@/utils/logging'
 
 import storeSyncConfig from './storeSync/storeSync.config'

--- a/src/router/BodLayerId.routerPlugin.js
+++ b/src/router/BodLayerId.routerPlugin.js
@@ -1,4 +1,5 @@
 import getFeature from '@/api/features/features.api'
+import { ActiveLayerConfig } from '@/utils/layerUtils'
 import log from '@/utils/logging'
 
 import storeSyncConfig from './storeSync/storeSync.config'
@@ -84,9 +85,11 @@ function handleBodIdParams(bodIdParams, store, to) {
     store.state.layers.activeLayers.forEach((layer) => {
         activeLayersIds.push(layer.getID())
     })
+
     if (!activeLayersIds.includes(bodIdParams.layer.getID())) {
+        const layerConfig = new ActiveLayerConfig(bodIdParams.layer.getID(), true)
         store.dispatch('addLayer', {
-            layer: bodIdParams.layer,
+            layerConfig: layerConfig,
             dispatcher: STORE_DISPATCHER_BOD_LAYER_ID_ROUTER_PLUGIN,
         })
     }

--- a/src/router/BodLayerId.routerPlugin.js
+++ b/src/router/BodLayerId.routerPlugin.js
@@ -157,11 +157,18 @@ async function retrieveAndDispatchFeaturesToStore(bodIdParams, needToZoom, store
     }
     if (!bodIdParams.showToolTip) {
         // we'll need to see how to do this better, as this doesn't  work
-        store.dispatch('hideLocationPopup') // this is apparently not the right thing to show
+        store.dispatch('hideToolTip') // this is apparently not the right thing to show
     }
 }
 
-function getZoomFromExtent(extent, center, store) {
+/**
+ * @param {[Number[], Number[]]} extent An array of two coordinates
+ * @param {Number[]} center The coordinates to the center of the extent. We could calculate it
+ *   inside, but it's already done
+ * @param {Store} store
+ * @returns {Number} The zoom level at which we can see the whole extent
+ */
+export function getZoomFromExtent(extent, center, store) {
     const extentSize = {
         width: Math.abs(extent[1][0] - extent[0][0]),
         height: Math.abs(extent[1][1] - extent[0][1]),

--- a/src/router/BodLayerId.routerPlugin.js
+++ b/src/router/BodLayerId.routerPlugin.js
@@ -111,7 +111,6 @@ function handleBodIdParams(bodIdParams, store, to, next) {
  */
 async function retrieveAndDispatchFeaturesToStore(bodIdParams, store) {
     const features = []
-    // TODO : handle tooltip show on view, not on backend calls
     bodIdParams.features.forEach((featureID) => {
         features.push(
             getFeature(
@@ -124,7 +123,6 @@ async function retrieveAndDispatchFeaturesToStore(bodIdParams, store) {
         )
     })
     store.dispatch('setPreSelectedFeatures', features)
-    // we might need to create a new flag
     if (!bodIdParams.showToolTip) {
         store.dispatch('hideLocationPopup')
     }

--- a/src/router/BodLayerId.routerPlugin.js
+++ b/src/router/BodLayerId.routerPlugin.js
@@ -188,9 +188,7 @@ async function retrieveAndDispatchFeaturesToStore(bodIdParams, needToZoom, store
 const bodLayerIdRouterPlugin = (router, store) => {
     router.beforeEach((to) => {
         if (to.name === 'MapView') {
-            const bodIdParams = window.location?.hash
-                ? parseBodLayerParamsFromQuery(to.query, store.state.layers.config)
-                : null
+            const bodIdParams = parseBodLayerParamsFromQuery(to.query, store.state.layers.config)
             if (bodIdParams?.layer) {
                 return handleBodIdParams(bodIdParams, store, to)
             }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -46,8 +46,8 @@ const router = createRouter({
 
 appLoadingManagementRouterPlugin(router, store)
 legacyPermalinkManagementRouterPlugin(router, store)
-storeSyncRouterPlugin(router, store)
 bodLayerIdRouterPlugin(router, store)
+storeSyncRouterPlugin(router, store)
 // exposing the router to Cypress, so that we may change URL param on the fly (without app reload),
 // and this way test app reaction to URL changes
 if (IS_TESTING_WITH_CYPRESS) {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,6 +9,8 @@ import { parseQuery, stringifyQuery } from '@/utils/url-router'
 import LoadingView from '@/views/LoadingView.vue'
 import MapView from '@/views/MapView.vue'
 
+import bodLayerIdRouterPlugin from './BodLayerId.routerPlugin'
+
 const history = createWebHashHistory()
 
 /**
@@ -45,7 +47,7 @@ const router = createRouter({
 appLoadingManagementRouterPlugin(router, store)
 legacyPermalinkManagementRouterPlugin(router, store)
 storeSyncRouterPlugin(router, store)
-
+bodLayerIdRouterPlugin(router, store)
 // exposing the router to Cypress, so that we may change URL param on the fly (without app reload),
 // and this way test app reaction to URL changes
 if (IS_TESTING_WITH_CYPRESS) {

--- a/src/router/storeSync/storeSync.routerPlugin.js
+++ b/src/router/storeSync/storeSync.routerPlugin.js
@@ -109,6 +109,7 @@ function urlQueryWatcher(store, to) {
     let requireQueryUpdate = false
     const newQuery = { ...to.query }
     // if this module did not trigger the route change, we need to check if a store change is needed
+    // TODO HERE: put the {bod-layer-id} param in the layer list,add selected features to the store
     storeSyncConfig.forEach((paramConfig) => {
         const queryValue = paramConfig.readValueFromQuery(to.query)
         const storeValue = paramConfig.readValueFromStore(store)

--- a/src/router/storeSync/storeSync.routerPlugin.js
+++ b/src/router/storeSync/storeSync.routerPlugin.js
@@ -181,7 +181,6 @@ function urlQueryWatcher(store, to) {
         // stays on `/#/`. When manually chaning any query param it works though.
         return { name: 'MapView', query: newQuery }
     }
-    // HERE : dispatch pre-selected features to the selected features
     return undefined
 }
 

--- a/src/router/storeSync/storeSync.routerPlugin.js
+++ b/src/router/storeSync/storeSync.routerPlugin.js
@@ -109,7 +109,6 @@ function urlQueryWatcher(store, to) {
     let requireQueryUpdate = false
     const newQuery = { ...to.query }
     // if this module did not trigger the route change, we need to check if a store change is needed
-    // TODO HERE: put the {bod-layer-id} param in the layer list,add selected features to the store
     storeSyncConfig.forEach((paramConfig) => {
         const queryValue = paramConfig.readValueFromQuery(to.query)
         const storeValue = paramConfig.readValueFromStore(store)
@@ -166,6 +165,7 @@ function urlQueryWatcher(store, to) {
             requireQueryUpdate = true
         }
     })
+
     // Fake call to a URL so that Cypress can wait for route changes without waiting for arbitrary length of time
     if (IS_TESTING_WITH_CYPRESS) {
         Promise.all(pendingStoreDispatch).then(() => {
@@ -181,6 +181,7 @@ function urlQueryWatcher(store, to) {
         // stays on `/#/`. When manually chaning any query param it works though.
         return { name: 'MapView', query: newQuery }
     }
+    // HERE : dispatch pre-selected features to the selected features
     return undefined
 }
 

--- a/src/store/modules/features.store.js
+++ b/src/store/modules/features.store.js
@@ -1,6 +1,5 @@
 import { EditableFeatureTypes } from '@/api/features/EditableFeature.class'
 import { allStylingColors, allStylingSizes } from '@/utils/featureStyleUtils'
-import log from '@/utils/logging'
 const getSelectedFeatureWithId = (state, featureId) => {
     return state.selectedFeatures.find((selectedFeature) => selectedFeature.id === featureId)
 }
@@ -20,30 +19,15 @@ export default {
     },
     actions: {
         /**
-         * This function will only be called at startup, if there is a Bod-Layer-Id parameter set
+         * This function will only be called if there is a Bod-Layer-Id parameter set
          *
          * @param {GeoAdminLayer} layer: The layer containing the features
          * @param {String[]} featuresIds: An array containing the featuresIds we wish to highlight
          */
-        setPreselectedFeatures({ commit }, { layer, featuresIds }) {
-            const features = []
-            featuresIds.forEach((featureId) => {
-                getFeature(layer, featureId)
-                    .then((feature) => {
-                        features.push(feature)
-                    })
-                    .catch((error) => {
-                        log.error(
-                            `Could not find feature ${featureId} for layer ${layer.getID()}`,
-                            error
-                        )
-                    })
-            })
-            commit('setPreselectedFeatures', features)
-            commit('setSelectedFeatures', features)
-        },
-        clearPreSelectedFeatures({ commit }) {
-            commit('setPreSelectedFeatures', [])
+        setPreSelectedFeatures({ commit }, features) {
+            if (Array.isArray(features)) {
+                commit('setPreSelectedFeatures', features)
+            }
         },
         /**
          * Tells the map to highlight a list of features (place a round marker at their location).
@@ -59,10 +43,6 @@ export default {
                 highlightedFeatureId: null,
                 dispatcher: 'setSelectedFeatures',
             })
-            if (Array.isArray(features)) {
-                commit('setSelectedFeatures', features)
-            }
-        },
         /** Removes all selected features from the map */
         clearAllSelectedFeatures({ commit }) {
             commit('setSelectedFeatures', [])
@@ -260,7 +240,7 @@ export default {
         },
     },
     mutations: {
-        setPreselectedFeatures(state, features) {
+        setPreSelectedFeatures(state, features) {
             state.preSelectedFeatures = [...features]
         },
         setSelectedFeatures(state, features) {

--- a/src/store/modules/features.store.js
+++ b/src/store/modules/features.store.js
@@ -7,8 +7,6 @@ const getSelectedFeatureWithId = (state, featureId) => {
 export default {
     state: {
         /** @type {SelectableFeature[]} */
-        preSelectedFeatures: [],
-        /** @type {SelectableFeature[]} */
         selectedFeatures: [],
         highlightedFeatureId: null,
     },
@@ -18,17 +16,6 @@ export default {
         },
     },
     actions: {
-        /**
-         * This function will only be called if there is a Bod-Layer-Id parameter set
-         *
-         * @param {GeoAdminLayer} layer: The layer containing the features
-         * @param {String[]} featuresIds: An array containing the featuresIds we wish to highlight
-         */
-        setPreSelectedFeatures({ commit }, features) {
-            if (Array.isArray(features)) {
-                commit('setPreSelectedFeatures', features)
-            }
-        },
         /**
          * Tells the map to highlight a list of features (place a round marker at their location).
          * Those features are currently shown by the tooltip. If in drawing mode, this functions
@@ -43,6 +30,10 @@ export default {
                 highlightedFeatureId: null,
                 dispatcher: 'setSelectedFeatures',
             })
+            if (Array.isArray(features)) {
+                commit('setSelectedFeatures', features)
+            }
+        },
         /** Removes all selected features from the map */
         clearAllSelectedFeatures({ commit }) {
             commit('setSelectedFeatures', [])
@@ -240,9 +231,6 @@ export default {
         },
     },
     mutations: {
-        setPreSelectedFeatures(state, features) {
-            state.preSelectedFeatures = [...features]
-        },
         setSelectedFeatures(state, features) {
             state.selectedFeatures = [...features]
         },

--- a/src/store/modules/position.store.js
+++ b/src/store/modules/position.store.js
@@ -237,8 +237,8 @@ const actions = {
                 })
             }
             const extentSize = {
-                width: extent[1][0] - extent[0][0],
-                height: extent[1][1] - extent[0][1],
+                width: Math.abs(extent[1][0] - extent[0][0]),
+                height: Math.abs(extent[1][1] - extent[0][1]),
             }
             let targetResolution
             // if the extent's height is greater than width, we base our resolution calculation on that

--- a/src/store/modules/position.store.js
+++ b/src/store/modules/position.store.js
@@ -215,7 +215,7 @@ const actions = {
             commit('setCenter', { x, y, dispatcher })
         }
     },
-    zoomToExtent: ({ commit, state, rootState }, extent) => {
+    zoomToExtent: ({ commit, state, rootState }, { extent, maxZoomLevel = 8, dispatcher }) => {
         if (extent && Array.isArray(extent) && extent.length === 2) {
             // Convert extent points to WGS84 as adding the coordinates in metric gives incorrect results.
             const points = [
@@ -233,7 +233,7 @@ const actions = {
                 commit('setCenter', {
                     x: centerOfExtent[0],
                     y: centerOfExtent[1],
-                    dispatcher: 'position.store/zoomToExtent',
+                    dispatcher,
                 })
             }
             const extentSize = {
@@ -257,10 +257,17 @@ const actions = {
             // zoom level required to show the full extent on the map (scale to fill).
             // So the view will be too zoomed-in to have an overview of the extent.
             // We then set the zoom level to the one calculated minus one (expect when the calculated zoom is 0...).
-            commit('setZoom', {
-                zoom: Math.max(zoomForResolution - 1, 0),
-                dispatcher: 'position.store/zoomToExtent',
-            })
+            if (maxZoomLevel) {
+                commit('setZoom', {
+                    zoom: Math.min(Math.max(zoomForResolution - 1, 0), maxZoomLevel),
+                    dispatcher,
+                })
+            } else {
+                commit('setZoom', {
+                    zoom: Math.max(zoomForResolution - 1, 0),
+                    dispatcher,
+                })
+            }
         }
     },
     increaseZoom: ({ dispatch, state }) =>

--- a/src/store/modules/search.store.js
+++ b/src/store/modules/search.store.js
@@ -108,7 +108,7 @@ const actions = {
                 break
             case RESULT_TYPE.LOCATION:
                 if (entry.extent.length === 2) {
-                    dispatch('zoomToExtent', entry.extent)
+                    dispatch('zoomToExtent', { extent: entry.extent })
                 } else if (entry.zoom) {
                     dispatch('setCenter', {
                         center: entry.coordinates,

--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -83,6 +83,14 @@ export default {
          * @type Boolean
          */
         floatingTooltip: false, // Configured in screen-size-management.plugin.js
+
+        /**
+         * Flag telling if the tooltip should be displayed at all. Only false when using a
+         * bod-layer-id parameter, and only until any new feature is selected
+         *
+         * @type Boolean
+         */
+        showToolTip: true,
         /**
          * Hostname on which the application is running (use to display warnings to the user on
          * 'non-production' hosts)
@@ -275,6 +283,14 @@ export default {
         setCompareSliderActive({ commit }, args) {
             commit('setCompareSliderActive', args)
         },
+        showToolTip({ commit, state }) {
+            if (!state.showToolTip) {
+                commit('setShowToolTip', true)
+            }
+        },
+        hideToolTip({ commit }) {
+            commit('setShowToolTip', false)
+        },
     },
     mutations: {
         setSize(state, { height, width }) {
@@ -319,6 +335,9 @@ export default {
         },
         setCompareSliderActive(state, { compareSliderActive }) {
             state.isCompareSliderActive = compareSliderActive
+        },
+        setShowToolTip(state, value) {
+            state.showToolTip = value
         },
     },
 }

--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -11,6 +11,7 @@ export const UIModes = {
     DESKTOP: 'DESKTOP', // formerly called "MENU_ALWAYS_OPEN", also used for tablets
     PHONE: 'PHONE', //  formerly called "MENU_OPENED_THROUGH_BUTTON"
 }
+
 /**
  * Module that stores all information related to the UI, for instance if a portion of the UI (like
  * the header) should be visible right now or not. Most actions from this module will be
@@ -84,13 +85,6 @@ export default {
          */
         floatingTooltip: false, // Configured in screen-size-management.plugin.js
 
-        /**
-         * Flag telling if the tooltip should be displayed at all. Only false when using a
-         * bod-layer-id parameter, and only until any new feature is selected
-         *
-         * @type Boolean
-         */
-        showToolTip: true,
         /**
          * Hostname on which the application is running (use to display warnings to the user on
          * 'non-production' hosts)
@@ -283,14 +277,6 @@ export default {
         setCompareSliderActive({ commit }, args) {
             commit('setCompareSliderActive', args)
         },
-        showToolTip({ commit, state }) {
-            if (!state.showToolTip) {
-                commit('setShowToolTip', true)
-            }
-        },
-        hideToolTip({ commit }) {
-            commit('setShowToolTip', false)
-        },
     },
     mutations: {
         setSize(state, { height, width }) {
@@ -335,9 +321,6 @@ export default {
         },
         setCompareSliderActive(state, { compareSliderActive }) {
             state.isCompareSliderActive = compareSliderActive
-        },
-        setShowToolTip(state, value) {
-            state.showToolTip = value
         },
     },
 }

--- a/src/store/plugins/app-readiness.plugin.js
+++ b/src/store/plugins/app-readiness.plugin.js
@@ -18,7 +18,9 @@ const appReadinessPlugin = (store) => {
     const unsubscribe = store.subscribe((mutation, state) => {
         // Log all mutations for debugging
         log.debug(
-            `[store mutation]: type=${mutation.type} dispatcher=${mutation.payload?.dispatcher ?? null} payload=`,
+            `[store mutation]: type=${mutation.type} dispatcher=${
+                mutation.payload?.dispatcher ?? null
+            } payload=`,
             mutation.payload
         )
 
@@ -46,7 +48,9 @@ const appReadinessPlugin = (store) => {
     if (ENVIRONMENT !== 'production') {
         store.subscribeAction((action, _state) => {
             log.debug(
-                `[store action]: type=${action.type} dispatcher=${action.payload?.dispatcher ?? null} payload=`,
+                `[store action]: type=${action.type} dispatcher=${
+                    action.payload?.dispatcher ?? null
+                } payload=`,
                 action.payload
             )
         })

--- a/src/store/plugins/click-on-map-management.plugin.js
+++ b/src/store/plugins/click-on-map-management.plugin.js
@@ -76,6 +76,7 @@ const clickOnMapManagementPlugin = (store) => {
                     store.state.i18n.lang,
                     state.position.projection
                 ).then((newSelectedFeatures) => {
+                    store.dispatch('showToolTip')
                     store.dispatch('setSelectedFeatures', newSelectedFeatures)
                 })
             }

--- a/src/store/plugins/click-on-map-management.plugin.js
+++ b/src/store/plugins/click-on-map-management.plugin.js
@@ -76,7 +76,7 @@ const clickOnMapManagementPlugin = (store) => {
                     store.state.i18n.lang,
                     state.position.projection
                 ).then((newSelectedFeatures) => {
-                    store.dispatch('showToolTip')
+                    // TODO if !store.state.ui.tooltipinfo : store.dispatch('settooltipinfo', 'default')
                     store.dispatch('setSelectedFeatures', newSelectedFeatures)
                 })
             }

--- a/tests/cypress/fixtures/layers.fixture.json
+++ b/tests/cypress/fixtures/layers.fixture.json
@@ -202,5 +202,24 @@
         "styleUrl": "//sys-api3.dev.bgdi.ch/static/vectorStyles/test.geojson.layer.json",
         "geojsonUrl": "https://data.geo.admin.ch/test.geojson.layer.json",
         "attributionUrl": "test.geojson.layer.url"
+    },
+    "ch.babs.kulturgueter": {
+        "opacity": 0.75,
+        "wmsLayers": "test.wms.layer",
+        "attribution": "attribution.test.wms.layer",
+        "background": false,
+        "searchable": false,
+        "format": "png",
+        "topics": "ech,test-topic-standard",
+        "wmsUrl": "https://wms.geo.admin.ch",
+        "tooltip": true,
+        "timeEnabled": false,
+        "singleTile": false,
+        "highlightable": true,
+        "chargeable": false,
+        "hasLegend": true,
+        "label": "WMS test layer",
+        "type": "wms",
+        "serverLayerName": "ch.babs.kulturgueter"
     }
 }

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -216,7 +216,7 @@ Cypress.Commands.add(
         cy.waitUntilState(
             (state, getters) => {
                 const active = state.layers.activeLayers.length
-                // The required layers can be set via topic or manually.
+                // The required layers can be set via topic or manually, or through a BOD ID parameter.
                 const targetTopic = getters.currentTopic?.layersToActivate.length
                 const targetLayers =
                     'layers' in queryParams
@@ -225,11 +225,34 @@ Cypress.Commands.add(
                             ? queryParams.layers.split(',').length
                             : queryParams.layers.split(';').length
                         : 0
-                // There are situations where neither value is falsy.
-                // But the higher value seems to always be the right one.
+                // if the layer given as a parameter is already present in the layers or activated by the
+                // topic, we would not count it
+                const targetBodIdParameter = state.layers.activeLayers.some((layer) => {
+                    console.log('-----------')
+                    console.log(layer.geoAdminID in queryParams)
+                    console.log(!queryParams.layers?.includes(layer.geoAdminID))
+                    console.log(queryParams.layers) // this is a string
+                    console.log(!getters.currentTopic?.layersToActivate.includes(layer.geoAdminID))
+                    return (
+                        layer.geoAdminID in queryParams &&
+                        !queryParams.layers?.includes(layer.geoAdminID) &&
+                        !getters.currentTopic?.layersToActivate.includes(layer.geoAdminID)
+                    )
+                })
+                    ? 1
+                    : 0
+                console.log(targetBodIdParameter)
+                console.log('_____________________________')
                 let target = Math.max(targetTopic, targetLayers)
+                console.log(target)
+                // If a layer has been set via a BodId Parameter, we just increment by one
+                target += Boolean(targetBodIdParameter)
                 // If a layer has been set via adminId we just increment by one.
                 target += Boolean(queryParams.adminId)
+                console.log('- - - - - - - -')
+                console.log(target)
+                console.log(state.layers.activeLayers)
+                console.log(active)
                 return active === target
             },
             {

--- a/tests/cypress/support/utils.js
+++ b/tests/cypress/support/utils.js
@@ -1,8 +1,5 @@
 import { BREAKPOINT_TABLET } from '@/config'
 
 export function isMobile() {
-    if (Cypress.config('viewportWidth') < BREAKPOINT_TABLET) {
-        return true
-    }
-    return false
+    return Cypress.config('viewportWidth') < BREAKPOINT_TABLET
 }

--- a/tests/cypress/tests-e2e/bodLayerId.cy.js
+++ b/tests/cypress/tests-e2e/bodLayerId.cy.js
@@ -1,13 +1,107 @@
 /// <reference types="cypress" />
 
 describe('Testing the Bod Id Layer Router ', () => {
+    const features = []
+    cy.fixture('features.fixture.json').then((features) => {
+        features['results'].forEach((feature) => {
+            features.push(feature)
+        })
+    })
+    const layer = features[0].layer
+
+    function intercept(numberOfFeatures) {
+        for (let i = 0; i < numberOfFeatures; i++) {
+            cy.intercept(`**/MapServer/${layer}/${features[i].id}`, { results: [features[i]] })
+        }
+    }
+    beforeEach(() => {
+        cy.intercept('**/MapServer/**/htmlPopup**', {
+            fixture: 'html-popup.fixture.html',
+        })
+    })
     context('Startup', () => {
         it('Shows only the given layer when there is no layers parameters', () => {
-            // here : test showtooltip = true
+            const featuresIds = []
+            for (let i = 0; i < 4; i++) {
+                featuresIds.push(features[i].id)
+            }
+            intercept(4)
+            const params = {}
+            params[layer] = featuresIds.join(';')
+            cy.goToMapView(params)
+
+            cy.readStoreValue('state.features.selectedFeatures').then((features) => {
+                expect(cy.wrap(features.length)).to.equal(4)
+                features.every((feature) => {
+                    featuresIds.include(feature.getID())
+                })
+            })
+
+            expect(cy.readStoreValue('state.features.highlightedFeature').getID()).to.equal(
+                features[0].getID()
+            )
+
+            cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
+                cy.expect(activeLayers.length).to.be(1)
+                cy.expect(activeLayers[0].getID()).to.be(layer.getID())
+            })
+            cy.readStoreValue('state.ui.zoom').should.be(8)
+            cy.readStoreValue('state.ui.center').should.equal(features[0].geometry.coordinates)
+
+            cy.get('data-cy=["popover"]').should('be.visible')
         })
         it('Shows all layers, when given a layers paramater which contains the given layer', () => {
-            // here : test showtooltip = false
+            const feature = features[0]
+            intercept(1)
+            const params = {
+                layers: `test.wms-layer.1,${feature.layer}`,
+                showtooltip: 'false',
+            }
+            params[feature.layer] = feature.id
+            cy.goToMapView(params)
+
+            cy.readStoreValue('state.features.selectedFeatures').then((features) => {
+                expect(cy.wrap(features.length)).to.equal(1)
+                expect(cy.wrap(features[0].id).to.equal(feature.id))
+            })
+
+            expect(cy.readStoreValue('state.features.highlightedFeature').getID()).to.equal(
+                feature.getID()
+            )
+
+            cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
+                cy.expect(activeLayers.length).to.be(2)
+                cy.expect(activeLayers.include(layer)).to.be(true)
+            })
+            cy.readStoreValue('state.ui.zoom').should.be(8)
+            cy.readStoreValue('state.ui.center').should.equal(feature.geometry.coordinates)
+
+            // if we decide to go with 'showtooltip = false' --> infobox : data-cy=["infobox"]
         })
-        it('adds a new layer when given a bod layer id that is not part of the layers parameters', () => {})
+        it('adds a new layer when given a bod layer id that is not part of the layers parameters', () => {
+            const feature = features[0]
+            intercept(1)
+            const params = {
+                layers: 'test.wms.layer.1,test.wmts.layer.2',
+                z: 5,
+            }
+            params[feature.layer] = feature.id
+            cy.goToMapView(params)
+            cy.readStoreValue('state.features.selectedFeatures').then((features) => {
+                expect(cy.wrap(features.length)).to.equal(1)
+                expect(cy.wrap(features[0].id).to.equal(feature.id))
+            })
+            expect(cy.readStoreValue('state.features.highlightedFeature').getID()).to.equal(
+                feature.getID()
+            )
+
+            // CHECK layers
+            cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
+                cy.expect(activeLayers.length).to.be(3)
+                cy.expect(activeLayers.include(layer)).to.be(true)
+            })
+            cy.readStoreValue('state.ui.zoom').should.be(5)
+            cy.readStoreValue('state.ui.center').should.equal(feature.geometry.coordinates)
+        })
     })
 })

--- a/tests/cypress/tests-e2e/bodLayerId.cy.js
+++ b/tests/cypress/tests-e2e/bodLayerId.cy.js
@@ -1,0 +1,13 @@
+/// <reference types="cypress" />
+
+describe('Testing the Bod Id Layer Router ', () => {
+    context('Startup', () => {
+        it('Shows only the given layer when there is no layers parameters', () => {
+            // here : test showtooltip = true
+        })
+        it('Shows all layers, when given a layers paramater which contains the given layer', () => {
+            // here : test showtooltip = false
+        })
+        it('adds a new layer when given a bod layer id that is not part of the layers parameters', () => {})
+    })
+})

--- a/tests/cypress/tests-e2e/bodLayerId.cy.js
+++ b/tests/cypress/tests-e2e/bodLayerId.cy.js
@@ -1,107 +1,171 @@
 /// <reference types="cypress" />
 
-describe('Testing the Bod Id Layer Router ', () => {
-    const features = []
-    cy.fixture('features.fixture.json').then((features) => {
-        features['results'].forEach((feature) => {
-            features.push(feature)
-        })
-    })
-    const layer = features[0].layer
+//const { isMobile } = require('../support/utils')
 
-    function intercept(numberOfFeatures) {
-        for (let i = 0; i < numberOfFeatures; i++) {
-            cy.intercept(`**/MapServer/${layer}/${features[i].id}`, { results: [features[i]] })
-        }
+//TODO dans un test : ajouter deux couches, vérifier qu'on en a qu'une
+describe('Testing the Bod Id Layer Router ', () => {
+    function checkFeatures(featuresIds) {
+        cy.readStoreValue('state.features.selectedFeatures').then((features) => {
+            cy.wrap(features.length).should('be.equal', featuresIds.length)
+            features.forEach((feature) => {
+                cy.wrap(featuresIds.includes(feature._id)).should('be.true')
+            })
+        })
     }
+    function checkLayers(layerId, expectedActiveLayersLength) {
+        cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
+            cy.wrap(activeLayers.length).should('be.equal', expectedActiveLayersLength)
+            // make general to see if at least one is the correct one
+            cy.wrap(activeLayers.some((activeLayer) => activeLayer.getID() === layerId))
+        })
+    }
+    function checkZoomAndPosition(expectedZoom, expectedCenter) {
+        cy.readStoreValue('state.position.zoom').should('be.equal', expectedZoom)
+        cy.readStoreValue('state.position.center').then((center) => {
+            cy.wrap(center[0]).should('be.closeTo', expectedCenter[0], 1)
+            cy.wrap(center[1]).should('be.closeTo', expectedCenter[1], 1)
+        })
+    }
+    /* function checkPopupVisibility(showToolTipParam) {
+        if (!showToolTipParam) {
+            cy.get('[data-cy="infobox"]').should('not.exist')
+            cy.get('[data-cy="popover"]').should('not.exist')
+        } else if (showToolTipParam === 'fixed' || (showToolTipParam === 'default' && isMobile())) {
+            cy.get('[data-cy="infobox"]').should('be.visible')
+        } else {
+            cy.get('[data-cy="popover"]').should('be.visible')
+        }
+    } */
+
     beforeEach(() => {
+        // add intercept for layer config
+        cy.intercept('**/rest/services/all/MapServer/layersConfig**', {
+            fixture: 'layers.fixture',
+        })
         cy.intercept('**/MapServer/**/htmlPopup**', {
             fixture: 'html-popup.fixture.html',
         })
     })
-    context('Startup', () => {
-        it('Shows only the given layer when there is no layers parameters', () => {
-            const featuresIds = []
-            for (let i = 0; i < 4; i++) {
-                featuresIds.push(features[i].id)
-            }
-            intercept(4)
-            const params = {}
-            params[layer] = featuresIds.join(';')
-            cy.goToMapView(params)
 
-            cy.readStoreValue('state.features.selectedFeatures').then((features) => {
-                expect(cy.wrap(features.length)).to.equal(4)
-                features.every((feature) => {
-                    featuresIds.include(feature.getID())
+    context('Startup', () => {
+        describe('Checks that will ensure we show the correct number of layers, features and zoom at the correct level', () => {
+            it('Shows only the given layer when there is no layers parameters', () => {
+                const features = []
+                const nbFeatures = 4
+                cy.fixture('features.fixture.json').then((results) => {
+                    results['results'].forEach((feature) => {
+                        features.push(feature)
+                    })
+                    const layer = features[0].layerBodId
+                    for (let i = 0; i < nbFeatures; i++) {
+                        cy.intercept(`**/MapServer/${layer}/${features[i].id}`, {
+                            results: [features[i]],
+                        })
+                    }
+
+                    const featuresIds = []
+
+                    for (let i = 0; i < nbFeatures; i++) {
+                        featuresIds.push(features[i].id.toString())
+                    }
+                    const params = {}
+                    params[layer] = featuresIds.join(',')
+                    cy.goToMapView(params)
+
+                    checkLayers(layer, 1)
+                    checkFeatures(featuresIds)
+                    checkZoomAndPosition(8, [2600867, 1199272])
+                    //checkPopupVisibility(null)
                 })
             })
+            it('Shows all layers, when given a layers paramater which contains the given layer', () => {
+                const features = []
+                cy.fixture('features.fixture.json').then((results) => {
+                    results['results'].forEach((feature) => {
+                        features.push(feature)
+                    })
 
-            expect(cy.readStoreValue('state.features.highlightedFeature').getID()).to.equal(
-                features[0].getID()
-            )
+                    const layer = features[0].layerBodId
 
-            cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
-                cy.expect(activeLayers.length).to.be(1)
-                cy.expect(activeLayers[0].getID()).to.be(layer.getID())
+                    cy.intercept(`**/MapServer/${layer}/${features[0].id}`, {
+                        results: [features[0]],
+                    })
+
+                    const featuresIds = []
+                    featuresIds.push(features[0].id)
+                    const params = {
+                        layers: `test.wms-layer.1;${layer}`,
+                        //showtooltip: 'default',
+                    }
+                    params[layer] = features[0].id
+                    console.log('-------------------------- TEST 2 ---------------------')
+                    cy.goToMapView(params)
+
+                    checkLayers(layer, 2)
+                    checkFeatures(featuresIds)
+                    checkZoomAndPosition(8, [features[0].properties.x, features[0].properties.y])
+                    //checkPopupVisibility("default")
+                })
             })
-            cy.readStoreValue('state.ui.zoom').should.be(8)
-            cy.readStoreValue('state.ui.center').should.equal(features[0].geometry.coordinates)
+            it('adds a new layer when given a bod layer id that is not part of the layers parameters', () => {
+                const features = []
+                cy.fixture('features.fixture.json').then((results) => {
+                    results['results'].forEach((feature) => {
+                        features.push(feature)
+                    })
+                    const layer = features[0].layerBodId
 
-            cy.get('data-cy=["popover"]').should('be.visible')
-        })
-        it('Shows all layers, when given a layers paramater which contains the given layer', () => {
-            const feature = features[0]
-            intercept(1)
-            const params = {
-                layers: `test.wms-layer.1,${feature.layer}`,
-                showtooltip: 'false',
-            }
-            params[feature.layer] = feature.id
-            cy.goToMapView(params)
+                    cy.intercept(`**/MapServer/${layer}/${features[0].id}`, {
+                        results: [features[0]],
+                    })
 
-            cy.readStoreValue('state.features.selectedFeatures').then((features) => {
-                expect(cy.wrap(features.length)).to.equal(1)
-                expect(cy.wrap(features[0].id).to.equal(feature.id))
+                    const featuresIds = []
+                    featuresIds.push(features[0].id)
+                    const params = {
+                        layers: 'test.wms.layer.1;test.wmts.layer.2',
+                        z: 5,
+                        //showtooltip: "floating"
+                    }
+                    params[layer] = features[0].id
+
+                    console.log('-------------------------- TEST 3 ---------------------')
+                    cy.goToMapView(params)
+
+                    checkLayers(layer, 3)
+                    checkFeatures(featuresIds)
+                    checkZoomAndPosition(5, [features[0].properties.x, features[0].properties.y])
+                    //checkPopupVisibility("floating")
+                })
             })
+            it('shows only one layer when two are given', () => {
+                const features = []
+                cy.fixture('features.fixture.json').then((results) => {
+                    results['results'].forEach((feature) => {
+                        features.push(feature)
+                    })
+                    const layer_1 = features[0].layerBodId
+                    const layer_2 = 'test.wms.layer.1'
+                    cy.intercept(`**/MapServer/${layer_1}/${features[0].id}`, {
+                        results: [features[0]],
+                    })
 
-            expect(cy.readStoreValue('state.features.highlightedFeature').getID()).to.equal(
-                feature.getID()
-            )
+                    const featuresIds = []
+                    featuresIds.push(features[0].id)
+                    featuresIds.push(features[1].id)
+                    const params = {
+                        z: 5,
+                        //showtooltip: "fixed"
+                    }
+                    params[layer_1] = features[0].id
+                    params[layer_2] = features[1].id
+                    cy.goToMapView(params)
 
-            cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
-                cy.expect(activeLayers.length).to.be(2)
-                cy.expect(activeLayers.include(layer)).to.be(true)
+                    checkLayers(layer_1, 1)
+                    checkFeatures([featuresIds[0]])
+                    checkZoomAndPosition(5, [features[0].properties.x, features[0].properties.y])
+                    //checkPopupVisibility("fixed")
+                })
             })
-            cy.readStoreValue('state.ui.zoom').should.be(8)
-            cy.readStoreValue('state.ui.center').should.equal(feature.geometry.coordinates)
-
-            // if we decide to go with 'showtooltip = false' --> infobox : data-cy=["infobox"]
-        })
-        it('adds a new layer when given a bod layer id that is not part of the layers parameters', () => {
-            const feature = features[0]
-            intercept(1)
-            const params = {
-                layers: 'test.wms.layer.1,test.wmts.layer.2',
-                z: 5,
-            }
-            params[feature.layer] = feature.id
-            cy.goToMapView(params)
-            cy.readStoreValue('state.features.selectedFeatures').then((features) => {
-                expect(cy.wrap(features.length)).to.equal(1)
-                expect(cy.wrap(features[0].id).to.equal(feature.id))
-            })
-            expect(cy.readStoreValue('state.features.highlightedFeature').getID()).to.equal(
-                feature.getID()
-            )
-
-            // CHECK layers
-            cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
-                cy.expect(activeLayers.length).to.be(3)
-                cy.expect(activeLayers.include(layer)).to.be(true)
-            })
-            cy.readStoreValue('state.ui.zoom').should.be(5)
-            cy.readStoreValue('state.ui.center').should.equal(feature.geometry.coordinates)
         })
     })
 })

--- a/tests/cypress/tests-e2e/drawing.cy.js
+++ b/tests/cypress/tests-e2e/drawing.cy.js
@@ -134,7 +134,9 @@ describe('Drawing module tests', () => {
             cy.wait('@update-kml').then((interception) => {
                 cy.checkKMLRequest(interception, [
                     new RegExp(
-                        `<IconStyle><scale>${LARGE.iconScale * LEGACY_ICON_XML_SCALE_FACTOR}</scale>`
+                        `<IconStyle><scale>${
+                            LARGE.iconScale * LEGACY_ICON_XML_SCALE_FACTOR
+                        }</scale>`
                     ),
                     new RegExp(`<Icon>.*?<gx:w>48</gx:w>.*?</Icon>`),
                     new RegExp(`<Icon>.*?<gx:h>48</gx:h>.*?</Icon>`),


### PR DESCRIPTION
Issue : We want to implement the {bod-layer-id} parameter functionality as follows :

parameter 1: {layer-id}={features,id,separated,by,commas}
	This should activate the layer, and select the features
parameter 2: showToolTip={true, false}
	If set to false, the features should be highlighted, but the
tooltip should remain hidden. This is only valid at startup.

We added a small router that should be called after the legacy Parameters router, whose goal is to get rid of the dynamic parameter in the URL, transfer it to the 'layers' param and ensure it is visible.

[Test link](https://sys-map.dev.bgdi.ch/preview/pb-190-implement-bodid-feature/index.html)