### PR TITLE
PB-285: Added `dispatcher` to  store actions and improve startup procedure (language  change)

### DIFF
--- a/src/api/topics.api.js
+++ b/src/api/topics.api.js
@@ -158,6 +158,17 @@ const loadTopicsFromBackend = (layersConfig) => {
                                     ...(rawTopic.selectedLayers ?? []),
                                 ]),
                             ]
+                                // Filter out layers that have been already added by the infamous
+                                // plConfig topic config that has priority, this avoid duplicate 
+                                // layers
+                                .filter(
+                                    (layerId) =>
+                                        !(
+                                            layersToActivate.findIndex(
+                                                (layer) => layer.getID() === layerId
+                                            ) !== -1
+                                        )
+                                )
                             activatedLayers.forEach((layerId) => {
                                 let layer = layersConfig.find((layer) => layer.getID() === layerId)
                                 if (layer) {

--- a/src/api/topics.api.js
+++ b/src/api/topics.api.js
@@ -160,11 +160,7 @@ const loadTopicsFromBackend = (layersConfig) => {
                                 // layers
                                 .filter(
                                     (layerId) =>
-                                        !(
-                                            layersToActivate.findIndex(
-                                                (layer) => layer.getID() === layerId
-                                            ) !== -1
-                                        )
+                                        !layersToActivate.some((layer) => layer.getID() === layerId)
                                 )
                             activatedLayers.forEach((layerId) => {
                                 let layer = layersConfig.find((layer) => layer.getID() === layerId)

--- a/src/api/topics.api.js
+++ b/src/api/topics.api.js
@@ -159,7 +159,7 @@ const loadTopicsFromBackend = (layersConfig) => {
                                 ]),
                             ]
                                 // Filter out layers that have been already added by the infamous
-                                // plConfig topic config that has priority, this avoid duplicate 
+                                // plConfig topic config that has priority, this avoid duplicate
                                 // layers
                                 .filter(
                                     (layerId) =>

--- a/src/api/topics.api.js
+++ b/src/api/topics.api.js
@@ -152,26 +152,27 @@ const loadTopicsFromBackend = (layersConfig) => {
                                     params.get('layers_timestamp')
                                 ),
                             ]
-                            if (rawTopic.activatedLayers?.length > 0) {
-                                rawTopic.activatedLayers.forEach((layerId) => {
-                                    let layer = layersConfig.find(
-                                        (layer) => layer.getID() === layerId
-                                    )
-                                    if (layer) {
-                                        // deep copy so that we can reassign values later on
-                                        // (layers come from the Vuex store so it can't be modified directly)
-                                        layer = layer.clone()
-                                        // checking if the layer should be also visible
-                                        layer.visible =
-                                            rawTopic.selectedLayers?.indexOf(layerId) !== -1 ??
-                                            false
-                                        // In the backend the layers are in the wrong order
-                                        // so we need to reverse the order here by simply adding
-                                        // the layer at the beginning of the array
-                                        layersToActivate.unshift(layer)
-                                    }
-                                })
-                            }
+                            const activatedLayers = [
+                                ...new Set([
+                                    ...(rawTopic.activatedLayers ?? []),
+                                    ...(rawTopic.selectedLayers ?? []),
+                                ]),
+                            ]
+                            activatedLayers.forEach((layerId) => {
+                                let layer = layersConfig.find((layer) => layer.getID() === layerId)
+                                if (layer) {
+                                    // deep copy so that we can reassign values later on
+                                    // (layers come from the Vuex store so it can't be modified directly)
+                                    layer = layer.clone()
+                                    // checking if the layer should be also visible
+                                    layer.visible =
+                                        rawTopic.selectedLayers?.indexOf(layerId) !== -1 ?? false
+                                    // In the backend the layers are in the wrong order
+                                    // so we need to reverse the order here by simply adding
+                                    // the layer at the beginning of the array
+                                    layersToActivate.unshift(layer)
+                                }
+                            })
                             topics.push(
                                 new Topic(
                                     topicId,

--- a/src/api/topics.api.js
+++ b/src/api/topics.api.js
@@ -71,14 +71,14 @@ const readTopicTreeRecursive = (node, availableLayers) => {
  * Loads the topic tree for a topic. This will be used to create the UI of the topic in the menu.
  *
  * @param {String} lang The lang in which to load the topic tree
- * @param {Topic} topic The topic we want to load the topic tree
+ * @param {String} topicId The topic we want to load the topic tree
  * @param {GeoAdminLayer[]} layersConfig All available layers for this app (the "layers config")
  * @returns {Promise<{ layers: GeoAdminLayer[]; itemIdToOpen: String[] }>} A list of topic's layers
  */
-export const loadTopicTreeForTopic = (lang, topic, layersConfig) => {
+export const loadTopicTreeForTopic = (lang, topicId, layersConfig) => {
     return new Promise((resolve, reject) => {
         axios
-            .get(`${API_BASE_URL}rest/services/${topic.id}/CatalogServer?lang=${lang}`)
+            .get(`${API_BASE_URL}rest/services/${topicId}/CatalogServer?lang=${lang}`)
             .then((response) => {
                 const treeItems = []
                 const topicRoot = response.data.results.root
@@ -86,10 +86,7 @@ export const loadTopicTreeForTopic = (lang, topic, layersConfig) => {
                     try {
                         treeItems.push(readTopicTreeRecursive(child, layersConfig))
                     } catch (err) {
-                        log.error(
-                            `Error while loading Layer ${child.id} for Topic ${topic.id}`,
-                            err
-                        )
+                        log.error(`Error while loading Layer ${child.id} for Topic ${topicId}`, err)
                     }
                 })
                 const itemIdToOpen = gatherItemIdThatShouldBeOpened(topicRoot)

--- a/src/api/topics.api.js
+++ b/src/api/topics.api.js
@@ -152,10 +152,7 @@ const loadTopicsFromBackend = (layersConfig) => {
                                     params.get('layers_timestamp')
                                 ),
                             ]
-                            if (
-                                Array.isArray(rawTopic.activatedLayers) &&
-                                rawTopic.activatedLayers.length > 0
-                            ) {
+                            if (rawTopic.activatedLayers?.length > 0) {
                                 rawTopic.activatedLayers.forEach((layerId) => {
                                     let layer = layersConfig.find(
                                         (layer) => layer.getID() === layerId
@@ -163,15 +160,15 @@ const loadTopicsFromBackend = (layersConfig) => {
                                     if (layer) {
                                         // deep copy so that we can reassign values later on
                                         // (layers come from the Vuex store so it can't be modified directly)
-                                        layer = Object.assign(
-                                            Object.create(Object.getPrototypeOf(layer)),
-                                            layer
-                                        )
+                                        layer = layer.clone()
                                         // checking if the layer should be also visible
                                         layer.visible =
-                                            Array.isArray(rawTopic.selectedLayers) &&
-                                            rawTopic.selectedLayers.indexOf(layerId) !== -1
-                                        layersToActivate.push(layer)
+                                            rawTopic.selectedLayers?.indexOf(layerId) !== -1 ??
+                                            false
+                                        // In the backend the layers are in the wrong order
+                                        // so we need to reverse the order here by simply adding
+                                        // the layer at the beginning of the array
+                                        layersToActivate.unshift(layer)
                                     }
                                 })
                             }

--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -156,7 +156,7 @@ async function closeDrawing() {
         await saveDrawing(false)
     }
 
-    await store.dispatch('toggleDrawingOverlay')
+    await store.dispatch('toggleDrawingOverlay', { dispatcher: 'DrawingModule.vue' })
     await store.dispatch('setShowLoadingBar', false)
 }
 </script>

--- a/src/modules/drawing/useKmlDataManagement.composable.js
+++ b/src/modules/drawing/useKmlDataManagement.composable.js
@@ -71,9 +71,15 @@ export default function useSaveKmlOnChange(drawingLayerDirectReference) {
                 // Meaning we must remove the old one from the layers; it will otherwise be there twice
                 // (once the pristine "old" KML, and once the new copy)
                 if (activeKmlLayer.value) {
-                    await store.dispatch('removeLayer', activeKmlLayer.value)
+                    await store.dispatch('removeLayer', {
+                        layer: activeKmlLayer.value,
+                        dispatcher: 'useKmlDataManagement.composable/saveDrawing',
+                    })
                 }
-                await store.dispatch('addLayer', kmlLayer)
+                await store.dispatch('addLayer', {
+                    layer: kmlLayer,
+                    dispatcher: 'useKmlDataManagement.composable/saveDrawing',
+                })
                 saveState.value = DrawingState.SAVED
             } else {
                 // if a KMLLayer is already defined, we update it

--- a/src/modules/i18n/components/LangButton.vue
+++ b/src/modules/i18n/components/LangButton.vue
@@ -41,7 +41,7 @@ export default {
         ...mapActions(['setLang']),
         changeLang() {
             log.debug('switching locale', this.lang)
-            this.setLang(this.lang)
+            this.setLang({ value: this.lang, dispatcher: 'LangButton.vue' })
         },
     },
 }

--- a/src/modules/i18n/components/LangButton.vue
+++ b/src/modules/i18n/components/LangButton.vue
@@ -41,7 +41,7 @@ export default {
         ...mapActions(['setLang']),
         changeLang() {
             log.debug('switching locale', this.lang)
-            this.setLang({ value: this.lang, dispatcher: 'LangButton.vue' })
+            this.setLang({ lang: this.lang, dispatcher: 'LangButton.vue' })
         },
     },
 }

--- a/src/modules/map/components/CompareSlider.vue
+++ b/src/modules/map/components/CompareSlider.vue
@@ -118,7 +118,7 @@ function releaseSlider() {
     window.removeEventListener('touchend', releaseSlider)
     compareSliderOffset.value = 0
     store.dispatch('setCompareRatio', {
-        value: compareRatio.value,
+        compareRatio: compareRatio.value,
         dispatcher: 'CompareSlider.vue',
     })
 }

--- a/src/modules/map/components/CompareSlider.vue
+++ b/src/modules/map/components/CompareSlider.vue
@@ -117,7 +117,10 @@ function releaseSlider() {
     window.removeEventListener('mouseup', releaseSlider)
     window.removeEventListener('touchend', releaseSlider)
     compareSliderOffset.value = 0
-    store.dispatch('setCompareRatio', compareRatio.value)
+    store.dispatch('setCompareRatio', {
+        value: compareRatio.value,
+        dispatcher: 'CompareSlider.vue',
+    })
 }
 </script>
 

--- a/src/modules/map/components/cesium/CesiumMap.vue
+++ b/src/modules/map/components/cesium/CesiumMap.vue
@@ -281,7 +281,7 @@ export default {
         }
     },
     unmounted() {
-        this.setCameraPosition({ position: null, source: 'CesiumMap unmount' })
+        this.setCameraPosition({ position: null, dispatcher: 'CesiumMap.vue/unmount' })
         this.viewer.destroy()
         delete this.viewer
     },
@@ -397,7 +397,7 @@ export default {
                 // reduce screen space error to downgrade visual quality but speed up tests
                 globe.maximumScreenSpaceError = 30
             }
-            this.mapModuleReady()
+            this.mapModuleReady({ dispatcher: 'CesiumMap.vue' })
         },
         highlightSelectedFeatures() {
             const [firstFeature] = this.selectedFeatures
@@ -472,7 +472,7 @@ export default {
                     pitch: parseFloat(CesiumMath.toDegrees(camera.pitch).toFixed(0)),
                     roll: parseFloat(CesiumMath.toDegrees(camera.roll).toFixed(0)),
                 },
-                source: 'CesiumMap camera move end',
+                dispatcher: 'CesiumMap.vue/onCameraMoveEnd',
             })
         },
         getCoordinateAtScreenCoordinate(x, y) {
@@ -594,7 +594,7 @@ export default {
                 const lon = CesiumMath.toDegrees(cameraTargetCartographic.longitude)
                 this.setCenter({
                     center: proj4(WGS84.epsg, this.projection.epsg, [lon, lat]),
-                    source: 'CesiumMap',
+                    dispatcher: 'CesiumMap.vue',
                 })
             }
         },

--- a/src/modules/map/components/footer/backgroundSelector/BackgroundSelector.vue
+++ b/src/modules/map/components/footer/backgroundSelector/BackgroundSelector.vue
@@ -44,7 +44,10 @@ const sortedBackgroundLayersWithVoid = computed(() =>
 )
 
 function selectBackground(backgroundLayer) {
-    store.dispatch('setBackground', backgroundLayer)
+    store.dispatch('setBackground', {
+        value: backgroundLayer,
+        dispatcher: 'BackgroundSelector.vue',
+    })
 }
 </script>
 

--- a/src/modules/map/components/footer/backgroundSelector/BackgroundSelector.vue
+++ b/src/modules/map/components/footer/backgroundSelector/BackgroundSelector.vue
@@ -45,7 +45,7 @@ const sortedBackgroundLayersWithVoid = computed(() =>
 
 function selectBackground(backgroundLayer) {
     store.dispatch('setBackground', {
-        value: backgroundLayer,
+        bgLayer: backgroundLayer,
         dispatcher: 'BackgroundSelector.vue',
     })
 }

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -53,7 +53,7 @@ if (IS_TESTING_WITH_CYPRESS) {
 map.once('rendercomplete', () => {
     // This is needed for cypress in order to start the tests only
     // when openlayer is rendered otherwise some tests will fail.
-    store.dispatch('mapModuleReady')
+    store.dispatch('mapModuleReady', { dispatcher: 'OpenLayersMap.vue' })
     log.info('Openlayer map rendered')
 })
 

--- a/src/modules/map/components/openlayers/utils/map-views.composable.js
+++ b/src/modules/map/components/openlayers/utils/map-views.composable.js
@@ -80,11 +80,11 @@ export default function useViewBasedOnProjection(map) {
         if (currentView) {
             const [x, y] = currentView.getCenter()
             if (x !== center.value[0] || y !== center.value[1]) {
-                store.dispatch('setCenter', { center: { x, y }, source: 'OpenLayers' })
+                store.dispatch('setCenter', { center: { x, y }, dispatcher: 'OpenLayers.vue' })
             }
             const currentZoom = round(currentView.getZoom(), 3)
             if (currentZoom && currentZoom !== zoom.value) {
-                store.dispatch('setZoom', { zoom: currentZoom, source: 'OpenLayers' })
+                store.dispatch('setZoom', { zoom: currentZoom, dispatcher: 'OpenLayers.vue' })
             }
             const currentRotation = currentView.getRotation()
             if (currentRotation !== rotation.value) {

--- a/src/modules/menu/components/LayerCatalogueItem.vue
+++ b/src/modules/menu/components/LayerCatalogueItem.vue
@@ -21,6 +21,8 @@ import { LV95 } from '@/utils/coordinates/coordinateSystems'
 import { ActiveLayerConfig } from '@/utils/layerUtils'
 import log from '@/utils/logging'
 
+const STORE_DISPATCHER_LAYER_CATALOGUE_ITEM = 'LayerCatalogueItem.vue'
+
 const props = defineProps({
     item: {
         type: AbstractLayer,
@@ -118,11 +120,20 @@ function addRemoveLayer() {
     // if this is a group of a layer then simply add it to the map
     const matchingActiveLayer = store.getters.getActiveLayerById(item.value.getID())
     if (matchingActiveLayer) {
-        store.dispatch('removeLayer', matchingActiveLayer)
+        store.dispatch('removeLayer', {
+            layer: matchingActiveLayer,
+            dispatcher: STORE_DISPATCHER_LAYER_CATALOGUE_ITEM,
+        })
     } else if (item.value.isExternal) {
-        store.dispatch('addLayer', item.value)
+        store.dispatch('addLayer', {
+            layer: item.value,
+            dispatcher: STORE_DISPATCHER_LAYER_CATALOGUE_ITEM,
+        })
     } else {
-        store.dispatch('addLayer', new ActiveLayerConfig(item.value.getID(), true))
+        store.dispatch('addLayer', {
+            layerConfig: new ActiveLayerConfig(item.value.getID(), true),
+            dispatcher: STORE_DISPATCHER_LAYER_CATALOGUE_ITEM,
+        })
     }
 }
 

--- a/src/modules/menu/components/activeLayers/MenuActiveLayersList.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersList.vue
@@ -39,6 +39,8 @@ import LayerLegendPopup from '@/modules/menu/components/LayerLegendPopup.vue'
 
 import MenuActiveLayersListItem from './MenuActiveLayersListItem.vue'
 
+const STORE_DISPATCHER_MENU_ACTIVE_LAYERS_LIST = 'MenuActiveLayersList.vue'
+
 /**
  * Component that maps the active layers from the state to the menu (and also forwards user
  * interactions to the state)
@@ -82,7 +84,10 @@ export default {
             'setOverlayShouldBeFront',
         ]),
         onRemoveLayer(layerId) {
-            this.removeLayer(layerId)
+            this.removeLayer({
+                layerId: layerId,
+                dispatcher: STORE_DISPATCHER_MENU_ACTIVE_LAYERS_LIST,
+            })
         },
         onToggleLayerVisibility(layerId) {
             this.toggleLayerVisibility(layerId)
@@ -96,7 +101,11 @@ export default {
             }
         },
         onOpacityChange(layerId, opacity) {
-            this.setLayerOpacity({ layerId, opacity })
+            this.setLayerOpacity({
+                layerId,
+                opacity,
+                dispatcher: STORE_DISPATCHER_MENU_ACTIVE_LAYERS_LIST,
+            })
         },
         isFirstLayer(layerId) {
             return this.activeLayers[0].getID() === layerId

--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItemTimeSelector.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItemTimeSelector.vue
@@ -50,6 +50,8 @@ import {
     YEAR_TO_DESCRIBE_ALL_OR_CURRENT_DATA,
 } from '@/api/layers/LayerTimeConfigEntry.class'
 
+const STORE_DISPATCHER_MENU_ACTIVE_LAYERS_LIST_TIME = 'MenuActiveLayersListItemTimeSelector.vue'
+
 export default {
     props: {
         layerId: {
@@ -119,6 +121,7 @@ export default {
             this.setTimedLayerCurrentYear({
                 layerId: this.layerId,
                 year,
+                dispatcher: STORE_DISPATCHER_MENU_ACTIVE_LAYERS_LIST_TIME,
             })
         },
         hidePopover() {

--- a/src/modules/menu/components/advancedTools/ImportFile/utils.js
+++ b/src/modules/menu/components/advancedTools/ImportFile/utils.js
@@ -48,7 +48,7 @@ export function handleFileContent(store, content, source) {
             throw new OutOfBoundsError(`KML out of projection bounds: ${extent}`)
         }
         store.dispatch('zoomToExtent', projectedExtent)
-        store.dispatch('addLayer', layer)
+        store.dispatch('addLayer', { layer, dispatcher: 'ImportFile.vue/kml' })
     } else if (isGpx(content)) {
         const gpxParser = new GPX()
         const metadata = gpxParser.readMetadata(content)
@@ -62,7 +62,7 @@ export function handleFileContent(store, content, source) {
             throw new OutOfBoundsError(`GPX out of projection bounds: ${extent}`)
         }
         store.dispatch('zoomToExtent', projectedExtent)
-        store.dispatch('addLayer', layer)
+        store.dispatch('addLayer', { layer, dispacther: 'ImportFile.vue/gpx' })
     } else {
         throw new Error(`Unsupported file ${source} content`)
     }

--- a/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
+++ b/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
@@ -7,6 +7,9 @@ import ImportCatalogue from '@/modules/menu/components/advancedTools/ImportCatal
 import ImportFile from '@/modules/menu/components/advancedTools/ImportFile/ImportFile.vue'
 import MenuAdvancedToolsListItem from '@/modules/menu/components/advancedTools/MenuAdvancedToolsListItem.vue'
 import ModalWithBackdrop from '@/utils/components/ModalWithBackdrop.vue'
+
+const STORE_DISPATCHER_MENU_ADVANCED_TOOL = 'MenuAdvancedToolsList.vue'
+
 const props = defineProps({
     compact: {
         type: Boolean,
@@ -29,9 +32,15 @@ function onToggleImportCatalogue() {
 function onToggleCompareSlider() {
     if (storeCompareRatio.value === null) {
         // this allows us to set a value to the compare ratio, in case there was none
-        store.dispatch('setCompareRatio', 0.5)
+        store.dispatch('setCompareRatio', {
+            value: 0.5,
+            dispatcher: STORE_DISPATCHER_MENU_ADVANCED_TOOL,
+        })
     }
-    store.dispatch('setCompareSliderActive', !isCompareSliderActive.value)
+    store.dispatch('setCompareSliderActive', {
+        value: !isCompareSliderActive.value,
+        dispatcher: STORE_DISPATCHER_MENU_ADVANCED_TOOL,
+    })
 }
 function onToggleImportFile() {
     if (!showImportFile.value && isPhoneMode.value) {

--- a/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
+++ b/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
@@ -33,12 +33,12 @@ function onToggleCompareSlider() {
     if (storeCompareRatio.value === null) {
         // this allows us to set a value to the compare ratio, in case there was none
         store.dispatch('setCompareRatio', {
-            value: 0.5,
+            compareRatio: 0.5,
             dispatcher: STORE_DISPATCHER_MENU_ADVANCED_TOOL,
         })
     }
     store.dispatch('setCompareSliderActive', {
-        value: !isCompareSliderActive.value,
+        compareSliderActive: !isCompareSliderActive.value,
         dispatcher: STORE_DISPATCHER_MENU_ADVANCED_TOOL,
     })
 }

--- a/src/modules/menu/components/debug/DebugToolbar.vue
+++ b/src/modules/menu/components/debug/DebugToolbar.vue
@@ -23,10 +23,10 @@ const isMercatorTheCurrentProjection = computed(
 
 function toggleProjection() {
     if (isMercatorTheCurrentProjection.value) {
-        store.dispatch('setProjection', { value: LV95, dispatcher: STORE_DISPATCHER_DEBUG_TB })
+        store.dispatch('setProjection', { projection: LV95, dispatcher: STORE_DISPATCHER_DEBUG_TB })
     } else {
         store.dispatch('setProjection', {
-            value: WEBMERCATOR,
+            projection: WEBMERCATOR,
             dispatcher: STORE_DISPATCHER_DEBUG_TB,
         })
     }

--- a/src/modules/menu/components/debug/DebugToolbar.vue
+++ b/src/modules/menu/components/debug/DebugToolbar.vue
@@ -6,6 +6,8 @@ import { useStore } from 'vuex'
 import Toggle3DLayerButton from '@/modules/menu/components/debug/Toggle3DLayerButton.vue'
 import { LV95, WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
 
+const STORE_DISPATCHER_DEBUG_TB = 'DebugToolbar.vue'
+
 const store = useStore()
 
 const showDebugTool = ref(false)
@@ -21,9 +23,12 @@ const isMercatorTheCurrentProjection = computed(
 
 function toggleProjection() {
     if (isMercatorTheCurrentProjection.value) {
-        store.dispatch('setProjection', LV95)
+        store.dispatch('setProjection', { value: LV95, dispatcher: STORE_DISPATCHER_DEBUG_TB })
     } else {
-        store.dispatch('setProjection', WEBMERCATOR)
+        store.dispatch('setProjection', {
+            value: WEBMERCATOR,
+            dispatcher: STORE_DISPATCHER_DEBUG_TB,
+        })
     }
 }
 function toggleShowTileDebugInfo() {

--- a/src/modules/menu/components/debug/Toggle3DLayerButton.vue
+++ b/src/modules/menu/components/debug/Toggle3DLayerButton.vue
@@ -7,8 +7,10 @@ const store = useStore()
 const showBuildings = computed(() => store.state.cesium.showBuildings)
 const showVegetation = computed(() => store.state.cesium.showVegetation)
 
-const toggleShow3dVegetation = () => store.dispatch('toggleShow3dVegetation')
-const toggleShow3dBuildings = () => store.dispatch('toggleShow3dBuildings')
+const toggleShow3dVegetation = () =>
+    store.dispatch('toggleShow3dVegetation', { dispatcher: 'Toggle3DLayerButton.vue' })
+const toggleShow3dBuildings = () =>
+    store.dispatch('toggleShow3dBuildings', { dispatcher: 'Toggle3DLayerButton.vue' })
 </script>
 
 <template>

--- a/src/modules/menu/components/header/HeaderWithSearch.vue
+++ b/src/modules/menu/components/header/HeaderWithSearch.vue
@@ -64,8 +64,9 @@ export default {
         ...mapState({
             showLoadingBar: (state) => state.ui.showLoadingBar,
             currentLang: (state) => state.i18n.lang,
+            currentTopicId: (state) => state.topics.current,
         }),
-        ...mapGetters(['currentTopicId', 'isPhoneMode', 'hasDevSiteWarning']),
+        ...mapGetters(['isPhoneMode', 'hasDevSiteWarning']),
     },
     mounted() {
         this.$nextTick(() => {

--- a/src/modules/menu/components/menu/MenuTray.vue
+++ b/src/modules/menu/components/menu/MenuTray.vue
@@ -27,7 +27,7 @@
                 secondary
                 :show-content="showDrawingOverlay"
                 data-cy="menu-tray-drawing-section"
-                @click:header="toggleDrawingOverlay()"
+                @click:header="toggleDrawingOverlay({ dispatcher: 'MenuTray.vue' })"
                 @open-menu-section="onOpenMenuSection"
                 @close-menu-section="onCloseMenuSection"
             />

--- a/src/modules/menu/components/toolboxRight/Toggle3dButton.vue
+++ b/src/modules/menu/components/toolboxRight/Toggle3dButton.vue
@@ -79,7 +79,7 @@ export default {
         ...mapActions(['set3dActive']),
         toggle3d() {
             if (this.webGlIsSupported && !this.showDrawingOverlay) {
-                this.set3dActive({ value: !this.isActive, dispatcher: 'Toggle3dButton.vue' })
+                this.set3dActive({ active: !this.isActive, dispatcher: 'Toggle3dButton.vue' })
             }
         },
         updateTooltipContent() {

--- a/src/modules/menu/components/toolboxRight/Toggle3dButton.vue
+++ b/src/modules/menu/components/toolboxRight/Toggle3dButton.vue
@@ -79,7 +79,7 @@ export default {
         ...mapActions(['set3dActive']),
         toggle3d() {
             if (this.webGlIsSupported && !this.showDrawingOverlay) {
-                this.set3dActive(!this.isActive)
+                this.set3dActive({ value: !this.isActive, dispatcher: 'Toggle3dButton.vue' })
             }
         },
         updateTooltipContent() {

--- a/src/modules/menu/components/topics/MenuTopicSection.vue
+++ b/src/modules/menu/components/topics/MenuTopicSection.vue
@@ -82,7 +82,7 @@ export default {
             this.showTopicSelectionPopup = true
         },
         selectTopic(topic) {
-            this.changeTopic(topic)
+            this.changeTopic({ value: topic, dispatcher: 'MenuTopicSection.vue' })
             this.showTopicSelectionPopup = false
         },
         close() {

--- a/src/modules/menu/components/topics/MenuTopicSection.vue
+++ b/src/modules/menu/components/topics/MenuTopicSection.vue
@@ -1,9 +1,8 @@
 <template>
     <MenuSection
-        v-if="currentTopic"
         id="menu-topic-section"
         ref="menuTopicSection"
-        :title="$t(currentTopic?.id)"
+        :title="$t(currentTopic)"
         :show-content="showTopicTree"
         light
         data-cy="menu-topic-section"
@@ -20,7 +19,7 @@
             <MenuTopicSelectionPopup
                 v-if="showTopicSelectionPopup"
                 :topics="allTopics"
-                :current-id="currentTopic?.id"
+                :current-id="currentTopic"
                 @select-topic="selectTopic"
                 @close="showTopicSelectionPopup = false"
             />
@@ -82,7 +81,7 @@ export default {
             this.showTopicSelectionPopup = true
         },
         selectTopic(topic) {
-            this.changeTopic({ value: topic, dispatcher: 'MenuTopicSection.vue' })
+            this.changeTopic({ value: topic.id, dispatcher: 'MenuTopicSection.vue' })
             this.showTopicSelectionPopup = false
         },
         close() {

--- a/src/modules/menu/components/topics/MenuTopicSection.vue
+++ b/src/modules/menu/components/topics/MenuTopicSection.vue
@@ -81,7 +81,7 @@ export default {
             this.showTopicSelectionPopup = true
         },
         selectTopic(topic) {
-            this.changeTopic({ value: topic.id, dispatcher: 'MenuTopicSection.vue' })
+            this.changeTopic({ topicId: topic.id, dispatcher: 'MenuTopicSection.vue' })
             this.showTopicSelectionPopup = false
         },
         close() {

--- a/src/router/appLoadingManagement.routerPlugin.js
+++ b/src/router/appLoadingManagement.routerPlugin.js
@@ -29,11 +29,11 @@ const appLoadingManagementRouterPlugin = (router, store) => {
             const lang = queryParams.get('lang') ?? store.state.i18n.lang
             const topic = queryParams.get('topic') ?? store.state.topics.current
             store.dispatch('changeTopic', {
-                value: topic,
+                topicId: topic,
                 dispatcher: STORE_DISPATCHER_APP_ROUTER_PLUGIN,
             })
             store.dispatch('setLang', {
-                value: lang,
+                lang: lang,
                 dispatcher: STORE_DISPATCHER_APP_ROUTER_PLUGIN,
             })
             log.debug(`App is not ready redirect to /#/startup?redirect=${to.fullPath}`)

--- a/src/router/storeSync/CameraParamConfig.class.js
+++ b/src/router/storeSync/CameraParamConfig.class.js
@@ -1,4 +1,6 @@
-import AbstractParamConfig from '@/router/storeSync/abstractParamConfig.class'
+import AbstractParamConfig, {
+    STORE_DISPATCHER_ROUTER_PLUGIN,
+} from '@/router/storeSync/abstractParamConfig.class'
 
 /**
  * Reads the camera position from the single URL param. Returns null if the camera position is not
@@ -33,7 +35,10 @@ function dispatchCameraFromUrlIntoStore(store, urlParamValue) {
     const camera = readCameraFromUrlParam(urlParamValue)
     if (camera) {
         promisesForAllDispatch.push(
-            store.dispatch('setCameraPosition', { position: camera, source: 'URL param parsing' })
+            store.dispatch('setCameraPosition', {
+                position: camera,
+                dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
+            })
         )
     }
     return Promise.all(promisesForAllDispatch)

--- a/src/router/storeSync/CompareSliderParamConfig.class.js
+++ b/src/router/storeSync/CompareSliderParamConfig.class.js
@@ -7,7 +7,7 @@ function dispatchCompareSliderFromUrlParam(store, urlParamValue) {
     if (urlParamValue) {
         promisesForAllDispatch.push(
             store.dispatch('setCompareRatio', {
-                value: urlParamValue,
+                compareRatio: urlParamValue,
                 dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
             })
         )
@@ -15,7 +15,7 @@ function dispatchCompareSliderFromUrlParam(store, urlParamValue) {
         if (urlParamValue > 0.0 && urlParamValue < 1.0) {
             promisesForAllDispatch.push(
                 store.dispatch('setCompareSliderActive', {
-                    value: true,
+                    compareSliderActive: true,
                     dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
                 })
             )

--- a/src/router/storeSync/CompareSliderParamConfig.class.js
+++ b/src/router/storeSync/CompareSliderParamConfig.class.js
@@ -1,12 +1,24 @@
-import AbstractParamConfig from '@/router/storeSync/abstractParamConfig.class'
+import AbstractParamConfig, {
+    STORE_DISPATCHER_ROUTER_PLUGIN,
+} from '@/router/storeSync/abstractParamConfig.class'
 
 function dispatchCompareSliderFromUrlParam(store, urlParamValue) {
     const promisesForAllDispatch = []
     if (urlParamValue) {
-        promisesForAllDispatch.push(store.dispatch('setCompareRatio', urlParamValue))
+        promisesForAllDispatch.push(
+            store.dispatch('setCompareRatio', {
+                value: urlParamValue,
+                dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
+            })
+        )
         // small check here: if the user is inserting a non valid value, we won't activate the slider
         if (urlParamValue > 0.0 && urlParamValue < 1.0) {
-            promisesForAllDispatch.push(store.dispatch('setCompareSliderActive', true))
+            promisesForAllDispatch.push(
+                store.dispatch('setCompareSliderActive', {
+                    value: true,
+                    dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
+                })
+            )
         }
     }
     return Promise.all(promisesForAllDispatch)

--- a/src/router/storeSync/CrossHairParamConfig.class.js
+++ b/src/router/storeSync/CrossHairParamConfig.class.js
@@ -1,21 +1,37 @@
-import AbstractParamConfig from '@/router/storeSync/abstractParamConfig.class'
+import AbstractParamConfig, {
+    STORE_DISPATCHER_ROUTER_PLUGIN,
+} from '@/router/storeSync/abstractParamConfig.class'
 import { round } from '@/utils/numberUtils'
 
 function dispatchCrossHairFromUrlIntoStore(store, urlParamValue) {
     const promisesForAllDispatch = []
 
     if (typeof urlParamValue !== 'string') {
-        promisesForAllDispatch.push(store.dispatch('setCrossHair', { crossHair: null }))
+        promisesForAllDispatch.push(
+            store.dispatch('setCrossHair', {
+                crossHair: null,
+                dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
+            })
+        )
     }
 
     const parts = urlParamValue.split(',')
     if (parts.length === 1) {
-        promisesForAllDispatch.push(store.dispatch('setCrossHair', { crossHair: urlParamValue }))
+        promisesForAllDispatch.push(
+            store.dispatch('setCrossHair', {
+                crossHair: urlParamValue,
+                dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
+            })
+        )
     } else if (parts.length === 3) {
         const crossHair = parts[0]
         const crossHairPosition = [parseFloat(parts[1]), parseFloat(parts[2])]
         promisesForAllDispatch.push(
-            store.dispatch('setCrossHair', { crossHair, crossHairPosition })
+            store.dispatch('setCrossHair', {
+                crossHair,
+                crossHairPosition,
+                dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
+            })
         )
     }
     return Promise.all(promisesForAllDispatch)

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -158,7 +158,7 @@ function dispatchLayersFromUrlIntoStore(store, urlParamValue) {
                 if (layerObject.type === LayerTypes.KML && layerObject.adminId) {
                     promisesForAllDispatch.push(
                         store.dispatch('setShowDrawingOverlay', {
-                            value: true,
+                            showDrawingOverlay: true,
                             dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
                         })
                     )

--- a/src/router/storeSync/PositionParamConfig.class.js
+++ b/src/router/storeSync/PositionParamConfig.class.js
@@ -1,4 +1,6 @@
-import AbstractParamConfig from '@/router/storeSync/abstractParamConfig.class'
+import AbstractParamConfig, {
+    STORE_DISPATCHER_ROUTER_PLUGIN,
+} from '@/router/storeSync/abstractParamConfig.class'
 
 export function readCenterFromUrlParam(urlParamValue) {
     if (urlParamValue) {
@@ -15,7 +17,7 @@ function dispatchCenterFromUrlIntoStore(store, urlParamValue) {
     const center = readCenterFromUrlParam(urlParamValue)
     if (center) {
         promisesForAllDispatch.push(
-            store.dispatch('setCenter', { center, source: 'URL param parsing' })
+            store.dispatch('setCenter', { center, dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN })
         )
     }
     return Promise.all(promisesForAllDispatch)

--- a/src/router/storeSync/QueryToStoreOnlyParamConfig.class.js
+++ b/src/router/storeSync/QueryToStoreOnlyParamConfig.class.js
@@ -1,4 +1,6 @@
-import AbstractParamConfig from '@/router/storeSync/abstractParamConfig.class'
+import AbstractParamConfig, {
+    STORE_DISPATCHER_ROUTER_PLUGIN,
+} from '@/router/storeSync/abstractParamConfig.class'
 
 /**
  * Definition of an Url parameter which needs to be synced with the store, but which doesn't change
@@ -31,7 +33,11 @@ export default class QueryToStoreOnlyParamConfig extends AbstractParamConfig {
         super(
             urlParamName,
             mutationsToWatch,
-            (store, urlParamValue) => store.dispatch(dispatchChangeTo, urlParamValue),
+            (store, urlParamValue) =>
+                store.dispatch(dispatchChangeTo, {
+                    value: urlParamValue,
+                    dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
+                }),
             () => null,
             keepInUrlWhenDefault,
             valueType,

--- a/src/router/storeSync/QueryToStoreOnlyParamConfig.class.js
+++ b/src/router/storeSync/QueryToStoreOnlyParamConfig.class.js
@@ -35,7 +35,7 @@ export default class QueryToStoreOnlyParamConfig extends AbstractParamConfig {
             mutationsToWatch,
             (store, urlParamValue) =>
                 store.dispatch(dispatchChangeTo, {
-                    value: urlParamValue,
+                    [urlParamName]: urlParamValue,
                     dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
                 }),
             () => null,

--- a/src/router/storeSync/SimpleUrlParamConfig.class.js
+++ b/src/router/storeSync/SimpleUrlParamConfig.class.js
@@ -21,6 +21,8 @@ export default class SimpleUrlParamConfig extends AbstractParamConfig {
      *   added to the URL even though its value is set to the default value of the param.
      * @param {NumberConstructor | StringConstructor | BooleanConstructor} valueType
      * @param {Boolean | Number | String | null} defaultValue
+     * @param {String} dispatchValueName Name to use in the dispatch object for the value (default
+     *   to UrlParamName)
      */
     constructor(
         urlParamName,
@@ -29,14 +31,15 @@ export default class SimpleUrlParamConfig extends AbstractParamConfig {
         extractValueFromStore,
         keepInUrlWhenDefault = false,
         valueType = String,
-        defaultValue = null
+        defaultValue = null,
+        dispatchValueName = urlParamName
     ) {
         super(
             urlParamName,
             mutationsToWatch,
             (store, urlParamValue) =>
                 store.dispatch(dispatchChangeTo, {
-                    value: urlParamValue,
+                    [dispatchValueName]: urlParamValue,
                     dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
                 }),
             extractValueFromStore,

--- a/src/router/storeSync/SimpleUrlParamConfig.class.js
+++ b/src/router/storeSync/SimpleUrlParamConfig.class.js
@@ -1,4 +1,6 @@
-import AbstractParamConfig from '@/router/storeSync/abstractParamConfig.class'
+import AbstractParamConfig, {
+    STORE_DISPATCHER_ROUTER_PLUGIN,
+} from '@/router/storeSync/abstractParamConfig.class'
 
 /**
  * Definition of a URL param that needs to be synced with the store.
@@ -32,7 +34,11 @@ export default class SimpleUrlParamConfig extends AbstractParamConfig {
         super(
             urlParamName,
             mutationsToWatch,
-            (store, urlParamValue) => store.dispatch(dispatchChangeTo, urlParamValue),
+            (store, urlParamValue) =>
+                store.dispatch(dispatchChangeTo, {
+                    value: urlParamValue,
+                    dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
+                }),
             extractValueFromStore,
             keepInUrlWhenDefault,
             valueType,

--- a/src/router/storeSync/ZoomParamConfig.class.js
+++ b/src/router/storeSync/ZoomParamConfig.class.js
@@ -1,4 +1,6 @@
-import AbstractParamConfig from '@/router/storeSync/abstractParamConfig.class'
+import AbstractParamConfig, {
+    STORE_DISPATCHER_ROUTER_PLUGIN,
+} from '@/router/storeSync/abstractParamConfig.class'
 
 export function readZoomFromUrlParam(urlParamValue) {
     if (urlParamValue) {
@@ -12,7 +14,10 @@ function dispatchZoomFromUrlIntoStore(store, urlParamValue) {
     const zoom = readZoomFromUrlParam(urlParamValue)
     if (zoom) {
         promisesForAllDispatch.push(
-            store.dispatch('setZoom', { zoom, source: 'URL param parsing' })
+            store.dispatch('setZoom', {
+                zoom,
+                dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
+            })
         )
     }
     return Promise.all(promisesForAllDispatch)

--- a/src/router/storeSync/abstractParamConfig.class.js
+++ b/src/router/storeSync/abstractParamConfig.class.js
@@ -1,3 +1,7 @@
+// NOTE: This is exported but should only be used in this module, if the value is needed outside
+// of this module we should use the string directly to avoid module dependencies.
+export const STORE_DISPATCHER_ROUTER_PLUGIN = 'storeSync.routerPlugin'
+
 /**
  * A description of one URL param that needs synchronization with the app {@link Vuex.Store} with
  * some helper functions.

--- a/src/router/storeSync/storeSync.config.js
+++ b/src/router/storeSync/storeSync.config.js
@@ -76,8 +76,8 @@ const storeSyncConfig = [
     new SimpleUrlParamConfig(
         'topic',
         'changeTopic',
-        'setTopicById',
-        (store) => store.getters.currentTopicId,
+        'changeTopic',
+        (store) => store.state.topics.current,
         true,
         String
     ),

--- a/src/router/storeSync/storeSync.config.js
+++ b/src/router/storeSync/storeSync.config.js
@@ -32,7 +32,8 @@ const storeSyncConfig = [
         (store) => store.state.position.projection.epsgNumber,
         false,
         Number,
-        DEFAULT_PROJECTION.epsgNumber
+        DEFAULT_PROJECTION.epsgNumber,
+        'projection'
     ),
     // Position must be processed after the projection param,
     // otherwise the position might be wrongly reprojected at app startup when SR is not equal
@@ -47,7 +48,8 @@ const storeSyncConfig = [
         (store) => store.state.cesium.active,
         false,
         Boolean,
-        false
+        false,
+        'active'
     ),
     new SimpleUrlParamConfig(
         'geolocation',
@@ -79,7 +81,9 @@ const storeSyncConfig = [
         'changeTopic',
         (store) => store.state.topics.current,
         true,
-        String
+        String,
+        null,
+        'topicId'
     ),
     // as the setSearchQuery action requires an object as payload, we need
     // to customize a bit the dispatch to this action (in order to build a correct payload)

--- a/src/router/storeSync/storeSync.config.js
+++ b/src/router/storeSync/storeSync.config.js
@@ -1,4 +1,5 @@
 import { DEFAULT_PROJECTION } from '@/config'
+import { STORE_DISPATCHER_ROUTER_PLUGIN } from '@/router/storeSync/abstractParamConfig.class'
 import CameraParamConfig from '@/router/storeSync/CameraParamConfig.class'
 import CrossHairParamConfig from '@/router/storeSync/CrossHairParamConfig.class'
 import CustomDispatchUrlParamConfig from '@/router/storeSync/CustomDispatchUrlParamConfig.class'
@@ -51,7 +52,7 @@ const storeSyncConfig = [
     new SimpleUrlParamConfig(
         'geolocation',
         'setGeolocationActive',
-        'toggleGeolocation',
+        'setGeolocation',
         (store) => store.state.geolocation.active,
         false,
         Boolean,
@@ -88,6 +89,7 @@ const storeSyncConfig = [
         (store, urlValue) =>
             store.dispatch('setSearchQuery', {
                 query: urlValue,
+                dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
             }),
         (store) => store.state.search.query,
         false,

--- a/src/router/storeSync/storeSync.routerPlugin.js
+++ b/src/router/storeSync/storeSync.routerPlugin.js
@@ -1,6 +1,7 @@
 import axios from 'axios'
 
 import { IS_TESTING_WITH_CYPRESS } from '@/config'
+import { STORE_DISPATCHER_ROUTER_PLUGIN } from '@/router/storeSync/abstractParamConfig.class'
 import storeSyncConfig from '@/router/storeSync/storeSync.config'
 import log from '@/utils/logging'
 
@@ -77,7 +78,9 @@ function storeMutationWatcher(store, mutation, router) {
             // and the share menu opened, we must close the share menu and
             // reset the shortlink
             if (store.state.share.shortLink) {
-                store.dispatch('closeShareMenuAndRemoveShortLinks')
+                store.dispatch('closeShareMenuAndRemoveShortLinks', {
+                    dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
+                })
             }
         }
     }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,5 +1,6 @@
 import { createStore } from 'vuex'
 
+import { ENVIRONMENT } from '@/config'
 import debug from '@/store/debug.store'
 import app from '@/store/modules/app.store'
 import cesium from '@/store/modules/cesium.store'
@@ -32,7 +33,8 @@ import syncCameraLonLatZoom from '@/store/plugins/sync-camera-lonlatzoom'
 import topicChangeManagementPlugin from '@/store/plugins/topic-change-management.plugin'
 
 const store = createStore({
-    strict: true,
+    // Do not run strict mode on production has it has performance cost
+    strict: ENVIRONMENT !== 'production',
     state: {},
     plugins: [
         loadLayersConfigOnLangChange,

--- a/src/store/modules/__tests__/layers.store.spec.js
+++ b/src/store/modules/__tests__/layers.store.spec.js
@@ -35,7 +35,7 @@ const secondLayer = new GeoAdminWMSLayer(
 
 const resetStore = async () => {
     await store.dispatch('clearLayers', { dispatcher: 'unit-test' })
-    await store.dispatch('setBackground', { value: null, dispatcher: 'unit-test' })
+    await store.dispatch('setBackground', { bgLayer: null, dispatcher: 'unit-test' })
     await store.dispatch('setLayerConfig', { config: [], dispatcher: 'unit-test' })
 }
 
@@ -50,19 +50,19 @@ describe('Background layer is correctly set', () => {
         expect(getBackgroundLayer()).to.be.null
     })
     it('does not select a background if the one given is not present in the config', async () => {
-        await store.dispatch('setBackground', { value: bgLayer.getID(), dispatcher: 'unit-test' })
+        await store.dispatch('setBackground', { bgLayer: bgLayer.getID(), dispatcher: 'unit-test' })
         expect(getBackgroundLayer()).to.be.null
     })
     it('does select the background if it is present in the config', async () => {
         await store.dispatch('setLayerConfig', { config: [bgLayer], dispatcher: 'unit-test' })
-        await store.dispatch('setBackground', { value: bgLayer.getID(), dispatcher: 'unit-test' })
+        await store.dispatch('setBackground', { bgLayer: bgLayer.getID(), dispatcher: 'unit-test' })
         expect(getBackgroundLayer()).to.be.an.instanceof(AbstractLayer)
         expect(getBackgroundLayer().getID()).to.eq(bgLayer.getID())
     })
     it('does not permit to select a background that has not the flag isBackground set to true', async () => {
         await store.dispatch('setLayerConfig', { config: [firstLayer], dispatcher: 'unit-test' })
         await store.dispatch('setBackground', {
-            value: firstLayer.getID(),
+            bgLayer: firstLayer.getID(),
             dispatcher: 'unit-test',
         })
         expect(getBackgroundLayer()).to.be.null
@@ -124,7 +124,7 @@ describe('Visible layers are filtered correctly by the store', () => {
         expect(getVisibleLayers()).to.be.an('Array').empty
     })
     it('does not give background layers with the visible layers', async () => {
-        await store.dispatch('setBackground', { value: bgLayer.getID(), dispatcher: 'unit-test' })
+        await store.dispatch('setBackground', { bgLayer: bgLayer.getID(), dispatcher: 'unit-test' })
         expect(getVisibleLayers()).to.be.an('Array').empty
     })
     it('adds correctly a layer to the visible layers after it is added to the map', async () => {
@@ -160,7 +160,7 @@ describe('Layer z-index are calculated correctly in the store', () => {
             dispatcher: 'unit-test',
         })
         // setting up the background layer
-        await store.dispatch('setBackground', { value: bgLayer, dispatcher: 'unit-test' })
+        await store.dispatch('setBackground', { bgLayer: bgLayer, dispatcher: 'unit-test' })
     })
 
     it('gives a z-index of -1 if the given layer is not valid', () => {

--- a/src/store/modules/__tests__/zoom.store.spec.js
+++ b/src/store/modules/__tests__/zoom.store.spec.js
@@ -14,7 +14,7 @@ describe('Zoom level is calculated correctly in the store when using WebMercator
     const getResolution = () => store.getters.resolution
 
     beforeEach(async () => {
-        await store.dispatch('setProjection', { value: WEBMERCATOR, dispatcher: 'unit-test' })
+        await store.dispatch('setProjection', { projection: WEBMERCATOR, dispatcher: 'unit-test' })
         // first we setup a fake screen of 100px by 100px
         await store.dispatch('setSize', {
             width: screenSize,

--- a/src/store/modules/__tests__/zoom.store.spec.js
+++ b/src/store/modules/__tests__/zoom.store.spec.js
@@ -14,7 +14,7 @@ describe('Zoom level is calculated correctly in the store when using WebMercator
     const getResolution = () => store.getters.resolution
 
     beforeEach(async () => {
-        await store.dispatch('setProjection', WEBMERCATOR)
+        await store.dispatch('setProjection', { value: WEBMERCATOR, dispatcher: 'unit-test' })
         // first we setup a fake screen of 100px by 100px
         await store.dispatch('setSize', {
             width: screenSize,
@@ -29,27 +29,30 @@ describe('Zoom level is calculated correctly in the store when using WebMercator
     it("Doesn't allow negative zoom level, or non numerical value as a zoom level", async () => {
         // setting the zoom at a valid value, and then setting it at an invalid value => the valid value should persist
         const validZoomLevel = 10
-        await store.dispatch('setZoom', { zoom: validZoomLevel })
-        await store.dispatch('setZoom', { zoom: -1 })
+        await store.dispatch('setZoom', { zoom: validZoomLevel, dispatcher: 'unit-test' })
+        await store.dispatch('setZoom', { zoom: -1, dispatcher: 'unit-test' })
         expect(getZoom()).to.eq(validZoomLevel, 'Should not accept negative zoom level')
         // checking with non numerical (but representing a number)
-        await store.dispatch('setZoom', { zoom: '' + (validZoomLevel - 1) })
+        await store.dispatch('setZoom', {
+            zoom: '' + (validZoomLevel - 1),
+            dispatcher: 'unit-test',
+        })
         expect(getZoom()).to.eq(
             validZoomLevel,
             'Should not accept non numerical values as zoom level'
         )
-        await store.dispatch('setZoom', { zoom: 'test' })
+        await store.dispatch('setZoom', { zoom: 'test', dispatcher: 'unit-test' })
         expect(getZoom()).to.eq(
             validZoomLevel,
             'Should not accept non numerical values as zoom level'
         )
         // checking with undefined or null
-        await store.dispatch('setZoom', { zoom: undefined })
+        await store.dispatch('setZoom', { zoom: undefined, dispatcher: 'unit-test' })
         expect(getZoom()).to.eq(
             validZoomLevel,
             'Should not accept undefined or null value as zoom level'
         )
-        await store.dispatch('setZoom', { zoom: null })
+        await store.dispatch('setZoom', { zoom: null, dispatcher: 'unit-test' })
         expect(getZoom()).to.eq(
             validZoomLevel,
             'Should not accept undefined or null value as zoom level'
@@ -58,20 +61,20 @@ describe('Zoom level is calculated correctly in the store when using WebMercator
     it('Set zoom level correctly from what is given in "setZoom"', async () => {
         // checking zoom level 0 to 24
         for (let zoom = 0; zoom < 24; zoom += 1) {
-            await store.dispatch('setZoom', { zoom })
+            await store.dispatch('setZoom', { zoom, dispatcher: 'unit-test' })
             expect(getZoom()).to.eq(zoom)
         }
     })
     it('Rounds zoom level to the third decimal if more are given', async () => {
         // flooring check
-        await store.dispatch('setZoom', { zoom: 5.4321 })
+        await store.dispatch('setZoom', { zoom: 5.4321, dispatcher: 'unit-test' })
         expect(getZoom()).to.eq(5.432)
         // ceiling check
-        await store.dispatch('setZoom', { zoom: 5.6789 })
+        await store.dispatch('setZoom', { zoom: 5.6789, dispatcher: 'unit-test' })
         expect(getZoom()).to.eq(5.679)
     })
     it('Calculate resolution from zoom levels according to OGC standard (with 0.1% error margin)', async () => {
-        await store.dispatch('setZoom', { zoom: 10 })
+        await store.dispatch('setZoom', { zoom: 10, dispatcher: 'unit-test' })
         // see https://wiki.openstreetmap.org/wiki/Zoom_levels
         // at zoom level 10, resolution should be of about 152.746 meter per pixel adjusted to latitude
         const resolutionAtZoom10 = 152.746
@@ -86,7 +89,7 @@ describe('Zoom level is calculated correctly in the store when using WebMercator
         await store.dispatch('setCenter', { center: proj4(WGS84.epsg, WEBMERCATOR.epsg, [lon, 0]) })
         expect(getResolution()).to.approximately(resolutionAtZoom10, toleratedDelta)
 
-        await store.dispatch('setZoom', { zoom: 2 })
+        await store.dispatch('setZoom', { zoom: 2, dispatcher: 'unit-test' })
         const resolutionAtZoom2 = 39103
         // we tolerate a 0.1% error margin
         toleratedDelta = resolutionAtZoom2 / 1000.0

--- a/src/store/modules/app.store.js
+++ b/src/store/modules/app.store.js
@@ -16,11 +16,11 @@ export default {
     },
     getters: {},
     actions: {
-        setAppIsReady: ({ commit }) => {
-            commit('setAppIsReady')
+        setAppIsReady: ({ commit }, { dispatcher }) => {
+            commit('setAppIsReady', { dispatcher })
         },
-        mapModuleReady: ({ commit }) => {
-            commit('mapModuleReady')
+        mapModuleReady: ({ commit }, { dispatcher }) => {
+            commit('mapModuleReady', { dispatcher })
         },
     },
     mutations: {

--- a/src/store/modules/cesium.store.js
+++ b/src/store/modules/cesium.store.js
@@ -55,19 +55,19 @@ export default {
         },
     },
     actions: {
-        set3dActive({ commit }, is3dActive) {
-            commit('set3dActive', !!is3dActive)
+        set3dActive({ commit }, { value, dispatcher }) {
+            commit('set3dActive', { value: !!value, dispatcher })
         },
-        toggleShow3dBuildings({ commit, state }) {
-            commit('setShowBuildings', !state.showBuildings)
+        toggleShow3dBuildings({ commit, state }, { dispatcher }) {
+            commit('setShowBuildings', { value: !state.showBuildings, dispatcher })
         },
-        toggleShow3dVegetation({ commit, state }) {
-            commit('setShowVegetation', !state.showVegetation)
+        toggleShow3dVegetation({ commit, state }, { dispatcher }) {
+            commit('setShowVegetation', { value: !state.showVegetation, dispatcher })
         },
     },
     mutations: {
-        set3dActive: (state, flagValue) => (state.active = flagValue),
-        setShowBuildings: (state, flagValue) => (state.showBuildings = flagValue),
-        setShowVegetation: (state, flagValue) => (state.showVegetation = flagValue),
+        set3dActive: (state, { value }) => (state.active = value),
+        setShowBuildings: (state, { value }) => (state.showBuildings = value),
+        setShowVegetation: (state, { value }) => (state.showVegetation = value),
     },
 }

--- a/src/store/modules/cesium.store.js
+++ b/src/store/modules/cesium.store.js
@@ -55,19 +55,19 @@ export default {
         },
     },
     actions: {
-        set3dActive({ commit }, { value, dispatcher }) {
-            commit('set3dActive', { value: !!value, dispatcher })
+        set3dActive({ commit }, { active, dispatcher }) {
+            commit('set3dActive', { active: !!active, dispatcher })
         },
         toggleShow3dBuildings({ commit, state }, { dispatcher }) {
-            commit('setShowBuildings', { value: !state.showBuildings, dispatcher })
+            commit('setShowBuildings', { showBuildings: !state.showBuildings, dispatcher })
         },
         toggleShow3dVegetation({ commit, state }, { dispatcher }) {
-            commit('setShowVegetation', { value: !state.showVegetation, dispatcher })
+            commit('setShowVegetation', { showVegetation: !state.showVegetation, dispatcher })
         },
     },
     mutations: {
-        set3dActive: (state, { value }) => (state.active = value),
-        setShowBuildings: (state, { value }) => (state.showBuildings = value),
-        setShowVegetation: (state, { value }) => (state.showVegetation = value),
+        set3dActive: (state, { active }) => (state.active = active),
+        setShowBuildings: (state, { showBuildings }) => (state.showBuildings = showBuildings),
+        setShowVegetation: (state, { showVegetation }) => (state.showVegetation = showVegetation),
     },
 }

--- a/src/store/modules/geolocation.store.js
+++ b/src/store/modules/geolocation.store.js
@@ -36,6 +36,9 @@ const state = {
 const getters = {}
 
 const actions = {
+    setGeolocation: ({ commit }, args) => {
+        commit('setGeolocationActive', args.value)
+    },
     toggleGeolocation: ({ commit, state }) => {
         const willBeActive = !state.active
         if (willBeActive) {

--- a/src/store/modules/i18n.store.js
+++ b/src/store/modules/i18n.store.js
@@ -20,16 +20,16 @@ const state = {
 const getters = {}
 
 const actions = {
-    setLang({ commit }, lang) {
-        commit(SET_LANG_MUTATION_KEY, lang)
+    setLang({ commit }, args) {
+        commit(SET_LANG_MUTATION_KEY, args)
     },
 }
 
 const mutations = {}
 
-mutations[SET_LANG_MUTATION_KEY] = function (state, lang) {
-    state.lang = lang
-    i18n.global.locale = lang
+mutations[SET_LANG_MUTATION_KEY] = function (state, { value }) {
+    state.lang = value
+    i18n.global.locale = value
 }
 
 export default {

--- a/src/store/modules/i18n.store.js
+++ b/src/store/modules/i18n.store.js
@@ -27,9 +27,9 @@ const actions = {
 
 const mutations = {}
 
-mutations[SET_LANG_MUTATION_KEY] = function (state, { value }) {
-    state.lang = value
-    i18n.global.locale = value
+mutations[SET_LANG_MUTATION_KEY] = function (state, { lang }) {
+    state.lang = lang
+    i18n.global.locale = lang
 }
 
 export default {

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -211,29 +211,25 @@ const actions = {
      */
     setLayerConfig({ commit, state, getters }, { config, dispatcher }) {
         const activeLayerBeforeConfigChange = [...state.activeLayers]
-        commit('clearLayers', { dispatcher })
         commit('setLayerConfig', { config, dispatcher })
-        activeLayerBeforeConfigChange.forEach((layer) => {
+        const layers = activeLayerBeforeConfigChange.map((layer) => {
             const layerConfig = getters.getLayerConfigById(layer.getID())
             if (layerConfig) {
                 // If we found a layer config we use as it might have changed the i18n translation
                 const clone = layerConfig.clone()
                 clone.visible = layer.visible
                 clone.opacity = layer.opacity
-                commit('addLayer', { layer: clone, dispatcher })
                 if (layer.timeConfig) {
-                    commit('setLayerYear', {
-                        layerId: clone.getID(),
-                        year: layer.timeConfig.currentYear,
-                        dispatcher,
-                    })
+                    clone.timeConfig.currentYear = layer.timeConfig.currentYear
                 }
+                return clone
             } else {
                 // if no config is found, then it is a layer that is not managed, like for example
                 // the KML layers, in this case we take the old active configuration as fallback.
-                commit('addLayer', { layer: layer.clone(), dispatcher })
+                return layer.clone()
             }
         })
+        commit('setLayers', { layers: layers, dispatcher })
     },
     /**
      * Add a layer to the active layers.

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -244,7 +244,7 @@ const actions = {
      *
      * @param {String | AbstractLayer | ActiveLayerConfig} layerIdOrObject
      */
-    async addLayer({ commit, getters }, layerIdOrObject) {
+    addLayer({ commit, getters }, layerIdOrObject) {
         // creating a clone of the config, so that we do not modify the initial config of the app
         // (it is possible to add one layer many times, so we want to always have the correct
         // default values when we add it, not the settings from the layer already added)
@@ -272,6 +272,19 @@ const actions = {
         } else {
             log.error('no layer found for payload:', layerIdOrObject)
         }
+    },
+    /**
+     * Sets the list of active layers. This replace the existing list.
+     *
+     * NOTE: the layers array is automatically deep cloned
+     *
+     * @param {[AbstractLayer]} layers List of active layers
+     */
+    setLayers({ commit }, layers) {
+        commit(
+            'setLayers',
+            layers.map((layer) => layer.clone())
+        )
     },
     removeLayer({ commit }, layerIdOrObject) {
         if (typeof layerIdOrObject === 'string') {
@@ -513,6 +526,9 @@ const mutations = {
         // first, remove it if already present to avoid duplicate layers
         state.activeLayers = removeActiveLayerById(state, layer.getID())
         state.activeLayers.push(layer)
+    },
+    setLayers(state, layers) {
+        state.activeLayers = layers
     },
     updateLayer(state, layer) {
         const layer2Update = getActiveLayerById(state, layer.getID())

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -188,8 +188,8 @@ const actions = {
      *
      * @param {String | AbstractLayer} layerIdOrObject
      */
-    setBackground({ commit, getters }, { value, dispatcher }) {
-        const layerIdOrObject = value
+    setBackground({ commit, getters }, { bgLayer, dispatcher }) {
+        const layerIdOrObject = bgLayer
         let futureBackground
         if (typeof layerIdOrObject === 'string') {
             futureBackground = getters.getLayerConfigById(layerIdOrObject)
@@ -197,9 +197,9 @@ const actions = {
             futureBackground = getters.getLayerConfigById(layerIdOrObject.getID())
         }
         if (futureBackground?.isBackground) {
-            commit('setBackground', { value: futureBackground, dispatcher })
+            commit('setBackground', { bgLayer: futureBackground, dispatcher })
         } else {
-            commit('setBackground', { value: null, dispatcher })
+            commit('setBackground', { bgLayer: null, dispatcher })
         }
     },
     /**
@@ -505,8 +505,8 @@ const actions = {
 }
 
 const mutations = {
-    setBackground(state, { value }) {
-        state.currentBackgroundLayer = value
+    setBackground(state, { bgLayer }) {
+        state.currentBackgroundLayer = bgLayer
         // forcing its visibility (if not void layer), as 3D layers have their visible flag set to false somehow
         if (state.currentBackgroundLayer) {
             state.currentBackgroundLayer.visible = true

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -4,7 +4,6 @@ import LayerTypes from '@/api/layers/LayerTypes.enum'
 import { getExtentForProjection } from '@/utils/extentUtils.js'
 import { getGpxExtent } from '@/utils/gpxUtils.js'
 import { getKmlExtent, parseKmlName } from '@/utils/kmlUtils'
-import { ActiveLayerConfig } from '@/utils/layerUtils'
 import log from '@/utils/logging'
 
 const getActiveLayerById = (state, layerId) =>
@@ -189,7 +188,8 @@ const actions = {
      *
      * @param {String | AbstractLayer} layerIdOrObject
      */
-    setBackground({ commit, getters }, layerIdOrObject) {
+    setBackground({ commit, getters }, { value, dispatcher }) {
+        const layerIdOrObject = value
         let futureBackground
         if (typeof layerIdOrObject === 'string') {
             futureBackground = getters.getLayerConfigById(layerIdOrObject)
@@ -197,9 +197,9 @@ const actions = {
             futureBackground = getters.getLayerConfigById(layerIdOrObject.getID())
         }
         if (futureBackground?.isBackground) {
-            commit('setBackground', futureBackground)
+            commit('setBackground', { value: futureBackground, dispatcher })
         } else {
-            commit('setBackground', null)
+            commit('setBackground', { value: null, dispatcher })
         }
     },
     /**
@@ -209,10 +209,10 @@ const actions = {
      *
      * @param {AbstractLayer[]} config
      */
-    setLayerConfig({ commit, state, getters }, config) {
+    setLayerConfig({ commit, state, getters }, { config, dispatcher }) {
         const activeLayerBeforeConfigChange = [...state.activeLayers]
-        commit('clearLayers')
-        commit('setLayerConfig', [...config])
+        commit('clearLayers', { dispatcher })
+        commit('setLayerConfig', { config, dispatcher })
         activeLayerBeforeConfigChange.forEach((layer) => {
             const layerConfig = getters.getLayerConfigById(layer.getID())
             if (layerConfig) {
@@ -220,17 +220,18 @@ const actions = {
                 const clone = layerConfig.clone()
                 clone.visible = layer.visible
                 clone.opacity = layer.opacity
-                commit('addLayer', clone)
+                commit('addLayer', { layer: clone, dispatcher })
                 if (layer.timeConfig) {
                     commit('setLayerYear', {
                         layerId: clone.getID(),
                         year: layer.timeConfig.currentYear,
+                        dispatcher,
                     })
                 }
             } else {
                 // if no config is found, then it is a layer that is not managed, like for example
                 // the KML layers, in this case we take the old active configuration as fallback.
-                commit('addLayer', layer.clone())
+                commit('addLayer', { layer: layer.clone(), dispatcher })
             }
         })
     },
@@ -242,35 +243,40 @@ const actions = {
      * layers list (for instance having a time enabled layer added multiple time with a different
      * timestamp)
      *
-     * @param {String | AbstractLayer | ActiveLayerConfig} layerIdOrObject
+     * @param {AbstractLayer} layer
+     * @param {String} layerId
+     * @param {ActiveLayerConfig} layerConfig
      */
-    addLayer({ commit, getters }, layerIdOrObject) {
+    addLayer(
+        { commit, getters },
+        { layer = null, layerId = null, layerConfig = null, dispatcher }
+    ) {
         // creating a clone of the config, so that we do not modify the initial config of the app
         // (it is possible to add one layer many times, so we want to always have the correct
         // default values when we add it, not the settings from the layer already added)
-        let layer = null
-        if (layerIdOrObject instanceof AbstractLayer) {
-            layer = layerIdOrObject.clone()
-        } else if (layerIdOrObject instanceof ActiveLayerConfig) {
+        let clone = null
+        if (layer) {
+            clone = layer.clone()
+        } else if (layerConfig) {
             // Get the AbstractLayer Config object, we need to clone it in order
             // to update the config (opacity/visible) if needed.
-            layer = getters.getLayerConfigById(layerIdOrObject.id)?.clone()
+            clone = getters.getLayerConfigById(layerConfig.id)?.clone() ?? null
 
-            if (layer) {
-                if (layerIdOrObject.visible !== undefined) {
-                    layer.visible = layerIdOrObject.visible
+            if (clone) {
+                if (layerConfig.visible !== undefined) {
+                    clone.visible = layerConfig.visible
                 }
-                if (layerIdOrObject.opacity !== undefined) {
-                    layer.opacity = layerIdOrObject.opacity
+                if (layerConfig.opacity !== undefined) {
+                    clone.opacity = layerConfig.opacity
                 }
             }
-        } else if (typeof layerIdOrObject === 'string') {
-            layer = getters.getLayerConfigById(layerIdOrObject)?.clone()
+        } else if (layerId) {
+            clone = getters.getLayerConfigById(layerId)?.clone() ?? null
         }
-        if (layer) {
-            commit('addLayer', layer)
+        if (clone) {
+            commit('addLayer', { layer: clone, dispatcher })
         } else {
-            log.error('no layer found for payload:', layerIdOrObject)
+            log.error('no layer found for payload:', layer, layerId, layerConfig, dispatcher)
         }
     },
     /**
@@ -280,19 +286,16 @@ const actions = {
      *
      * @param {[AbstractLayer]} layers List of active layers
      */
-    setLayers({ commit }, layers) {
-        commit(
-            'setLayers',
-            layers.map((layer) => layer.clone())
-        )
+    setLayers({ commit }, { layers, dispatcher }) {
+        commit('setLayers', { layers: layers.map((layer) => layer.clone()), dispatcher })
     },
-    removeLayer({ commit }, layerIdOrObject) {
-        if (typeof layerIdOrObject === 'string') {
-            commit('removeLayerWithId', layerIdOrObject)
-        } else if (layerIdOrObject instanceof AbstractLayer) {
-            commit('removeLayerWithId', layerIdOrObject.getID())
+    removeLayer({ commit }, { layer = null, layerId = null, dispatcher }) {
+        if (layerId) {
+            commit('removeLayerWithId', { layerId, dispatcher })
+        } else if (layer) {
+            commit('removeLayerWithId', { layerId: layer.getID(), dispatcher })
         } else {
-            log.error('Can not remove layer that is not yet added', layerIdOrObject)
+            log.error('Can not remove layer that is not yet added', layer, layerId, dispatcher)
         }
     },
     /**
@@ -325,8 +328,8 @@ const actions = {
             throw new Error(`Failed to update layer, invalid type ${typeof layer}`)
         }
     },
-    clearLayers({ commit }) {
-        commit('clearLayers')
+    clearLayers({ commit }, args) {
+        commit('clearLayers', args)
     },
     toggleLayerVisibility({ commit, state }, layerIdOrObject) {
         let layer = null
@@ -354,16 +357,9 @@ const actions = {
         }
     },
     setLayerOpacity({ commit }, payload) {
-        if ('opacity' in payload && 'layerId' in payload) {
-            commit('setLayerOpacity', {
-                layerId: payload.layerId,
-                opacity: Number(payload.opacity),
-            })
-        } else {
-            log.error('Cannot set layer opacity invalid payload', payload)
-        }
+        commit('setLayerOpacity', payload)
     },
-    setTimedLayerCurrentYear({ commit, getters }, { layerId, year }) {
+    setTimedLayerCurrentYear({ commit, getters }, { layerId, year, dispatcher }) {
         if (layerId && year) {
             const layer = getters.getActiveLayerById(layerId)
             if (layer && layer.timeConfig) {
@@ -373,6 +369,7 @@ const actions = {
                     commit('setLayerYear', {
                         layerId,
                         year: year,
+                        dispatcher,
                     })
                 } else {
                     log.error('timestamp for year not found, ignoring change', layer, year)
@@ -512,22 +509,22 @@ const actions = {
 }
 
 const mutations = {
-    setBackground(state, backgroundLayer) {
-        state.currentBackgroundLayer = backgroundLayer
+    setBackground(state, { value }) {
+        state.currentBackgroundLayer = value
         // forcing its visibility (if not void layer), as 3D layers have their visible flag set to false somehow
         if (state.currentBackgroundLayer) {
             state.currentBackgroundLayer.visible = true
         }
     },
-    setLayerConfig(state, config) {
+    setLayerConfig(state, { config }) {
         state.config = config
     },
-    addLayer(state, layer) {
+    addLayer(state, { layer }) {
         // first, remove it if already present to avoid duplicate layers
         state.activeLayers = removeActiveLayerById(state, layer.getID())
         state.activeLayers.push(layer)
     },
-    setLayers(state, layers) {
+    setLayers(state, { layers }) {
         state.activeLayers = layers
     },
     updateLayer(state, layer) {
@@ -540,7 +537,7 @@ const mutations = {
             )
         }
     },
-    removeLayerWithId(state, layerId) {
+    removeLayerWithId(state, { layerId }) {
         state.activeLayers = removeActiveLayerById(state, layerId)
     },
     clearLayers(state) {
@@ -558,7 +555,7 @@ const mutations = {
     setLayerOpacity(state, { layerId, opacity }) {
         const layerMatchingId = getActiveLayerById(state, layerId)
         if (layerMatchingId) {
-            layerMatchingId.opacity = opacity
+            layerMatchingId.opacity = Number(opacity)
         }
     },
     setLayerYear(state, { layerId, year }) {

--- a/src/store/modules/position.store.js
+++ b/src/store/modules/position.store.js
@@ -279,17 +279,17 @@ const actions = {
      */
     setCrossHair: ({ commit, state }, { crossHair, crossHairPosition, dispatcher }) => {
         if (crossHair === null) {
-            commit('setCrossHair', { value: null, dispatcher })
-            commit('setCrossHairPosition', { value: null, dispatcher })
+            commit('setCrossHair', { crossHair: null, dispatcher })
+            commit('setCrossHairPosition', { crossHairPosition: null, dispatcher })
         } else if (crossHair in CrossHairs) {
-            commit('setCrossHair', { value: CrossHairs[crossHair], dispatcher })
+            commit('setCrossHair', { crossHair: CrossHairs[crossHair], dispatcher })
 
             // if a position is defined as param we use it
             if (crossHairPosition) {
-                commit('setCrossHairPosition', { value: crossHairPosition, dispatcher })
+                commit('setCrossHairPosition', { crossHairPosition: crossHairPosition, dispatcher })
             } else {
                 // if no position was given, we use the current center of the map as crosshair position
-                commit('setCrossHairPosition', { value: state.center, dispatcher })
+                commit('setCrossHairPosition', { crossHairPosition: state.center, dispatcher })
             }
         }
     },
@@ -302,8 +302,7 @@ const actions = {
     setCameraPosition({ commit }, { position, dispatcher }) {
         commit('setCameraPosition', { position, dispatcher })
     },
-    setProjection({ commit, state }, { value, dispatcher }) {
-        const projection = value
+    setProjection({ commit, state }, { projection, dispatcher }) {
         let matchingProjection
         if (projection instanceof CoordinateSystem) {
             matchingProjection = projection
@@ -363,10 +362,14 @@ const actions = {
             }
 
             if (state.crossHairPosition) {
-                commit(
-                    'setCrossHairPosition',
-                    proj4(oldProjection.epsg, matchingProjection.epsg, state.crossHairPosition)
-                )
+                commit('setCrossHairPosition', {
+                    crossHairPosition: proj4(
+                        oldProjection.epsg,
+                        matchingProjection.epsg,
+                        state.crossHairPosition
+                    ),
+                    dispatcher: 'position.store/setProjection',
+                })
             }
 
             commit('setProjection', { projection: matchingProjection, dispatcher })
@@ -380,8 +383,9 @@ const mutations = {
     setZoom: (state, { zoom }) => (state.zoom = zoom),
     setRotation: (state, rotation) => (state.rotation = rotation),
     setCenter: (state, { x, y }) => (state.center = [x, y]),
-    setCrossHair: (state, { value }) => (state.crossHair = value),
-    setCrossHairPosition: (state, { value }) => (state.crossHairPosition = value),
+    setCrossHair: (state, { crossHair }) => (state.crossHair = crossHair),
+    setCrossHairPosition: (state, { crossHairPosition }) =>
+        (state.crossHairPosition = crossHairPosition),
     setCameraPosition: (state, { position }) => (state.camera = position),
     setProjection: (state, { projection }) => (state.projection = projection),
 }

--- a/src/store/modules/position.store.js
+++ b/src/store/modules/position.store.js
@@ -264,9 +264,15 @@ const actions = {
         }
     },
     increaseZoom: ({ dispatch, state }) =>
-        dispatch('setZoom', { zoom: Number(state.zoom) + 1, dispatcher: 'position.store/increaseZoom' }),
+        dispatch('setZoom', {
+            zoom: Number(state.zoom) + 1,
+            dispatcher: 'position.store/increaseZoom',
+        }),
     decreaseZoom: ({ dispatch, state }) =>
-        dispatch('setZoom', { zoom: Number(state.zoom) - 1, dispatcher: 'position.store/decreaseZoom' }),
+        dispatch('setZoom', {
+            zoom: Number(state.zoom) - 1,
+            dispatcher: 'position.store/decreaseZoom',
+        }),
     /**
      * @param {CrossHairs | String | null} crossHair
      * @param {Number[] | null} crossHairPosition

--- a/src/store/modules/position.store.js
+++ b/src/store/modules/position.store.js
@@ -195,7 +195,7 @@ const actions = {
      * @param dispatcher Source of this change, for debug purposes (won't be stored, will be in
      *   output of the debug console)
      */
-    setCenter: ({ commit }, { center, dispatcher = 'unknown' }) => {
+    setCenter: ({ commit }, { center, dispatcher }) => {
         if (
             !center ||
             (Array.isArray(center) && center.length !== 2) ||

--- a/src/store/modules/search.store.js
+++ b/src/store/modules/search.store.js
@@ -38,38 +38,43 @@ const actions = {
             // checking first if this corresponds to a set of coordinates (or a what3words)
             const coordinate = coordinateFromString(query, currentProjection)
             if (coordinate) {
-                dispatch('setCenter', { center: coordinate, source: 'search coordinates' })
+                const dispatcherCoordinate = 'search.store/setSearchQuery/coordinate'
+                dispatch('setCenter', {
+                    center: coordinate,
+                    dispatcher: dispatcherCoordinate,
+                })
                 if (currentProjection instanceof CustomCoordinateSystem) {
                     dispatch('setZoom', {
                         zoom: currentProjection.transformStandardZoomLevelToCustom(
                             STANDARD_ZOOM_LEVEL_1_25000_MAP
                         ),
-                        source: 'search coordinates',
+                        dispatcher: dispatcherCoordinate,
                     })
                 } else {
                     dispatch('setZoom', {
                         zoom: STANDARD_ZOOM_LEVEL_1_25000_MAP,
-                        source: 'search coordinates',
+                        dispatcher: dispatcherCoordinate,
                     })
                 }
                 dispatch('setPinnedLocation', coordinate)
             } else if (isWhat3WordsString(query)) {
                 retrieveWhat3WordsLocation(query, currentProjection).then((what3wordLocation) => {
+                    const dispatcherWhat3words = 'search.store/setSearchQuery/what3words'
                     dispatch('setCenter', {
                         center: what3wordLocation,
-                        source: 'search what3words',
+                        dispatcher: dispatcherWhat3words,
                     })
                     if (currentProjection instanceof CustomCoordinateSystem) {
                         dispatch('setZoom', {
                             zoom: currentProjection.transformStandardZoomLevelToCustom(
                                 STANDARD_ZOOM_LEVEL_1_25000_MAP
                             ),
-                            source: 'search what3words',
+                            dispatcher: dispatcherWhat3words,
                         })
                     } else {
                         dispatch('setZoom', {
                             zoom: STANDARD_ZOOM_LEVEL_1_25000_MAP,
-                            source: 'search what3words',
+                            dispatcher: dispatcherWhat3words,
                         })
                     }
                     dispatch('setPinnedLocation', what3wordLocation)
@@ -93,9 +98,13 @@ const actions = {
      * @param {SearchResult | LayerSearchResult | FeatureSearchResult} entry
      */
     selectResultEntry: ({ dispatch }, entry) => {
+        const dipsatcherSelectResultEntry = 'search.store/selectResultEntry'
         switch (entry.resultType) {
             case RESULT_TYPE.LAYER:
-                dispatch('addLayer', new ActiveLayerConfig(entry.layerId, true))
+                dispatch('addLayer', {
+                    layerConfig: new ActiveLayerConfig(entry.layerId, true),
+                    dispatcher: dipsatcherSelectResultEntry,
+                })
                 break
             case RESULT_TYPE.LOCATION:
                 if (entry.extent.length === 2) {
@@ -103,9 +112,12 @@ const actions = {
                 } else if (entry.zoom) {
                     dispatch('setCenter', {
                         center: entry.coordinates,
-                        source: 'search select entry',
+                        dispatcher: dipsatcherSelectResultEntry,
                     })
-                    dispatch('setZoom', { zoom: entry.zoom, source: 'search select entry' })
+                    dispatch('setZoom', {
+                        zoom: entry.zoom,
+                        dispatcher: dipsatcherSelectResultEntry,
+                    })
                 }
                 dispatch('setPinnedLocation', entry.coordinates)
                 break

--- a/src/store/modules/topics.store.js
+++ b/src/store/modules/topics.store.js
@@ -48,26 +48,26 @@ const actions = {
     setTopicTree: ({ commit }, { layers, dispatcher }) => {
         commit('setTopicTree', { layers: layers.map((layer) => layer.clone()), dispatcher })
     },
-    changeTopic: ({ commit, state }, { value, dispatcher }) => {
+    changeTopic: ({ commit, state }, { topicId, dispatcher }) => {
         if (
-            state.config.find((topic) => topic.id === value) ||
+            state.config.find((topic) => topic.id === topicId) ||
             // during appLoadingManagement.routerPlugin the topics are not yet set
             // therefore we cannot validate the topic ID
             dispatcher === 'appLoadingManagement.routerPlugin'
         ) {
-            commit('changeTopic', { value, dispatcher })
+            commit('changeTopic', { topicId, dispatcher })
         } else {
-            log.error(`Invalid topic ID ${value}`)
+            log.error(`Invalid topic ID ${topicId}`)
         }
     },
-    setTopicTreeOpenedThemesIds: ({ commit }, { value, dispatcher }) => {
-        if (typeof value === 'string') {
+    setTopicTreeOpenedThemesIds: ({ commit }, { catalogNodes, dispatcher }) => {
+        if (typeof catalogNodes === 'string') {
             commit('setTopicTreeOpenedThemesIds', {
-                themes: value.indexOf(',') !== -1 ? value.split(',') : [value],
+                themes: catalogNodes.indexOf(',') !== -1 ? catalogNodes.split(',') : [catalogNodes],
                 dispatcher,
             })
-        } else if (Array.isArray(value)) {
-            commit('setTopicTreeOpenedThemesIds', { themes: value.slice(), dispatcher })
+        } else if (Array.isArray(catalogNodes)) {
+            commit('setTopicTreeOpenedThemesIds', { themes: catalogNodes.slice(), dispatcher })
         }
     },
 }
@@ -75,7 +75,7 @@ const mutations = {
     setTopics: (state, { topics }) => (state.config = topics),
     setTopicTree: (state, { layers }) => (state.tree = layers),
     setTopicTreeOpenedThemesIds: (state, { themes }) => (state.openedTreeThemesIds = themes),
-    changeTopic: (state, { value }) => (state.current = value),
+    changeTopic: (state, { topicId }) => (state.current = topicId),
 }
 
 export default {

--- a/src/store/modules/topics.store.js
+++ b/src/store/modules/topics.store.js
@@ -1,7 +1,5 @@
 import log from '@/utils/logging'
 
-export const CHANGE_TOPIC_MUTATION = 'changeTopic'
-
 const state = {
     /**
      * List of all available topics
@@ -15,7 +13,7 @@ const state = {
      *
      * @type {Topic}
      */
-    current: null,
+    current: 'ech',
     /**
      * Current topic's layers tree (that will help the user select layers belonging to this topic)
      *
@@ -32,14 +30,14 @@ const state = {
 
 const getters = {
     isDefaultTopic: (state) => {
-        return state.current && state.current.id === 'ech'
+        return state.current === 'ech'
     },
     /** Returns the current topic's id, or `ech` if no topic is selected */
     currentTopicId: (state) => {
-        if (state.current) {
-            return state.current.id
-        }
-        return 'ech'
+        return state.current
+    },
+    currentTopic: (state) => {
+        return state.config.find((topic) => topic.id === state.current)
     },
 }
 
@@ -50,16 +48,16 @@ const actions = {
     setTopicTree: ({ commit }, { layers, dispatcher }) => {
         commit('setTopicTree', { layers: layers.map((layer) => layer.clone()), dispatcher })
     },
-    changeTopic: ({ commit }, args) => {
-        commit(CHANGE_TOPIC_MUTATION, args)
-    },
-    setTopicById: ({ commit, state }, { value, dispatcher }) => {
-        const topicId = value
-        const topic = state.config.find((topic) => topic.id === topicId)
-        if (topic) {
-            commit(CHANGE_TOPIC_MUTATION, { value: topic, dispatcher })
+    changeTopic: ({ commit, state }, { value, dispatcher }) => {
+        if (
+            state.config.find((topic) => topic.id === value) ||
+            // during appLoadingManagement.routerPlugin the topics are not yet set
+            // therefore we cannot validate the topic ID
+            dispatcher === 'appLoadingManagement.routerPlugin'
+        ) {
+            commit('changeTopic', { value, dispatcher })
         } else {
-            log.error('No topic found with ID', topicId)
+            log.error(`Invalid topic ID ${value}`)
         }
     },
     setTopicTreeOpenedThemesIds: ({ commit }, { value, dispatcher }) => {
@@ -77,8 +75,8 @@ const mutations = {
     setTopics: (state, { topics }) => (state.config = topics),
     setTopicTree: (state, { layers }) => (state.tree = layers),
     setTopicTreeOpenedThemesIds: (state, { themes }) => (state.openedTreeThemesIds = themes),
+    changeTopic: (state, { value }) => (state.current = value),
 }
-mutations[CHANGE_TOPIC_MUTATION] = (state, { value }) => (state.current = value)
 
 export default {
     state,

--- a/src/store/modules/topics.store.js
+++ b/src/store/modules/topics.store.js
@@ -8,10 +8,10 @@ const state = {
      */
     config: [],
     /**
-     * Current topic (either default 'ech' at app startup, or another from the config later chosen
-     * by the user)
+     * Current topic ID (either default 'ech' at app startup, or another from the config later
+     * chosen by the user)
      *
-     * @type {Topic}
+     * @type {String}
      */
     current: 'ech',
     /**
@@ -50,7 +50,7 @@ const actions = {
     },
     changeTopic: ({ commit, state }, { topicId, dispatcher }) => {
         if (
-            state.config.find((topic) => topic.id === topicId) ||
+            state.config.some((topic) => topic.id === topicId) ||
             // during appLoadingManagement.routerPlugin the topics are not yet set
             // therefore we cannot validate the topic ID
             dispatcher === 'appLoadingManagement.routerPlugin'
@@ -63,7 +63,7 @@ const actions = {
     setTopicTreeOpenedThemesIds: ({ commit }, { catalogNodes, dispatcher }) => {
         if (typeof catalogNodes === 'string') {
             commit('setTopicTreeOpenedThemesIds', {
-                themes: catalogNodes.indexOf(',') !== -1 ? catalogNodes.split(',') : [catalogNodes],
+                themes: catalogNodes.split(','),
                 dispatcher,
             })
         } else if (Array.isArray(catalogNodes)) {

--- a/src/store/modules/topics.store.js
+++ b/src/store/modules/topics.store.js
@@ -44,44 +44,41 @@ const getters = {
 }
 
 const actions = {
-    setTopics: ({ commit }, topics) => {
-        if (Array.isArray(topics)) {
-            commit('setTopicConfig', topics)
-        }
+    setTopics: ({ commit }, { topics, dispatcher }) => {
+        commit('setTopics', { topics, dispatcher })
     },
-    setTopicTree: ({ commit }, tree) => {
-        if (Array.isArray(tree)) {
-            commit('setTopicTree', tree)
-        }
+    setTopicTree: ({ commit }, { layers, dispatcher }) => {
+        commit('setTopicTree', { layers: layers.map((layer) => layer.clone()), dispatcher })
     },
-    changeTopic: ({ commit }, topic) => {
-        commit(CHANGE_TOPIC_MUTATION, topic)
+    changeTopic: ({ commit }, args) => {
+        commit(CHANGE_TOPIC_MUTATION, args)
     },
-    setTopicById: ({ commit, state }, topicId) => {
+    setTopicById: ({ commit, state }, { value, dispatcher }) => {
+        const topicId = value
         const topic = state.config.find((topic) => topic.id === topicId)
         if (topic) {
-            commit(CHANGE_TOPIC_MUTATION, topic)
+            commit(CHANGE_TOPIC_MUTATION, { value: topic, dispatcher })
         } else {
             log.error('No topic found with ID', topicId)
         }
     },
-    setTopicTreeOpenedThemesIds: ({ commit }, themes) => {
-        if (typeof themes === 'string') {
-            commit(
-                'setTopicTreeOpenedThemesIds',
-                themes.indexOf(',') !== -1 ? themes.split(',') : [themes]
-            )
-        } else if (Array.isArray(themes)) {
-            commit('setTopicTreeOpenedThemesIds', themes)
+    setTopicTreeOpenedThemesIds: ({ commit }, { value, dispatcher }) => {
+        if (typeof value === 'string') {
+            commit('setTopicTreeOpenedThemesIds', {
+                themes: value.indexOf(',') !== -1 ? value.split(',') : [value],
+                dispatcher,
+            })
+        } else if (Array.isArray(value)) {
+            commit('setTopicTreeOpenedThemesIds', { themes: value.slice(), dispatcher })
         }
     },
 }
 const mutations = {
-    setTopicConfig: (state, topics) => (state.config = [...topics]),
-    setTopicTree: (state, tree) => (state.tree = [...tree]),
-    setTopicTreeOpenedThemesIds: (state, themesIds) => (state.openedTreeThemesIds = [...themesIds]),
+    setTopics: (state, { topics }) => (state.config = topics),
+    setTopicTree: (state, { layers }) => (state.tree = layers),
+    setTopicTreeOpenedThemesIds: (state, { themes }) => (state.openedTreeThemesIds = themes),
 }
-mutations[CHANGE_TOPIC_MUTATION] = (state, topic) => (state.current = topic)
+mutations[CHANGE_TOPIC_MUTATION] = (state, { value }) => (state.current = value)
 
 export default {
     state,

--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -214,8 +214,8 @@ export default {
         toggleFullscreenMode({ commit, state }) {
             commit('setFullscreenMode', !state.fullscreenMode)
         },
-        setEmbeddedMode({ commit }, { value, dispatcher }) {
-            commit('setEmbeddedMode', { value: !!value, dispatcher })
+        setEmbeddedMode({ commit }, { embed, dispatcher }) {
+            commit('setEmbeddedMode', { embed: !!embed, dispatcher })
         },
         setShowLoadingBar({ commit }, value) {
             commit('setShowLoadingBar', !!value)
@@ -224,10 +224,16 @@ export default {
             commit('setShowLoadingBar', !state.showLoadingBar)
         },
         toggleDrawingOverlay({ commit, state }, { dispatcher }) {
-            commit('setShowDrawingOverlay', { value: !state.showDrawingOverlay, dispatcher })
+            commit('setShowDrawingOverlay', {
+                showDrawingOverlay: !state.showDrawingOverlay,
+                dispatcher,
+            })
         },
-        setShowDrawingOverlay({ commit }, { value, dispatcher }) {
-            commit('setShowDrawingOverlay', { value: !!value, dispatcher })
+        setShowDrawingOverlay({ commit }, { showDrawingOverlay, dispatcher }) {
+            commit('setShowDrawingOverlay', {
+                showDrawingOverlay: !!showDrawingOverlay,
+                dispatcher,
+            })
         },
         toggleFloatingTooltip({ commit, state }) {
             commit('setFloatingTooltip', !state.floatingTooltip)
@@ -253,17 +259,17 @@ export default {
         setMenuTrayWidth({ commit }, width) {
             commit('setMenuTrayWidth', parseFloat(width))
         },
-        setCompareRatio({ commit }, { value, dispatcher }) {
+        setCompareRatio({ commit }, { compareRatio, dispatcher }) {
             /*
                 This check is here to make sure the compare ratio doesn't get out of hand
                 The logic is, we want the compare ratio to be either in its visible range,
                 which is 0.001 to 0.999, and it's "storage range" (-0.001 to -0.999). If
                 we are not within these bounds, we revert to the default value (-0.5)
             */
-            if (value > 0.0 && value < 1.0) {
-                commit('setCompareRatio', { value, dispatcher })
+            if (compareRatio > 0.0 && compareRatio < 1.0) {
+                commit('setCompareRatio', { compareRatio, dispatcher })
             } else {
-                commit('setCompareRatio', { value: null, dispatcher })
+                commit('setCompareRatio', { compareRatio: null, dispatcher })
             }
         },
         setCompareSliderActive({ commit }, args) {
@@ -281,14 +287,14 @@ export default {
         setFullscreenMode(state, flagValue) {
             state.fullscreenMode = flagValue
         },
-        setEmbeddedMode(state, { value }) {
-            state.embeddedMode = value
+        setEmbeddedMode(state, { embed }) {
+            state.embeddedMode = embed
         },
         setShowLoadingBar(state, flagValue) {
             state.showLoadingBar = flagValue
         },
-        setShowDrawingOverlay(state, { value }) {
-            state.showDrawingOverlay = value
+        setShowDrawingOverlay(state, { showDrawingOverlay }) {
+            state.showDrawingOverlay = showDrawingOverlay
         },
         setFloatingTooltip(state, flagValue) {
             state.floatingTooltip = flagValue
@@ -308,11 +314,11 @@ export default {
         setMenuTrayWidth(state, width) {
             state.menuTrayWidth = width
         },
-        setCompareRatio(state, { value }) {
-            state.compareRatio = value
+        setCompareRatio(state, { compareRatio }) {
+            state.compareRatio = compareRatio
         },
-        setCompareSliderActive(state, { value }) {
-            state.isCompareSliderActive = value
+        setCompareSliderActive(state, { compareSliderActive }) {
+            state.isCompareSliderActive = compareSliderActive
         },
     },
 }

--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -214,8 +214,8 @@ export default {
         toggleFullscreenMode({ commit, state }) {
             commit('setFullscreenMode', !state.fullscreenMode)
         },
-        setEmbeddedMode({ commit }, isEmbedded) {
-            commit('setEmbeddedMode', !!isEmbedded)
+        setEmbeddedMode({ commit }, { value, dispatcher }) {
+            commit('setEmbeddedMode', { value: !!value, dispatcher })
         },
         setShowLoadingBar({ commit }, value) {
             commit('setShowLoadingBar', !!value)
@@ -223,11 +223,11 @@ export default {
         toggleLoadingBar({ commit, state }) {
             commit('setShowLoadingBar', !state.showLoadingBar)
         },
-        toggleDrawingOverlay({ commit, state }) {
-            commit('setShowDrawingOverlay', !state.showDrawingOverlay)
+        toggleDrawingOverlay({ commit, state }, { dispatcher }) {
+            commit('setShowDrawingOverlay', { value: !state.showDrawingOverlay, dispatcher })
         },
-        setShowDrawingOverlay({ commit }, value) {
-            commit('setShowDrawingOverlay', !!value)
+        setShowDrawingOverlay({ commit }, { value, dispatcher }) {
+            commit('setShowDrawingOverlay', { value: !!value, dispatcher })
         },
         toggleFloatingTooltip({ commit, state }) {
             commit('setFloatingTooltip', !state.floatingTooltip)
@@ -253,7 +253,7 @@ export default {
         setMenuTrayWidth({ commit }, width) {
             commit('setMenuTrayWidth', parseFloat(width))
         },
-        setCompareRatio({ commit }, value) {
+        setCompareRatio({ commit }, { value, dispatcher }) {
             /*
                 This check is here to make sure the compare ratio doesn't get out of hand
                 The logic is, we want the compare ratio to be either in its visible range,
@@ -261,13 +261,13 @@ export default {
                 we are not within these bounds, we revert to the default value (-0.5)
             */
             if (value > 0.0 && value < 1.0) {
-                commit('setCompareRatio', value)
+                commit('setCompareRatio', { value, dispatcher })
             } else {
-                commit('setCompareRatio', null)
+                commit('setCompareRatio', { value: null, dispatcher })
             }
         },
-        setCompareSliderActive({ commit }, value) {
-            commit('setCompareSliderActive', value)
+        setCompareSliderActive({ commit }, args) {
+            commit('setCompareSliderActive', args)
         },
     },
     mutations: {
@@ -281,14 +281,14 @@ export default {
         setFullscreenMode(state, flagValue) {
             state.fullscreenMode = flagValue
         },
-        setEmbeddedMode(state, flagValue) {
-            state.embeddedMode = flagValue
+        setEmbeddedMode(state, { value }) {
+            state.embeddedMode = value
         },
         setShowLoadingBar(state, flagValue) {
             state.showLoadingBar = flagValue
         },
-        setShowDrawingOverlay(state, flagValue) {
-            state.showDrawingOverlay = flagValue
+        setShowDrawingOverlay(state, { value }) {
+            state.showDrawingOverlay = value
         },
         setFloatingTooltip(state, flagValue) {
             state.floatingTooltip = flagValue
@@ -308,10 +308,10 @@ export default {
         setMenuTrayWidth(state, width) {
             state.menuTrayWidth = width
         },
-        setCompareRatio(state, value) {
+        setCompareRatio(state, { value }) {
             state.compareRatio = value
         },
-        setCompareSliderActive(state, value) {
+        setCompareSliderActive(state, { value }) {
             state.isCompareSliderActive = value
         },
     },

--- a/src/store/plugins/2d-to-3d-management.plugin.js
+++ b/src/store/plugins/2d-to-3d-management.plugin.js
@@ -7,6 +7,8 @@ export const backgroundMatriceBetween2dAnd3d = {
     'ch.swisstopo.swissimage': 'ch.swisstopo.swissimage_3d',
 }
 
+const STORE_DISPATCHER_2D_3D_PLUGIN = '2d-to-3d-management.plugin'
+
 /**
  * Plugin to switch to WebMercator coordinate system when we go 3D, and swap back to the default
  * projection when 2D is re-activated
@@ -25,14 +27,20 @@ export default function from2Dto3Dplugin(store) {
                         return layerId3d === state.layers.currentBackgroundLayer?.getID()
                     })
                     if (matching2dBackgroundId?.length > 0) {
-                        store.dispatch('setBackground', matching2dBackgroundId[0])
+                        store.dispatch('setBackground', {
+                            value: matching2dBackgroundId[0],
+                            dispatcher: STORE_DISPATCHER_2D_3D_PLUGIN,
+                        })
                     }
                 } else if (state.layers.currentBackgroundLayer) {
                     // when going 3D, as we are before the action
                     const matching3dBackgroundId =
                         backgroundMatriceBetween2dAnd3d[state.layers.currentBackgroundLayer.getID()]
                     if (matching3dBackgroundId) {
-                        store.dispatch('setBackground', matching3dBackgroundId)
+                        store.dispatch('setBackground', {
+                            value: matching3dBackgroundId,
+                            dispatcher: STORE_DISPATCHER_2D_3D_PLUGIN,
+                        })
                     }
                 }
             }
@@ -41,9 +49,15 @@ export default function from2Dto3Dplugin(store) {
             if (action.type === 'set3dActive') {
                 if (DEFAULT_PROJECTION.epsg !== WEBMERCATOR.epsg) {
                     if (state.cesium.active) {
-                        store.dispatch('setProjection', WEBMERCATOR)
+                        store.dispatch('setProjection', {
+                            value: WEBMERCATOR,
+                            dispatcher: STORE_DISPATCHER_2D_3D_PLUGIN,
+                        })
                     } else {
-                        store.dispatch('setProjection', DEFAULT_PROJECTION)
+                        store.dispatch('setProjection', {
+                            value: DEFAULT_PROJECTION,
+                            dispatcher: STORE_DISPATCHER_2D_3D_PLUGIN,
+                        })
                     }
                 }
             }

--- a/src/store/plugins/2d-to-3d-management.plugin.js
+++ b/src/store/plugins/2d-to-3d-management.plugin.js
@@ -28,7 +28,7 @@ export default function from2Dto3Dplugin(store) {
                     })
                     if (matching2dBackgroundId?.length > 0) {
                         store.dispatch('setBackground', {
-                            value: matching2dBackgroundId[0],
+                            bgLayer: matching2dBackgroundId[0],
                             dispatcher: STORE_DISPATCHER_2D_3D_PLUGIN,
                         })
                     }
@@ -38,7 +38,7 @@ export default function from2Dto3Dplugin(store) {
                         backgroundMatriceBetween2dAnd3d[state.layers.currentBackgroundLayer.getID()]
                     if (matching3dBackgroundId) {
                         store.dispatch('setBackground', {
-                            value: matching3dBackgroundId,
+                            bgLayer: matching3dBackgroundId,
                             dispatcher: STORE_DISPATCHER_2D_3D_PLUGIN,
                         })
                     }
@@ -50,12 +50,12 @@ export default function from2Dto3Dplugin(store) {
                 if (DEFAULT_PROJECTION.epsg !== WEBMERCATOR.epsg) {
                     if (state.cesium.active) {
                         store.dispatch('setProjection', {
-                            value: WEBMERCATOR,
+                            projection: WEBMERCATOR,
                             dispatcher: STORE_DISPATCHER_2D_3D_PLUGIN,
                         })
                     } else {
                         store.dispatch('setProjection', {
-                            value: DEFAULT_PROJECTION,
+                            projection: DEFAULT_PROJECTION,
                             dispatcher: STORE_DISPATCHER_2D_3D_PLUGIN,
                         })
                     }

--- a/src/store/plugins/app-readiness.plugin.js
+++ b/src/store/plugins/app-readiness.plugin.js
@@ -17,7 +17,10 @@ import log from '@/utils/logging'
 const appReadinessPlugin = (store) => {
     const unsubscribe = store.subscribe((mutation, state) => {
         // Log all mutations for debugging
-        log.debug(`[store mutation]: type=${mutation.type} payload=`, mutation.payload)
+        log.debug(
+            `[store mutation]: type=${mutation.type} dispatcher=${mutation.payload?.dispatcher ?? null} payload=`,
+            mutation.payload
+        )
 
         // if app is not ready yet, we go through the checklist
         if (!state.app.isReady) {
@@ -27,7 +30,7 @@ const appReadinessPlugin = (store) => {
                 Object.keys(state.layers.config).length > 0 &&
                 state.topics.config.length > 0
             ) {
-                store.dispatch('setAppIsReady')
+                store.dispatch('setAppIsReady', 'app-readiness-plugin')
 
                 // In production build we are not interested anymore in the mutation logs
                 // therefore unsubscribe here
@@ -42,7 +45,10 @@ const appReadinessPlugin = (store) => {
     // only subscribe to action logs for non productive build
     if (ENVIRONMENT !== 'production') {
         store.subscribeAction((action, _state) => {
-            log.debug(`[store action]: type=${action.type} payload=`, action.payload)
+            log.debug(
+                `[store action]: type=${action.type} dispatcher=${action.payload?.dispatcher ?? null} payload=`,
+                action.payload
+            )
         })
     }
 }

--- a/src/store/plugins/external-layers.plugin.js
+++ b/src/store/plugins/external-layers.plugin.js
@@ -22,15 +22,15 @@ export default function loadExternalLayerAttributes(store) {
     store.subscribe((mutation, state) => {
         if (
             mutation.type === 'addLayer' &&
-            mutation.payload instanceof ExternalLayer &&
-            mutation.payload.isLoading
+            mutation.payload.layer instanceof ExternalLayer &&
+            mutation.payload.layer?.isLoading
         ) {
             log.debug(
                 `Loading state external layer added, trigger attribute updated`,
                 mutation,
                 state
             )
-            updateExternalLayer(store, mutation.payload, state.position.projection)
+            updateExternalLayer(store, mutation.payload.layer, state.position.projection)
         }
     })
 }

--- a/src/store/plugins/geolocation-management.plugin.js
+++ b/src/store/plugins/geolocation-management.plugin.js
@@ -7,6 +7,8 @@ import CustomCoordinateSystem from '@/utils/coordinates/CustomCoordinateSystem.c
 import { STANDARD_ZOOM_LEVEL_1_25000_MAP } from '@/utils/coordinates/SwissCoordinateSystem.class.js'
 import log from '@/utils/logging'
 
+const STORE_DISPATCHER_GEOLOCATION_PLUGIN = 'geolocation-management.plugin'
+
 let geolocationWatcher = null
 let firstTimeActivatingGeolocation = true
 
@@ -21,7 +23,10 @@ const handlePositionAndDispatchToStore = (position, store) => {
     store.dispatch('setGeolocationAccuracy', position.coords.accuracy)
     // if tracking is active, we center the view of the map on the position received
     if (store.state.geolocation.tracking) {
-        store.dispatch('setCenter', { center: positionProjected, source: 'geolocation tracking' })
+        store.dispatch('setCenter', {
+            center: positionProjected,
+            dispatcher: STORE_DISPATCHER_GEOLOCATION_PLUGIN,
+        })
     }
 }
 
@@ -78,7 +83,10 @@ const geolocationManagementPlugin = (store) => {
                                         zoomLevel
                                     )
                             }
-                            store.dispatch('setZoom', { zoom: zoomLevel, source: 'geolocation' })
+                            store.dispatch('setZoom', {
+                                zoom: zoomLevel,
+                                dispatcher: STORE_DISPATCHER_GEOLOCATION_PLUGIN,
+                            })
                         }
                         geolocationWatcher = navigator.geolocation.watchPosition(
                             (position) => handlePositionAndDispatchToStore(position, store),

--- a/src/store/plugins/load-geojson-style-and-data.plugin.js
+++ b/src/store/plugins/load-geojson-style-and-data.plugin.js
@@ -52,11 +52,11 @@ export default function loadGeojsonStyleAndData(store) {
     store.subscribe((mutation) => {
         if (
             mutation.type === 'addLayer' &&
-            mutation.payload instanceof GeoAdminGeoJsonLayer &&
-            mutation.payload.isLoading
+            mutation.payload.layer instanceof GeoAdminGeoJsonLayer &&
+            mutation.payload.layer?.isLoading
         ) {
             log.debug(`Loading data/style for added GeoJSON layer`, mutation.payload)
-            loadDataAndStyle(store, mutation.payload)
+            loadDataAndStyle(store, mutation.payload.layer)
         }
     })
 }

--- a/src/store/plugins/load-gpx-data.plugin.js
+++ b/src/store/plugins/load-gpx-data.plugin.js
@@ -41,10 +41,10 @@ export default function loadGpxDataAndMetadata(store) {
     store.subscribe((mutation) => {
         if (
             mutation.type === 'addLayer' &&
-            mutation.payload instanceof GPXLayer &&
-            (!mutation.payload.gpxData || !mutation.payload.gpxMetadata)
+            mutation.payload.layer instanceof GPXLayer &&
+            (!mutation.payload.layer?.gpxData || !mutation.payload.layer?.gpxMetadata)
         ) {
-            loadGpx(store, mutation.payload)
+            loadGpx(store, mutation.payload.layer)
         }
     })
 }

--- a/src/store/plugins/load-kml-data.plugin.js
+++ b/src/store/plugins/load-kml-data.plugin.js
@@ -51,10 +51,10 @@ export default function loadKmlDataAndMetadata(store) {
     store.subscribe((mutation) => {
         if (
             mutation.type === 'addLayer' &&
-            mutation.payload instanceof KMLLayer &&
-            (!mutation.payload.kmlData || !mutation.payload.kmlMetadata)
+            mutation.payload.layer instanceof KMLLayer &&
+            (!mutation.payload.layer.kmlData || !mutation.payload.layer.kmlMetadata)
         ) {
-            const kmlLayer = mutation.payload
+            const kmlLayer = mutation.payload.layer
 
             if (!kmlLayer.kmlData) {
                 loadData(store, kmlLayer)

--- a/src/store/plugins/load-layersconfig-on-lang-change.js
+++ b/src/store/plugins/load-layersconfig-on-lang-change.js
@@ -82,7 +82,7 @@ const loadLayersConfigOnLangChange = (store) => {
         if (mutation.type === SET_LANG_MUTATION_KEY) {
             loadLayersAndTopicsConfigAndDispatchToStore(
                 store,
-                mutation.payload.value,
+                mutation.payload.lang,
                 store.state.topics.current,
                 STORE_DISPATCHER_LANG_CHANGE
             )

--- a/src/store/plugins/sync-camera-lonlatzoom.js
+++ b/src/store/plugins/sync-camera-lonlatzoom.js
@@ -14,13 +14,13 @@ import { WGS84 } from '@/utils/coordinates/coordinateSystems'
  * @param {Vuex.Store} store
  */
 export default function syncCameraLonLatZoom(store) {
-    const self = 'sync 3D camera'
+    const self = 'sync-camera-lonlatzoom.plugin'
     store.subscribe((mutation, state) => {
         // only reacting to mutation when the camera is set (when 3D is active and loaded)
         if (state.position.camera === null) {
             return
         }
-        if (mutation.type === 'setCameraPosition' && mutation.payload.source !== self) {
+        if (mutation.type === 'setCameraPosition' && mutation.payload.dispatcher !== self) {
             const lon = state.position.camera.x
             const lat = state.position.camera.y
             const height = state.position.camera.z
@@ -39,13 +39,13 @@ export default function syncCameraLonLatZoom(store) {
                 centerExpressedInWantedProjection
             )
             store.dispatch('setCenter', {
-                center: proj4(WGS84.epsg, state.position.projection.epsg, centerWGS84),
-                source: self,
+                center: centerExpressedInWantedProjection,
+                dispatcher: self,
             })
-            store.dispatch('setZoom', { zoom, source: self })
+            store.dispatch('setZoom', { zoom, dispatcher: self })
             store.dispatch('setRotation', normalizeAngle((rotation * Math.PI) / 180))
         }
-        if (mutation.type === 'setCenter' && mutation.payload.source !== self) {
+        if (mutation.type === 'setCenter' && mutation.payload.dispatcher !== self) {
             store.dispatch('setCameraPosition', {
                 position: {
                     x: store.getters.centerEpsg4326[0],
@@ -55,10 +55,10 @@ export default function syncCameraLonLatZoom(store) {
                     pitch: CesiumMath.toDegrees(-CesiumMath.PI_OVER_TWO),
                     roll: 0,
                 },
-                source: self,
+                dispatcher: self,
             })
         }
-        if (mutation.type === 'setZoom' && mutation.payload.source !== self) {
+        if (mutation.type === 'setZoom' && mutation.payload.dispatcher !== self) {
             const newHeight = calculateHeight(store.getters.resolution, state.ui.width)
             store.dispatch('setCameraPosition', {
                 position: {
@@ -69,7 +69,7 @@ export default function syncCameraLonLatZoom(store) {
                     pitch: CesiumMath.toDegrees(-CesiumMath.PI_OVER_TWO),
                     roll: 0,
                 },
-                source: self,
+                dispatcher: self,
             })
         }
     })

--- a/src/store/plugins/topic-change-management.plugin.js
+++ b/src/store/plugins/topic-change-management.plugin.js
@@ -52,12 +52,12 @@ const topicChangeManagementPlugin = (store) => {
             ) {
                 if (currentTopic.defaultBackgroundLayer) {
                     store.dispatch('setBackground', {
-                        value: currentTopic.defaultBackgroundLayer.getID(),
+                        bgLayer: currentTopic.defaultBackgroundLayer.getID(),
                         dispatcher: STORE_DISPATCHER_TOPIC_PLUGIN,
                     })
                 } else {
                     store.dispatch('setBackground', {
-                        value: null,
+                        bgLayer: null,
                         dispatcher: STORE_DISPATCHER_TOPIC_PLUGIN,
                     })
                 }
@@ -79,7 +79,7 @@ const topicChangeManagementPlugin = (store) => {
             }
 
             log.debug(
-                `Topic change management plugin: topic changed to ${mutation.payload.value} bg and layers dispatched: ${performance.now() - startTime}ms`,
+                `Topic change management plugin: topic changed to ${mutation.payload} bg and layers dispatched: ${performance.now() - startTime}ms`,
                 currentTopic.layersToActivate
             )
             // loading topic tree
@@ -96,14 +96,14 @@ const topicChangeManagementPlugin = (store) => {
                 // overwrite them here
                 if (store.state.topics.openedTreeThemesIds.length === 0) {
                     store.dispatch('setTopicTreeOpenedThemesIds', {
-                        value: topicTree.itemIdToOpen,
+                        catalogNodes: topicTree.itemIdToOpen,
                         dispatcher: STORE_DISPATCHER_TOPIC_PLUGIN,
                     })
                 }
 
                 let endTime = performance.now()
                 log.debug(
-                    `Finished Topic change management plugin: topic changed to ${mutation.payload.value}: ${endTime - startTime}ms`
+                    `Finished Topic change management plugin: topic changed to ${mutation.payload}: ${endTime - startTime}ms`
                 )
             })
         }

--- a/src/store/plugins/topic-change-management.plugin.js
+++ b/src/store/plugins/topic-change-management.plugin.js
@@ -1,5 +1,4 @@
 import { loadTopicTreeForTopic } from '@/api/topics.api'
-import { STORE_DISPATCHER_ROUTER_PLUGIN } from '@/router/storeSync/abstractParamConfig.class'
 import log from '@/utils/logging'
 import { getUrlQuery } from '@/utils/utils'
 

--- a/src/store/plugins/topic-change-management.plugin.js
+++ b/src/store/plugins/topic-change-management.plugin.js
@@ -33,7 +33,6 @@ const topicChangeManagementPlugin = (store) => {
             (mutation.type === 'changeTopic' && store.state.topics.config.length > 0) ||
             mutation.type === 'setTopics'
         ) {
-            let startTime = performance.now()
             log.debug(`Topic change management plugin: topic changed to`, mutation.payload)
 
             const currentTopic = store.getters.currentTopic
@@ -78,10 +77,6 @@ const topicChangeManagementPlugin = (store) => {
                 })
             }
 
-            log.debug(
-                `Topic change management plugin: topic changed to ${mutation.payload} bg and layers dispatched: ${performance.now() - startTime}ms`,
-                currentTopic.layersToActivate
-            )
             // loading topic tree
             loadTopicTreeForTopic(
                 store.state.i18n.lang,
@@ -101,9 +96,8 @@ const topicChangeManagementPlugin = (store) => {
                     })
                 }
 
-                let endTime = performance.now()
                 log.debug(
-                    `Finished Topic change management plugin: topic changed to ${mutation.payload}: ${endTime - startTime}ms`
+                    `Finished Topic change management plugin: topic changed to ${mutation.payload}`
                 )
             })
         }

--- a/src/store/plugins/topic-change-management.plugin.js
+++ b/src/store/plugins/topic-change-management.plugin.js
@@ -3,6 +3,8 @@ import { CHANGE_TOPIC_MUTATION } from '@/store/modules/topics.store'
 
 let isFirstSetTopic = true
 
+const STORE_DISPATCHER_TOPIC_PLUGIN = 'topic-change-management.plugin'
+
 /**
  * Vuex plugins that will manage topic switching.
  *
@@ -33,16 +35,25 @@ const topicChangeManagementPlugin = (store) => {
             // we set it anyway if the URL doesn't contain a bgLayer URL param
             if (!isFirstSetTopic || window.location.href.indexOf('bgLayer=') === -1) {
                 if (currentTopic.defaultBackgroundLayer) {
-                    store.dispatch('setBackground', currentTopic.defaultBackgroundLayer.getID())
+                    store.dispatch('setBackground', {
+                        value: currentTopic.defaultBackgroundLayer.getID(),
+                        dispatcher: STORE_DISPATCHER_TOPIC_PLUGIN,
+                    })
                 } else {
-                    store.dispatch('setBackground', null)
+                    store.dispatch('setBackground', {
+                        value: null,
+                        dispatcher: STORE_DISPATCHER_TOPIC_PLUGIN,
+                    })
                 }
             }
 
             // at init, if there is no active layer yet, but the topic has some, we add them
             // after init we always add all layers from topic
             if (!isFirstSetTopic || state.layers.activeLayers.length === 0) {
-                store.dispatch('setLayers', currentTopic.layersToActivate)
+                store.dispatch('setLayers', {
+                    layers: currentTopic.layersToActivate,
+                    dispatcher: STORE_DISPATCHER_TOPIC_PLUGIN,
+                })
             }
             // loading topic tree
             loadTopicTreeForTopic(
@@ -50,10 +61,16 @@ const topicChangeManagementPlugin = (store) => {
                 currentTopic,
                 store.state.layers.config
             ).then((topicTree) => {
-                store.dispatch('setTopicTree', topicTree.layers)
+                store.dispatch('setTopicTree', {
+                    layers: topicTree.layers,
+                    dispatcher: STORE_DISPATCHER_TOPIC_PLUGIN,
+                })
                 // checking that no values were set in the URL at app startup, otherwise we might overwrite them here
                 if (!isFirstSetTopic || store.state.topics.openedTreeThemesIds.length === 0) {
-                    store.dispatch('setTopicTreeOpenedThemesIds', topicTree.itemIdToOpen)
+                    store.dispatch('setTopicTreeOpenedThemesIds', {
+                        value: topicTree.itemIdToOpen,
+                        dispatcher: STORE_DISPATCHER_TOPIC_PLUGIN,
+                    })
                 }
                 isFirstSetTopic = false
             })

--- a/src/store/plugins/topic-change-management.plugin.js
+++ b/src/store/plugins/topic-change-management.plugin.js
@@ -38,20 +38,11 @@ const topicChangeManagementPlugin = (store) => {
                     store.dispatch('setBackground', null)
                 }
             }
-            // we only set/clear layers after the first setTopic has occurred (after app init)
-            if (!isFirstSetTopic) {
-                store.dispatch('clearLayers')
-            }
+
             // at init, if there is no active layer yet, but the topic has some, we add them
             // after init we always add all layers from topic
             if (!isFirstSetTopic || state.layers.activeLayers.length === 0) {
-                // somehow topic layers are stored in reverse (top to bottom) so we swap the order before adding them
-                currentTopic.layersToActivate
-                    .slice()
-                    .reverse()
-                    .forEach((layer) => {
-                        store.dispatch('addLayer', layer)
-                    })
+                store.dispatch('setLayers', currentTopic.layersToActivate)
             }
             // loading topic tree
             loadTopicTreeForTopic(

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -25,10 +25,7 @@ export const LogLevel = {
  */
 const log = (level, ...message) => {
     // In production we don't log debug level
-    if (
-        ENVIRONMENT === 'production' &&
-        [LogLevel.ERROR, LogLevel.WARNING, LogLevel.INFO].includes(level)
-    ) {
+    if (ENVIRONMENT === 'production' && [LogLevel.ERROR, LogLevel.WARNING].includes(level)) {
         return
     }
 

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -24,8 +24,11 @@ export const LogLevel = {
  * @param {...any} message
  */
 const log = (level, ...message) => {
-    // In production we only log errors.
-    if (ENVIRONMENT === 'production' && level !== LogLevel.ERROR) {
+    // In production we don't log debug level
+    if (
+        ENVIRONMENT === 'production' &&
+        [LogLevel.ERROR, LogLevel.WARNING, LogLevel.INFO].includes(level)
+    ) {
         return
     }
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -174,3 +174,17 @@ export function geometryInfo(type, coordinates, epsg) {
 export function formatAngle(value, digits = 2) {
     return `${value.toFixed(digits)}°`
 }
+
+/**
+ * Returns the URL raw query parameters.
+ *
+ * @returns {URLSearchParams} Parsed URL query parameters
+ * @WARNING This method should be used with care and should only be
+ * used to get URL query parameter that are identical in legacy URL paramenters !
+ */
+export function getUrlQuery() {
+    return new URLSearchParams(
+        // The legacy link uses the query, while new permalink are behind the hash
+        window.location.search || window.location.hash.replace('#/map?', '')
+    )
+}

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -214,10 +214,10 @@ Cypress.Commands.add(
         // waiting for the app to load and layers to be configured.
         cy.waitUntilState((state) => state.app.isMapReady, { timeout: 15000 })
         cy.waitUntilState(
-            (state) => {
+            (state, getters) => {
                 const active = state.layers.activeLayers.length
                 // The required layers can be set via topic or manually.
-                const targetTopic = state.topics.current?.layersToActivate.length
+                const targetTopic = getters.currentTopic?.layersToActivate.length
                 const targetLayers =
                     'layers' in queryParams
                         ? // Legacy layers come with an additional param. At least in our tests.
@@ -328,7 +328,8 @@ Cypress.Commands.add('clickOnLanguage', (lang) => {
 // cy.readStoreValue doesn't work as `.its` will prevent retries.
 Cypress.Commands.add('waitUntilState', (predicate, options = {}) => {
     cy.waitUntil(
-        () => cy.window({ log: false }).then((win) => predicate(win.store.state)),
+        () =>
+            cy.window({ log: false }).then((win) => predicate(win.store.state, win.store.getters)),
         Object.assign(
             {
                 errorMsg:

--- a/tests/cypress/tests-e2e/geodesicDrawing.cy.js
+++ b/tests/cypress/tests-e2e/geodesicDrawing.cy.js
@@ -9,7 +9,7 @@ const olSelector = '.ol-viewport'
 const acceptableDelta = 0.01
 
 function moveMapPos(newCenter) {
-    cy.writeStoreValue('setCenter', { center: newCenter, source: 'Cypress geodesic tests' })
+    cy.writeStoreValue('setCenter', { center: newCenter, dispatcher: 'e2e-test' })
     /* In headed mode, the tests work perfectly fine even without these waits. In headless mode
     hovewer, they are needed, as else, the mouse click event following may not be registered
     correctly by the Draw and Modify interactions. The reasons for that are still unclear. */

--- a/tests/cypress/tests-e2e/header.cy.js
+++ b/tests/cypress/tests-e2e/header.cy.js
@@ -81,8 +81,7 @@ describe('Test functions for the header / search bar', () => {
         const checkLangAndTopic = (expectedLang = 'en', expectedTopicId = 'ech') => {
             cy.readStoreValue('state.i18n.lang').should('eq', expectedLang)
             cy.readStoreValue('state.topics.current').then((currentTopic) => {
-                expect(currentTopic).to.not.be.undefined
-                expect(currentTopic.id).to.eq(expectedTopicId)
+                expect(currentTopic).to.eq(expectedTopicId)
             })
         }
         const selectTopicStandardAndAddLayerFromTopicTree = () => {

--- a/tests/cypress/tests-e2e/mouseposition.cy.js
+++ b/tests/cypress/tests-e2e/mouseposition.cy.js
@@ -256,7 +256,7 @@ describe('Test mouse position and interactions', () => {
             cy.intercept(/^http[s]?:\/\/(sys-s\.\w+\.bgdi\.ch|s\.geo\.admin\.ch)\//, {
                 body: { shorturl: shortUrl, success: true },
             }).as('shortlink-bg-void')
-            cy.writeStoreValue('setBackground', { value: null, dispatcher: 'e2e-test' })
+            cy.writeStoreValue('setBackground', { bgLayer: null, dispatcher: 'e2e-test' })
             cy.wait('@shortlink-bg-void').then((interception) => {
                 expect(interception.request.body.url).be.a('string')
                 const query = interception.request.body.url.split('?')[1]

--- a/tests/cypress/tests-e2e/mouseposition.cy.js
+++ b/tests/cypress/tests-e2e/mouseposition.cy.js
@@ -256,7 +256,7 @@ describe('Test mouse position and interactions', () => {
             cy.intercept(/^http[s]?:\/\/(sys-s\.\w+\.bgdi\.ch|s\.geo\.admin\.ch)\//, {
                 body: { shorturl: shortUrl, success: true },
             }).as('shortlink-bg-void')
-            cy.writeStoreValue('setBackground', null)
+            cy.writeStoreValue('setBackground', { value: null, dispatcher: 'e2e-test' })
             cy.wait('@shortlink-bg-void').then((interception) => {
                 expect(interception.request.body.url).be.a('string')
                 const query = interception.request.body.url.split('?')[1]

--- a/tests/cypress/tests-e2e/topics.cy.js
+++ b/tests/cypress/tests-e2e/topics.cy.js
@@ -54,8 +54,7 @@ describe('Topics', () => {
         })
         // checking the default topic at app startup (must be ech)
         cy.readStoreValue('state.topics.current').then((currentTopic) => {
-            expect(currentTopic).to.be.an('Object')
-            expect(currentTopic.id).to.eq('ech')
+            expect(currentTopic).to.eq('ech')
         })
         cy.url().should('contain', 'topic=ech')
         // checking that it keeps the topic tree closed at app startup (with default topic)
@@ -226,8 +225,7 @@ describe('Topics', () => {
             topic: topicWithActiveLayers.id,
         })
         cy.readStoreValue('state.topics.current').then((currentTopic) => {
-            expect(currentTopic).to.be.an('Object')
-            expect(currentTopic.id).to.eq(topicWithActiveLayers.id)
+            expect(currentTopic).to.eq(topicWithActiveLayers.id)
         })
         cy.url().should('contain', `topic=${topicWithActiveLayers.id}`)
     })
@@ -251,6 +249,6 @@ describe('Topics', () => {
         cy.get('[data-cy="catalogue-tree-item-title-3"]').click()
         cy.get('[data-cy="catalogue-tree-item-test.wmts.layer"]').should('be.visible')
         cy.url().should('contain', 'catalogNodes=2')
-        cy.url().should('not.contain', 'catalogNodes=2,3')
+        cy.url().should('not.contain', 'catalogNodes=2,')
     })
 })

--- a/tests/cypress/tests-e2e/topics.cy.js
+++ b/tests/cypress/tests-e2e/topics.cy.js
@@ -8,6 +8,7 @@ describe('Topics', () => {
     // mimic the output of `/rest/services` endpoint
     let mockupTopics = {}
     const selectTopicWithId = (topicId) => {
+        cy.log(`Select topic ${topicId}`)
         cy.readStoreValue('state.ui').then((ui) => {
             // only click on the menu button if the menu is not opened yet
             if (!ui.showMenu) {
@@ -122,7 +123,7 @@ describe('Topics', () => {
         const complexTopic = mockupTopics.topics[4]
         selectTopicWithId(complexTopic.id)
         // from the mocked up response above
-        const expectedActiveLayers = ['test.wms.layer', 'test.wmts.layer']
+        const expectedActiveLayers = ['test.wmts.layer', 'test.wms.layer']
         const expectedVisibleLayers = ['test.wmts.layer']
         const expectedOpacity = {
             'test.wmts.layer': 0.6,


### PR DESCRIPTION
In order to improve startup procedure I added a global new `dispatcher` attribute to all store actions related to the URL query parameter. This should also be done for all actions, but for the time being only added it to the url parameter related actions.

This new generic parameter gives the possibility to do different actions in the
store plugins depending on the source of the event. This avoid bulky/flaky tests
using local closure flags.

This PR already improved some performances:

- language changes performance improves as it don't re-add every layer one at a time, but in a bulk operation
- Don't load the layer config and topics at startup twice if the language is not the browser default
- Setting default topic layers is now about 400-500 ms faster due to bulk store mutation `setLayers`
- improve logging for debugging by introducing a debug log for every mutation

It also solved the following bugs:

- meteoschweiz and schneesport topic default layer reverse order (due to plConfig)
- Fix topics that only specified selectedLayers in backend (BFS, IVS, KGS, ...)

TODO in separate PR:
- [ ] readme about store mutations, see #645 
- [ ] bulk operation for adding layer from URL param and bug fixing url layers param order

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-259-performance/index.html)