### PR TITLE
Avoid error log during language change

### DIFF
--- a/src/modules/menu/components/advancedTools/ImportCatalogue/ProviderUrl.vue
+++ b/src/modules/menu/components/advancedTools/ImportCatalogue/ProviderUrl.vue
@@ -32,8 +32,10 @@ const connectButtonKey = computed(() => (isLoading.value ? 'loading' : 'connect'
 const lang = computed(() => store.state.i18n.lang)
 
 watch(lang, () => {
-    // When the language changes re-connect to reload the translated capabilities
-    connect()
+    if (isValid.value) {
+        // When the language changes re-connect to reload the translated capabilities
+        connect()
+    }
 })
 
 // Methods


### PR DESCRIPTION
When changing the language the import external catalog was triggered even if
no url was provided which resulted in errors

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-lang-change/index.html)