### PR TITLE
Fix error on prod when debug store module is absent

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -66,11 +66,8 @@ const store = createStore({
         share,
         cesium,
         print,
+        debug,
     },
 })
-
-if (store.getters.hasDevSiteWarning) {
-    store.registerModule('debug', debug)
-}
 
 export default store


### PR DESCRIPTION
adding it anyway, the UI to edit its value won't be added to the app on PROD

[Test link](https://sys-map.dev.bgdi.ch/preview/fix_debug_store_module/index.html)