### PR TITLE
PB-293: Corrected external layer order at startup and improve a bit performance

### DIFF
--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -1,4 +1,3 @@
-import AbstractLayer from '@/api/layers/AbstractLayer.class'
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
 import GPXLayer from '@/api/layers/GPXLayer.class.js'
@@ -8,7 +7,6 @@ import AbstractParamConfig, {
     STORE_DISPATCHER_ROUTER_PLUGIN,
 } from '@/router/storeSync/abstractParamConfig.class'
 import layersParamParser from '@/router/storeSync/layersParamParser'
-import { ActiveLayerConfig } from '@/utils/layerUtils'
 import log from '@/utils/logging'
 
 /**
@@ -93,100 +91,26 @@ function dispatchLayersFromUrlIntoStore(store, urlParamValue) {
         store.state.layers.activeLayers,
         parsedLayers
     )
-    // going through layers that are already present to set opacity / visibility
-    store.state.layers.activeLayers.forEach((activeLayer) => {
-        const matchingLayerMetadata = parsedLayers.find((layer) => layer.id === activeLayer.getID())
-        if (matchingLayerMetadata) {
-            log.debug(
-                `  Update layer ${activeLayer.getID()} parameters (visible, opacity,...); new:`,
-                matchingLayerMetadata,
-                `current:`,
-                activeLayer
-            )
-            if (matchingLayerMetadata.opacity) {
-                if (activeLayer.opacity !== matchingLayerMetadata.opacity) {
-                    promisesForAllDispatch.push(
-                        store.dispatch('setLayerOpacity', {
-                            layerId: activeLayer.getID(),
-                            opacity: matchingLayerMetadata.opacity,
-                            dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
-                        })
-                    )
-                }
-            } else {
-                // checking if this active layer's opacity matches the default opacity from the config
-                const configForThisLayer = store.getters.getLayerConfigById(activeLayer.getID())
-                if (configForThisLayer && configForThisLayer.opacity !== activeLayer.opacity) {
-                    promisesForAllDispatch.push(
-                        store.dispatch('setLayerOpacity', {
-                            layerId: activeLayer.getID(),
-                            opacity: configForThisLayer.opacity,
-                            dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
-                        })
-                    )
-                }
-            }
-            if (activeLayer.visible !== matchingLayerMetadata.visible) {
+
+    const layers = parsedLayers.map((parsedLayer) => {
+        const layerObject = createLayerObject(parsedLayer)
+        if (layerObject) {
+            if (layerObject.type === LayerTypes.KML && layerObject.adminId) {
                 promisesForAllDispatch.push(
-                    store.dispatch('setLayerVisibility', {
-                        layerId: activeLayer.getID(),
-                        visible: matchingLayerMetadata.visible,
+                    store.dispatch('setShowDrawingOverlay', {
+                        showDrawingOverlay: true,
                         dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
                     })
                 )
             }
-        } else {
-            // this layer has to be removed (not present in the URL anymore)
-            log.debug(`  Remove layer ${activeLayer.getID()} from active layers`)
-            promisesForAllDispatch.push(
-                store.dispatch('removeLayer', {
-                    layer: activeLayer,
-                    dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
-                })
-            )
+            log.debug(`  Add layer ${parsedLayer.id} to active layers`, layerObject)
         }
+        return layerObject
     })
-    // adding any layer that is not present yet
-    parsedLayers.forEach((parsedLayer) => {
-        if (
-            !store.state.layers.activeLayers.find(
-                (activeLayer) => activeLayer.getID() === parsedLayer.id
-            )
-        ) {
-            const layerObject = createLayerObject(parsedLayer)
-            if (layerObject) {
-                if (layerObject.type === LayerTypes.KML && layerObject.adminId) {
-                    promisesForAllDispatch.push(
-                        store.dispatch('setShowDrawingOverlay', {
-                            showDrawingOverlay: true,
-                            dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
-                        })
-                    )
-                }
-                log.debug(`  Add layer ${parsedLayer.id} to active layers`, layerObject)
-                promisesForAllDispatch.push(
-                    store.dispatch('addLayer', {
-                        layer: layerObject instanceof AbstractLayer ? layerObject : null,
-                        layerConfig: layerObject instanceof ActiveLayerConfig ? layerObject : null,
-                        dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
-                    })
-                )
-            }
-        }
-    })
-    // setting year fore timed layers if specified in the URL
-    parsedLayers
-        .filter((layer) => layer.customAttributes && layer.customAttributes.year)
-        .forEach((timedLayer) => {
-            log.debug(`  Set year to timed layer ${timedLayer.id}`, timedLayer)
-            promisesForAllDispatch.push(
-                store.dispatch('setTimedLayerCurrentYear', {
-                    layerId: timedLayer.id,
-                    year: timedLayer.customAttributes.year,
-                    dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
-                })
-            )
-        })
+    promisesForAllDispatch.push(
+        store.dispatch('setLayers', { layers: layers, dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN })
+    )
+
     return Promise.all(promisesForAllDispatch)
 }
 
@@ -213,6 +137,7 @@ export default class LayerParamConfig extends AbstractParamConfig {
                 'moveActiveLayerFromIndexToIndex',
                 'setLayerOpacity',
                 'setLayerYear',
+                'setLayers',
             ].join(','),
             dispatchLayersFromUrlIntoStore,
             generateLayerUrlParamFromStoreValues,

--- a/src/router/storeSync/storeSync.routerPlugin.js
+++ b/src/router/storeSync/storeSync.routerPlugin.js
@@ -98,13 +98,14 @@ function storeMutationWatcher(store, mutation, router) {
  *   parameter.
  */
 function urlQueryWatcher(store, to) {
-    log.debug('Url query watcher', routeChangeIsTriggeredByThisModule, to)
     if (routeChangeIsTriggeredByThisModule) {
+        log.debug(`Url query watcher triggered by itself ignore it`, to)
         // Only sync route params when the route change has not been
         // triggered by the sync from store mutations watcher above.
         routeChangeIsTriggeredByThisModule = false
         return undefined
     }
+    log.debug(`Url query watcher `, to)
     const pendingStoreDispatch = []
     let requireQueryUpdate = false
     const newQuery = { ...to.query }
@@ -129,9 +130,9 @@ function urlQueryWatcher(store, to) {
         if (queryValue && queryValue !== storeValue) {
             // dispatching URL value to the store
             log.debug(
-                'dispatching URL param',
+                '  URL param ',
                 paramConfig.urlParamName,
-                'to store with value',
+                ': dispatching to store with value',
                 queryValue
             )
             pendingStoreDispatch.push(setValueInStore(paramConfig, store, queryValue))
@@ -139,9 +140,9 @@ function urlQueryWatcher(store, to) {
             if (paramConfig.keepInUrlWhenDefault) {
                 // if we don't have a query value but a store value update the url query with it
                 log.debug(
-                    'URL param',
+                    '  URL param',
                     paramConfig.urlParamName,
-                    'was not present in URL, setting it back with value',
+                    ': was not present in URL, setting it back with value',
                     storeValue
                 )
                 newQuery[paramConfig.urlParamName] = storeValue
@@ -149,9 +150,9 @@ function urlQueryWatcher(store, to) {
                 // if the query value has been removed (or set to false for a Boolean) and is meant to disappear from
                 // the URL with this value, we set it to a falsy value in the store and remove it from the URL
                 log.debug(
-                    'URL param',
+                    '  URL param',
                     paramConfig.urlParamName,
-                    'has been removed from the URL, setting it to falsy value in the store'
+                    ': has been removed from the URL, setting it to falsy value in the store'
                 )
                 pendingStoreDispatch.push(
                     setValueInStore(

--- a/src/store/plugins/external-layers.plugin.js
+++ b/src/store/plugins/external-layers.plugin.js
@@ -19,18 +19,20 @@ import log from '@/utils/logging'
  * @param {Vuex.Store} store
  */
 export default function loadExternalLayerAttributes(store) {
+    const addLayerSubscriber = (layer, state) => {
+        if (layer instanceof ExternalLayer && layer?.isLoading) {
+            log.debug(`Loading state external layer added, trigger attribute updated`, state)
+            updateExternalLayer(store, layer, state.position.projection)
+        }
+    }
     store.subscribe((mutation, state) => {
-        if (
-            mutation.type === 'addLayer' &&
-            mutation.payload.layer instanceof ExternalLayer &&
-            mutation.payload.layer?.isLoading
-        ) {
-            log.debug(
-                `Loading state external layer added, trigger attribute updated`,
-                mutation,
-                state
-            )
-            updateExternalLayer(store, mutation.payload.layer, state.position.projection)
+        if (mutation.type === 'addLayer') {
+            addLayerSubscriber(mutation.payload.layer, state)
+        }
+        if (mutation.type === 'setLayers') {
+            mutation.payload.layers?.forEach((layer) => {
+                addLayerSubscriber(layer, state)
+            })
         }
     })
 }

--- a/src/store/plugins/load-geojson-style-and-data.plugin.js
+++ b/src/store/plugins/load-geojson-style-and-data.plugin.js
@@ -50,13 +50,19 @@ async function loadDataAndStyle(store, geoJsonLayer) {
  */
 export default function loadGeojsonStyleAndData(store) {
     store.subscribe((mutation) => {
-        if (
-            mutation.type === 'addLayer' &&
-            mutation.payload.layer instanceof GeoAdminGeoJsonLayer &&
-            mutation.payload.layer?.isLoading
-        ) {
-            log.debug(`Loading data/style for added GeoJSON layer`, mutation.payload)
-            loadDataAndStyle(store, mutation.payload.layer)
+        const addLayerSubscriber = (layer) => {
+            if (layer instanceof GeoAdminGeoJsonLayer && layer?.isLoading) {
+                log.debug(`Loading data/style for added GeoJSON layer`, layer)
+                loadDataAndStyle(store, layer)
+            }
+        }
+        if (mutation.type === 'addLayer') {
+            addLayerSubscriber(mutation.payload.layer)
+        }
+        if (mutation.type === 'setLayers') {
+            mutation.payload.layers?.forEach((layer) => {
+                addLayerSubscriber(layer)
+            })
         }
     })
 }

--- a/src/store/plugins/load-gpx-data.plugin.js
+++ b/src/store/plugins/load-gpx-data.plugin.js
@@ -39,12 +39,18 @@ async function loadGpx(store, gpxLayer) {
  */
 export default function loadGpxDataAndMetadata(store) {
     store.subscribe((mutation) => {
-        if (
-            mutation.type === 'addLayer' &&
-            mutation.payload.layer instanceof GPXLayer &&
-            (!mutation.payload.layer?.gpxData || !mutation.payload.layer?.gpxMetadata)
-        ) {
-            loadGpx(store, mutation.payload.layer)
+        const addLayerSubscriber = (layer) => {
+            if (layer instanceof GPXLayer && (!layer?.gpxData || !layer?.gpxMetadata)) {
+                loadGpx(store, layer)
+            }
+        }
+        if (mutation.type === 'addLayer') {
+            addLayerSubscriber(mutation.payload.layer)
+        }
+        if (mutation.type === 'setLayers') {
+            mutation.payload.layers?.forEach((layer) => {
+                addLayerSubscriber(layer)
+            })
         }
     })
 }

--- a/src/store/plugins/load-kml-data.plugin.js
+++ b/src/store/plugins/load-kml-data.plugin.js
@@ -48,20 +48,24 @@ async function loadData(store, kmlLayer) {
  * @param {Vuex.Store} store
  */
 export default function loadKmlDataAndMetadata(store) {
+    const addLayerSubscriber = (layer) => {
+        if (layer instanceof KMLLayer && (!layer.kmlData || !layer.kmlMetadata)) {
+            if (!layer.kmlData) {
+                loadData(store, layer)
+            }
+            if (!layer.kmlMetadata && !layer.isExternal) {
+                loadMetadata(store, layer)
+            }
+        }
+    }
     store.subscribe((mutation) => {
-        if (
-            mutation.type === 'addLayer' &&
-            mutation.payload.layer instanceof KMLLayer &&
-            (!mutation.payload.layer.kmlData || !mutation.payload.layer.kmlMetadata)
-        ) {
-            const kmlLayer = mutation.payload.layer
-
-            if (!kmlLayer.kmlData) {
-                loadData(store, kmlLayer)
-            }
-            if (!kmlLayer.kmlMetadata && !kmlLayer.isExternal) {
-                loadMetadata(store, kmlLayer)
-            }
+        if (mutation.type === 'addLayer') {
+            addLayerSubscriber(mutation.payload.layer)
+        }
+        if (mutation.type === 'setLayers') {
+            mutation.payload.layers?.forEach((layer) => {
+                addLayerSubscriber(layer)
+            })
         }
     })
 }

--- a/tests/cypress/tests-e2e/layers.cy.js
+++ b/tests/cypress/tests-e2e/layers.cy.js
@@ -146,12 +146,9 @@ describe('Test of layer handling', () => {
                     }
                 ).as('externalWMTS')
 
-                cy.goToMapView(
-                    {
-                        layers: fakeLayerUrlId,
-                    },
-                    true
-                ) // with hash, otherwise the legacy parser kicks in and ruins the day
+                cy.goToMapView({
+                    layers: fakeLayerUrlId,
+                })
                 cy.wait('@externalWMTSGetCap')
                 cy.readStoreValue('getters.visibleLayers').then((layers) => {
                     expect(layers).to.have.lengthOf(1)
@@ -165,12 +162,13 @@ describe('Test of layer handling', () => {
                 cy.checkOlLayer(fakeLayerId)
 
                 // reads and sets non default layer config; visible and opacity
-                cy.goToMapView(
-                    {
-                        layers: `${fakeLayerUrlId},f,0.5`,
-                    },
-                    true
-                ) // with hash, otherwise the legacy parser kicks in and ruins the day
+                cy.goToMapView({
+                    layers: `${fakeLayerUrlId},f,0.5`,
+                })
+                // TODO due to a non ideal startup procedure the GetCapabilities is called 3 times
+                // therefore we need to wait for all three otherwise the later wait will not be
+                // sufficient for the last test.
+                cy.wait(Array(3).fill('@externalWMTSGetCap'))
                 cy.readStoreValue('getters.visibleLayers').should('be.empty')
                 cy.readStoreValue('state.layers.activeLayers').then((layers) => {
                     expect(layers).to.be.an('Array').length(1)

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -296,7 +296,7 @@ describe('Test on legacy param import', () => {
                     layers: `test.wmts.layer,WMTS||${layerId}||${url}`,
                     layers_opacity: '1,1',
                     layers_visibility: 'false,true',
-                    layers_timestam: ',',
+                    layers_timestamp: '18641231,',
                 },
                 false
             )
@@ -311,7 +311,7 @@ describe('Test on legacy param import', () => {
                 expect(externalLayer.name).to.eq(layerName)
                 expect(externalLayer.isLoading).to.be.false
             })
-            const expectedHash = `#/map?layers=test.wmts.layer,f,1;WMTS%7C${url}%7C${layerId},,1&layers_timestam=,&lang=en&center=2660013.5,1185172&z=1&bgLayer=test.background.layer2&topic=ech`
+            const expectedHash = `#/map?lang=en&center=2660013.5,1185172&z=1&bgLayer=test.background.layer2&topic=ech&layers=test.wmts.layer,f;WMTS%7C${url}%7C${layerId},,1`
             cy.location().should((location) => {
                 expect(location.hash).to.eq(expectedHash)
                 expect(location.search).to.eq('')


### PR DESCRIPTION
The external layers were always put at the top during startup even if they
were in the middle of the layers parameter.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-293-ext-layer-order/index.html)