### PR TITLE
Fix Drag&Drop e2e test on CI

### DIFF
--- a/tests/cypress/tests-e2e/layers.cy.js
+++ b/tests/cypress/tests-e2e/layers.cy.js
@@ -674,11 +674,11 @@ describe('Test of layer handling', () => {
                     cy.location('hash').then((hash) => {
                         const layersParam = new URLSearchParams(hash).get('layers')
                         const layers = layersParam.split(';')
-                        expect(layers).to.be.an('Array').lengthOf(3)
+                        cy.wrap(layers).should('have.lengthOf', 3)
                         const [firstUrlLayer, secondUrlLayer, thirdUrlLayer] = layers
-                        expect(firstUrlLayer).to.contains(expectedBottomLayerId)
-                        expect(secondUrlLayer).to.contains(expectedMiddleLayerId)
-                        expect(thirdUrlLayer).to.contains(expectedTopLayerId)
+                        cy.wrap(firstUrlLayer).should('contain', expectedBottomLayerId)
+                        cy.wrap(secondUrlLayer).should('contain', expectedMiddleLayerId)
+                        cy.wrap(thirdUrlLayer).should('contain', expectedTopLayerId)
                     })
                 }
                 // the bottom layer should now be on top, so the order is now

--- a/tests/cypress/tests-e2e/layers.cy.js
+++ b/tests/cypress/tests-e2e/layers.cy.js
@@ -671,7 +671,7 @@ describe('Test of layer handling', () => {
                     expectedMiddleLayerId,
                     expectedTopLayerId
                 ) => {
-                    cy.location('hash').should((hash) => {
+                    cy.location('hash').then((hash) => {
                         const layersParam = new URLSearchParams(hash).get('layers')
                         const layers = layersParam.split(';')
                         expect(layers).to.be.an('Array').lengthOf(3)


### PR DESCRIPTION
Change should to then, trying to fix the issue we have that only happen on the CI e2e tests

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_fix_dragndrop_e2e_test_on_ci/index.html)