### PR TITLE
PB-259: Improve startup performance by rendering menu section only when the map is rendered

### DIFF
--- a/src/modules/menu/components/menu/MenuTray.vue
+++ b/src/modules/menu/components/menu/MenuTray.vue
@@ -49,12 +49,14 @@
             :compact="compact"
             @open-menu-section="onOpenMenuSection"
         />
+        <!-- Here below we MUST wait that the map has been rendered before displaying any menu
+             content, otherwise this would slow down the application startup -->
         <MenuSection
             id="activeLayersSection"
             ref="activeLayersSection"
             :title="$t('layers_displayed')"
             light
-            show-content
+            :show-content="mapModuleReady"
             data-cy="menu-active-layers"
             @open-menu-section="onOpenMenuSection"
         >
@@ -121,6 +123,7 @@ export default {
             is3dMode: (state) => state.cesium.active,
             showImportFile: (state) => state.ui.importFile,
             showDrawingOverlay: (state) => state.ui.showDrawingOverlay,
+            mapModuleReady: (state) => state.app.isMapReady,
         }),
         ...mapGetters(['isPhoneMode', 'hasDevSiteWarning']),
     },

--- a/src/modules/menu/components/topics/MenuTopicSection.vue
+++ b/src/modules/menu/components/topics/MenuTopicSection.vue
@@ -35,6 +35,7 @@ const showTopicTree = computed(() => {
     // If we have defined catalog themes to be opened in the URL, it makes sense to open the catalog
     return !isDefaultTopic.value || openThemesIds.value.length > 0
 })
+const mapModuleReady = computed(() => store.state.app.isMapReady)
 
 function setShowTopicSelectionPopup() {
     showTopicSelectionPopup.value = true
@@ -78,7 +79,10 @@ defineExpose({ close })
                 @close="showTopicSelectionPopup = false"
             />
         </template>
+        <!-- The topic menu is very performance costly and should only be rendered once the
+             map has been rendered, otherwise it would slow down the application startup -->
         <LayerCatalogue
+            v-if="mapModuleReady"
             data-cy="menu-topic-tree"
             :layer-catalogue="currentTopicTree"
             :compact="compact"

--- a/src/router/storeSync/storeSync.routerPlugin.js
+++ b/src/router/storeSync/storeSync.routerPlugin.js
@@ -49,15 +49,15 @@ let routeChangeIsTriggeredByThisModule = false
  * @param {Router} router
  */
 function storeMutationWatcher(store, mutation, router) {
-    log.debug(
-        '[store sync router] store mutation',
-        mutation,
-        'Current route',
-        router.currentRoute.value
-    )
-
     // Ignore mutation that has been triggered by the router.beforeEach below.
     if (mutationNotTriggeredByModule(mutation) && mutationWatched(mutation)) {
+        log.debug(
+            '[store sync router] store mutation',
+            mutation,
+            'Current route',
+            router.currentRoute.value
+        )
+
         // if the value in the store differs from the one in the URL
         if (isRoutePushNeeded(store, router.currentRoute.value)) {
             const query = {}
@@ -73,7 +73,7 @@ function storeMutationWatcher(store, mutation, router) {
                     query,
                 })
                 .catch((error) => {
-                    log.info('Error while routing to', query, error)
+                    log.error('Error while routing to', query, error)
                 })
                 .finally(() => {
                     routeChangeIsTriggeredByThisModule = false

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -253,6 +253,14 @@ Cypress.Commands.add(
 )
 
 /**
+ * Wait until the map has been rendered and is ready. This is useful and needed during the
+ * application startup phase
+ */
+Cypress.Commands.add('waitMapIsReady', ({ timeout = 15000 } = {}) => {
+    cy.waitUntilState((state) => state.app.isMapReady, { timeout: timeout })
+})
+
+/**
  * Changes a URL parameter without reloading the app.
  *
  * Help when you want to change a value in the URL but don't want the whole app be reloaded from

--- a/tests/cypress/tests-e2e/importToolFile.cy.js
+++ b/tests/cypress/tests-e2e/importToolFile.cy.js
@@ -205,6 +205,7 @@ describe('The Import File Tool', () => {
         // Test reloading the page
         cy.log('Test reloading the page should only keep online external layers')
         cy.reload()
+        cy.waitMapIsReady()
         cy.clickOnMenuButtonIfMobile()
         cy.get('[data-cy="menu-section-active-layers"]:visible').children().should('have.length', 1)
         cy.get(`[data-cy="active-layer-name-KML|${secondValidOnlineUrl}"]`).should('be.visible')
@@ -536,6 +537,7 @@ describe('The Import File Tool', () => {
         // Test reloading the page
         cy.log('Test reloading the page should only keep online external layers')
         cy.reload()
+        cy.waitMapIsReady()
         cy.wait('@getGpxFile')
         // only the URL GPX should be kept while reloading
         cy.checkOlLayer(gpxOnlineLayerId)

--- a/tests/cypress/tests-e2e/importToolMaps.cy.js
+++ b/tests/cypress/tests-e2e/importToolMaps.cy.js
@@ -349,6 +349,7 @@ describe('The Import Maps Tool', () => {
         //---------------------------------------------------------------------
         cy.log('Reload should keep the layers')
         cy.reload()
+        cy.waitMapIsReady()
         cy.clickOnMenuButtonIfMobile()
         cy.get('[data-cy="menu-section-active-layers"]:visible').children().should('have.length', 3)
         cy.get(`[data-cy="active-layer-name-${singleLayerFullId}"]`).should('be.visible')


### PR DESCRIPTION
The rendering of catalogue is very costly and store events would re-trigger it
therefore wait that the map has been rendered before rendering the catalogue,
it is anyway not visible at startup until the user click on the menu entry.
It still needs to be always rendered once the application has been started, otherwise
the toggling of the menu would be too slow.

Also differ the rendering and opening of the active layers for the same reason
and also because if the menu contains external layer (e.g. kml, gpx, ...) the
application needs to load its metadata/data before rendering the correct name
in the list. For kml and GPX it would use at startup the default KML or GPX
name until the name has been loading. By defering the active layers list
we avoid having the name changing.

Several other options has been tried but they did not improve the performances:

- using shallow ref on the layer catalogue, but this had no impact. Shallow ref is not easy to use on store content, the store content needs to be anyway added as computed value in order to use shallow ref. This might be better and more efficient to use with pinia store.
- using new events instead of the mapIsReady, see #661 

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-259-performance-menu-off/index.html)