### PR TITLE
PB-322: Avoid reloading external layer upon browser history navigation

### DIFF
--- a/tests/cypress/tests-e2e/layers.cy.js
+++ b/tests/cypress/tests-e2e/layers.cy.js
@@ -168,7 +168,6 @@ describe('Test of layer handling', () => {
                 cy.goToMapView({
                     layers: `${fakeLayerUrlId},f,0.5`,
                 })
-                cy.wait('@externalWMTSGetCap')
                 cy.readStoreValue('getters.visibleLayers').should('be.empty')
                 cy.readStoreValue('state.layers.activeLayers').then((layers) => {
                     cy.wrap(layers).should('have.length', 1)


### PR DESCRIPTION
When changing the config (opacity, visibility) of an external layer (KML, GPX,
WMS or WMTS) and then use the browser history navigation to revert the changes,
it triggered a reload of the layer and set its name back to the default until
the layer has been reloaded.

We can simply avoid this by updating the current layer object instead of
creating a new one.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-external-layer/index.html)