### PR TITLE
Fix active layers scrolling on touch device

### DIFF
--- a/src/modules/menu/components/activeLayers/MenuActiveLayersList.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersList.vue
@@ -34,6 +34,9 @@ const activeLayers = computed(() => store.state.layers.activeLayers.slice().reve
 let sortable
 onMounted(() => {
     sortable = Sortable.create(activeLayersList.value, {
+        delay: 250,
+        delayOnTouchOnly: true,
+        touchStartThreshold: 3,
         animation: 150,
         onStart: function () {
             aLayerIsDragged.value = true


### PR DESCRIPTION
Due to drag and drop the layer scroll on touch device was not possible anymore as a touch triggered a drag and drop.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-drag-and-drop/index.html)