### PR TITLE
Fix layer drag and drop blocking transparency slider usage

### DIFF
--- a/src/modules/menu/components/activeLayers/MenuActiveLayersList.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersList.vue
@@ -38,6 +38,8 @@ onMounted(() => {
         delayOnTouchOnly: true,
         touchStartThreshold: 3,
         animation: 150,
+        direction: 'vertical',
+        handle: '.menu-layer-item-title',
         onStart: function () {
             aLayerIsDragged.value = true
         },


### PR DESCRIPTION
only react to drag and dropping when the title of the layer is handled, and not the settings area anymore


[Test link](https://sys-map.dev.bgdi.ch/preview/bug_fix_layer_drag_drop_block_settings_events/index.html)