### PR TITLE
Small improvement : wrap camera angles

### DIFF
--- a/src/store/modules/position.store.js
+++ b/src/store/modules/position.store.js
@@ -6,6 +6,7 @@ import allCoordinateSystems, { LV95, WGS84 } from '@/utils/coordinates/coordinat
 import CustomCoordinateSystem from '@/utils/coordinates/CustomCoordinateSystem.class'
 import StandardCoordinateSystem from '@/utils/coordinates/StandardCoordinateSystem.class'
 import log from '@/utils/logging'
+import { wrapDegrees } from '@/utils/numberUtils.js'
 
 /** @enum */
 export const CrossHairs = {
@@ -300,7 +301,16 @@ const actions = {
      *   of the debug console)
      */
     setCameraPosition({ commit }, { position, dispatcher }) {
-        commit('setCameraPosition', { position, dispatcher })
+        const wrappedPosition = {
+            x: position.x,
+            y: position.y,
+            z: position.z,
+            // wrapping all angle-based values so that they do not exceed a full-circle value
+            roll: wrapDegrees(position.roll),
+            pitch: wrapDegrees(position.pitch),
+            heading: wrapDegrees(position.heading),
+        }
+        commit('setCameraPosition', { position: wrappedPosition, dispatcher })
     },
     setProjection({ commit, state }, { projection, dispatcher }) {
         let matchingProjection

--- a/src/utils/__tests__/numberUtils.spec.js
+++ b/src/utils/__tests__/numberUtils.spec.js
@@ -8,6 +8,7 @@ import {
     isNumber,
     randomIntBetween,
     round,
+    wrapDegrees,
 } from '@/utils/numberUtils'
 
 describe('Unit test functions from numberUtils.js', () => {
@@ -137,6 +138,26 @@ describe('Unit test functions from numberUtils.js', () => {
             expect(formatThousand(2123.345)).to.eq("2'123.345")
             expect(formatThousand(1.23456)).to.eq('1.23456')
             expect(formatThousand(2000, ' ')).to.eq('2 000')
+        })
+    })
+
+    describe('wrapDegrees(angle)', () => {
+        it('returns the angle untouched if already in range', () => {
+            expect(wrapDegrees(-359.99)).to.eq(-359.99)
+            expect(wrapDegrees(0)).to.eq(0)
+            expect(wrapDegrees(359.99)).to.eq(359.99)
+        })
+        it('wraps an angle that are greater than 0 to the 0...360 range', () => {
+            expect(wrapDegrees(360)).to.eq(0)
+            expect(wrapDegrees(361)).to.eq(1)
+            expect(wrapDegrees(540)).to.eq(180)
+            expect(wrapDegrees(720)).to.eq(0)
+        })
+        it('wraps an angle that are smaller than zero to match the -360...0 range', () => {
+            expect(wrapDegrees(-360)).to.eq(0)
+            expect(wrapDegrees(-361)).to.eq(-1)
+            expect(wrapDegrees(-540)).to.eq(-180)
+            expect(wrapDegrees(-720)).to.eq(0)
         })
     })
 })

--- a/src/utils/numberUtils.js
+++ b/src/utils/numberUtils.js
@@ -98,3 +98,21 @@ export function formatThousand(num, separator = "'") {
     parts[0] = parts[0].replace(thousandSeparatorRegex, separator)
     return parts.join(decimalSeparator)
 }
+
+/**
+ * Makes sure that the given angle stays between -359.99999 and 359.9999 degrees (will start over at
+ * 0 whenever a full-circle is present)
+ *
+ * @param {Number} angleInDegrees
+ */
+export function wrapDegrees(angleInDegrees) {
+    const sign = Math.sign(angleInDegrees)
+    const absoluteAngle = Math.abs(angleInDegrees)
+    if (absoluteAngle > 360) {
+        return sign * (absoluteAngle % 360)
+    }
+    if (absoluteAngle === 360) {
+        return 0
+    }
+    return angleInDegrees
+}

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -354,7 +354,7 @@ describe('Test on legacy param import', () => {
             cy.readStoreValue('state.position.camera.z').should('eq', elevation)
             cy.readStoreValue('state.position.camera.heading').should('eq', heading)
             cy.readStoreValue('state.position.camera.pitch').should('eq', pitch)
-            cy.readStoreValue('state.position.camera.roll').should('eq', 360)
+            cy.readStoreValue('state.position.camera.roll').should('eq', 0)
 
             // EPSG is set to 3857
             cy.readStoreValue('state.position.projection.epsgNumber').should('eq', 3857)
@@ -379,7 +379,7 @@ describe('Test on legacy param import', () => {
             cy.readStoreValue('state.position.camera.z').should('eq', 0)
             cy.readStoreValue('state.position.camera.heading').should('eq', heading)
             cy.readStoreValue('state.position.camera.pitch').should('eq', 0)
-            cy.readStoreValue('state.position.camera.roll').should('eq', 360)
+            cy.readStoreValue('state.position.camera.roll').should('eq', 0)
 
             // EPSG is set to 3857
             cy.readStoreValue('state.position.projection.epsgNumber').should('eq', 3857)
@@ -403,7 +403,7 @@ describe('Test on legacy param import', () => {
             cy.readStoreValue('state.position.camera.x').should('not.be.null')
             cy.readStoreValue('state.position.camera.y').should('not.be.null')
             cy.readStoreValue('state.position.camera.z').should('not.be.null')
-            cy.readStoreValue('state.position.camera.heading').should('eq', 360)
+            cy.readStoreValue('state.position.camera.heading').should('eq', 0)
             cy.readStoreValue('state.position.camera.pitch').should('eq', -90)
             cy.readStoreValue('state.position.camera.roll').should('eq', 0)
 


### PR DESCRIPTION
so that this values do not extend above 360 (or bellow -360). This was resulting in some e2e test flakiness when a 360 deg would sometimes be interpreted as 360, and other times 0. With this change, it will be way more predictable and consistent

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_fix_camera_angle_unwrapped/index.html)