### PR TITLE
PB-259, PB-329: Improve external WMS/WMTS layers startup performance

### DIFF
--- a/src/api/layers/ExternalWMSLayer.class.js
+++ b/src/api/layers/ExternalWMSLayer.class.js
@@ -1,5 +1,6 @@
 import ExternalLayer from '@/api/layers/ExternalLayer.class'
 import { InvalidLayerDataError } from '@/api/layers/InvalidLayerData.error'
+import { encodeExternalLayerParam } from '@/api/layers/layers-external.api'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
 
 /**
@@ -63,7 +64,8 @@ export default class ExternalWMSLayer extends ExternalLayer {
             name,
             // format coming from https://github.com/geoadmin/web-mapviewer/blob/develop/adr/2021_03_16_url_param_structure.md
             // base URL and name must be URL encoded (no & signs or other reserved URL chars must pass, or it could break URL param parsing)
-            id: `WMS|${baseUrl}|${externalLayerId}`,
+            // NOTE the pipe character needs to be encoded in order to not break the parsing
+            id: `WMS|${encodeExternalLayerParam(baseUrl)}|${encodeExternalLayerParam(externalLayerId)}`,
             type: LayerTypes.WMS,
             externalLayerId,
             baseUrl,

--- a/src/api/layers/ExternalWMTSLayer.class.js
+++ b/src/api/layers/ExternalWMTSLayer.class.js
@@ -1,5 +1,6 @@
 import ExternalLayer from '@/api/layers/ExternalLayer.class'
 import { InvalidLayerDataError } from '@/api/layers/InvalidLayerData.error'
+import { encodeExternalLayerParam } from '@/api/layers/layers-external.api'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
 
 /**
@@ -56,7 +57,8 @@ export default class ExternalWMTSLayer extends ExternalLayer {
         super({
             name,
             // format coming from https://github.com/geoadmin/web-mapviewer/blob/develop/adr/2021_03_16_url_param_structure.md
-            id: `WMTS|${baseUrl}|${externalLayerId}`,
+            // NOTE the pipe character needs to be encoded in order to not break the parsing
+            id: `WMTS|${encodeExternalLayerParam(baseUrl)}|${encodeExternalLayerParam(externalLayerId)}`,
             type: LayerTypes.WMTS,
             externalLayerId,
             baseUrl,

--- a/src/api/layers/GPXLayer.class.js
+++ b/src/api/layers/GPXLayer.class.js
@@ -1,5 +1,6 @@
 import AbstractLayer, { LayerAttribution } from '@/api/layers/AbstractLayer.class'
 import { InvalidLayerDataError } from '@/api/layers/InvalidLayerData.error'
+import { encodeExternalLayerParam } from '@/api/layers/layers-external.api'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
 
 export default class GPXLayer extends AbstractLayer {
@@ -34,7 +35,8 @@ export default class GPXLayer extends AbstractLayer {
         const attributionName = isLocalFile ? gpxFileUrl : new URL(gpxFileUrl).hostname
         super({
             name: gpxMetadata?.name ?? 'GPX',
-            id: `GPX|${gpxFileUrl}`,
+            // NOTE the pipe character needs to be encoded in order to not break the parsing
+            id: `GPX|${encodeExternalLayerParam(gpxFileUrl)}`,
             type: LayerTypes.GPX,
             opacity: opacity,
             visible: visible,

--- a/src/api/layers/KMLLayer.class.js
+++ b/src/api/layers/KMLLayer.class.js
@@ -1,5 +1,6 @@
 import AbstractLayer, { LayerAttribution } from '@/api/layers/AbstractLayer.class'
 import { InvalidLayerDataError } from '@/api/layers/InvalidLayerData.error'
+import { encodeExternalLayerParam } from '@/api/layers/layers-external.api'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
 import { API_SERVICE_KML_BASE_URL } from '@/config'
 import { parseKmlName } from '@/utils/kmlUtils'
@@ -52,7 +53,8 @@ export default class KMLLayer extends AbstractLayer {
         super({
             name: 'KML',
             // format coming from https://github.com/geoadmin/web-mapviewer/blob/develop/adr/2021_03_16_url_param_structure.md
-            id: `KML|${kmlFileUrl}`,
+            // NOTE the pipe character needs to be encoded in order to not break the parsing
+            id: `KML|${encodeExternalLayerParam(kmlFileUrl)}`,
             type: LayerTypes.KML,
             opacity: opacity ?? 1.0,
             visible: visible ?? true,

--- a/src/api/layers/WMSCapabilitiesParser.class.js
+++ b/src/api/layers/WMSCapabilitiesParser.class.js
@@ -71,7 +71,7 @@ export default class WMSCapabilitiesParser {
         const { layer, parents } = this.findLayer(layerId)
         if (!layer) {
             const msg = `No WMS layer ${layerId} found in Capabilities ${this.originUrl.toString()}`
-            log.error(msg)
+            log.error(msg, this)
             if (ignoreError) {
                 return null
             }

--- a/src/api/layers/layers-external.api.js
+++ b/src/api/layers/layers-external.api.js
@@ -157,3 +157,29 @@ export function parseWmtsCapabilities(content, originUrl) {
         )
     }
 }
+
+const ENC_PIPE = '%7C'
+
+/**
+ * Encode an external layer parameter.
+ *
+ * This percent encode the special character | used to separate external layer parameters.
+ *
+ * @param {string} param Parameter to encode
+ * @returns {string} Percent encoded parameter
+ */
+export function encodeExternalLayerParam(param) {
+    return param.replace('|', ENC_PIPE)
+}
+
+/**
+ * Decode an external layer parameter.
+ *
+ * This percent decode the special character | used to separate external layer parameters.
+ *
+ * @param {string} param Parameter to encode
+ * @returns {string} Percent encoded parameter
+ */
+export function decodeExternalLayerParam(param) {
+    return param.replace(ENC_PIPE, '|')
+}

--- a/src/api/layers/layers-external.api.js
+++ b/src/api/layers/layers-external.api.js
@@ -165,6 +165,10 @@ const ENC_PIPE = '%7C'
  *
  * This percent encode the special character | used to separate external layer parameters.
  *
+ * NOTE: We don't use encodeURIComponent here because the Vue Router will anyway do the
+ * encodeURIComponent() therefore by only encoding | we avoid to encode other special character
+ * twice. But we need to encode | twice to avoid layer parsing issue.
+ *
  * @param {string} param Parameter to encode
  * @returns {string} Percent encoded parameter
  */
@@ -176,6 +180,10 @@ export function encodeExternalLayerParam(param) {
  * Decode an external layer parameter.
  *
  * This percent decode the special character | used to separate external layer parameters.
+ *
+ * NOTE: We don't use decodeURIComponent here because the Vue Router will anyway do the
+ * decodeURIComponent() therefore by only decoding | we avoid to decode other special character
+ * twice. But we need to decode | twice to avoid layer parsing issue.
  *
  * @param {string} param Parameter to encode
  * @returns {string} Percent encoded parameter

--- a/src/api/layers/layers-external.api.js
+++ b/src/api/layers/layers-external.api.js
@@ -54,6 +54,7 @@ export function setWmsGetCapParams(url, language) {
  */
 export async function readWmsCapabilities(baseUrl, language = null) {
     const url = setWmsGetCapParams(new URL(baseUrl), language).toString()
+    log.debug(`Read WMTS Get Capabilities: ${url}`)
     let response = null
     try {
         response = await axios.get(url, { timeout: EXTERNAL_SERVER_TIMEOUT })
@@ -117,6 +118,7 @@ export function setWmtsGetCapParams(url, language) {
  */
 export async function readWmtsCapabilities(baseUrl, language = null) {
     const url = setWmtsGetCapParams(new URL(baseUrl), language).toString()
+    log.debug(`Read WMTS Get Capabilities: ${url}`)
 
     let response = null
     try {

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -1,7 +1,7 @@
 import proj4 from 'proj4'
 import { START_LOCATION } from 'vue-router'
 
-import { transformLayerIntoUrlString } from '@/router/storeSync/LayerParamConfig.class'
+import { transformLayerIntoUrlString } from '@/router/storeSync/layersParamParser'
 import { backgroundMatriceBetween2dAnd3d as backgroundMatriceBetweenLegacyAndNew } from '@/store/plugins/2d-to-3d-management.plugin'
 import { LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 import CustomCoordinateSystem from '@/utils/coordinates/CustomCoordinateSystem.class'

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -20,6 +20,7 @@ import log from '@/utils/logging'
  *   corresponding layer if the given layer is an external one, otherwise returns `null`
  */
 export function createLayerObject(parsedLayer, currentLayer) {
+    const defaultOpacity = 1.0
     let layer = parsedLayer
     const [layerType, url, id] = parsedLayer.id.split('|').map(decodeExternalLayerParam)
     if (['KML', 'GPX', 'WMTS', 'WMS'].includes(layerType) && currentLayer) {
@@ -28,7 +29,8 @@ export function createLayerObject(parsedLayer, currentLayer) {
         // layer display name) when using the browser history navigation.
         layer = currentLayer.clone()
         layer.visible = parsedLayer.visible
-        layer.opacity = parsedLayer.opacity
+        // external layer have a default opacity of 1.0
+        layer.opacity = parsedLayer.opacity ?? defaultOpacity
         if (parsedLayer.customAttributes?.adminId) {
             layer.adminId = parsedLayer.customAttributes.adminId
         }
@@ -38,7 +40,7 @@ export function createLayerObject(parsedLayer, currentLayer) {
             layer = new KMLLayer({
                 kmlFileUrl: url,
                 visible: parsedLayer.visible,
-                opacity: parsedLayer.opacity,
+                opacity: parsedLayer.opacity ?? defaultOpacity,
                 adminId: parsedLayer.customAttributes.adminId,
             })
         } else {
@@ -53,7 +55,7 @@ export function createLayerObject(parsedLayer, currentLayer) {
             layer = new GPXLayer({
                 gpxFileUrl: url,
                 visible: parsedLayer.visible,
-                opacity: parsedLayer.opacity,
+                opacity: parsedLayer.opacity ?? defaultOpacity,
             })
         } else {
             // we can't re-load GPX files loaded through a file import; this GPX file is ignored
@@ -65,7 +67,7 @@ export function createLayerObject(parsedLayer, currentLayer) {
         layer = new ExternalWMTSLayer({
             name: id,
             opacity: parsedLayer.opacity,
-            visible: parsedLayer.visible,
+            visible: parsedLayer.visible ?? defaultOpacity,
             baseUrl: url,
             externalLayerId: id,
         })
@@ -77,7 +79,7 @@ export function createLayerObject(parsedLayer, currentLayer) {
         layer = new ExternalWMSLayer({
             name: id,
             opacity: parsedLayer.opacity,
-            visible: parsedLayer.visible,
+            visible: parsedLayer.visible ?? defaultOpacity,
             baseUrl: url,
             externalLayerId: id,
         })

--- a/src/router/storeSync/__tests__/layersParamParser.spec.js
+++ b/src/router/storeSync/__tests__/layersParamParser.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { describe, it } from 'vitest'
 
-import layersParamParser from '@/router/storeSync/layersParamParser'
+import { parseLayersParam } from '@/router/storeSync/layersParamParser'
 
 describe('Testing layersParamParser', () => {
     const checkLayer = (layer, id, visible = true, opacity = undefined, customAttributes = {}) => {
@@ -22,17 +22,17 @@ describe('Testing layersParamParser', () => {
         const customAttributes = {
             myCustomParam: customParamValue,
         }
-        const [layer] = layersParamParser(`${layerId}@myCustomParam=${customParamValue}`)
+        const [layer] = parseLayersParam(`${layerId}@myCustomParam=${customParamValue}`)
         checkLayer(layer, layerId, true, undefined, customAttributes)
     }
 
     it('Returns nothing if the query value is an empty array', () => {
-        expect(layersParamParser(null)).to.be.an('Array').empty
-        expect(layersParamParser(null)).to.be.an('Array').empty
+        expect(parseLayersParam(null)).to.be.an('Array').empty
+        expect(parseLayersParam(null)).to.be.an('Array').empty
     })
     it('Returns an object containing the layer info if a layer ID is in the query', () => {
         const layerId = 'fake-layer-id'
-        const result = layersParamParser(layerId)
+        const result = parseLayersParam(layerId)
         expect(result).to.be.an('Array').length(1)
         checkLayer(result[0], layerId, true)
     })
@@ -92,7 +92,7 @@ describe('Testing layersParamParser', () => {
                 queryString += `,${layer.opacity}`
             }
         })
-        const results = layersParamParser(queryString)
+        const results = parseLayersParam(queryString)
         expect(results).to.be.an('Array').length(layers.length)
         layers.forEach((layer, index) => {
             checkLayer(
@@ -108,19 +108,19 @@ describe('Testing layersParamParser', () => {
     describe('Visibility/Opacity parsing', () => {
         it('Parses correctly the visible when specified', () => {
             const layerId = 'fake-layer-id'
-            const result = layersParamParser(`${layerId},f`)
+            const result = parseLayersParam(`${layerId},f`)
             checkLayer(result[0], layerId, false)
         })
         it('Parses correctly the visible and opacity when both specified', () => {
             const layerId = 'fake-layer-id'
             const opacity = 0.36
-            const result = layersParamParser(`${layerId},f,${opacity}`)
+            const result = parseLayersParam(`${layerId},f,${opacity}`)
             checkLayer(result[0], layerId, false, opacity)
         })
         it('Sets default value to visible if it is ignored and opacity is set', () => {
             const layerId = 'fake-layer-id'
             const opacity = 0.5
-            const result = layersParamParser(`${layerId},,${opacity}`)
+            const result = parseLayersParam(`${layerId},,${opacity}`)
             checkLayer(result[0], layerId, true, opacity)
         })
     })
@@ -149,7 +149,7 @@ describe('Testing layersParamParser', () => {
                 queryString += `@${key}=${customParams[key]}`
             })
             queryString += `,f,${opacity}`
-            const [layer] = layersParamParser(queryString)
+            const [layer] = parseLayersParam(queryString)
             checkLayer(layer, layerId, false, opacity, customParams)
         })
     })
@@ -157,7 +157,7 @@ describe('Testing layersParamParser', () => {
     describe('External layer management', () => {
         it('parse correctly an external KML layer', () => {
             const externalLayerId = 'KML|https://somerandomurl.ch/file.kml|Some custom label'
-            const result = layersParamParser(`${externalLayerId},f,0.6`)
+            const result = parseLayersParam(`${externalLayerId},f,0.6`)
             expect(result).to.be.an('Array').with.lengthOf(1)
             const [layer] = result
             expect(layer).to.be.an('Object')
@@ -168,7 +168,7 @@ describe('Testing layersParamParser', () => {
         it('parses an external WMTS layer correctly', () => {
             const externalLayerIdInUrl =
                 'WMTS|https://fake.wmts.admin.ch|some_fake_layer_id|Fake WMTS Layer'
-            const results = layersParamParser(`${externalLayerIdInUrl},t,1.0`)
+            const results = parseLayersParam(`${externalLayerIdInUrl},t,1.0`)
             expect(results).to.be.an('Array').length(1)
             const [externalWMTSLayer] = results
             expect(externalWMTSLayer).to.be.an('Object')
@@ -179,7 +179,7 @@ describe('Testing layersParamParser', () => {
         it('parses an external WMS layer correctly', () => {
             const externalLayerIdInUrl =
                 'WMS|https://fake.wms.admin.ch|some_fake_layer_id|0.0.0|Fake WMS Layer'
-            const results = layersParamParser(`${externalLayerIdInUrl},t,0.8`)
+            const results = parseLayersParam(`${externalLayerIdInUrl},t,0.8`)
             expect(results).to.be.an('Array').length(1)
             const [externalWMSLayer] = results
             expect(externalWMSLayer).to.be.an('Object')

--- a/src/router/storeSync/layersParamParser.js
+++ b/src/router/storeSync/layersParamParser.js
@@ -1,6 +1,34 @@
 import { ActiveLayerConfig } from '@/utils/layerUtils'
 import { isNumber } from '@/utils/numberUtils'
 
+const ENC_COMMA = '%2C'
+const ENC_SEMI_COLON = '%3B'
+const ENC_AT = '%40'
+
+/**
+ * Encode an layer parameter.
+ *
+ * This percent encode the special character , ; and @ used to separate layer parameters.
+ *
+ * @param {string} param Parameter to encode
+ * @returns {string} Percent encoded parameter
+ */
+export function encodeLayerParam(param) {
+    return param.replace(',', ENC_COMMA).replace(';', ENC_SEMI_COLON).replace('@', ENC_AT)
+}
+
+/**
+ * Decode an layer parameter.
+ *
+ * This percent decode the special character , ; and @ used to separate layer parameters.
+ *
+ * @param {string} param Parameter to encode
+ * @returns {string} Percent encoded parameter
+ */
+export function decodeLayerParam(param) {
+    return param.replace(ENC_COMMA, ',').replace(ENC_SEMI_COLON, ';').replace(ENC_AT, '@')
+}
+
 /**
  * Parses the URL param value for `layers` as described in the ADR :
  * `/adr/2021_03_16_url_param_structure.md`
@@ -8,12 +36,14 @@ import { isNumber } from '@/utils/numberUtils'
  * @param {String} queryValue The value of the `layers` URL param
  * @returns {ActiveLayerConfig[]} Metadata for layers that must be activated in the app
  */
-const parseLayersParam = (queryValue) => {
+export function parseLayersParam(queryValue) {
     const parsedLayer = []
     if (queryValue && queryValue.length > 0) {
         queryValue.split(';').forEach((layerQueryString) => {
             const [layerIdWithCustomParams, visible, opacity] = layerQueryString.split(',')
-            const [layerId, ...otherParams] = layerIdWithCustomParams.split('@')
+            const [layerId, ...otherParams] = layerIdWithCustomParams
+                .split('@')
+                .map(decodeLayerParam)
             const customAttributes = {}
             if (otherParams && otherParams.length > 0) {
                 otherParams.forEach((param) => {
@@ -42,4 +72,29 @@ const parseLayersParam = (queryValue) => {
     return parsedLayer
 }
 
-export default parseLayersParam
+/**
+ * Transform a layer metadata into a string. This value can then be used in the URL to describe a
+ * layer and its state (visibility, opacity, etc...)
+ *
+ * @param {AbstractLayer} layer
+ * @param {GeoAdminLayer} [defaultLayerConfig]
+ * @returns {string}
+ */
+export function transformLayerIntoUrlString(layer, defaultLayerConfig) {
+    // NOTE we need to encode ,;@ characters from the layer to avoid parsing issue.
+    let layerUrlString = encodeLayerParam(layer.id)
+    if (layer.timeConfig?.timeEntries.length > 1) {
+        layerUrlString += `@year=${layer.timeConfig.currentYear}`
+    }
+    if (!layer.visible) {
+        layerUrlString += `,f`
+    }
+    // if no default layers config (e.g. external layers) or if the opacity is not the same as the default one
+    if (!defaultLayerConfig || layer.opacity !== defaultLayerConfig.opacity) {
+        if (layer.visible) {
+            layerUrlString += ','
+        }
+        layerUrlString += `,${layer.opacity}`
+    }
+    return layerUrlString
+}

--- a/src/router/storeSync/layersParamParser.js
+++ b/src/router/storeSync/layersParamParser.js
@@ -10,6 +10,10 @@ const ENC_AT = '%40'
  *
  * This percent encode the special character , ; and @ used to separate layer parameters.
  *
+ * NOTE: We don't use encodeURIComponent here because the Vue Router will anyway do the
+ * encodeURIComponent() therefore by only encoding the layer parameter separators we avoid to encode
+ * other special character twice. But we need to encode them twice to avoid layer parsing issue.
+ *
  * @param {string} param Parameter to encode
  * @returns {string} Percent encoded parameter
  */
@@ -21,6 +25,10 @@ export function encodeLayerParam(param) {
  * Decode an layer parameter.
  *
  * This percent decode the special character , ; and @ used to separate layer parameters.
+ *
+ * NOTE: We don't use encodeURIComponent here because the Vue Router will anyway do the
+ * encodeURIComponent() therefore by only encoding the layer parameter separators we avoid to encode
+ * other special character twice. But we need to encode them twice to avoid layer parsing issue.
  *
  * @param {string} param Parameter to encode
  * @returns {string} Percent encoded parameter

--- a/src/router/storeSync/layersParamParser.js
+++ b/src/router/storeSync/layersParamParser.js
@@ -89,8 +89,11 @@ export function transformLayerIntoUrlString(layer, defaultLayerConfig) {
     if (!layer.visible) {
         layerUrlString += `,f`
     }
-    // if no default layers config (e.g. external layers) or if the opacity is not the same as the default one
-    if (!defaultLayerConfig || layer.opacity !== defaultLayerConfig.opacity) {
+    if (
+        (defaultLayerConfig && layer.opacity !== defaultLayerConfig.opacity) ||
+        // for layer that don't have a default config (e.g. external layer) use 1.0 as default opacity
+        (!defaultLayerConfig && layer.opacity !== 1.0)
+    ) {
         if (layer.visible) {
             layerUrlString += ','
         }

--- a/src/store/plugins/external-layers.plugin.js
+++ b/src/store/plugins/external-layers.plugin.js
@@ -7,7 +7,6 @@
  */
 
 import ExternalGroupOfLayers from '@/api/layers/ExternalGroupOfLayers.class'
-import ExternalLayer from '@/api/layers/ExternalLayer.class'
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
 import { readWmsCapabilities, readWmtsCapabilities } from '@/api/layers/layers-external.api'
@@ -21,73 +20,98 @@ const dispatcher = { dispatcher: 'external-layers.plugin' }
  * @param {Vuex.Store} store
  */
 export default function loadExternalLayerAttributes(store) {
-    const addLayerSubscriber = (layer, state) => {
-        if (layer instanceof ExternalLayer && layer?.isLoading) {
-            log.debug(`Loading state external layer added, trigger attribute updated`, state)
-            updateExternalLayer(store, layer, state.position.projection)
-        }
+    const layersSubscriber = async (layers, state) => {
+        const externalLayers = layers.filter(
+            (layer) =>
+                layer.isLoading &&
+                (layer instanceof ExternalWMSLayer ||
+                    layer instanceof ExternalGroupOfLayers ||
+                    layer instanceof ExternalWMTSLayer)
+        )
+        // We get first the capabilities
+        const wmsCapabilities = getWMSCababilitiesForLayers(externalLayers)
+        const wmtsCapabilities = getWMTSCababilitiesForLayers(externalLayers)
+        const updatedLayers = []
+        externalLayers.forEach(async (layer) => {
+            updatedLayers.push(
+                updateExternalLayer(
+                    store,
+                    layer instanceof ExternalWMTSLayer
+                        ? wmtsCapabilities[layer.baseUrl]
+                        : wmsCapabilities[layer.baseUrl],
+                    layer,
+                    state.position.projection
+                )
+            )
+        })
+        store.dispatch('updateLayers', {
+            layers: (await Promise.all(updatedLayers)).filter((layer) => !!layer),
+            ...dispatcher,
+        })
     }
     store.subscribe((mutation, state) => {
         if (mutation.type === 'addLayer') {
-            addLayerSubscriber(mutation.payload.layer, state)
+            layersSubscriber([mutation.payload.layer], state)
         }
         if (mutation.type === 'setLayers') {
-            mutation.payload.layers?.forEach((layer) => {
-                addLayerSubscriber(layer, state)
-            })
+            layersSubscriber(mutation.payload.layers, state)
         }
     })
 }
 
-async function updateExternalLayer(store, externalLayer, projection) {
-    try {
-        let updatedExternalLayer = null
-        if (
-            externalLayer instanceof ExternalWMSLayer ||
-            externalLayer instanceof ExternalGroupOfLayers
-        ) {
-            updatedExternalLayer = await updatedWMSLayerAttributes(externalLayer, projection)
-        } else if (externalLayer instanceof ExternalWMTSLayer) {
-            updatedExternalLayer = await updatedWMTSLayerAttributes(externalLayer, projection)
-        } else {
-            throw new Error(`Unsupported type of layer: ${typeof externalLayer}`)
-        }
+function getWMSCababilitiesForLayers(layers) {
+    const capabilities = {}
+    // here we use a Set to take the unique URL to avoid loading multiple times the get capabilities
+    // for example when adding several layers from the same source.
+    new Set(
+        layers
+            .filter(
+                (layer) =>
+                    layer instanceof ExternalWMSLayer || layer instanceof ExternalGroupOfLayers
+            )
+            .map((layer) => layer.baseUrl)
+    ).forEach((url) => {
+        capabilities[url] = readWmsCapabilities(url)
+    })
+    return capabilities
+}
 
-        updatedExternalLayer.isLoading = false
-        store.dispatch('updateLayer', {
-            layer: updatedExternalLayer,
-            ...dispatcher,
-        })
+function getWMTSCababilitiesForLayers(layers) {
+    const capabilities = {}
+    // here we use a Set to take the unique URL to avoid loading multiple times the get capabilities
+    // for example when adding several layers from the same source.
+    new Set(
+        layers.filter((layer) => layer instanceof ExternalWMTSLayer).map((layer) => layer.baseUrl)
+    ).forEach((url) => {
+        capabilities[url] = readWmtsCapabilities(url)
+    })
+    return capabilities
+}
+
+async function updateExternalLayer(store, capabilities, layer, projection) {
+    try {
+        const resolvedCapabilities = await capabilities
+        log.debug(
+            `Update External layer ${layer.id} with capabilities`,
+            layer,
+            resolvedCapabilities
+        )
+        const updated = resolvedCapabilities.getExternalLayerObject(
+            layer.externalLayerId,
+            projection,
+            layer.opacity,
+            layer.visible,
+            false /* throw Error in case of  error */
+        )
+        updated.isLoading = false
+        return updated
     } catch (error) {
-        log.error(`Failed to update external layer: `, error)
+        log.error(`Failed to update external layer ${layer.id}: `, error)
         store.dispatch('setLayerErrorKey', {
-            layerId: externalLayer.id,
+            layerId: layer.id,
             errorKey: error.key ? error.key : 'error',
             ...dispatcher,
         })
+        return null
     }
-}
-
-async function updatedWMSLayerAttributes(externalLayer, projection) {
-    const capabilities = await readWmsCapabilities(externalLayer.baseUrl)
-    const newObject = capabilities.getExternalLayerObject(
-        externalLayer.externalLayerId,
-        projection,
-        externalLayer.opacity,
-        externalLayer.visible,
-        false /* throw Error in case of  error */
-    )
-    return newObject
-}
-
-async function updatedWMTSLayerAttributes(externalLayer, projection) {
-    const capabilities = await readWmtsCapabilities(externalLayer.baseUrl)
-    const newObject = capabilities.getExternalLayerObject(
-        externalLayer.externalLayerId,
-        projection,
-        externalLayer.opacity,
-        externalLayer.visible,
-        false /* throw Error in case of  error */
-    )
-    return newObject
 }

--- a/tests/cypress/fixtures/external-wms-getcap-1.fixture.xml
+++ b/tests/cypress/fixtures/external-wms-getcap-1.fixture.xml
@@ -44,11 +44,11 @@
                     <HTTP>
                         <Get>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://fake.wms.base.url/?" />
+                                xlink:href="https://fake.wms.base-1.url/?" />
                         </Get>
                         <Post>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://fake.wms.base.url/?" />
+                                xlink:href="https://fake.wms.base-1.url/?" />
                         </Post>
                     </HTTP>
                 </DCPType>
@@ -64,11 +64,11 @@
                     <HTTP>
                         <Get>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://fake.wms.base.url/?" />
+                                xlink:href="https://fake.wms.base-1.url/?" />
                         </Get>
                         <Post>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://fake.wms.base.url/?" />
+                                xlink:href="https://fake.wms.base-1.url/?" />
                         </Post>
                     </HTTP>
                 </DCPType>
@@ -85,11 +85,11 @@
                     <HTTP>
                         <Get>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://fake.wms.base.url/?" />
+                                xlink:href="https://fake.wms.base-1.url/?" />
                         </Get>
                         <Post>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://fake.wms.base.url/?" />
+                                xlink:href="https://fake.wms.base-1.url/?" />
                         </Post>
                     </HTTP>
                 </DCPType>
@@ -100,11 +100,11 @@
                     <HTTP>
                         <Get>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://fake.wms.base.url/?" />
+                                xlink:href="https://fake.wms.base-1.url/?" />
                         </Get>
                         <Post>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://fake.wms.base.url/?" />
+                                xlink:href="https://fake.wms.base-1.url/?" />
                         </Post>
                     </HTTP>
                 </DCPType>
@@ -116,11 +116,11 @@
                     <HTTP>
                         <Get>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://fake.wms.base.url/?" />
+                                xlink:href="https://fake.wms.base-1.url/?" />
                         </Get>
                         <Post>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://fake.wms.base.url/?" />
+                                xlink:href="https://fake.wms.base-1.url/?" />
                         </Post>
                     </HTTP>
                 </DCPType>
@@ -131,11 +131,11 @@
                     <HTTP>
                         <Get>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://fake.wms.base.url/?" />
+                                xlink:href="https://fake.wms.base-1.url/?" />
                         </Get>
                         <Post>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                xlink:href="https://fake.wms.base.url/?" />
+                                xlink:href="https://fake.wms.base-1.url/?" />
                         </Post>
                     </HTTP>
                 </DCPType>
@@ -221,7 +221,7 @@
             </Layer>
             <!-- Layer without .Name -->
             <Layer queryable="1" opaque="0" cascaded="0">
-                <Title>Periodic-Tracking</Title>
+                <Title>Periodic Tracking, with | comma &amp; @ ; äö</Title>
                 <Abstract>Layer without Name element should use the Title</Abstract>
                 <KeywordList>
                     <Keyword>ch.swisstopo-vd.geometa-periodische_nachfuehrung.wms_ows_keywordlist</Keyword>

--- a/tests/cypress/fixtures/external-wms-getcap-2.fixture.xml
+++ b/tests/cypress/fixtures/external-wms-getcap-2.fixture.xml
@@ -1,0 +1,417 @@
+<?xml version='1.0' encoding="UTF-8" standalone="no"?>
+<WMS_Capabilities version="1.3.0" xmlns="http://www.opengis.net/wms"
+    xmlns:sld="http://www.opengis.net/sld" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+    xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd
+                        http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd
+                        http://mapserver.gis.umn.edu/mapserver https://wms.geo.admin.ch/?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
+
+    <Service>
+        <Name>WMS-2</Name>
+        <Title>WMS BGDI 2</Title>
+        <Abstract>Öffentliche Daten der Bundes Geodaten-Infrastruktur (BGDI)</Abstract>
+        <KeywordList>
+            <Keyword>BGDI Geodaten</Keyword>
+        </KeywordList>
+        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+            xlink:href="https://wms.geo.admin.ch/?" />
+        <ContactInformation>
+            <ContactPersonPrimary>
+                <ContactPerson>webgis@swisstopo.ch</ContactPerson>
+                <ContactOrganization>Bundesamt für Landestopografie swisstopo</ContactOrganization>
+            </ContactPersonPrimary>
+            <ContactAddress>
+                <AddressType>text/html</AddressType>
+                <Address>Seftigenstrasse 264</Address>
+                <City>Wabern</City>
+                <StateOrProvince>Kanton Bern</StateOrProvince>
+                <PostCode>3084</PostCode>
+                <Country>Schweiz</Country>
+            </ContactAddress>
+            <ContactVoiceTelephone>+41 (0)58 / 000 00 00</ContactVoiceTelephone>
+            <ContactFacsimileTelephone>+41 (0)58 / 000 00 01</ContactFacsimileTelephone>
+        </ContactInformation>
+        <Fees>none</Fees>
+        <MaxWidth>10000</MaxWidth>
+        <MaxHeight>10000</MaxHeight>
+    </Service>
+
+    <Capability>
+        <Request>
+            <GetCapabilities>
+                <Format>text/xml</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://fake.wms.base-2.url/?" />
+                        </Get>
+                        <Post>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://fake.wms.base-2.url/?" />
+                        </Post>
+                    </HTTP>
+                </DCPType>
+            </GetCapabilities>
+            <GetMap>
+                <Format>image/jpeg</Format>
+                <Format>image/png</Format>
+                <Format>image/pnga</Format>
+                <Format>image/png; mode=32bit</Format>
+                <Format>image/png; mode=8bit</Format>
+                <Format>image/tiff</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://fake.wms.base-2.url/?" />
+                        </Get>
+                        <Post>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://fake.wms.base-2.url/?" />
+                        </Post>
+                    </HTTP>
+                </DCPType>
+            </GetMap>
+            <GetFeatureInfo>
+                <Format>application/json</Format>
+                <Format>application/json; subtype=geojson</Format>
+                <Format>application/vnd.ogc.gml</Format>
+                <Format>text/plain</Format>
+                <Format>text/xml</Format>
+                <Format>text/xml; subtype=gml/3.1.1</Format>
+                <Format>text/xml; subtype=gml/3.2.1</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://fake.wms.base-2.url/?" />
+                        </Get>
+                        <Post>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://fake.wms.base-2.url/?" />
+                        </Post>
+                    </HTTP>
+                </DCPType>
+            </GetFeatureInfo>
+            <sld:DescribeLayer>
+                <Format>text/xml</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://fake.wms.base-2.url/?" />
+                        </Get>
+                        <Post>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://fake.wms.base-2.url/?" />
+                        </Post>
+                    </HTTP>
+                </DCPType>
+            </sld:DescribeLayer>
+            <sld:GetLegendGraphic>
+                <Format>image/png</Format>
+                <Format>image/jpeg</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://fake.wms.base-2.url/?" />
+                        </Get>
+                        <Post>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://fake.wms.base-2.url/?" />
+                        </Post>
+                    </HTTP>
+                </DCPType>
+            </sld:GetLegendGraphic>
+            <ms:GetStyles>
+                <Format>text/xml</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://fake.wms.base-2.url/?" />
+                        </Get>
+                        <Post>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="https://fake.wms.base-2.url/?" />
+                        </Post>
+                    </HTTP>
+                </DCPType>
+            </ms:GetStyles>
+        </Request>
+        <Exception>
+            <Format>XML</Format>
+            <Format>INIMAGE</Format>
+            <Format>BLANK</Format>
+        </Exception>
+        <sld:UserDefinedSymbolization SupportSLD="1" UserLayer="0" UserStyle="1" RemoteWFS="0"
+            InlineFeature="0" RemoteWCS="0" />
+        <Layer>
+            <Title>WMS BGDI 2</Title>
+            <Abstract>Öffentliche Daten der Bundes Geodaten-Infrastruktur (BGDI)</Abstract>
+            <KeywordList>
+                <Keyword>BGDI Geodaten</Keyword>
+            </KeywordList>
+            <CRS>EPSG:2056</CRS>
+            <CRS>EPSG:21781</CRS>
+            <CRS>EPSG:4326</CRS>
+            <CRS>EPSG:3857</CRS>
+            <CRS>EPSG:3034</CRS>
+            <CRS>EPSG:3035</CRS>
+            <CRS>EPSG:4258</CRS>
+            <CRS>EPSG:25832</CRS>
+            <CRS>EPSG:25833</CRS>
+            <CRS>EPSG:31467</CRS>
+            <CRS>EPSG:32632</CRS>
+            <CRS>EPSG:32633</CRS>
+            <CRS>EPSG:900913</CRS>
+            <EX_GeographicBoundingBox>
+                <westBoundLongitude>0.659866</westBoundLongitude>
+                <eastBoundLongitude>11.514</eastBoundLongitude>
+                <southBoundLatitude>45.2401</southBoundLatitude>
+                <northBoundLatitude>48.7511</northBoundLatitude>
+            </EX_GeographicBoundingBox>
+            <BoundingBox CRS="EPSG:2056"
+                minx="2.1e+06" miny="1.03e+06" maxx="2.9e+06" maxy="1.4e+06" />
+            <Attribution>
+                <Title>The federal geoportal</Title>
+                <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                    xlink:href="https://www.geo.admin.ch/attribution" />
+                <LogoURL width="50" height="45">
+                    <Format>image/png</Format>
+                    <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple"
+                        xlink:href="http://wms.geo.admin.ch/medias/ch45x50.png" />
+                </LogoURL>
+            </Attribution>
+            <Layer queryable="1" opaque="0" cascaded="1">
+                <Name>ch.swisstopo-vd.official-survey-2</Name>
+                <Title>OpenData-AV 2</Title>
+                <Abstract>The official survey (AV).</Abstract>
+                <KeywordList>
+                    <Keyword>ch.swisstopo-vd.official-survey.wms_ows_keywordlist</Keyword>
+                </KeywordList>
+                <CRS>EPSG:2056</CRS>
+                <CRS>EPSG:21781</CRS>
+                <CRS>EPSG:4326</CRS>
+                <CRS>EPSG:3857</CRS>
+                <CRS>EPSG:3034</CRS>
+                <CRS>EPSG:3035</CRS>
+                <CRS>EPSG:4258</CRS>
+                <CRS>EPSG:25832</CRS>
+                <CRS>EPSG:25833</CRS>
+                <CRS>EPSG:31467</CRS>
+                <CRS>EPSG:32632</CRS>
+                <CRS>EPSG:32633</CRS>
+                <CRS>EPSG:900913</CRS>
+                <EX_GeographicBoundingBox>
+                    <westBoundLongitude>0.659866</westBoundLongitude>
+                    <eastBoundLongitude>11.514</eastBoundLongitude>
+                    <southBoundLatitude>45.2401</southBoundLatitude>
+                    <northBoundLatitude>48.7511</northBoundLatitude>
+                </EX_GeographicBoundingBox>
+                <BoundingBox CRS="EPSG:2056"
+                    minx="2.1e+06" miny="1.03e+06" maxx="2.9e+06" maxy="1.4e+06" />
+                <MetadataURL type="TC211">
+                    <Format>text/xml</Format>
+                    <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple"
+                        xlink:href="https://wms.geo.admin.ch/?request=GetMetadata&amp;layer=ch.swisstopo-vd.official-survey" />
+                </MetadataURL>
+            </Layer>
+            <!-- Layer without .Name -->
+            <Layer queryable="1" opaque="0" cascaded="0">
+                <Title>Periodic-Tracking 2</Title>
+                <Abstract>Layer without Name element should use the Title</Abstract>
+                <KeywordList>
+                    <Keyword>ch.swisstopo-vd.geometa-periodische_nachfuehrung.wms_ows_keywordlist</Keyword>
+                </KeywordList>
+                <CRS>EPSG:2056</CRS>
+                <CRS>EPSG:21781</CRS>
+                <CRS>EPSG:4326</CRS>
+                <CRS>EPSG:3857</CRS>
+                <CRS>EPSG:3034</CRS>
+                <CRS>EPSG:3035</CRS>
+                <CRS>EPSG:4258</CRS>
+                <CRS>EPSG:25832</CRS>
+                <CRS>EPSG:25833</CRS>
+                <CRS>EPSG:31467</CRS>
+                <CRS>EPSG:32632</CRS>
+                <CRS>EPSG:32633</CRS>
+                <CRS>EPSG:900913</CRS>
+                <EX_GeographicBoundingBox>
+                    <westBoundLongitude>5.96</westBoundLongitude>
+                    <eastBoundLongitude>10.49</eastBoundLongitude>
+                    <southBoundLatitude>45.82</southBoundLatitude>
+                    <northBoundLatitude>47.81</northBoundLatitude>
+                </EX_GeographicBoundingBox>
+                <BoundingBox CRS="EPSG:4326"
+                    minx="5.96" miny="45.82" maxx="10.49" maxy="47.81" />
+                <Attribution>
+                    <Title>BGDI</Title>
+                    <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                        xlink:href="https://www.geo.admin.ch/attribution-bgdi" />
+                    <LogoURL width="50" height="45">
+                        <Format>image/png</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                            xlink:type="simple"
+                            xlink:href="http://wms.geo.admin.ch/medias/ch45x50.png" />
+                    </LogoURL>
+                </Attribution>
+                <MetadataURL type="TC211">
+                    <Format>text/xml</Format>
+                    <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple"
+                        xlink:href="https://wms.geo.admin.ch/?request=GetMetadata&amp;layer=ch.swisstopo-vd.geometa-periodische_nachfuehrung" />
+                </MetadataURL>
+                <Style>
+                    <Name>default</Name>
+                    <Title>default</Title>
+                    <LegendURL width="168" height="22">
+                        <Format>image/png</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                            xlink:type="simple"
+                            xlink:href="https://wms.geo.admin.ch/?version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=ch.swisstopo-vd.geometa-periodische_nachfuehrung&amp;format=image/png&amp;STYLE=default" />
+                    </LegendURL>
+                </Style>
+            </Layer>
+            <Layer queryable="1" opaque="0" cascaded="0">
+                <Name>ch.swisstopo-vd.ortschaftenverzeichnis_plz-2</Name>
+                <Title>PLZ und Ortschaften 2</Title>
+                <Abstract>Mit Artikel 24 der Verordnung über die geografischen Namen (GeoNV) wurde das Bundesamt für Landestopografie swisstopo beauftragt, das neue amtliche Ortschaftenverzeichnis mit Postleitzahl und Perimeter zu erstellen, zu verwalten und zu veröffentlichen. Dieser Datensatz wird zentral bei swisstopo geführt und entspricht mit Ausnahme des entfernten Identifikators `IDENT PLZ, Zusatzziffern` in der Tabelle `PLZ` dem TOPIC `PLZOrtschaft` der amtlichen Vermessung. Der Datensatz ist flächendeckend über die ganze Schweiz und kann kostenlos bezogen werden (Datensatz wird monatlich nachgeführt).</Abstract>
+                <KeywordList>
+                    <Keyword>ch.swisstopo-vd.ortschaftenverzeichnis_plz.wms_ows_keywordlist</Keyword>
+                </KeywordList>
+                <CRS>EPSG:2056</CRS>
+                <CRS>EPSG:21781</CRS>
+                <CRS>EPSG:4326</CRS>
+                <CRS>EPSG:3857</CRS>
+                <CRS>EPSG:3034</CRS>
+                <CRS>EPSG:3035</CRS>
+                <CRS>EPSG:4258</CRS>
+                <CRS>EPSG:25832</CRS>
+                <CRS>EPSG:25833</CRS>
+                <CRS>EPSG:31467</CRS>
+                <CRS>EPSG:32632</CRS>
+                <CRS>EPSG:32633</CRS>
+                <CRS>EPSG:900913</CRS>
+                <EX_GeographicBoundingBox>
+                    <westBoundLongitude>0.659866</westBoundLongitude>
+                    <eastBoundLongitude>11.514</eastBoundLongitude>
+                    <southBoundLatitude>45.2401</southBoundLatitude>
+                    <northBoundLatitude>48.7511</northBoundLatitude>
+                </EX_GeographicBoundingBox>
+                <BoundingBox CRS="EPSG:2056"
+                    minx="2.1e+06" miny="1.03e+06" maxx="2.9e+06" maxy="1.4e+06" />
+                <MetadataURL type="TC211">
+                    <Format>text/xml</Format>
+                    <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple"
+                        xlink:href="https://wms.geo.admin.ch/?request=GetMetadata&amp;layer=ch.swisstopo-vd.ortschaftenverzeichnis_plz" />
+                </MetadataURL>
+                <Style>
+                    <Name>default</Name>
+                    <Title>default</Title>
+                    <LegendURL width="55" height="22">
+                        <Format>image/png</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                            xlink:type="simple"
+                            xlink:href="https://wms.geo.admin.ch/?version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=ch.swisstopo-vd.ortschaftenverzeichnis_plz&amp;format=image/png&amp;STYLE=default" />
+                    </LegendURL>
+                </Style>
+            </Layer>
+            <Layer queryable="1" opaque="0" cascaded="0">
+                <Name>ch.swisstopo-vd.spannungsarme-gebiete-2</Name>
+                <Title>Spannungsarme Gebiete 2</Title>
+                <Abstract>Bei Feldarbeiten in der amtlichen Vermessung muss jeweils eine lokale Einpassung durchgeführt werden oder zumindest der Nachweis erbracht werden, dass auf eine solche verzichtet werden kann. In spannungsarmen Gebieten erübrigt sich eine lokale Einpassung, weil die geometrische Genauigkeit erhöhten Qualitätskriterien entspricht. In der praktischen Anwendung erleichtert die Kenntnis solcher spannungsarmen Gebiete die Arbeiten mit satellitengestützten Messmethoden, insbesondere mit Positionierungsdiensten wie zum Beispiel swipos.</Abstract>
+                <KeywordList>
+                    <Keyword>ch.swisstopo-vd.spannungsarme-gebiete.wms_ows_keywordlist</Keyword>
+                </KeywordList>
+                <CRS>EPSG:2056</CRS>
+                <CRS>EPSG:21781</CRS>
+                <CRS>EPSG:4326</CRS>
+                <CRS>EPSG:3857</CRS>
+                <CRS>EPSG:3034</CRS>
+                <CRS>EPSG:3035</CRS>
+                <CRS>EPSG:4258</CRS>
+                <CRS>EPSG:25832</CRS>
+                <CRS>EPSG:25833</CRS>
+                <CRS>EPSG:31467</CRS>
+                <CRS>EPSG:32632</CRS>
+                <CRS>EPSG:32633</CRS>
+                <CRS>EPSG:900913</CRS>
+                <EX_GeographicBoundingBox>
+                    <westBoundLongitude>0.659866</westBoundLongitude>
+                    <eastBoundLongitude>11.514</eastBoundLongitude>
+                    <southBoundLatitude>45.2401</southBoundLatitude>
+                    <northBoundLatitude>48.7511</northBoundLatitude>
+                </EX_GeographicBoundingBox>
+                <BoundingBox CRS="EPSG:2056"
+                    minx="2.1e+06" miny="1.03e+06" maxx="2.9e+06" maxy="1.4e+06" />
+                <MetadataURL type="TC211">
+                    <Format>text/xml</Format>
+                    <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple"
+                        xlink:href="https://wms.geo.admin.ch/?request=GetMetadata&amp;layer=ch.swisstopo-vd.spannungsarme-gebiete" />
+                </MetadataURL>
+                <Style>
+                    <Name>default</Name>
+                    <Title>default</Title>
+                    <LegendURL width="166" height="22">
+                        <Format>image/png</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                            xlink:type="simple"
+                            xlink:href="https://wms.geo.admin.ch/?version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=ch.swisstopo-vd.spannungsarme-gebiete&amp;format=image/png&amp;STYLE=default" />
+                    </LegendURL>
+                </Style>
+            </Layer>
+            <Layer queryable="1">
+                <Name>ch.swisstopo-vd.stand-oerebkataster-2</Name>
+                <Title>Verfügbarkeit des ÖREB-Katasters 2</Title>
+                <Abstract>Der Datensatz zeigt pro Gemeinde, ob der Kataster der öffentlich-rechtlichen Eigentumsbeschränkungen (ÖREB-Kataster) verfügbar ist, ermöglicht den direkten Link zum kantonalen Geodatenportal sowie die direkte Bestellung des statischen Auszugs (PDF) zum ausgewählten Grundstück via WebService. Ausserdem finden Sie den Namen und die Adresse der zuständigen kantonalen Fachstelle.</Abstract>
+                <Style>
+                    <Name>default</Name>
+                    <Title>default</Title>
+                    <LegendURL width="33" height="5">
+                        <Format>image/png</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                            xlink:type="simple"
+                            xlink:href="https://wms.geo.admin.ch/?version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=ch.swisstopo-vd.stand-oerebkataster&amp;format=image/png&amp;STYLE=default" />
+                    </LegendURL>
+                </Style>
+                <Layer queryable="1" opaque="0" cascaded="0">
+                    <Name>ch.swisstopo-vd.stand-oerebkataster-2</Name>
+                    <Title>Verfügbarkeit des ÖREB-Katasters 2</Title>
+                    <Abstract>Der Datensatz zeigt pro Gemeinde, ob der Kataster der öffentlich-rechtlichen Eigentumsbeschränkungen (ÖREB-Kataster) verfügbar ist, ermöglicht den direkten Link zum kantonalen Geodatenportal sowie die direkte Bestellung des statischen Auszugs (PDF) zum ausgewählten Grundstück via WebService. Ausserdem finden Sie den Namen und die Adresse der zuständigen kantonalen Fachstelle.</Abstract>
+                    <KeywordList>
+                        <Keyword>ch.swisstopo-vd.stand-oerebkataster.wms_ows_keywordlist</Keyword>
+                    </KeywordList>
+                    <CRS>EPSG:2056</CRS>
+                    <CRS>EPSG:21781</CRS>
+                    <CRS>EPSG:4326</CRS>
+                    <CRS>EPSG:3857</CRS>
+                    <CRS>EPSG:3034</CRS>
+                    <CRS>EPSG:3035</CRS>
+                    <CRS>EPSG:4258</CRS>
+                    <CRS>EPSG:25832</CRS>
+                    <CRS>EPSG:25833</CRS>
+                    <CRS>EPSG:31467</CRS>
+                    <CRS>EPSG:32632</CRS>
+                    <CRS>EPSG:32633</CRS>
+                    <CRS>EPSG:900913</CRS>
+                    <EX_GeographicBoundingBox>
+                        <westBoundLongitude>0.659866</westBoundLongitude>
+                        <eastBoundLongitude>11.514</eastBoundLongitude>
+                        <southBoundLatitude>45.2401</southBoundLatitude>
+                        <northBoundLatitude>48.7511</northBoundLatitude>
+                    </EX_GeographicBoundingBox>
+                    <BoundingBox CRS="EPSG:2056"
+                        minx="2.1e+06" miny="1.03e+06" maxx="2.9e+06" maxy="1.4e+06" />
+                    <MetadataURL type="TC211">
+                        <Format>text/xml</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                            xlink:type="simple"
+                            xlink:href="https://wms.geo.admin.ch/?request=GetMetadata&amp;layer=ch.swisstopo-vd.stand-oerebkataster" />
+                    </MetadataURL>
+                </Layer>
+            </Layer>
+        </Layer>
+    </Capability>
+</WMS_Capabilities>

--- a/tests/cypress/fixtures/external-wmts-getcap-1.fixture.xml
+++ b/tests/cypress/fixtures/external-wmts-getcap-1.fixture.xml
@@ -53,13 +53,13 @@
                 template="http://test.wmts.png/wmts/1.0.0/TestExternalWMTS-1/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
         </Layer>
         <Layer>
-            <ows:Title>Test External WMTS 2</ows:Title>
+            <ows:Title>Test External WMTS 2;,|@special-chars-äö</ows:Title>
             <ows:Abstract></ows:Abstract>
             <ows:WGS84BoundingBox>
                 <ows:LowerCorner>8.320060826607648 47.12881677848421</ows:LowerCorner>
                 <ows:UpperCorner>9.033594243299833 47.717017745636404</ows:UpperCorner>
             </ows:WGS84BoundingBox>
-            <ows:Identifier>TestExternalWMTS-2</ows:Identifier>
+            <ows:Identifier>TestExternalWMTS-2;,|@special-chars-äö</ows:Identifier>
             <Style>
                 <ows:Identifier>default</ows:Identifier>
             </Style>

--- a/tests/cypress/fixtures/external-wmts-getcap-1.fixture.xml
+++ b/tests/cypress/fixtures/external-wmts-getcap-1.fixture.xml
@@ -35,13 +35,13 @@
     </ows:ServiceProvider>
     <Contents>
         <Layer>
-            <ows:Title>Test External WMTS</ows:Title>
+            <ows:Title>Test External WMTS 1</ows:Title>
             <ows:Abstract></ows:Abstract>
             <ows:WGS84BoundingBox>
                 <ows:LowerCorner>8.320060826607648 47.12881677848421</ows:LowerCorner>
                 <ows:UpperCorner>9.033594243299833 47.717017745636404</ows:UpperCorner>
             </ows:WGS84BoundingBox>
-            <ows:Identifier>TestExternalWMTS</ows:Identifier>
+            <ows:Identifier>TestExternalWMTS-1</ows:Identifier>
             <Style>
                 <ows:Identifier>default</ows:Identifier>
             </Style>
@@ -50,7 +50,25 @@
                 <TileMatrixSet>ktzh</TileMatrixSet>
             </TileMatrixSetLink>
             <ResourceURL format="image/png" resourceType="tile"
-                template="http://test.wmts.png/wmts/1.0.0/TestExternalWMTS/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
+                template="http://test.wmts.png/wmts/1.0.0/TestExternalWMTS-1/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
+        </Layer>
+        <Layer>
+            <ows:Title>Test External WMTS 2</ows:Title>
+            <ows:Abstract></ows:Abstract>
+            <ows:WGS84BoundingBox>
+                <ows:LowerCorner>8.320060826607648 47.12881677848421</ows:LowerCorner>
+                <ows:UpperCorner>9.033594243299833 47.717017745636404</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <ows:Identifier>TestExternalWMTS-2</ows:Identifier>
+            <Style>
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>ktzh</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile"
+                template="http://test.wmts.png/wmts/1.0.0/TestExternalWMTS-2/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
         </Layer>
         <TileMatrixSet>
             <ows:Identifier>ktzh</ows:Identifier>
@@ -66,5 +84,5 @@
             </TileMatrix>
         </TileMatrixSet>
     </Contents>
-    <ServiceMetadataURL xlink:href="http://test.wmts.url/mapproxy/wmts/1.0.0/WMTSCapabilities.xml" />
+    <ServiceMetadataURL xlink:href="https://fake.wmts.getcap-1.url/WMTSGetCapabilities.xml" />
 </Capabilities>

--- a/tests/cypress/fixtures/external-wmts-getcap-2.fixture.xml
+++ b/tests/cypress/fixtures/external-wmts-getcap-2.fixture.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0"?>
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0" xmlns:ows="http://www.opengis.net/ows/1.1"
+    xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:gml="http://www.opengis.net/gml"
+    xsi:schemaLocation="http://www.opengis.net/wmts/1.0 http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd"
+    version="1.0.0">
+    <ows:ServiceIdentification>
+        <ows:Title>WMTS GIS Stadt Zuerich</ows:Title>
+        <ows:Abstract>WMTS GIS Stadt Zuerich</ows:Abstract>
+        <ows:ServiceType>OGC WMTS</ows:ServiceType>
+        <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+        <ows:Fees>None</ows:Fees>
+        <ows:AccessConstraints>None</ows:AccessConstraints>
+    </ows:ServiceIdentification>
+    <ows:ServiceProvider>
+        <ows:ProviderName>GIS-Zentrum Stadt Zuerich</ows:ProviderName>
+        <ows:ProviderSite xlink:href="" />
+        <ows:ServiceContact>
+            <ows:IndividualName>Georg Andersson</ows:IndividualName>
+            <ows:PositionName></ows:PositionName>
+            <ows:ContactInfo>
+                <ows:Phone>
+                    <ows:Voice>+41(44)412 46 01</ows:Voice>
+                    <ows:Facsimile></ows:Facsimile>
+                </ows:Phone>
+                <ows:Address>
+                    <ows:DeliveryPoint>GIS-Zentrum Stadt Zuerich</ows:DeliveryPoint>
+                    <ows:City>Zuerich</ows:City>
+                    <ows:PostalCode>8004</ows:PostalCode>
+                    <ows:Country>Schweiz</ows:Country>
+                    <ows:ElectronicMailAddress>georg.andersson@zuerich.ch</ows:ElectronicMailAddress>
+                </ows:Address>
+            </ows:ContactInfo>
+        </ows:ServiceContact>
+    </ows:ServiceProvider>
+    <Contents>
+        <Layer>
+            <ows:Title>Test External WMTS 3</ows:Title>
+            <ows:Abstract></ows:Abstract>
+            <ows:WGS84BoundingBox>
+                <ows:LowerCorner>8.320060826607648 47.12881677848421</ows:LowerCorner>
+                <ows:UpperCorner>9.033594243299833 47.717017745636404</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <ows:Identifier>TestExternalWMTS-3</ows:Identifier>
+            <Style>
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>ktzh</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile"
+                template="http://test.wmts.png/wmts/1.0.0/TestExternalWMTS-3/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
+        </Layer>
+        <Layer>
+            <ows:Title>Test External WMTS 4</ows:Title>
+            <ows:Abstract></ows:Abstract>
+            <ows:WGS84BoundingBox>
+                <ows:LowerCorner>8.320060826607648 47.12881677848421</ows:LowerCorner>
+                <ows:UpperCorner>9.033594243299833 47.717017745636404</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <ows:Identifier>TestExternalWMTS-4</ows:Identifier>
+            <Style>
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>ktzh</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile"
+                template="http://test.wmts.png/wmts/1.0.0/TestExternalWMTS-4/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
+        </Layer>
+        <TileMatrixSet>
+            <ows:Identifier>ktzh</ows:Identifier>
+            <ows:SupportedCRS>EPSG:2056</ows:SupportedCRS>
+            <TileMatrix>
+                <ows:Identifier>00</ows:Identifier>
+                <ScaleDenominator>241904.76190464283</ScaleDenominator>
+                <TopLeftCorner>2480237.0 1315832.0</TopLeftCorner>
+                <TileWidth>512</TileWidth>
+                <TileHeight>512</TileHeight>
+                <MatrixWidth>11</MatrixWidth>
+                <MatrixHeight>8</MatrixHeight>
+            </TileMatrix>
+        </TileMatrixSet>
+    </Contents>
+    <ServiceMetadataURL xlink:href="https://fake.wmts.getcap-2.url/WMTSGetCapabilities.xml" />
+</Capabilities>

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -190,7 +190,7 @@ Cypress.Commands.add(
                 // for true boolean param, only the key is required
                 flattenedQueryParams += `${key}&`
             } else {
-                flattenedQueryParams += `${key}=${value}&`
+                flattenedQueryParams += `${key}=${encodeURIComponent(value)}&`
             }
         })
         // removing trailing &

--- a/tests/cypress/tests-e2e/importToolMaps.cy.js
+++ b/tests/cypress/tests-e2e/importToolMaps.cy.js
@@ -361,6 +361,7 @@ describe('The Import Maps Tool', () => {
         cy.log('Reload should keep the layers')
         cy.reload()
         cy.waitMapIsReady()
+        cy.wait('@wms-get-capabilities')
         cy.openMenuIfMobile()
         cy.get('[data-cy="menu-section-active-layers"]:visible').children().should('have.length', 3)
         cy.get(`[data-cy="active-layer-name-${singleLayerFullId}"]`).should('be.visible')

--- a/tests/cypress/tests-e2e/layers.cy.js
+++ b/tests/cypress/tests-e2e/layers.cy.js
@@ -1,5 +1,8 @@
 /// <reference types="cypress" />
 
+import { encodeExternalLayerParam } from '@/api/layers/layers-external.api'
+import { encodeLayerParam } from '@/router/storeSync/layersParamParser'
+
 /**
  * This function is used as a parameter to `JSON.stringify` to remove all properties with the name
  * `lang`.
@@ -85,82 +88,81 @@ describe('Test of layer handling', () => {
             })
         })
         context('External layers', () => {
-            it('reads and adds an external WMS correctly', () => {
-                const fakeWmsBaseUrl = 'https://fake.wms.base.url/?'
-                const fakeLayerId = 'ch.swisstopo-vd.official-survey'
-                // format is WMS|BASE_URL|LAYER_IDS
-                const fakeLayerUrlId = `WMS|${fakeWmsBaseUrl}|${fakeLayerId}`
+            // Fake WMS
+            const fakeWmsBaseUrl1 = 'https://fake.wms.base-1.url/?'
+            const fakeWmsBaseUrl2 = 'https://fake.wms.base-2.url/?'
 
-                // intercepting call to our fake WMS
+            const fakeWmsLayerId1 = 'ch.swisstopo-vd.official-survey'
+            const fakeWmsLayerId2 = 'Periodic Tracking, with | comma & @ ; äö'
+            const fakeWmsLayerId3 = 'ch.swisstopo-vd.spannungsarme-gebiete-2'
+            const fakeWmsLayerId4 = 'ch.swisstopo-vd.stand-oerebkataster-2'
+
+            const fakeWmsLayerName1 = 'OpenData-AV'
+            const fakeWmsLayerName2 = 'Periodic Tracking, with | comma & @ ; äö'
+            const fakeWmsLayerName3 = 'Spannungsarme Gebiete 2'
+            const fakeWmsLayerName4 = 'Verfügbarkeit des ÖREB-Katasters 2'
+
+            // format is WMS|BASE_URL|LAYER_IDS
+            const fakeWmsLayerUrlId1 = `WMS|${fakeWmsBaseUrl1}|${fakeWmsLayerId1}`
+            const fakeWmsLayerUrlId2 = `WMS|${fakeWmsBaseUrl1}|${encodeExternalLayerParam(fakeWmsLayerId2)}`
+            const fakeWmsLayerUrlId3 = `WMS|${fakeWmsBaseUrl2}|${fakeWmsLayerId3}`
+            const fakeWmsLayerUrlId4 = `WMS|${fakeWmsBaseUrl2}|${fakeWmsLayerId4}`
+
+            // Fake WMTS
+            const fakeWmtsGetCapUrl1 = 'https://fake.wmts.getcap-1.url/WMTSGetCapabilities.xml'
+            const fakeWmtsGetCapUrl2 = 'https://fake.wmts.getcap-2.url/WMTSGetCapabilities.xml'
+            const fakeWmtsLayerId1 = 'TestExternalWMTS-1'
+            const fakeWmtsLayerId2 = 'TestExternalWMTS-2;,|@special-chars-äö'
+            const fakeWmtsLayerId3 = 'TestExternalWMTS-3'
+            const fakeWmtsLayerId4 = 'TestExternalWMTS-4'
+            const fakeWmtsLayerName1 = 'Test External WMTS 1'
+            const fakeWmtsLayerName2 = 'Test External WMTS 2;,|@special-chars-äö'
+            const fakeWmtsLayerName3 = 'Test External WMTS 3'
+            const fakeWmtsLayerName4 = 'Test External WMTS 4'
+            // format is WMTS|GET_CAPABILITIES_URL|LAYER_ID
+            const fakeWmtsLayerUrlId1 = `WMTS|${fakeWmtsGetCapUrl1}|${fakeWmtsLayerId1}`
+            const fakeWmtsLayerUrlId2 = `WMTS|${fakeWmtsGetCapUrl1}|${encodeExternalLayerParam(fakeWmtsLayerId2)}`
+            const fakeWmtsLayerUrlId3 = `WMTS|${fakeWmtsGetCapUrl2}|${fakeWmtsLayerId3}`
+            const fakeWmtsLayerUrlId4 = `WMTS|${fakeWmtsGetCapUrl2}|${fakeWmtsLayerId4}`
+
+            beforeEach(() => {
+                // WMS intercept URL 1
                 cy.intercept(
-                    { url: `${fakeWmsBaseUrl}**`, query: { REQUEST: 'GetMap' } },
+                    { url: `${fakeWmsBaseUrl1}**`, query: { REQUEST: 'GetMap' } },
                     {
                         fixture: '256.png',
                     }
-                ).as('externalWMSGetMap')
+                ).as('externalWMSGetMap-1')
                 cy.intercept(
-                    { url: `${fakeWmsBaseUrl}**`, query: { REQUEST: 'GetCapabilities' } },
-                    { fixture: 'external-wms-getcap.fixture.xml' }
-                ).as('externalWMSGetCap')
+                    { url: `${fakeWmsBaseUrl1}**`, query: { REQUEST: 'GetCapabilities' } },
+                    { fixture: 'external-wms-getcap-1.fixture.xml' }
+                ).as('externalWMSGetCap-1')
 
-                cy.goToMapView(
+                // WMS intercept URL 2
+                cy.intercept(
+                    { url: `${fakeWmsBaseUrl2}**`, query: { REQUEST: 'GetMap' } },
                     {
-                        layers: fakeLayerUrlId,
-                    },
-                    true
-                ) // with hash, otherwise the legacy parser kicks in and ruins the day
-                cy.wait('@externalWMSGetMap')
-                cy.wait('@externalWMSGetCap')
-                cy.readStoreValue('getters.visibleLayers').then((layers) => {
-                    expect(layers).to.have.lengthOf(1)
-                    const [externalWmsLayer] = layers
-                    expect(externalWmsLayer.wmsVersion).to.eq('1.3.0')
-                    expect(externalWmsLayer.externalLayerId).to.eq(fakeLayerId)
-                    expect(externalWmsLayer.baseUrl).to.eq(fakeWmsBaseUrl)
-                    expect(externalWmsLayer.id).to.eq(fakeLayerUrlId)
-                    expect(externalWmsLayer.name).to.eq('OpenData-AV')
-                    expect(externalWmsLayer.isLoading).to.be.false
-                })
+                        fixture: '256.png',
+                    }
+                ).as('externalWMSGetMap-2')
+                cy.intercept(
+                    { url: `${fakeWmsBaseUrl2}**`, query: { REQUEST: 'GetCapabilities' } },
+                    { fixture: 'external-wms-getcap-2.fixture.xml' }
+                ).as('externalWMSGetCap-2')
 
-                // shows a red icon to signify a layer is from an external source
-                cy.openMenuIfMobile()
-                cy.get(`[data-cy="menu-active-layer-${fakeLayerUrlId}"]`)
-                    .get('[data-cy="menu-external-disclaimer-icon"]')
-                    .should('be.visible')
-
-                cy.checkOlLayer([bgLayer, fakeLayerId])
-            })
-            it('reads and adds an external WMTS correctly', () => {
-                const fakeGetCapUrl1 = 'https://fake.wmts.getcap-1.url/WMTSGetCapabilities.xml'
-                const fakeGetCapUrl2 = 'https://fake.wmts.getcap-2.url/WMTSGetCapabilities.xml'
-                const fakeLayerId1 = 'TestExternalWMTS-1'
-                const fakeLayerId2 = 'TestExternalWMTS-2'
-                const fakeLayerId3 = 'TestExternalWMTS-3'
-                const fakeLayerId4 = 'TestExternalWMTS-4'
-                const fakeLayerName1 = 'Test External WMTS 1'
-                const fakeLayerName2 = 'Test External WMTS 2'
-                const fakeLayerName3 = 'Test External WMTS 3'
-                const fakeLayerName4 = 'Test External WMTS 4'
-                // format is WMTS|GET_CAPABILITIES_URL|LAYER_ID
-                const fakeLayerUrlId1 = `WMTS|${fakeGetCapUrl1}|${fakeLayerId1}`
-                const fakeLayerUrlId2 = `WMTS|${fakeGetCapUrl1}|${fakeLayerId2}`
-                const fakeLayerUrlId3 = `WMTS|${fakeGetCapUrl2}|${fakeLayerId3}`
-                const fakeLayerUrlId4 = `WMTS|${fakeGetCapUrl2}|${fakeLayerId4}`
-
-                const layers = [fakeLayerUrlId1, fakeLayerUrlId2, fakeLayerUrlId3, fakeLayerUrlId4]
-
-                // intercepting call to our fake WMTS
-                cy.intercept(`${fakeGetCapUrl1}`, {
+                // WMTS intercept URL 1
+                cy.intercept(`${fakeWmtsGetCapUrl1}`, {
                     fixture: 'external-wmts-getcap-1.fixture.xml',
                 }).as('externalWMTSGetCapOl-1')
-                cy.intercept(`${fakeGetCapUrl1}?**`, {
+                cy.intercept(`${fakeWmtsGetCapUrl1}?**`, {
                     fixture: 'external-wmts-getcap-1.fixture.xml',
                 }).as('externalWMTSGetCap-1')
 
-                cy.intercept(`${fakeGetCapUrl2}`, {
+                // WMTS intercept URL 2
+                cy.intercept(`${fakeWmtsGetCapUrl2}`, {
                     fixture: 'external-wmts-getcap-2.fixture.xml',
                 }).as('externalWMTSGetCapOl-2')
-                cy.intercept(`${fakeGetCapUrl2}?**`, {
+                cy.intercept(`${fakeWmtsGetCapUrl2}?**`, {
                     fixture: 'external-wmts-getcap-2.fixture.xml',
                 }).as('externalWMTSGetCap-2')
 
@@ -170,6 +172,83 @@ describe('Test of layer handling', () => {
                         fixture: '256.png',
                     }
                 ).as('externalWMTS')
+            })
+
+            it('reads and adds an external WMS correctly', () => {
+                const layers = [
+                    fakeWmsLayerUrlId1,
+                    `${encodeLayerParam(fakeWmsLayerUrlId2)},,0.8`,
+                    `${fakeWmsLayerUrlId3},f`,
+                    `${fakeWmsLayerUrlId4},f,0.4`,
+                ].join(';')
+                cy.goToMapView({ layers })
+
+                cy.wait(['@externalWMSGetCap-1', '@externalWMSGetCap-2'])
+                cy.readStoreValue('state.layers.activeLayers').then((layers) => {
+                    cy.wrap(layers).should('have.length', 4)
+                    layers.forEach((layer) => {
+                        cy.wrap(layer.isLoading).should('be.false')
+                        cy.wrap(layer.isExternal).should('be.true')
+                    })
+                    cy.wrap(layers[0].id).should('be.eq', fakeWmsLayerUrlId1)
+                    cy.wrap(layers[0].baseUrl).should('be.eq', fakeWmsBaseUrl1)
+                    cy.wrap(layers[0].externalLayerId).should('be.eq', fakeWmsLayerId1)
+                    cy.wrap(layers[0].name).should('be.eq', fakeWmsLayerName1)
+                    cy.wrap(layers[0].wmsVersion).should('be.eq', '1.3.0')
+                    cy.wrap(layers[0].visible).should('be.true')
+                    cy.wrap(layers[0].opacity).should('be.eq', 1.0)
+
+                    cy.wrap(layers[1].id).should('be.eq', fakeWmsLayerUrlId2)
+                    cy.wrap(layers[1].baseUrl).should('be.eq', fakeWmsBaseUrl1)
+                    cy.wrap(layers[1].externalLayerId).should('be.eq', fakeWmsLayerId2)
+                    cy.wrap(layers[1].name).should('be.eq', fakeWmsLayerName2)
+                    cy.wrap(layers[1].wmsVersion).should('be.eq', '1.3.0')
+                    cy.wrap(layers[1].visible).should('be.true')
+                    cy.wrap(layers[1].opacity).should('be.eq', 0.8)
+
+                    cy.wrap(layers[2].id).should('be.eq', fakeWmsLayerUrlId3)
+                    cy.wrap(layers[2].baseUrl).should('be.eq', fakeWmsBaseUrl2)
+                    cy.wrap(layers[2].externalLayerId).should('be.eq', fakeWmsLayerId3)
+                    cy.wrap(layers[2].name).should('be.eq', fakeWmsLayerName3)
+                    cy.wrap(layers[2].wmsVersion).should('be.eq', '1.3.0')
+                    cy.wrap(layers[2].visible).should('be.false')
+                    cy.wrap(layers[2].opacity).should('be.eq', 1.0)
+
+                    cy.wrap(layers[3].id).should('be.eq', fakeWmsLayerUrlId4)
+                    cy.wrap(layers[3].baseUrl).should('be.eq', fakeWmsBaseUrl2)
+                    cy.wrap(layers[3].externalLayerId).should('be.eq', fakeWmsLayerId4)
+                    cy.wrap(layers[3].name).should('be.eq', fakeWmsLayerName4)
+                    cy.wrap(layers[3].wmsVersion).should('be.eq', '1.3.0')
+                    cy.wrap(layers[3].visible).should('be.false')
+                    cy.wrap(layers[3].opacity).should('be.eq', 0.4)
+                })
+
+                // shows a red icon to signify a layer is from an external source
+                cy.openMenuIfMobile()
+                cy.get(`[data-cy^="menu-active-layer-"]`).each(($el) => {
+                    cy.wrap($el)
+                        .get('[data-cy="menu-external-disclaimer-icon"]')
+                        .should('be.visible')
+                })
+                cy.get('[data-cy^="menu-active-layer-"]').eq(0).should('contain', fakeWmsLayerName4)
+                cy.get('[data-cy^="menu-active-layer-"]').eq(1).should('contain', fakeWmsLayerName3)
+                cy.get('[data-cy^="menu-active-layer-"]').eq(2).should('contain', fakeWmsLayerName2)
+                cy.get('[data-cy^="menu-active-layer-"]').eq(3).should('contain', fakeWmsLayerName1)
+
+                cy.checkOlLayer([
+                    { id: fakeWmsLayerId4, visible: false, opacity: 0.4 },
+                    { id: fakeWmsLayerId3, visible: false, opacity: 1.0 },
+                    { id: fakeWmsLayerId2, visible: true, opacity: 0.8 },
+                    { id: fakeWmsLayerId1, visible: true, opacity: 1.0 },
+                ])
+            })
+            it('reads and adds an external WMTS correctly', () => {
+                const layers = [
+                    fakeWmtsLayerUrlId1,
+                    encodeLayerParam(fakeWmtsLayerUrlId2),
+                    fakeWmtsLayerUrlId3,
+                    fakeWmtsLayerUrlId4,
+                ]
 
                 cy.goToMapView({
                     layers: layers.join(';'),
@@ -182,33 +261,47 @@ describe('Test of layer handling', () => {
                         cy.wrap(layer.visible).should('be.true')
                         cy.wrap(layer.opacity).should('be.eq', 1.0)
                     })
-                    cy.wrap(layers[0].id).should('be.eq', fakeLayerUrlId1)
-                    cy.wrap(layers[0].baseUrl).should('be.eq', fakeGetCapUrl1)
-                    cy.wrap(layers[0].externalLayerId).should('be.eq', fakeLayerId1)
-                    cy.wrap(layers[0].name).should('be.eq', fakeLayerName1)
+                    cy.wrap(layers[0].id).should('be.eq', fakeWmtsLayerUrlId1)
+                    cy.wrap(layers[0].baseUrl).should('be.eq', fakeWmtsGetCapUrl1)
+                    cy.wrap(layers[0].externalLayerId).should('be.eq', fakeWmtsLayerId1)
+                    cy.wrap(layers[0].name).should('be.eq', fakeWmtsLayerName1)
 
-                    cy.wrap(layers[1].id).should('be.eq', fakeLayerUrlId2)
-                    cy.wrap(layers[1].baseUrl).should('be.eq', fakeGetCapUrl1)
-                    cy.wrap(layers[1].externalLayerId).should('be.eq', fakeLayerId2)
-                    cy.wrap(layers[1].name).should('be.eq', fakeLayerName2)
+                    cy.wrap(layers[1].id).should('be.eq', fakeWmtsLayerUrlId2)
+                    cy.wrap(layers[1].baseUrl).should('be.eq', fakeWmtsGetCapUrl1)
+                    cy.wrap(layers[1].externalLayerId).should('be.eq', fakeWmtsLayerId2)
+                    cy.wrap(layers[1].name).should('be.eq', fakeWmtsLayerName2)
 
-                    cy.wrap(layers[2].id).should('be.eq', fakeLayerUrlId3)
-                    cy.wrap(layers[2].baseUrl).should('be.eq', fakeGetCapUrl2)
-                    cy.wrap(layers[2].externalLayerId).should('be.eq', fakeLayerId3)
-                    cy.wrap(layers[2].name).should('be.eq', fakeLayerName3)
+                    cy.wrap(layers[2].id).should('be.eq', fakeWmtsLayerUrlId3)
+                    cy.wrap(layers[2].baseUrl).should('be.eq', fakeWmtsGetCapUrl2)
+                    cy.wrap(layers[2].externalLayerId).should('be.eq', fakeWmtsLayerId3)
+                    cy.wrap(layers[2].name).should('be.eq', fakeWmtsLayerName3)
 
-                    cy.wrap(layers[3].id).should('be.eq', fakeLayerUrlId4)
-                    cy.wrap(layers[3].baseUrl).should('be.eq', fakeGetCapUrl2)
-                    cy.wrap(layers[3].externalLayerId).should('be.eq', fakeLayerId4)
-                    cy.wrap(layers[3].name).should('be.eq', fakeLayerName4)
+                    cy.wrap(layers[3].id).should('be.eq', fakeWmtsLayerUrlId4)
+                    cy.wrap(layers[3].baseUrl).should('be.eq', fakeWmtsGetCapUrl2)
+                    cy.wrap(layers[3].externalLayerId).should('be.eq', fakeWmtsLayerId4)
+                    cy.wrap(layers[3].name).should('be.eq', fakeWmtsLayerName4)
                 })
-                cy.checkOlLayer([bgLayer, fakeLayerId1, fakeLayerId2, fakeLayerId3, fakeLayerId4])
-                cy.clickOnMenuButtonIfMobile()
+                cy.checkOlLayer([
+                    bgLayer,
+                    fakeWmtsLayerId1,
+                    fakeWmtsLayerId2,
+                    fakeWmtsLayerId3,
+                    fakeWmtsLayerId4,
+                ])
+                cy.openMenuIfMobile()
                 cy.get('[data-cy^="menu-active-layer-"]').should('have.length', 4)
-                cy.get('[data-cy^="menu-active-layer-"]').eq(0).should('contain', fakeLayerName4)
-                cy.get('[data-cy^="menu-active-layer-"]').eq(1).should('contain', fakeLayerName3)
-                cy.get('[data-cy^="menu-active-layer-"]').eq(2).should('contain', fakeLayerName2)
-                cy.get('[data-cy^="menu-active-layer-"]').eq(3).should('contain', fakeLayerName1)
+                cy.get('[data-cy^="menu-active-layer-"]')
+                    .eq(0)
+                    .should('contain', fakeWmtsLayerName4)
+                cy.get('[data-cy^="menu-active-layer-"]')
+                    .eq(1)
+                    .should('contain', fakeWmtsLayerName3)
+                cy.get('[data-cy^="menu-active-layer-"]')
+                    .eq(2)
+                    .should('contain', fakeWmtsLayerName2)
+                cy.get('[data-cy^="menu-active-layer-"]')
+                    .eq(3)
+                    .should('contain', fakeWmtsLayerName1)
                 cy.get('[data-cy^="menu-active-layer-"]').each(($layer) => {
                     cy.wrap($layer)
                         .get('[data-cy="menu-external-disclaimer-icon"]')
@@ -217,31 +310,37 @@ describe('Test of layer handling', () => {
 
                 // reads and sets non default layer config; visible and opacity
                 cy.goToMapView({
-                    layers: `${fakeLayerUrlId1},f,0.5;${fakeLayerUrlId2};${fakeLayerUrlId3},f,0.8`,
+                    layers: `${fakeWmtsLayerUrlId1},f,0.5;${encodeLayerParam(fakeWmtsLayerUrlId2)},f;${fakeWmtsLayerUrlId3},,0.8`,
                 })
                 cy.readStoreValue('getters.visibleLayers').should('have.length', 1)
                 cy.readStoreValue('state.layers.activeLayers').then((layers) => {
                     cy.wrap(layers).should('have.length', 3)
 
-                    cy.wrap(layers[0].id).should('be.eq', fakeLayerUrlId1)
+                    cy.wrap(layers[0].id).should('be.eq', fakeWmtsLayerUrlId1)
                     cy.wrap(layers[0].visible).should('be.false')
                     cy.wrap(layers[0].opacity).should('be.eq', 0.5)
 
-                    cy.wrap(layers[1].id).should('be.eq', fakeLayerUrlId2)
-                    cy.wrap(layers[1].visible).should('be.true')
+                    cy.wrap(layers[1].id).should('be.eq', fakeWmtsLayerUrlId2)
+                    cy.wrap(layers[1].visible).should('be.false')
                     cy.wrap(layers[1].opacity).should('be.eq', 1.0)
 
-                    cy.wrap(layers[2].id).should('be.eq', fakeLayerUrlId3)
-                    cy.wrap(layers[2].visible).should('be.false')
+                    cy.wrap(layers[2].id).should('be.eq', fakeWmtsLayerUrlId3)
+                    cy.wrap(layers[2].visible).should('be.true')
                     cy.wrap(layers[2].opacity).should('be.eq', 0.8)
                 })
 
                 // shows a red icon to signify a layer is from an external source
                 cy.openMenuIfMobile()
                 cy.get('[data-cy^="menu-active-layer-"]').should('have.length', 3)
-                cy.get('[data-cy^="menu-active-layer-"]').eq(0).should('contain', fakeLayerName3)
-                cy.get('[data-cy^="menu-active-layer-"]').eq(1).should('contain', fakeLayerName2)
-                cy.get('[data-cy^="menu-active-layer-"]').eq(2).should('contain', fakeLayerName1)
+                cy.get('[data-cy^="menu-active-layer-"]')
+                    .eq(0)
+                    .should('contain', fakeWmtsLayerName3)
+                cy.get('[data-cy^="menu-active-layer-"]')
+                    .eq(1)
+                    .should('contain', fakeWmtsLayerName2)
+                cy.get('[data-cy^="menu-active-layer-"]')
+                    .eq(2)
+                    .should('contain', fakeWmtsLayerName1)
                 cy.get('[data-cy^="menu-active-layer-"]').each(($layer) => {
                     cy.wrap($layer)
                         .get('[data-cy="menu-external-disclaimer-icon"]')
@@ -249,9 +348,9 @@ describe('Test of layer handling', () => {
                 })
                 cy.checkOlLayer([
                     bgLayer,
-                    { id: fakeLayerId3, visible: false, opacity: 0.8 },
-                    { id: fakeLayerId2, visible: true, opacity: 1.0 },
-                    { id: fakeLayerId1, visible: false, opacity: 0.5 },
+                    { id: fakeWmtsLayerId3, visible: true, opacity: 0.8 },
+                    { id: fakeWmtsLayerId2, visible: false, opacity: 1.0 },
+                    { id: fakeWmtsLayerId1, visible: false, opacity: 0.5 },
                 ])
 
                 cy.log(`Make sure that the external backend have not been called twice`)

--- a/tests/cypress/tests-e2e/layers.cy.js
+++ b/tests/cypress/tests-e2e/layers.cy.js
@@ -236,6 +236,7 @@ describe('Test of layer handling', () => {
                 cy.get('[data-cy^="menu-active-layer-"]').eq(3).should('contain', fakeWmsLayerName1)
 
                 cy.checkOlLayer([
+                    bgLayer,
                     { id: fakeWmsLayerId4, visible: false, opacity: 0.4 },
                     { id: fakeWmsLayerId3, visible: false, opacity: 1.0 },
                     { id: fakeWmsLayerId2, visible: true, opacity: 0.8 },

--- a/tests/cypress/tests-e2e/layers.cy.js
+++ b/tests/cypress/tests-e2e/layers.cy.js
@@ -237,10 +237,10 @@ describe('Test of layer handling', () => {
 
                 cy.checkOlLayer([
                     bgLayer,
-                    { id: fakeWmsLayerId4, visible: false, opacity: 0.4 },
-                    { id: fakeWmsLayerId3, visible: false, opacity: 1.0 },
-                    { id: fakeWmsLayerId2, visible: true, opacity: 0.8 },
                     { id: fakeWmsLayerId1, visible: true, opacity: 1.0 },
+                    { id: fakeWmsLayerId2, visible: true, opacity: 0.8 },
+                    { id: fakeWmsLayerId3, visible: false, opacity: 1.0 },
+                    { id: fakeWmsLayerId4, visible: false, opacity: 0.4 },
                 ])
             })
             it('reads and adds an external WMTS correctly', () => {

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -240,7 +240,7 @@ describe('Test on legacy param import', () => {
         it('External WMS layer', () => {
             const layerName = 'OpenData-AV'
             const layerId = 'ch.swisstopo-vd.official-survey'
-            const url = 'https://fake.wms.base.url/?'
+            const url = 'https://fake.wms.base-1.url/?'
             cy.intercept(
                 { url: `${url}**`, query: { REQUEST: 'GetMap' } },
                 {
@@ -249,7 +249,7 @@ describe('Test on legacy param import', () => {
             ).as('externalWMSGetMap')
             cy.intercept(
                 { url: `${url}**`, query: { REQUEST: 'GetCapabilities' } },
-                { fixture: 'external-wms-getcap.fixture.xml' }
+                { fixture: 'external-wms-getcap-1.fixture.xml' }
             ).as('externalWMSGetCap')
 
             cy.goToMapView(
@@ -283,7 +283,7 @@ describe('Test on legacy param import', () => {
                 fixture: 'external-wmts-getcap-1.fixture.xml',
             }).as('externalWMTSGetCap')
             cy.intercept(
-                'http://test.wmts.png/wmts/1.0.0/TestExternalWMTS/default/ktzh/**/*/*.png',
+                'http://test.wmts.png/wmts/1.0.0/TestExternalWMTS-*/default/ktzh/**/*/*.png',
                 {
                     fixture: '256.png',
                 }

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -272,7 +272,7 @@ describe('Test on legacy param import', () => {
                 expect(externalLayer.name).to.eq(layerName)
                 expect(externalLayer.isLoading).to.false
             })
-            const expectedHash = `#/map?layers=test.wms.layer,f,1;WMS%7C${url}%7C${layerId},,1&layers_timestam=,&lang=en&center=2660013.5,1185172&z=1&bgLayer=test.background.layer2&topic=ech`
+            const expectedHash = `#/map?layers=test.wms.layer,f,1;WMS%7C${url}%7C${layerId}&layers_timestam=,&lang=en&center=2660013.5,1185172&z=1&bgLayer=test.background.layer2&topic=ech`
             cy.location().should((location) => {
                 expect(location.hash).to.eq(expectedHash)
                 expect(location.search).to.eq('')
@@ -313,7 +313,7 @@ describe('Test on legacy param import', () => {
             })
 
             const expectedQuery = new URLSearchParams(
-                `lang=en&center=2660013.5,1185172&z=1&bgLayer=test.background.layer2&topic=ech&layers=test.wmts.layer,f;WMTS%7C${url}%7C${layerId},,1`
+                `lang=en&center=2660013.5,1185172&z=1&bgLayer=test.background.layer2&topic=ech&layers=test.wmts.layer,f;WMTS%7C${url}%7C${layerId}`
             )
             expectedQuery.sort()
             cy.location('search').should('be.empty')

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -280,7 +280,7 @@ describe('Test on legacy param import', () => {
         })
         it('External WMTS layer', () => {
             cy.intercept('http://wmts-test.url/**', {
-                fixture: 'external-wmts-getcap.fixture.xml',
+                fixture: 'external-wmts-getcap-1.fixture.xml',
             }).as('externalWMTSGetCap')
             cy.intercept(
                 'http://test.wmts.png/wmts/1.0.0/TestExternalWMTS/default/ktzh/**/*/*.png',
@@ -288,8 +288,8 @@ describe('Test on legacy param import', () => {
                     fixture: '256.png',
                 }
             )
-            const layerId = 'TestExternalWMTS'
-            const layerName = 'Test External WMTS'
+            const layerId = 'TestExternalWMTS-1'
+            const layerName = 'Test External WMTS 1'
             const url = 'http://wmts-test.url/'
             cy.goToMapView(
                 {


### PR DESCRIPTION
Avoid loading multiple times the WMS/WMTS capabilities and avoid doing multiple
dispatch.

This reduce the startup time especially with multiple layers of the same source
we can gain several seconds.

- [x] TODO e2e tests

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-259-update-layers/index.html)