### PR TITLE
PB-102: Fix legacy external layers with coma in layer tilte

### DIFF
--- a/src/api/layers/WMSCapabilitiesParser.class.js
+++ b/src/api/layers/WMSCapabilitiesParser.class.js
@@ -53,7 +53,7 @@ export default class WMSCapabilitiesParser {
      *   Capability layer node and its parents or an empty object if not found
      */
     findLayer(layerId) {
-        return findLayer(layerId, this.Capability?.Layer?.Layer, [this.Capability?.Layer])
+        return findLayer(layerId, [this.Capability.Layer], [this.Capability.Layer])
     }
 
     /**

--- a/src/api/layers/__tests__/WMSCapabitliesParser.class.spec.js
+++ b/src/api/layers/__tests__/WMSCapabitliesParser.class.spec.js
@@ -31,8 +31,15 @@ describe('WMSCapabilitiesParser of wms-geoadmin-sample.xml', () => {
         expect(capabilities.originUrl.toString()).toBe('https://wms.geo.admin.ch/')
     })
     it('Parse layer attributes', () => {
+        // Base layer
+        let layer = capabilities.getExternalLayerObject('wms-bgdi', WGS84)
+        expect(layer.externalLayerId).toBe('wms-bgdi')
+        expect(layer.name).toBe('WMS BGDI')
+        expect(layer.abstract).toBe('Public Federal Geo Infrastructure (BGDI)')
+        expect(layer.baseUrl).toBe('https://wms.geo.admin.ch/?')
+
         // General layer
-        let layer = capabilities.getExternalLayerObject('ch.swisstopo-vd.official-survey', WGS84)
+        layer = capabilities.getExternalLayerObject('ch.swisstopo-vd.official-survey', WGS84)
         expect(layer.externalLayerId).toBe('ch.swisstopo-vd.official-survey')
         expect(layer.name).toBe('OpenData-AV')
         expect(layer.abstract).toBe('The official survey (AV).')

--- a/src/api/layers/__tests__/wms-geoadmin-sample.xml
+++ b/src/api/layers/__tests__/wms-geoadmin-sample.xml
@@ -149,8 +149,9 @@
         <sld:UserDefinedSymbolization SupportSLD="1" UserLayer="0" UserStyle="1" RemoteWFS="0"
             InlineFeature="0" RemoteWCS="0" />
         <Layer>
+            <Name>wms-bgdi</Name>
             <Title>WMS BGDI</Title>
-            <Abstract>Öffentliche Daten der Bundes Geodaten-Infrastruktur (BGDI)</Abstract>
+            <Abstract>Public Federal Geo Infrastructure (BGDI)</Abstract>
             <KeywordList>
                 <Keyword>BGDI Geodaten</Keyword>
             </KeywordList>

--- a/src/utils/__tests__/legacyLayerParamUtils.spec.js
+++ b/src/utils/__tests__/legacyLayerParamUtils.spec.js
@@ -186,7 +186,7 @@ describe('Test parsing of legacy URL param into new params', () => {
                 expect(kmlLayer.visible).to.be.true
             })
             it('parses a legacy external WMS layer correctly', () => {
-                const wmsLayerName = 'Name of the WMS layer'
+                const wmsLayerName = 'Name of the WMS layer, with a comma'
                 const wmsBaseUrl = 'https://fake.url?SERVICE=GetMap&'
                 const wmsLayerId = 'fake.layer.id'
                 const wmsVersion = '9.9.9'
@@ -238,7 +238,7 @@ describe('Test parsing of legacy URL param into new params', () => {
             it('does not parse an external layer if it is in the current format', () => {
                 const wmtsResult = getLayersFromLegacyUrlParams(
                     fakeLayerConfig,
-                    'WMTS|https://url.to.wmts.server|layer.id|LayerName',
+                    'WMTS|https://url.to.wmts.server|layer.id',
                     undefined,
                     undefined,
                     undefined
@@ -246,7 +246,7 @@ describe('Test parsing of legacy URL param into new params', () => {
                 expect(wmtsResult).to.be.an('Array').empty
                 const wmsResult = getLayersFromLegacyUrlParams(
                     fakeLayerConfig,
-                    `WMS|${'https://wms.server.url?PARAM1=x&'}|layer.id|5.4.3|LayerName`,
+                    `WMS|${'https://wms.server.url?PARAM1=x&'}|layer.id`,
                     undefined,
                     undefined,
                     undefined

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -74,7 +74,7 @@ export function getLayersFromLegacyUrlParams(
     // In the case these parameters are not defined, we ensure we have empty arrays rather than
     // 'undefined' elements. Since the function is also called in `topics.api.js`, it can be called
     // with a completely empty string.
-    const layersIds = layers?.split(',').map(decodeURIComponent) ?? []
+    const layersIds = layers?.split(/,(?![^|]* )/g).map(decodeURIComponent) ?? []
     const layerOpacities = legacyOpacities?.split(',').map(parseOpacity) ?? []
     const layerVisibilities = legacyVisibilities?.split(',') ?? []
     const layerTimestamps = legacyTimestamp?.split(',') ?? []


### PR DESCRIPTION
In the legacy viewer the layer title was part of the URL and some layer
could contain a coma in its title which broke the layers parsing as the layers
in URL are separated by coma.


[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-102-legacy-external-layer/index.html)