### PR TITLE
PB-190 : implement legacy support for bod layer id parameter

### DIFF
--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -17,7 +17,7 @@ import SwissCoordinateSystem from '@/utils/coordinates/SwissCoordinateSystem.cla
 import {
     getKmlLayerFromLegacyAdminIdParam,
     getLayersFromLegacyUrlParams,
-    handleBodLayerIdParam,
+    handleLegacyFeaturePreSelectionParam,
     isLegacyParams,
 } from '@/utils/legacyLayerParamUtils'
 import log from '@/utils/logging'
@@ -202,7 +202,7 @@ const handleLegacyParams = async (legacyParams, store, originView) => {
         newQuery['center'] = legacyCoordinates.join(',')
     }
 
-    handleBodLayerIdParam(legacyParams, store, newQuery)
+    handleLegacyFeaturePreSelectionParam(legacyParams, store, newQuery)
 
     // removing old query part (new ones will be added by vue-router after the /# part of the URL)
     const urlWithoutQueryParam = window.location.href.substr(0, window.location.href.indexOf('?'))

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -10,6 +10,7 @@ import {
     MAP_VIEW,
     MAP_VIEWS,
 } from '@/router/viewNames'
+import { FeatureInfoPositions } from '@/store/modules/ui.store'
 import { backgroundMatriceBetween2dAnd3d as backgroundMatriceBetweenLegacyAndNew } from '@/store/plugins/2d-to-3d-management.plugin'
 import { LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 import CustomCoordinateSystem from '@/utils/coordinates/CustomCoordinateSystem.class'
@@ -134,7 +135,11 @@ const handleLegacyParam = (
         case 'heading':
             cameraPosition[4] = Number(legacyValue)
             break
-
+        case 'showTooltip':
+            key = 'featureInfo'
+            newValue =
+                legacyValue === 'true' ? FeatureInfoPositions.DEFAULT : FeatureInfoPositions.NONE
+            break
         // if no special work to do, we just copy past legacy params to the new viewer
         default:
             newValue = legacyValue

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -201,6 +201,8 @@ const handleLegacyParams = async (legacyParams, store, originView) => {
         newQuery['center'] = legacyCoordinates.join(',')
     }
 
+    handleBodLayerIdParam(legacyParams, store, newQuery)
+
     // removing old query part (new ones will be added by vue-router after the /# part of the URL)
     const urlWithoutQueryParam = window.location.href.substr(0, window.location.href.indexOf('?'))
     window.history.replaceState(window.history.state, document.title, urlWithoutQueryParam)

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -17,6 +17,7 @@ import SwissCoordinateSystem from '@/utils/coordinates/SwissCoordinateSystem.cla
 import {
     getKmlLayerFromLegacyAdminIdParam,
     getLayersFromLegacyUrlParams,
+    handleBodLayerIdParam,
     isLegacyParams,
 } from '@/utils/legacyLayerParamUtils'
 import log from '@/utils/logging'

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -1,4 +1,4 @@
-import getFeature, { getExtentOfFeatures } from '@/api/features/features.api'
+import getFeature from '@/api/features/features.api'
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
 import GPXLayer from '@/api/layers/GPXLayer.class.js'
@@ -153,12 +153,12 @@ async function getAndDispatchFeatures(to, featuresPromise, store) {
                 dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
             })
 
-            const extent = getExtentOfFeatures(features)
+            const extent = getExtentOfGeometries(features.map((feature) => feature.geometry))
             // If the zoom level has been specifically set to a level, we don't want to override that.
             // otherwise, we go to the zoom level which encompass all features
             const query = getUrlQuery()
             if (!query.z) {
-                store.dispatch('zoomToExtent', {
+                await store.dispatch('zoomToExtent', {
                     extent: extent,
                     maxZoom: 8,
                     dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
@@ -168,7 +168,7 @@ async function getAndDispatchFeatures(to, featuresPromise, store) {
                     [(extent[0][0] + extent[1][0]) / 2],
                     [(extent[0][1] + extent[1][1]) / 2],
                 ]
-                store.dispatch('setCenter', {
+                await store.dispatch('setCenter', {
                     center: center,
                     dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
                 })

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -1,4 +1,4 @@
-import getFeature from '@/api/features/features.api'
+import getFeature, { getExtentOfFeatures } from '@/api/features/features.api'
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
 import GPXLayer from '@/api/layers/GPXLayer.class.js'
@@ -149,6 +149,27 @@ async function getAndDispatchFeatures(to, featuresPromise, store) {
                 features: features,
                 dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
             })
+
+            const extent = getExtentOfFeatures(features)
+            // If the zoom level has been specifically set to a level, we don't want to override that.
+            // otherwise, we go to the zoom level which encompass all features
+            const query = getUrlQuery()
+            if (!query.z) {
+                store.dispatch('zoomToExtent', {
+                    extent: extent,
+                    maxZoom: 8,
+                    dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
+                })
+            } else {
+                const center = [
+                    [(extent[0][0] + extent[1][0]) / 2],
+                    [(extent[0][1] + extent[1][1]) / 2],
+                ]
+                store.dispatch('setCenter', {
+                    center: center,
+                    dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
+                })
+            }
         }
     } catch (error) {
         log.error(`Error while processing features in feature preselection. error is ${error}`)

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -149,27 +149,6 @@ async function getAndDispatchFeatures(to, featuresPromise, store) {
                 features: features,
                 dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
             })
-
-            const extent = getExtentOfGeometries(features.map((feature) => feature.geometry))
-            // If the zoom level has been specifically set to a level, we don't want to override that.
-            // otherwise, we go to the zoom level which encompass all features
-            const query = to.query
-            if (!query.z) {
-                await store.dispatch('zoomToExtent', {
-                    extent: extent,
-                    maxZoom: 8,
-                    dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
-                })
-            } else {
-                const center = [
-                    [(extent[0][0] + extent[1][0]) / 2],
-                    [(extent[0][1] + extent[1][1]) / 2],
-                ]
-                await store.dispatch('setCenter', {
-                    center: center,
-                    dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
-                })
-            }
         }
     } catch (error) {
         log.error(`Error while processing features in feature preselection. error is ${error}`)

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -156,7 +156,7 @@ async function getAndDispatchFeatures(to, featuresPromise, store) {
             const extent = getExtentOfGeometries(features.map((feature) => feature.geometry))
             // If the zoom level has been specifically set to a level, we don't want to override that.
             // otherwise, we go to the zoom level which encompass all features
-            const query = getUrlQuery()
+            const query = to.query
             if (!query.z) {
                 await store.dispatch('zoomToExtent', {
                     extent: extent,

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -13,6 +13,9 @@ import { getExtentOfGeometries } from '@/utils/geoJsonUtils'
 import log from '@/utils/logging'
 
 /**
+ * Parse layers such as described in
+ * https://github.com/geoadmin/web-mapviewer/blob/develop/adr/2021_03_16_url_param_structure.md#layerid
+ *
  * @param {ActiveLayerConfig} parsedLayer Layer config parsed from URL
  * @param {AbstractLayer | null} currentLayer Current layer if it is found in active layers
  * @returns {KMLLayer | ExternalWMTSLayer | ExternalWMSLayer | null} Will return an instance of the

--- a/src/utils/__tests__/legacyLayerParamUtils.spec.js
+++ b/src/utils/__tests__/legacyLayerParamUtils.spec.js
@@ -9,6 +9,7 @@ import GeoAdminWMTSLayer from '@/api/layers/GeoAdminWMTSLayer.class'
 import LayerTimeConfig from '@/api/layers/LayerTimeConfig.class'
 import LayerTimeConfigEntry from '@/api/layers/LayerTimeConfigEntry.class'
 import {
+    createLayersParamForFeaturePreselection,
     getLayersFromLegacyUrlParams,
     isLegacyParams,
     parseOpacity,
@@ -280,6 +281,33 @@ describe('Test parsing of legacy URL param into new params', () => {
                     expect(isLegacyParams('#?test=false')).to.equal(false)
                     expect(isLegacyParams('#/?test=false')).to.equal(false)
                 })
+            })
+        })
+        describe('ensure layers parameter handler for feature preselection works as intended', () => {
+            it('checks that all possible layers given as parameter return what we expect', () => {
+                const layersParams = [
+                    'layer.id;layer.id2',
+                    'layer.id,,0.3;layer.id2',
+                    'layer.id@time=1234;layer.id2',
+                    'layer.id@features=3:4:5;layer.id2',
+                    'layer.id@features=3:4:5@time=1234,f,0.2;layer.id2',
+                ]
+                const expectedResults = [
+                    'layer.id@features=1:2:3;layer.id2',
+                    'layer.id@features=1:2:3,,0.3;layer.id2',
+                    'layer.id@time=1234@features=1:2:3;layer.id2',
+                    'layer.id@features=1:2:3:4:5;layer.id2',
+                    'layer.id@features=1:2:3:4:5@time=1234,f,0.2;layer.id2',
+                ]
+                const results = []
+                layersParams.forEach((params) => {
+                    results.push(
+                        createLayersParamForFeaturePreselection('layer.id', '1,2,3', params)
+                    )
+                })
+                for (let i = 0; i < results.length; i++) {
+                    expect(expectedResults[i]).to.eq(results[i])
+                }
             })
         })
     })

--- a/src/utils/__tests__/legacyLayerParamUtils.spec.js
+++ b/src/utils/__tests__/legacyLayerParamUtils.spec.js
@@ -297,7 +297,7 @@ describe('Test parsing of legacy URL param into new params', () => {
                     'layer.id@features=1:2:3,,0.3;layer.id2',
                     'layer.id@time=1234@features=1:2:3;layer.id2',
                     'layer.id@features=1:2:3:4:5;layer.id2',
-                    'layer.id@features=1:2:3:4:5@time=1234,f,0.2;layer.id2',
+                    'layer.id@time=1234@features=1:2:3:4:5,f,0.2;layer.id2',
                 ]
                 const results = []
                 layersParams.forEach((params) => {

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -1,4 +1,3 @@
-import getFeature from '@/api/features/features.api'
 import { getKmlMetadataByAdminId } from '@/api/files.api'
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
@@ -174,45 +173,20 @@ export async function getKmlLayerFromLegacyAdminIdParam(adminId) {
 }
 
 export function handleBodLayerIdParam(params, store, newQuery) {
-    let layer = null
-    const featuresRequests = []
-
     params.forEach((param_value, param_key) => {
+        let layer = null
         layer = store.state.layers.config.find((layer) => layer.getID() === param_key)
         if (layer) {
-            const featuresIds = param_value.split(',').joins(':')
-            if (newQuery['layers'].includes(param_key)) {
-                //if the feature already exist, we insert the features id parameter
-                const [layerIdWithCustomParams, visible, opacity] = newQuery['layers'].split(',')
-                newQuery['layers'] =
-                    `${layerIdWithCustomParams}@features=${featuresIds},${visible},${opacity}`
+            const featuresIds = param_value.split(',').join(':')
+            if (newQuery.layers?.includes(param_key)) {
+                //if the layer already exist, we insert the features id parameter
+                const [layerIdWithCustomParams, visible, opacity] = newQuery.layers.split(',')
+                newQuery.layers = `${layerIdWithCustomParams}@features=${featuresIds},${visible},${opacity}`
+            } else if (newQuery.layers) {
+                newQuery.layers = newQuery.layers + `;${param_key}@features=${featuresIds}`
             } else {
-                newQuery['layers'] = newQuery['layers'] + `;${param_key}@features=${featuresIds}`
+                newQuery.layers = `${param_key}@features=${featuresIds}`
             }
-            param_value
-                .toString()
-                .split(',')
-                .forEach((featureId) => {
-                    featuresRequests.push(
-                        getFeature(
-                            store.getters.getLayerConfigById(param_key),
-                            featureId,
-                            store.state.position.projection,
-                            store.state.i18n.lang
-                        )
-                    )
-                })
         }
     })
-    if (featuresRequests.length > 0) {
-        Promise.all(featuresRequests).then((features) => {
-            const extent = getExtentOfFeatures(features)
-            const center = `${(extent[0][0] + extent[1][0]) / 2},${(extent[0][1] + extent[1][1]) / 2}`
-            if (!newQuery['z']) {
-                newQuery['z'] = store.state.projection.getZoomForResolutionAndCenter(extent, center)
-            }
-            // in the old viewer, the position was always overriden
-            newQuery['center'] = center
-        })
-    }
 }

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -174,9 +174,7 @@ export async function getKmlLayerFromLegacyAdminIdParam(adminId) {
 
 export function handleBodLayerIdParam(params, store, newQuery) {
     params.forEach((param_value, param_key) => {
-        let layer = null
-        layer = store.state.layers.config.find((layer) => layer.getID() === param_key)
-        if (layer) {
+        if (store.state.layers.config.find((layer) => layer.id === param_key)) {
             const featuresIds = param_value.split(',').join(':')
             if (newQuery.layers?.includes(param_key)) {
                 newQuery.layers = createLayersParamForFeaturePreselection(

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -214,7 +214,7 @@ export function createLayersParamForFeaturePreselection(layerId, featuresIds, la
     const layersArray = layers.split(';')
     for (let layerIndex = 0; layerIndex < layersArray.length; layerIndex++) {
         const [layerIdWithCustomParams, visible, opacity] = layersArray[layerIndex].split(',')
-        if (layerIdWithCustomParams.split['@'][0] === layerId) {
+        if (layerIdWithCustomParams.split('@')[0] === layerId) {
             // here, we manipulate the layer string for which we received a parameter
 
             // we declare the string that will replace the current string
@@ -228,7 +228,7 @@ export function createLayersParamForFeaturePreselection(layerId, featuresIds, la
                     if (splittedLayer[i].includes('features')) {
                         // we mix the features and ensure the unicity of each feature id
                         const featuresIds = splittedLayer[i].split('=')[1].split(':')
-                        featuresIds.split.forEach((feature_id) => {
+                        featuresIds.forEach((feature_id) => {
                             if (!featuresArray.includes(feature_id)) {
                                 featuresArray.push(feature_id)
                             }

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -332,7 +332,7 @@ Cypress.Commands.add('waitAllLayersLoaded', ({ queryParams = {}, legacy = false 
                 let targetLegacyFeaturePreselection = 0
                 state.layers.activeLayers.forEach((layer) => {
                     targetLegacyFeaturePreselection += Boolean(
-                        layer.geoAdminID in queryParams &&
+                        Object.keys(queryParams).includes(layer.id) &&
                             !queryParams.layers?.includes(layer.geoAdminID)
                     )
                 })

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -335,6 +335,13 @@ Cypress.Commands.add('waitAllLayersLoaded', ({ queryParams = {}, legacy = false 
             // When handling a legacy parameter, the {bod Layer Id} parameter,
             // which has been reworked into the 'features' layer attribute might add extra
             // layers, thus the need to check if those extra layers have been added
+            if (legacy) {
+                const layersConfig = getters.layers.layersConfig
+                target += Object.keys(queryParams)
+                    .filter((key) => layersConfig.find((layer) => layer.id === key)) // this removes all parameters that are not layers ids
+                    .filter((key) => !queryParams.layers?.split(',').includes(key)).length // we removes all layers that are in the query params
+                // filter out standard params, legacy specific params, non layers config
+            }
             if (legacy && active !== target) {
                 let targetLegacyFeaturePreselection = 0
                 state.layers.activeLayers.forEach((layer) => {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -127,6 +127,12 @@ const addCesiumTilesetIntercepts = () => {
     }).as('cesiumTerrainConfig')
 }
 
+const addHtmlPopupIntercepts = () => {
+    cy.intercept('**/MapServer/**/htmlPopup**', {
+        fixture: 'html-popup.fixture.html',
+    }).as('htmlPopup')
+}
+
 export function getDefaultFixturesAndIntercepts() {
     return {
         addVueRouterIntercept,
@@ -142,6 +148,7 @@ export function getDefaultFixturesAndIntercepts() {
         addSecondIconsFixtureAndIntercept,
         addGeoJsonIntercept,
         addCesiumTilesetIntercepts,
+        addHtmlPopupIntercepts,
     }
 }
 

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -325,17 +325,18 @@ Cypress.Commands.add('waitAllLayersLoaded', ({ queryParams = {}, legacy = false 
                 // In legacy drawing with adminId the layer is not added to the layers parameter
                 target += 1
             }
-            // When handling a legacy parameter, the bod Layer Id might add extra
+            // When handling a legacy parameter, the {bod Layer Id} parameter,
+            // which has been reworked into the 'features' layer attribute might add extra
             // layers, thus the need to check if those extra layers have been added
             if (legacy && active !== target) {
-                let targetBodIdParameter = 0
+                let targetLegacyFeaturePreselection = 0
                 state.layers.activeLayers.forEach((layer) => {
-                    targetBodIdParameter += Boolean(
+                    targetLegacyFeaturePreselection += Boolean(
                         layer.geoAdminID in queryParams &&
                             !queryParams.layers?.includes(layer.geoAdminID)
                     )
                 })
-                target += targetBodIdParameter
+                target += targetLegacyFeaturePreselection
             }
             return active === target
         },

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -336,21 +336,11 @@ Cypress.Commands.add('waitAllLayersLoaded', ({ queryParams = {}, legacy = false 
             // which has been reworked into the 'features' layer attribute might add extra
             // layers, thus the need to check if those extra layers have been added
             if (legacy) {
-                const layersConfig = getters.layers.layersConfig
+                const layersConfig = state.layers.config
                 target += Object.keys(queryParams)
                     .filter((key) => layersConfig.find((layer) => layer.id === key)) // this removes all parameters that are not layers ids
                     .filter((key) => !queryParams.layers?.split(',').includes(key)).length // we removes all layers that are in the query params
                 // filter out standard params, legacy specific params, non layers config
-            }
-            if (legacy && active !== target) {
-                let targetLegacyFeaturePreselection = 0
-                state.layers.activeLayers.forEach((layer) => {
-                    targetLegacyFeaturePreselection += Boolean(
-                        Object.keys(queryParams).includes(layer.id) &&
-                            !queryParams.layers?.includes(layer.geoAdminID)
-                    )
-                })
-                target += targetLegacyFeaturePreselection
             }
             return active === target
         },

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -324,6 +324,18 @@ Cypress.Commands.add('waitAllLayersLoaded', ({ queryParams = {}, legacy = false 
                 // In legacy drawing with adminId the layer is not added to the layers parameter
                 target += 1
             }
+            // When handling a legacy parameter, the bod Layer Id might add extra
+            // layers, thus the need to check if those extra layers have been added
+            if (legacy && active !== target) {
+                let targetBodIdParameter = 0
+                state.layers.activeLayers.forEach((layer) => {
+                    targetBodIdParameter += Boolean(
+                        layer.geoAdminID in queryParams &&
+                            !queryParams.layers?.includes(layer.geoAdminID)
+                    )
+                })
+                target += targetBodIdParameter
+            }
             return active === target
         },
         {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -213,6 +213,7 @@ Cypress.Commands.add(
         cy.visit(`/${withHash ? '#/' : ''}${flattenedQueryParams}`, {
             onBeforeLoad: (win) => mockGeolocation(win, geolocationMockupOptions),
         })
+
         // In the legacy URL, 3d is not found. We check if the map in 3d or not by checking the pitch, heading, and elevation
         const isLegacy3d =
             'pitch' in queryParams || 'heading' in queryParams || 'elevation' in queryParams

--- a/tests/cypress/tests-e2e/featurePreSelection.cy.js
+++ b/tests/cypress/tests-e2e/featurePreSelection.cy.js
@@ -7,11 +7,6 @@ describe('Testing the feature selection in the URL', () => {
             cy.get('@featuresIds').then((featuresIds) => {
                 cy.wrap(features.length).should('be.equal', featuresIds.length)
 
-                const modifiedFeaturesIds = featuresIds.map(
-                    // feature.id returns a string in the form of `layer.id-feature.id`
-                    // thus a small adaptation to check we get the correct result
-                    (featureId) => `${features[0].layer.id}-${featureId}`
-                )
                 features.forEach((feature) => {
                     cy.log('checking feature', feature.id, 'is part of', featuresIds.join(','))
                     cy.wrap(featuresIds.includes(feature.id)).should('be.true')

--- a/tests/cypress/tests-e2e/featurePreSelection.cy.js
+++ b/tests/cypress/tests-e2e/featurePreSelection.cy.js
@@ -7,6 +7,12 @@ describe('Testing the feature selection in the URL', () => {
             cy.get('@featuresIds').then((featuresIds) => {
                 cy.wrap(features.length).should('be.equal', featuresIds.length)
 
+                const modifiedFeaturesIds = featuresIds.map(
+                    // feature.id returns a string in the form of `layer.id-feature.id`
+                    // thus a small adaptation to check we get the correct result
+                    (featureId) => `${features[0].layer.id}-${featureId}`
+                )
+                console.log(modifiedFeaturesIds)
                 features.forEach((feature) => {
                     cy.log('checking feature', feature.id, 'is part of', featuresIds.join(','))
                     cy.wrap(featuresIds.includes(feature.id)).should('be.true')

--- a/tests/cypress/tests-e2e/featurePreSelection.cy.js
+++ b/tests/cypress/tests-e2e/featurePreSelection.cy.js
@@ -12,7 +12,6 @@ describe('Testing the feature selection in the URL', () => {
                     // thus a small adaptation to check we get the correct result
                     (featureId) => `${features[0].layer.id}-${featureId}`
                 )
-                console.log(modifiedFeaturesIds)
                 features.forEach((feature) => {
                     cy.log('checking feature', feature.id, 'is part of', featuresIds.join(','))
                     cy.wrap(featuresIds.includes(feature.id)).should('be.true')

--- a/tests/cypress/tests-e2e/featurePreSelection.cy.js
+++ b/tests/cypress/tests-e2e/featurePreSelection.cy.js
@@ -48,14 +48,6 @@ describe('Testing the feature selection in the URL', () => {
         })
     }
     beforeEach(() => {
-        // add intercept for layer config
-        cy.intercept('**/rest/services/all/MapServer/layersConfig**', {
-            fixture: 'layers.fixture',
-        })
-        // add intercept for the html popup
-        cy.intercept('**/MapServer/**/htmlPopup**', {
-            fixture: 'html-popup.fixture.html',
-        })
         // add intercept for all features, and allow their Ids to be used in tests
         cy.fixture('features.fixture.json').then((jsonResult) => {
             const features = [...jsonResult.results]

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -457,7 +457,7 @@ describe('Test on legacy param import', () => {
                 cy.readStoreValue('state.features.selectedFeatures').should((features) => {
                     expect(features.length).to.eq(featuresIds.length)
                     const modifiedFeaturesIds = featuresIds.map(
-                        (featureId) => `${features[0].layer.id}-${featureId}`
+                        (featureId) => `ch.babs.kulturgueter-${featureId}`
                     )
                     features.forEach((feature) => {
                         expect(modifiedFeaturesIds.includes(feature.id)).to.eq(true)
@@ -486,12 +486,11 @@ describe('Test on legacy param import', () => {
                 // ---------------------------------------------------------------------------------
                 cy.log('When showTooltip is not specified, we should have no tooltip')
 
-                cy.get('@features').then((features) => {
-                    cy.get('@featuresIds').then((featuresIds) => {
-                        const params = {}
-                        params[features[0].layerBodId] = featuresIds.join(',')
-                        cy.goToMapView(params)
-                    })
+                cy.get('@featuresIds').then((featuresIds) => {
+                    const params = {
+                        'ch.babs.kulturgueter': featuresIds.join(','),
+                    }
+                    cy.goToMapView(params, false)
                 })
                 checkFeatures()
                 cy.readStoreValue('state.ui.featureInfoPosition').should(
@@ -503,12 +502,12 @@ describe('Test on legacy param import', () => {
                 // ---------------------------------------------------------------------------------
                 cy.log('When showTooltip is true, featureInfo should be none ')
 
-                cy.get('@features').then((features) => {
-                    cy.get('@featuresIds').then((featuresIds) => {
-                        const params = { showTooltip: 'true' }
-                        params[features[0].layerBodId] = featuresIds.join(',')
-                        cy.goToMapView(params)
-                    })
+                cy.get('@featuresIds').then((featuresIds) => {
+                    const params = {
+                        'ch.babs.kulturgueter': featuresIds.join(','),
+                        showTooltip: 'true',
+                    }
+                    cy.goToMapView(params, false)
                 })
                 checkFeatures()
                 cy.readStoreValue('state.ui.featureInfoPosition').should(
@@ -520,12 +519,12 @@ describe('Test on legacy param import', () => {
                 // ---------------------------------------------------------------------------------
                 cy.log('When showTooltip is given a fantasist value, we should have no tooltip')
 
-                cy.get('@features').then((features) => {
-                    cy.get('@featuresIds').then((featuresIds) => {
-                        const params = { showTooltip: 'aFantasyValue' }
-                        params[features[0].layerBodId] = featuresIds.join(',')
-                        cy.goToMapView(params)
-                    })
+                cy.get('@featuresIds').then((featuresIds) => {
+                    const params = {
+                        'ch.babs.kulturgueter': featuresIds.join(','),
+                        showTooltip: 'aFantasyValue',
+                    }
+                    cy.goToMapView(params, false)
                 })
                 checkFeatures()
                 cy.readStoreValue('state.ui.featureInfoPosition').should(

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -457,7 +457,7 @@ describe('Test on legacy param import', () => {
                 cy.readStoreValue('state.features.selectedFeatures').should((features) => {
                     expect(features.length).to.eq(featuresIds.length)
                     const modifiedFeaturesIds = featuresIds.map(
-                        (featureId) => `ch.babs.kulturgueter-${featureId}`
+                        (featureId) => `${features[0].layer.id}-${featureId}`
                     )
                     features.forEach((feature) => {
                         expect(modifiedFeaturesIds.includes(feature.id)).to.eq(true)

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -466,17 +466,6 @@ describe('Test on legacy param import', () => {
             })
         }
 
-        beforeEach(() => {
-            // add intercept for layer config
-            cy.intercept('**/rest/services/all/MapServer/layersConfig**', {
-                fixture: 'layers.fixture',
-            })
-            // add intercept for the html popup
-            cy.intercept('**/MapServer/**/htmlPopup**', {
-                fixture: 'html-popup.fixture.html',
-            })
-        })
-
         describe('Checks that the legacy bod layer id translate in the new implementation', () => {
             it('Select a few features and shows the tooltip in its correct spot', () => {
                 const features = []

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -448,5 +448,55 @@ describe('Test on legacy param import', () => {
             cy.readStoreValue('state.ui.isCompareSliderActive').should('be.equal', true)
             cy.get('[data-cy="compareSlider"]').should('be.visible')
         })
+        context('Bod Layer Id import', () => {
+            function checkFeatures(featuresIds) {
+                cy.readStoreValue('state.features.selectedFeatures').then((features) => {
+                    cy.wrap(features.length).should('be.equal', featuresIds.length)
+                    features.forEach((feature) => {
+                        cy.wrap(featuresIds.includes(feature._id)).should('be.true')
+                    })
+                })
+            }
+
+            beforeEach(() => {
+                // add intercept for layer config
+                cy.intercept('**/rest/services/all/MapServer/layersConfig**', {
+                    fixture: 'layers.fixture',
+                })
+                // add intercept for the html popup
+                cy.intercept('**/MapServer/**/htmlPopup**', {
+                    fixture: 'html-popup.fixture.html',
+                })
+            })
+
+            describe('Checks that the legacy bod layer id translate in the new implementation', () => {
+                it('Select a few features and shows the tooltip in its correct spot', () => {
+                    const features = []
+                    const nbFeatures = 4
+                    cy.fixture('features.fixture.json').then((results) => {
+                        results['results'].forEach((feature) => {
+                            features.push(feature)
+                        })
+                        const layer = features[0].layerBodId
+                        for (let i = 0; i < nbFeatures; i++) {
+                            // we intercept every feature we want to retrieve
+                            cy.intercept(`**/MapServer/${layer}/${features[i].id}`, {
+                                results: [features[i]],
+                            })
+                        }
+
+                        const featuresIds = []
+
+                        for (let i = 0; i < nbFeatures; i++) {
+                            featuresIds.push(features[i].id.toString())
+                        }
+                        const params = {}
+                        params[layer] = featuresIds.join(',')
+                        cy.goToMapView(params, false)
+                        checkFeatures(featuresIds)
+                    })
+                })
+            })
+        })
     })
 })

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -449,12 +449,19 @@ describe('Test on legacy param import', () => {
             cy.get('[data-cy="compareSlider"]').should('be.visible')
         })
     })
-    context('Bod Layer Id import', () => {
+
+    context('Feature Pre Selection Import', () => {
         function checkFeatures(featuresIds) {
             cy.readStoreValue('state.features.selectedFeatures').then((features) => {
                 cy.wrap(features.length).should('be.equal', featuresIds.length)
+                const modifiedFeaturesIds = featuresIds.map(
+                    // feature.id returns a string in the form of `layer.id-feature.id`
+                    // thus a small adaptation to check we get the correct result
+                    (featureId) => `${features[0].layer.id}-${featureId}`
+                )
+
                 features.forEach((feature) => {
-                    cy.wrap(featuresIds.includes(feature._id)).should('be.true')
+                    cy.wrap(modifiedFeaturesIds.includes(feature.id)).should('be.true')
                 })
             })
         }
@@ -492,7 +499,7 @@ describe('Test on legacy param import', () => {
                         featuresIds.push(features[i].id.toString())
                     }
                     const params = {}
-                    params[layer] = featuresIds.join(',')
+                    params[features[0].layerBodId] = featuresIds.join(',')
                     cy.goToMapView(params, false)
                     checkFeatures(featuresIds)
                 })

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -456,11 +456,9 @@ describe('Test on legacy param import', () => {
             cy.get('@featuresIds').then((featuresIds) => {
                 cy.readStoreValue('state.features.selectedFeatures').should((features) => {
                     expect(features.length).to.eq(featuresIds.length)
-                    const modifiedFeaturesIds = featuresIds.map(
-                        (featureId) => `${features[0].layer.id}-${featureId}`
-                    )
+
                     features.forEach((feature) => {
-                        expect(modifiedFeaturesIds.includes(feature.id)).to.eq(true)
+                        expect(featuresIds.includes(feature.id)).to.eq(true)
                     })
                 })
             })

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -448,53 +448,53 @@ describe('Test on legacy param import', () => {
             cy.readStoreValue('state.ui.isCompareSliderActive').should('be.equal', true)
             cy.get('[data-cy="compareSlider"]').should('be.visible')
         })
-        context('Bod Layer Id import', () => {
-            function checkFeatures(featuresIds) {
-                cy.readStoreValue('state.features.selectedFeatures').then((features) => {
-                    cy.wrap(features.length).should('be.equal', featuresIds.length)
-                    features.forEach((feature) => {
-                        cy.wrap(featuresIds.includes(feature._id)).should('be.true')
-                    })
-                })
-            }
-
-            beforeEach(() => {
-                // add intercept for layer config
-                cy.intercept('**/rest/services/all/MapServer/layersConfig**', {
-                    fixture: 'layers.fixture',
-                })
-                // add intercept for the html popup
-                cy.intercept('**/MapServer/**/htmlPopup**', {
-                    fixture: 'html-popup.fixture.html',
+    })
+    context('Bod Layer Id import', () => {
+        function checkFeatures(featuresIds) {
+            cy.readStoreValue('state.features.selectedFeatures').then((features) => {
+                cy.wrap(features.length).should('be.equal', featuresIds.length)
+                features.forEach((feature) => {
+                    cy.wrap(featuresIds.includes(feature._id)).should('be.true')
                 })
             })
+        }
 
-            describe('Checks that the legacy bod layer id translate in the new implementation', () => {
-                it('Select a few features and shows the tooltip in its correct spot', () => {
-                    const features = []
-                    const nbFeatures = 4
-                    cy.fixture('features.fixture.json').then((results) => {
-                        results['results'].forEach((feature) => {
-                            features.push(feature)
-                        })
-                        const layer = features[0].layerBodId
-                        for (let i = 0; i < nbFeatures; i++) {
-                            // we intercept every feature we want to retrieve
-                            cy.intercept(`**/MapServer/${layer}/${features[i].id}`, {
-                                results: [features[i]],
-                            })
-                        }
+        beforeEach(() => {
+            // add intercept for layer config
+            cy.intercept('**/rest/services/all/MapServer/layersConfig**', {
+                fixture: 'layers.fixture',
+            })
+            // add intercept for the html popup
+            cy.intercept('**/MapServer/**/htmlPopup**', {
+                fixture: 'html-popup.fixture.html',
+            })
+        })
 
-                        const featuresIds = []
-
-                        for (let i = 0; i < nbFeatures; i++) {
-                            featuresIds.push(features[i].id.toString())
-                        }
-                        const params = {}
-                        params[layer] = featuresIds.join(',')
-                        cy.goToMapView(params, false)
-                        checkFeatures(featuresIds)
+        describe('Checks that the legacy bod layer id translate in the new implementation', () => {
+            it('Select a few features and shows the tooltip in its correct spot', () => {
+                const features = []
+                const nbFeatures = 4
+                cy.fixture('features.fixture.json').then((results) => {
+                    results['results'].forEach((feature) => {
+                        features.push(feature)
                     })
+                    const layer = features[0].layerBodId
+                    for (let i = 0; i < nbFeatures; i++) {
+                        // we intercept every feature we want to retrieve
+                        cy.intercept(`**/MapServer/${layer}/${features[i].id}`, {
+                            results: [features[i]],
+                        })
+                    }
+
+                    const featuresIds = []
+
+                    for (let i = 0; i < nbFeatures; i++) {
+                        featuresIds.push(features[i].id.toString())
+                    }
+                    const params = {}
+                    params[layer] = featuresIds.join(',')
+                    cy.goToMapView(params, false)
+                    checkFeatures(featuresIds)
                 })
             })
         })


### PR DESCRIPTION
Translate the {bod-layer-id} parameter from the legacy viewer to the new 'selected features' layer parameter.

[Test link](https://sys-map.dev.bgdi.ch/preview/pb-190-legacy-param-for-bodlayerid/index.html)