### PR TITLE
Replace the single clickOnMenuIfMobile by two open/close utils

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -483,10 +483,27 @@ Cypress.Commands.add('waitUntilCesiumTilesLoaded', () => {
     )
 })
 
-Cypress.Commands.add('clickOnMenuButtonIfMobile', () => {
+Cypress.Commands.add('openMenuIfMobile', () => {
     if (isMobile()) {
-        // mobile/tablet : clicking on the menu button
-        cy.get('[data-cy="menu-button"]').click()
+        cy.readStoreValue('state.ui.showMenu').then((isMenuCurrentlyOpen) => {
+            if (!isMenuCurrentlyOpen) {
+                cy.get('[data-cy="menu-button"]').click()
+            }
+            // waiting on the animation to finish by grabbing the content of the menu and assessing its visibility
+            cy.get('[data-cy="menu-tray-inner"]').should('be.visible')
+        })
+    }
+})
+
+Cypress.Commands.add('closeMenuIfMobile', () => {
+    if (isMobile()) {
+        cy.readStoreValue('state.ui.showMenu').then((isMenuCurrentlyOpen) => {
+            if (isMenuCurrentlyOpen) {
+                cy.get('[data-cy="menu-button"]').click()
+            }
+            // waiting on the animation to finish by grabbing the content of the menu and assessing its (in)visibility
+            cy.get('[data-cy="menu-tray-inner"]').should('not.be.visible')
+        })
     }
 })
 

--- a/tests/cypress/tests-e2e/3d/layers.cy.js
+++ b/tests/cypress/tests-e2e/3d/layers.cy.js
@@ -39,7 +39,7 @@ describe('Test of layer handling in 3D', () => {
             '3d': true,
         })
         cy.waitUntilCesiumTilesLoaded()
-        cy.clickOnMenuButtonIfMobile()
+        cy.openMenuIfMobile()
         cy.get('[data-cy="searchbar"]').paste('test')
         cy.wait(['@search-locations', '@search-layers'])
         cy.get('[data-cy="search-result-entry-layer"]').first().click()
@@ -99,7 +99,7 @@ describe('Test of layer handling in 3D', () => {
             true
         ) // with hash, so that we can have external layer support
         cy.waitUntilCesiumTilesLoaded()
-        cy.clickOnMenuButtonIfMobile()
+        cy.openMenuIfMobile()
         // lower the order of the first layer
         cy.openLayerSettings(firstLayerId)
         cy.get(`[data-cy="button-raise-order-layer-${firstLayerId}"]`).should('be.visible').click()
@@ -157,7 +157,7 @@ describe('Test of layer handling in 3D', () => {
         cy.readWindowValue('cesiumViewer').then((viewer) => {
             expect(viewer.scene.primitives.length).to.eq(4) // labels + buildings + constructions + GeoJSON layer
         })
-        cy.clickOnMenuButtonIfMobile()
+        cy.openMenuIfMobile()
         cy.get(`[data-cy="button-remove-layer-${visibleLayerIds[3]}"]`).should('be.visible').click()
         cy.readWindowValue('cesiumViewer').then((viewer) => {
             expect(viewer.scene.primitives.length).to.eq(3) // labels, constructions and buildings are still present
@@ -183,7 +183,7 @@ describe('Test of layer handling in 3D', () => {
         cy.get('[data-cy="drawing-style-feature-title"]').type('This is a title')
         cy.wait('@post-kml')
         cy.get('[data-cy="drawing-toolbox-close-button"]').click()
-        cy.clickOnMenuButtonIfMobile()
+        cy.closeMenuIfMobile()
         cy.get('[data-cy="3d-button"]').click()
         cy.waitUntilCesiumTilesLoaded()
         cy.readWindowValue('cesiumViewer').then((viewer) => {

--- a/tests/cypress/tests-e2e/compareSlider.cy.js
+++ b/tests/cypress/tests-e2e/compareSlider.cy.js
@@ -181,21 +181,21 @@ describe('Testing of the compare slider', () => {
                 // in initial state, only feature 2 should be visible
                 checkIfFeaturesAreAt(feature_1_coordinates[0], feature_1_coordinates[1], true)
                 checkIfFeaturesAreAt(feature_2_coordinates[0], feature_2_coordinates[1], false)
-                cy.clickOnMenuButtonIfMobile()
+                cy.openMenuIfMobile()
                 cy.get(`[data-cy="button-lower-order-layer-${layer1}"]`)
                     .should('be.visible')
                     .click()
-                cy.clickOnMenuButtonIfMobile()
+                cy.closeMenuIfMobile()
 
                 // We check here that feature 1 is present, but feature 2 is not
                 checkIfFeaturesAreAt(feature_1_coordinates[0], feature_1_coordinates[1], false)
                 checkIfFeaturesAreAt(feature_2_coordinates[0], feature_2_coordinates[1], true)
                 // making a clean state for the next parts of the tests
-                cy.clickOnMenuButtonIfMobile()
+                cy.openMenuIfMobile()
                 cy.get(`[data-cy="button-lower-order-layer-${layer2}"]`)
                     .should('be.visible')
                     .click()
-                cy.clickOnMenuButtonIfMobile()
+                cy.closeMenuIfMobile()
 
                 cy.log('Moving the slider around and see what is cut')
 
@@ -217,10 +217,11 @@ describe('Testing of the compare slider', () => {
                 cy.log(
                     'checking that if we remove a layer, the compare slider will cut the other layer'
                 )
-                cy.clickOnMenuButtonIfMobile()
+                cy.openMenuIfMobile()
                 cy.get(`[data-cy="button-toggle-visibility-layer-${layer1}"`)
                     .should('be.visible')
                     .click()
+                cy.closeMenuIfMobile()
 
                 checkIfFeaturesAreAt(feature_1_coordinates[0], feature_1_coordinates[1], false)
                 checkIfFeaturesAreAt(feature_2_coordinates[0], feature_2_coordinates[1], false)
@@ -228,10 +229,11 @@ describe('Testing of the compare slider', () => {
                 console.log(
                     'checking that we remove the compare slider upon removing the last visible layer'
                 )
-                cy.clickOnMenuButtonIfMobile()
+                cy.openMenuIfMobile()
                 cy.get(`[data-cy="button-toggle-visibility-layer-${layer2}"`)
                     .should('be.visible')
                     .click()
+                cy.closeMenuIfMobile()
                 cy.get('[data-cy="compare_slider"]').should('not.exist')
             })
         })
@@ -246,7 +248,7 @@ describe('Testing of the compare slider', () => {
                     // see it's red, and still not see the compare slider.
                     // So we'll need to check that the button color switched to red / the activated value is true
                     cy.goToMapView({}, true)
-                    cy.clickOnMenuButtonIfMobile()
+                    cy.openMenuIfMobile()
                     cy.get('[data-cy="menu-tray-tool-section"]').click()
                     cy.get('[data-cy="menu-advanced-tools-compare"]').click()
                     cy.readStoreValue('state.ui.compareRatio').then((compareRatio) => {
@@ -260,7 +262,7 @@ describe('Testing of the compare slider', () => {
                 })
                 it('stays "active" when we remove the last layer', () => {
                     cy.goToMapView({ layers: 'test-1.wms.layer', compare_ratio: '0.3' }, true)
-                    cy.clickOnMenuButtonIfMobile()
+                    cy.openMenuIfMobile()
                     cy.readStoreValue('state.ui.compareRatio').then((compareRatio) => {
                         expect(compareRatio).to.eq(0.3)
                     })
@@ -292,7 +294,7 @@ describe('Testing of the compare slider', () => {
                         true
                     )
                     cy.get('[data-cy="compare_slider"]').should('be.visible')
-                    cy.clickOnMenuButtonIfMobile()
+                    cy.openMenuIfMobile()
                     cy.get('[data-cy="menu-tray-tool-section"]').click()
                     cy.get('[data-cy="menu-advanced-tools-compare"]').should('be.visible')
                     cy.readStoreValue('state.ui.compareRatio').then((compareRatio) => {
@@ -351,14 +353,14 @@ describe('The compare Slider and the menu elements should not be available in 3d
                 },
                 true
             )
-            cy.clickOnMenuButtonIfMobile()
+            cy.openMenuIfMobile()
             cy.get('[data-cy="menu-tray-tool-section"]').click()
             cy.get('[data-cy="menu-advanced-tools-compare"]').should('be.visible')
-            cy.clickOnMenuButtonIfMobile()
+            cy.closeMenuIfMobile()
 
             cy.get('[data-cy="3d-button"]').click()
 
-            cy.clickOnMenuButtonIfMobile()
+            cy.openMenuIfMobile()
 
             cy.get('[data-cy="menu-advanced-tools-compare"]').should('not.exist')
         })

--- a/tests/cypress/tests-e2e/drawing.cy.js
+++ b/tests/cypress/tests-e2e/drawing.cy.js
@@ -249,7 +249,7 @@ describe('Drawing module tests', () => {
             )
             cy.log('Coordinates for marker can be copied while not in drawing mode')
             cy.get('[data-cy="drawing-toolbox-close-button"]').click()
-            cy.clickOnMenuButtonIfMobile()
+            cy.closeMenuIfMobile()
             cy.get('[data-cy="ol-map"]').click(160, 200)
             readCoordinateClipboard('feature-detail-coordinate-copy', "2'660'013.50, 1'227'172.00")
             cy.log('Coordinates for marker are updated when selecting new marker')
@@ -320,7 +320,7 @@ describe('Drawing module tests', () => {
             )
             cy.log('Coordinates for annotation can be copied while not in drawing mode')
             cy.get('[data-cy="drawing-toolbox-close-button"]').click()
-            cy.clickOnMenuButtonIfMobile()
+            cy.closeMenuIfMobile()
             cy.get('[data-cy="ol-map"]').click(160, 200)
             readCoordinateClipboard('feature-detail-coordinate-copy', "2'660'013.50, 1'227'172.00")
             cy.log('Coordinates for annotation are updated when selecting new marker')
@@ -482,7 +482,7 @@ describe('Drawing module tests', () => {
                 cy.reload()
                 cy.waitMapIsReady()
                 cy.wait('@get-kml')
-                cy.clickOnMenuButtonIfMobile()
+                cy.openMenuIfMobile()
 
                 cy.log(`Check that the KML file ${kmlId} is present on the active layer list`)
                 cy.get(

--- a/tests/cypress/tests-e2e/importToolFile.cy.js
+++ b/tests/cypress/tests-e2e/importToolFile.cy.js
@@ -4,7 +4,7 @@ describe('The Import File Tool', () => {
     it('Import KML file', () => {
         cy.goToMapView({}, true)
         cy.readStoreValue('state.layers.activeLayers').should('be.empty')
-        cy.clickOnMenuButtonIfMobile()
+        cy.openMenuIfMobile()
         cy.get('[data-cy="menu-tray-tool-section"]:visible').click()
         cy.get('[data-cy="menu-advanced-tools-import-file"]:visible').click()
 
@@ -145,7 +145,7 @@ describe('The Import File Tool', () => {
         //----------------------------------------------------------------------
         // Open the menu and check the layer list
         cy.log('Check that the external layers have been added to the active layers menu')
-        cy.clickOnMenuButtonIfMobile()
+        cy.openMenuIfMobile()
         cy.get('[data-cy="menu-section-active-layers"]')
             .should('be.visible')
             .children()
@@ -198,7 +198,7 @@ describe('The Import File Tool', () => {
         //---------------------------------------------------------------------
         // Test the disclaimer in the footer
         cy.log('Test the external layer disclaimer in the footer')
-        cy.clickOnMenuButtonIfMobile()
+        cy.closeMenuIfMobile()
         cy.get('[data-cy="layer-copyright-example.com"]').should('be.visible')
 
         //---------------------------------------------------------------------
@@ -206,7 +206,7 @@ describe('The Import File Tool', () => {
         cy.log('Test reloading the page should only keep online external layers')
         cy.reload()
         cy.waitMapIsReady()
-        cy.clickOnMenuButtonIfMobile()
+        cy.openMenuIfMobile()
         cy.get('[data-cy="menu-section-active-layers"]:visible').children().should('have.length', 1)
         cy.get(`[data-cy="active-layer-name-KML|${secondValidOnlineUrl}"]`).should('be.visible')
         cy.get('[data-cy="button-loading-metadata-spinner"]').should('not.exist')
@@ -240,7 +240,7 @@ describe('The Import File Tool', () => {
             },
             true
         )
-        cy.clickOnMenuButtonIfMobile()
+        cy.openMenuIfMobile()
 
         //---------------------------------------------------------------------
         cy.log('Test invalid external KML file from url parameter')
@@ -459,7 +459,7 @@ describe('The Import File Tool', () => {
         cy.get('[data-cy="import-file-close-button"]:visible').click()
         cy.get('[data-cy="import-file-content"]').should('not.exist')
 
-        cy.clickOnMenuButtonIfMobile()
+        cy.openMenuIfMobile()
         cy.get('[data-cy="menu-section-active-layers"]').should('not.be.visible')
         cy.get('[data-cy="menu-section-no-layers"]').should('be.visible')
     })
@@ -470,7 +470,7 @@ describe('The Import File Tool', () => {
 
         cy.goToMapView({}, true)
         cy.readStoreValue('state.layers.activeLayers').should('be.empty')
-        cy.clickOnMenuButtonIfMobile()
+        cy.openMenuIfMobile()
         cy.get('[data-cy="menu-tray-tool-section"]:visible').click()
         cy.get('[data-cy="menu-advanced-tools-import-file"]:visible').click()
 
@@ -544,7 +544,7 @@ describe('The Import File Tool', () => {
         cy.checkOlLayer([bgLayer, gpxOnlineLayerId])
         // Test removing a layer
         cy.log('Test removing an external GPX layer')
-        cy.clickOnMenuButtonIfMobile()
+        cy.openMenuIfMobile()
         cy.get(`[data-cy="button-remove-layer-${gpxOnlineLayerId}"]:visible`).click()
         cy.readStoreValue('state.layers.activeLayers').should('be.empty')
     })

--- a/tests/cypress/tests-e2e/importToolMaps.cy.js
+++ b/tests/cypress/tests-e2e/importToolMaps.cy.js
@@ -6,7 +6,7 @@ describe('The Import Maps Tool', () => {
     const bgLayer = 'test.background.layer2'
     beforeEach(() => {
         cy.goToMapView({}, true)
-        cy.clickOnMenuButtonIfMobile()
+        cy.openMenuIfMobile()
     })
     it('Import external wms layers', () => {
         cy.intercept(
@@ -361,7 +361,7 @@ describe('The Import Maps Tool', () => {
         cy.log('Reload should keep the layers')
         cy.reload()
         cy.waitMapIsReady()
-        cy.clickOnMenuButtonIfMobile()
+        cy.openMenuIfMobile()
         cy.get('[data-cy="menu-section-active-layers"]:visible').children().should('have.length', 3)
         cy.get(`[data-cy="active-layer-name-${singleLayerFullId}"]`).should('be.visible')
         cy.get(`[data-cy="button-loading-metadata-spinner-${singleLayerFullId}"]`).should(

--- a/tests/cypress/tests-e2e/layers.cy.js
+++ b/tests/cypress/tests-e2e/layers.cy.js
@@ -123,7 +123,7 @@ describe('Test of layer handling', () => {
                 })
 
                 // shows a red icon to signify a layer is from an external source
-                cy.clickOnMenuButtonIfMobile()
+                cy.openMenuIfMobile()
                 cy.get(`[data-cy="menu-active-layer-${fakeLayerUrlId}"]`)
                     .get('[data-cy="menu-external-disclaimer-icon"]')
                     .should('be.visible')
@@ -181,7 +181,7 @@ describe('Test of layer handling', () => {
                 })
 
                 // shows a red icon to signify a layer is from an external source
-                cy.clickOnMenuButtonIfMobile()
+                cy.openMenuIfMobile()
                 cy.get(`[data-cy="menu-active-layer-${fakeLayerUrlId}"]`)
                     .get('[data-cy="menu-external-disclaimer-icon"]')
                     .should('be.visible')
@@ -243,7 +243,7 @@ describe('Test of layer handling', () => {
                 cy.wait('@external-wmts-invalid')
                 cy.wait('@external-wms-unreachable')
                 cy.wait('@external-wms-invalid')
-                cy.clickOnMenuButtonIfMobile()
+                cy.openMenuIfMobile()
 
                 //----------------------------------------------------------------------------------
                 cy.log('WMTS URL unreachable')
@@ -383,7 +383,7 @@ describe('Test of layer handling', () => {
                 },
                 true
             ) // with hash, so that we can have external layer support
-            cy.clickOnMenuButtonIfMobile()
+            cy.openMenuIfMobile()
         }
         context('Adding/removing layers', () => {
             it('shows active layers in the menu', () => {
@@ -413,7 +413,7 @@ describe('Test of layer handling', () => {
             })
             it('shows a hyphen when no layer is selected', () => {
                 cy.goToMapView()
-                cy.clickOnMenuButtonIfMobile()
+                cy.openMenuIfMobile()
                 cy.get('[data-cy="menu-active-layers"]').click()
                 cy.get('[data-cy="menu-section-no-layers"]').should('be.visible')
             })
@@ -426,13 +426,13 @@ describe('Test of layer handling', () => {
                 cy.goToMapView({
                     layers: visibleLayerIds.join(';'),
                 })
-                cy.clickOnMenuButtonIfMobile()
+                cy.openMenuIfMobile()
                 cy.get('[data-cy="menu-active-layers"]').click()
                 cy.get('[data-cy="menu-section-no-layers"]').should('be.hidden')
             })
             it('add layer from topic (should be visible)', () => {
                 cy.goToMapView()
-                cy.clickOnMenuButtonIfMobile()
+                cy.openMenuIfMobile()
                 const testLayerId = 'test.wmts.layer'
                 const testLayerSelector = `[data-cy="catalogue-tree-item-${testLayerId}"]`
                 cy.get('[data-cy="menu-topic-section"]').should('be.visible').click()
@@ -475,7 +475,7 @@ describe('Test of layer handling', () => {
                     'search-locations'
                 )
                 cy.goToMapView()
-                cy.clickOnMenuButtonIfMobile()
+                cy.openMenuIfMobile()
                 cy.readStoreValue('getters.visibleLayers').should('be.empty')
                 cy.get('[data-cy="searchbar"]').paste('test')
                 cy.wait(['@search-locations', '@search-layers'])
@@ -800,7 +800,7 @@ describe('Test of layer handling', () => {
             })
 
             // Open the menu and change the language.
-            cy.clickOnMenuButtonIfMobile()
+            cy.openMenuIfMobile()
             cy.clickOnLanguage(langAfter)
 
             // Wait until the active layers are updated.

--- a/tests/cypress/tests-e2e/mouseposition.cy.js
+++ b/tests/cypress/tests-e2e/mouseposition.cy.js
@@ -137,7 +137,7 @@ describe('Test mouse position and interactions', () => {
 
             cy.get('[data-cy="drawing-toolbox-close-button"]').click()
             // closing the menu if mobile
-            cy.clickOnMenuButtonIfMobile()
+            cy.closeMenuIfMobile()
             cy.get('[data-cy="map"]').rightclick()
 
             cy.wait('@convert-to-w3w')
@@ -212,9 +212,9 @@ describe('Test mouse position and interactions', () => {
             cy.intercept(/^http[s]?:\/\/(sys-s\.\w+\.bgdi\.ch|s\.geo\.admin\.ch)\//, {
                 body: { shorturl: shortUrl, success: true },
             }).as('shortlink')
-            cy.clickOnMenuButtonIfMobile()
+            cy.openMenuIfMobile()
             cy.clickOnLanguage('de')
-            cy.clickOnMenuButtonIfMobile()
+            cy.closeMenuIfMobile()
             cy.get('[data-cy="menu-share-input-copy-button"]').should(
                 'contain.value',
                 'https://s.geo.admin.ch/2222222'


### PR DESCRIPTION
and waiting on the animation of the menu to finish before giving the caller the control back (should alleviate some race condition we had with menu open/close and action triggered just after the call to the util)

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_add_open_close_menu_mobile_test_utils/index.html)