### PR TITLE
PB-339: Fix layer z-index computation

### DIFF
--- a/src/modules/map/components/common/z-index.composable.js
+++ b/src/modules/map/components/common/z-index.composable.js
@@ -2,6 +2,7 @@ import { computed } from 'vue'
 import { useStore } from 'vuex'
 
 import LayerTypes from '@/api/layers/LayerTypes.enum'
+import log from '@/utils/logging'
 
 /** Composable that gives utility function to calculate/get layers' and features' z-index */
 export function useLayerZIndexCalculation() {
@@ -20,13 +21,7 @@ export function useLayerZIndexCalculation() {
     const showTileDebugInfo = computed(() => store.state.debug.showTileDebugInfo)
     const showLayerExtents = computed(() => store.state.debug.showLayerExtents)
 
-    const startingZIndexForVisibleLayers = computed(() => {
-        if (backgroundLayers.value && backgroundLayers.value.length > 0) {
-            return backgroundLayers.value.length - 1
-        }
-        return 0
-    })
-    const visibleLayersHoldingAZIndex = computed(() => {
+    const visibleLayers = computed(() => {
         const visibleLayersWithZIndex = [...backgroundLayers.value]
         if (is3dActive.value) {
             // in 3D, GeoJSON and KML layers are not given a ZIndex as Cesium handles them differently
@@ -45,9 +40,16 @@ export function useLayerZIndexCalculation() {
 
     // from here: things that will be exported
 
-    const startingZIndexForThingsOnTopOfLayers = computed(
-        () => visibleLayersHoldingAZIndex.value.length
-    )
+    const startingZIndexForThingsOnTopOfLayers = computed(() => {
+        // Here we need to take into account the group of layers
+        const nbOfSubLayers = visibleLayers.value
+            .filter((l) => l?.type === LayerTypes.GROUP)
+            // counting how many layers they have inside each group, note the first layer of the
+            // group is already counted in the visibleLayers, therefore remove 1 from the total here
+            .map((l) => l.layers.length - 1)
+            .reduce((a, b) => a + b, 0)
+        return visibleLayers.value.length + nbOfSubLayers
+    })
     const zIndexHighlightedFeatures = computed(() => startingZIndexForThingsOnTopOfLayers.value)
     const zIndexDroppedPin = computed(() => {
         let zIndex = zIndexHighlightedFeatures.value
@@ -101,25 +103,25 @@ export function useLayerZIndexCalculation() {
      */
     function getZIndexForLayer(layer) {
         // trying to find a match among the visible layers
-        const indexOfLayerInVisibleLayers = visibleLayersHoldingAZIndex.value.indexOf(layer)
-        if (indexOfLayerInVisibleLayers === -1) {
+        const layerIndex = visibleLayers.value.indexOf(layer)
+        if (layerIndex === -1) {
+            log.error(
+                `Layer ${layer.id} not found in visible layers, cannot return its zIndex, return -1`
+            )
             return -1
         }
         // checking if there are some group of layers before, meaning more than one z-index for this entry
-        const subLayersPresentUnderThisLayer = visibleLayersHoldingAZIndex.value
+        const subLayersPresentUnderThisLayer = visibleLayers.value
             // only keeping previous layers (if layer is first, an empty array will be returned by slice(0, 0))
-            .slice(0, Math.max(indexOfLayerInVisibleLayers - 1, 0))
+            .slice(0, layerIndex)
             // only keeping groups of layers
             .filter((previousLayer) => previousLayer?.type === LayerTypes.GROUP)
-            // counting how many layers they have inside each group
-            .map((previousGroup) => previousGroup.layers.length)
+            // counting how many layers they have inside each group, note the first layer of the
+            // group is already counted in the visibleLayers, therefore remove 1 from the total here
+            .map((previousGroup) => previousGroup.layers.length - 1)
             // sum
             .reduce((a, b) => a + b, 0)
-        return (
-            startingZIndexForVisibleLayers.value +
-            subLayersPresentUnderThisLayer +
-            indexOfLayerInVisibleLayers
-        )
+        return subLayersPresentUnderThisLayer + layerIndex
     }
 
     return {

--- a/tests/cypress/tests-e2e/importToolMaps.cy.js
+++ b/tests/cypress/tests-e2e/importToolMaps.cy.js
@@ -287,17 +287,16 @@ describe('The Import Maps Tool', () => {
 
         //---------------------------------------------------------------------------------
         cy.log('Check that the single layer has been added to the map')
-        // TODO PB-339 singleLayerId has been added twice ! And the group of layer have wrong zIndex
         // NOTE here below itemId-1 should be present twice, one from the group of layer itemId and
         // once as single layer
-        // cy.checkOlLayer([
-        //     bgLayer,
-        //     `${itemId}-1`,
-        //     `${itemId}-2`,
-        //     `${itemId}-3`,
-        //     `${itemId}-1`,
-        //     singleLayerId,
-        // ])
+        cy.checkOlLayer([
+            bgLayer,
+            `${itemId}-1`,
+            `${itemId}-2`,
+            `${itemId}-3`,
+            `${itemId}-1`,
+            singleLayerId,
+        ])
 
         //-----------------------------------------------------------------------------------------
         cy.log('Toggle import menu')
@@ -461,8 +460,7 @@ describe('The Import Maps Tool', () => {
                 cy.wrap(layers[1].opacity).should('be.equal', 1)
                 cy.wrap(layers[1].isExternal).should('be.true')
             })
-        // TODO PB-339 layer2Id has been added twice in open layers map !
-        // cy.checkOlLayer([bgLayer, layer1Id, layer2Id])
+        cy.checkOlLayer([bgLayer, layer1Id, layer2Id])
 
         //---------------------------------------------------------------------------------
         cy.log('Check layer 1 show legend')


### PR DESCRIPTION
The logic has two issues, one is that for group of layers we counted always
one index too much, and that for the on top of all layers we did not took the
group of layers into account.

This solve the issues in the e2e tests for the external layers.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-339-layers-zindex/index.html)