### PR TITLE
PB 113: Legacy test coverage

### DIFF
--- a/tests/cypress/tests-e2e/geolocation.cy.js
+++ b/tests/cypress/tests-e2e/geolocation.cy.js
@@ -52,7 +52,7 @@ describe('Geolocation cypress', () => {
             const [x, y] = proj4(WGS84.epsg, DEFAULT_PROJECTION.epsg, [longitude, latitude])
 
             beforeEach(() => {
-                cy.goToMapView({}, false, { latitude, longitude })
+                cy.goToMapView({}, true, { latitude, longitude })
                 getGeolocationButtonAndClickIt()
             })
 


### PR DESCRIPTION
We are adding tests for every official legacy parameter

Only missing now : 
`bod-layer-id` and `showTooltip` which are part of PB-190
`time` which is not yet implemented and will be part of PB-307

[Test link](https://sys-map.dev.bgdi.ch/preview/pb-113-legacy-test-coverage/index.html)