### PR TITLE
PB-315: Handle legacy embed view

### DIFF
--- a/src/router/appLoadingManagement.routerPlugin.js
+++ b/src/router/appLoadingManagement.routerPlugin.js
@@ -1,6 +1,5 @@
 import { START_LOCATION } from 'vue-router'
 
-import { MAP_VIEWS } from '@/router/viewNames'
 import { isLegacyParams } from '@/utils/legacyLayerParamUtils'
 import log from '@/utils/logging'
 
@@ -26,11 +25,7 @@ const appLoadingManagementRouterPlugin = (router, store) => {
         const isLegacyUrl = isLegacyParams(window?.location?.search)
 
         const unRegisterRouterHook = router.beforeEach((to, from) => {
-            if (
-                from === START_LOCATION &&
-                MAP_VIEWS.includes(to.name) &&
-                to.meta.requiresAppReady
-            ) {
+            if (from === START_LOCATION && to.meta.requiresAppReady) {
                 // Upon application startup we need to first get the language and
                 // topic from the URL in order to quickly load the layers config and
                 // topics. We do this as early as possible as we need topics and config to define
@@ -52,12 +47,12 @@ const appLoadingManagementRouterPlugin = (router, store) => {
                     isLegacyUrl,
                     ...dispatcher,
                 })
+                unRegisterRouterHook()
             }
         })
         const unSubscribeStore = store.subscribe((mutation) => {
             // listening to the store for the "Go" when the app is ready
             if (mutation.type === 'setAppIsReady') {
-                unRegisterRouterHook()
                 unSubscribeStore()
                 log.info('App is ready, unregister app loading management plugin')
             }

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -257,7 +257,12 @@ const legacyPermalinkManagementRouterPlugin = (router, store) => {
         ? new URLSearchParams(window?.location?.search)
         : null
     if (legacyParams) {
-        const legacyEmbed = window?.location?.pathname === '/embed.html'
+        // NOTE: the legacy embed view was at /embed.html. Unfortunately we cannot in this application
+        // reroute to another path before the #, because the vue router using the createWebHashHistory
+        // can only handle route after the hash. Therefore we have an external redirect service
+        // that will redirect to /embed.html to ?legacyEmbed. We use this pseudo legacyEmbed to
+        // redirect to #/embed once the other legacy parameters have been translated.
+        const legacyEmbed = legacyParams.has('legacyEmbed')
         log.debug(
             `[Legacy URL] starts legacy url param plugin params=${legacyParams.toString()}, legacyEmbed=${legacyEmbed}`,
             legacyParams
@@ -290,8 +295,9 @@ const legacyPermalinkManagementRouterPlugin = (router, store) => {
                         router.replace(newRoute)
                     }
                 })
+
                 return {
-                    name: to.name === EMBED_VIEW ? LEGACY_EMBED_PARAM_VIEW : LEGACY_PARAM_VIEW,
+                    name: legacyEmbed ? LEGACY_EMBED_PARAM_VIEW : LEGACY_PARAM_VIEW,
                     replace: true,
                 }
             }

--- a/src/utils/__tests__/utils.spec.js
+++ b/src/utils/__tests__/utils.spec.js
@@ -6,7 +6,6 @@ import {
     formatMinutesTime,
     formatPointCoordinates,
     parseUrlHashQuery,
-    transformUrlEmbedToMap,
     transformUrlMapToEmbed,
 } from '@/utils/utils'
 
@@ -77,7 +76,7 @@ describe('utils', () => {
                 'https://map.geo.admin.ch/map?de',
                 'https://map.geo.admin.ch/test#/map',
             ]
-            urls.forEach((url) => expect(transformUrlEmbedToMap(url)).to.equal(url))
+            urls.forEach((url) => expect(transformUrlMapToEmbed(url)).to.equal(url))
         })
     })
     describe('parseUrlHashQuery', () => {
@@ -119,39 +118,6 @@ describe('utils', () => {
             expect(result.urlObj).not.to.be.null
             expect(result.hash).to.equal('')
             expect(result.query).to.equal('')
-        })
-    })
-    describe('transformUrlEmbedToMap', () => {
-        it('transform #/embed to #/map', () => {
-            expect(transformUrlEmbedToMap('https://map.geo.admin.ch/#/embed')).to.equal(
-                'https://map.geo.admin.ch/#/map'
-            )
-            expect(transformUrlEmbedToMap('http://map.geo.admin.ch/#/embed')).to.equal(
-                'http://map.geo.admin.ch/#/map'
-            )
-            expect(transformUrlEmbedToMap('http://map.geo.admin.ch/#/embed?')).to.equal(
-                'http://map.geo.admin.ch/#/map?'
-            )
-            expect(transformUrlEmbedToMap('https://map.geo.admin.ch/#/embed?lang=de')).to.equal(
-                'https://map.geo.admin.ch/#/map?lang=de'
-            )
-            expect(
-                transformUrlEmbedToMap(
-                    'https://map.geo.admin.ch/#/embed?lang=de&layers=https://test.com?hello=world'
-                )
-            ).to.equal('https://map.geo.admin.ch/#/map?lang=de&layers=https://test.com?hello=world')
-        })
-        it('does not transform non #/embed url', () => {
-            const urls = [
-                'https://map.geo.admin.ch/#/embedview',
-                'https://map.geo.admin.ch/#/embed/view',
-                'https://map.geo.admin.ch/#/hello',
-                'https://map.geo.admin.ch/#/hello?lang=de',
-                'https://map.geo.admin.ch/embed',
-                'https://map.geo.admin.ch/embed?de',
-                'https://map.geo.admin.ch/test#/embed',
-            ]
-            urls.forEach((url) => expect(transformUrlEmbedToMap(url)).to.equal(url))
         })
     })
 })

--- a/src/utils/components/OpenFullAppLink.vue
+++ b/src/utils/components/OpenFullAppLink.vue
@@ -1,20 +1,20 @@
 <script setup>
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
 
 import SwissFlag from '@/modules/menu/components/header/SwissFlag.vue'
-import { transformUrlEmbedToMap } from '@/utils/utils'
+import { MAP_VIEW } from '@/router/viewNames'
 
 const i18n = useI18n()
+const router = useRouter()
 
 const currentHost = ref(window.location.host)
 
 const linkMessage = computed(() =>
     i18n.t('view_on_mapgeoadminch_webmapviewer', { url: currentHost.value })
 )
-const urlWithoutEmbed = computed(() => {
-    return transformUrlEmbedToMap(window.location.href)
-})
+const mapView = computed(() => router.resolve({ ...router.currentRoute.value, name: MAP_VIEW }))
 </script>
 
 <template>
@@ -23,14 +23,14 @@ const urlWithoutEmbed = computed(() => {
         data-cy="open-full-app-link"
     >
         <SwissFlag :sm="true" class="my-1" />
-        <a
+        <router-link
             class="ms-1 fw-bold text-black"
             data-cy="open-full-app-link-anchor"
             target="_blank"
-            :href="urlWithoutEmbed"
+            :to="mapView"
         >
             {{ linkMessage }}
-        </a>
+        </router-link>
     </div>
 </template>
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -217,22 +217,3 @@ export function transformUrlMapToEmbed(url) {
     }
     return urlObj.toString()
 }
-
-/**
- * Transform a /#/embed url to /#/map url
- *
- * If the URL is not a SCHEME://DOMAIN/#/embed then it is returned unchanged.
- *
- * @param {string} url Url to transform on /#/map
- * @returns {string} Url transformed to /#/map
- */
-export function transformUrlEmbedToMap(url) {
-    const { urlObj, hash, query } = parseUrlHashQuery(url)
-    if (urlObj.pathname !== '/') {
-        return url
-    }
-    if (hash === '#/embed') {
-        urlObj.hash = `#/map${query}`
-    }
-    return urlObj.toString()
-}

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -271,11 +271,16 @@ Cypress.Commands.add(
         })
         // removing trailing &
         flattenedQueryParams = flattenedQueryParams.slice(0, -1)
-        flattenedQueryParams = flattenedQueryParams.length ? `?${flattenedQueryParams}` : ''
+        if (flattenedQueryParams.length) {
+            flattenedQueryParams = legacy ? `&${flattenedQueryParams}` : `?${flattenedQueryParams}`
+        }
 
-        cy.visit(`${legacy ? '/embed.html' : '/#/embed'}${flattenedQueryParams}`, {
-            onBeforeLoad: (win) => mockGeolocation(win, geolocationMockupOptions),
-        })
+        cy.visit(
+            legacy ? `?legacyEmbed${flattenedQueryParams}` : `/#/embed${flattenedQueryParams}`,
+            {
+                onBeforeLoad: (win) => mockGeolocation(win, geolocationMockupOptions),
+            }
+        )
 
         // In the legacy URL, 3d is not found. We check if the map in 3d or not by checking the pitch, heading, and elevation
         const isLegacy3d =
@@ -299,7 +304,7 @@ Cypress.Commands.add('waitMapIsReady', ({ timeout = 15000, olMap = true } = {}) 
     cy.waitUntilState((state) => state.app.isMapReady, { timeout: timeout })
     // We also need to wait for the pointer event to be set
     if (olMap) {
-        cy.window().its('mapPointerEventReady', { timeout: 10000 }).should('be.true')
+        cy.window().its('mapPointerEventReady', { timeout: timeout }).should('be.true')
     }
 })
 
@@ -322,7 +327,7 @@ Cypress.Commands.add('waitAllLayersLoaded', ({ queryParams = {}, legacy = false 
             return active === target
         },
         {
-            timeout: 10000,
+            timeout: 15000,
             customMessage: 'all layers have been loaded',
             errorMsg: 'Timeout waiting for all layers to be loaded',
         }

--- a/tests/cypress/tests-e2e/embed.cy.js
+++ b/tests/cypress/tests-e2e/embed.cy.js
@@ -28,15 +28,15 @@ describe('Testing the embed view', () => {
         cy.get('[data-cy="scaleline"]').should('be.visible')
         cy.get('[data-cy="layers-copyrights"]').should('be.visible')
 
-        cy.location().then((location) => {
-            cy.log(`Check the link url`)
-            cy.get('[data-cy="open-full-app-link"]')
-                .should('be.visible')
-                .should('contain', 'View on ')
-            cy.get('[data-cy="open-full-app-link-anchor"]')
-                .should('have.attr', 'href', `${location.origin}/#/map`)
-                .should('have.attr', 'target', '_blank')
-        })
+        cy.log(`Check the link url`)
+        cy.get('[data-cy="open-full-app-link"]').should('be.visible').should('contain', 'View on ')
+        cy.get('[data-cy="open-full-app-link-anchor"]', { timeout: 20000 })
+            .should(
+                'have.attr',
+                'href',
+                `#/map?lang=en&center=2660000,1190000&z=1&bgLayer=test.background.layer2&topic=ech&layers=`
+            )
+            .should('have.attr', 'target', '_blank')
 
         cy.log('Test mouse zoom scrolling')
         cy.location('hash').should('contain', 'z=1')
@@ -64,7 +64,7 @@ describe('Testing the embed view', () => {
 
         cy.get('[data-cy="scaleline"]').should('be.visible')
 
-        cy.readStoreValue('getters.visibleLayers').then((layers) => {
+        cy.readStoreValue('getters.visibleLayers').should((layers) => {
             expect(layers).to.be.an('Array').length(3)
             expect(layers[0].id).to.eq('test-1.wms.layer')
             expect(layers[0].opacity).to.eq(0.75)
@@ -73,10 +73,123 @@ describe('Testing the embed view', () => {
             expect(layers[2].id).to.eq('test.timeenabled.wmts.layer')
         })
 
+        cy.log(`Check attributions of visible layers`)
         cy.get('[data-cy="layer-copyright-attribution.test-1.wms.layer"]').should('be.visible')
         cy.get('[data-cy="layer-copyright-attribution.test.wmts.layer"]').should('be.visible')
         cy.get('[data-cy="layer-copyright-attribution.timeenabled.wmts.layer"]').should(
             'be.visible'
         )
+
+        cy.log(`Check attribution of non visible layers, they should not exists`)
+        cy.get('[data-cy="layer-copyright-attribution.test-2.wms.layer"]').should('not.exist')
+
+        cy.log(`Check the link url`)
+        cy.get('[data-cy="open-full-app-link"]').should('be.visible').should('contain', 'View on ')
+        cy.get('[data-cy="open-full-app-link-anchor"]')
+            .should(
+                'have.attr',
+                'href',
+                `#/map?layers=test-1.wms.layer;test.wmts.layer,,0.5;test-2.wms.layer,f;test.timeenabled.wmts.layer&lang=en&center=2660000,1190000&z=1.667&bgLayer=test.background.layer2&topic=ech`
+            )
+            .should('have.attr', 'target', '_blank')
+    })
+    it('Open in legacy embed mode and can jump to the non embed mode', () => {
+        cy.log(`Open in legacy mode without parameters`)
+        cy.goToEmbedView({ legacy: true })
+
+        cy.log(`Check that the menu and the header are not displayed`)
+
+        cy.get('[data-cy="app-header"]').should('not.exist')
+        cy.get('[data-cy="menu-tray"]').should('not.exist')
+        cy.get('[data-cy="mouse-position-select"]').should('not.exist')
+        cy.get('[data-cy="mouse-position"]').should('not.exist')
+
+        cy.get('[data-cy="zoom-in"]').should('be.visible')
+        cy.get('[data-cy="zoom-out"]').should('be.visible')
+        cy.get('[data-cy="3d-button"]').should('be.visible')
+
+        cy.get('[data-cy="geolocation-button"]').should('not.exist')
+        cy.get('[data-cy="toolbox-fullscreen-button"]').should('not.exist')
+        cy.get('[data-cy="time-slider-button"]').should('not.exist')
+
+        cy.get('[data-cy="app-version"]').should('not.exist')
+        cy.get('[data-cy^=app-copyright-]').should('not.exist')
+
+        cy.get('[data-cy="background-selector-open-wheel-button"]').should('not.exist')
+
+        cy.log(`Check for the scale line and copyright presence`)
+        cy.get('[data-cy="scaleline"]').should('be.visible')
+        cy.get('[data-cy="layers-copyrights"]').should('be.visible')
+
+        cy.log(`Check the link url`)
+        cy.get('[data-cy="open-full-app-link"]').should('be.visible').should('contain', 'View on ')
+        cy.get('[data-cy="open-full-app-link-anchor"]')
+            .should(
+                'have.attr',
+                'href',
+                `#/map?lang=en&center=2660000,1190000&z=1&bgLayer=test.background.layer2&topic=ech`
+            )
+            .should('have.attr', 'target', '_blank')
+
+        cy.log('Test mouse zoom scrolling')
+        cy.location('hash').should('contain', 'z=1')
+        cy.get('[data-cy="scaleline"]').should('contain', '50 km')
+        cy.get('[data-cy="ol-map"]').realMouseWheel({ deltaY: -200 })
+        cy.location('hash').should('contain', 'z=1.667')
+        cy.get('[data-cy="scaleline"]').should('contain', '20 km')
+
+        cy.log('Test that location popup is deactivated')
+        cy.get('[data-cy="ol-map"]').realClick({ button: 'right' })
+        cy.get('[data-cy="location-popup"]').should('not.exist')
+
+        cy.log('Test with non default legacy query parameters')
+        cy.log('Test with a specific layer: test-1.wms.layer')
+        cy.goToEmbedView({
+            queryParams: {
+                layers: 'test-1.wms.layer,test.wmts.layer,test-2.wms.layer,test.timeenabled.wmts.layer',
+                layers_visibility: 'true,true,false,true',
+                layers_opacity: '0.75,0.5,1,1',
+                layers_timestamp: ',,,20160101',
+            },
+            legacy: true,
+        })
+
+        cy.get('[data-cy="app-header"]').should('not.exist')
+        cy.get('[data-cy="menu-tray"]').should('not.exist')
+
+        cy.get('[data-cy="time-slider-button"]').should('not.exist')
+
+        cy.get('[data-cy="scaleline"]').should('be.visible')
+
+        cy.readStoreValue('getters.visibleLayers').should((layers) => {
+            expect(layers).to.be.an('Array').length(3)
+            expect(layers[0].id).to.eq('test-1.wms.layer')
+            expect(layers[0].opacity).to.eq(0.75)
+            expect(layers[1].id).to.eq('test.wmts.layer')
+            expect(layers[1].opacity).to.eq(0.5)
+            expect(layers[2].id).to.eq('test.timeenabled.wmts.layer')
+            expect(layers[2].opacity).to.eq(1.0)
+            expect(layers[2].timeConfig.currentTimeEntry.timestamp).to.eq('20160101')
+        })
+
+        cy.log(`Check attributions of visible layers`)
+        cy.get('[data-cy="layer-copyright-attribution.test-1.wms.layer"]').should('be.visible')
+        cy.get('[data-cy="layer-copyright-attribution.test.wmts.layer"]').should('be.visible')
+        cy.get('[data-cy="layer-copyright-attribution.timeenabled.wmts.layer"]').should(
+            'be.visible'
+        )
+
+        cy.log(`Check attribution of non visible layers, they should not exists`)
+        cy.get('[data-cy="layer-copyright-attribution.test-2.wms.layer"]').should('not.exist')
+
+        cy.log(`Check the link url`)
+        cy.get('[data-cy="open-full-app-link"]').should('be.visible').should('contain', 'View on ')
+        cy.get('[data-cy="open-full-app-link-anchor"]')
+            .should(
+                'have.attr',
+                'href',
+                `#/map?layers=test-1.wms.layer;test.wmts.layer,,0.5;test-2.wms.layer,f,1;test.timeenabled.wmts.layer@year=2016,,1&lang=en&center=2660000,1190000&z=1&bgLayer=test.background.layer2&topic=ech`
+            )
+            .should('have.attr', 'target', '_blank')
     })
 })


### PR DESCRIPTION
The legacy embed view was at hostname/embed.html. Unfortunately we cannot reroute
here to another path before the #, because the vue router using the createWebHashHistory
can only handle route after the hash. Therefore we have an external redirect
service  that will redirect to /embed.html to ?legacyEmbed.

We use this pseudo legacyEmbed to redirect to #/embed once the other legacy
parameters have been translated.

NOTE: I first tried to set the redirect service directly to #/embed but then it made the startup procedure difficult as we needed to detect if other legacy parameters had to be translated and wait on them first. So for simplicity we use a legacy parameter as redirect
which simplify a lot the startup procedure which is then identical for other legacy parameters.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-315-legacy-embed/index.html)