### PR TITLE
Compare Ratio Case Change

### DIFF
--- a/src/modules/map/components/CompareSlider.vue
+++ b/src/modules/map/components/CompareSlider.vue
@@ -130,7 +130,7 @@ function releaseSlider() {
 <template>
     <div
         class="compare-slider position-absolute top-0 translate-middle-x h-100 d-inline-block"
-        data-cy="compare_slider"
+        data-cy="compareSlider"
         :style="compareSliderPosition"
         @touchstart.passive="grabSlider"
         @mousedown.passive="grabSlider"

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -103,7 +103,7 @@ const handleLegacyParam = (
         // Setting the position of the compare slider
         case 'swipe_ratio':
             newValue = legacyValue
-            key = 'compare_ratio'
+            key = 'compareRatio'
             break
         case 'layers_opacity':
         case 'layers_visibility':

--- a/src/router/storeSync/CompareSliderParamConfig.class.js
+++ b/src/router/storeSync/CompareSliderParamConfig.class.js
@@ -33,13 +33,13 @@ function generateCompareSliderUrlParamFromStore(store) {
 
 /**
  * This ensure the following: When the compare ratio is set in the url, the flag telling if the
- * compare slider is active is set to true. We remove the compare_ratio parameter from the URL when
+ * compare slider is active is set to true. We remove the compareRatio parameter from the URL when
  * the compare slider is not active The default value of the parameter is null
  */
 export default class CompareSliderParamConfig extends AbstractParamConfig {
     constructor() {
         super(
-            'compare_ratio',
+            'compareRatio',
             'setCompareRatio, setCompareSliderActive',
             dispatchCompareSliderFromUrlParam,
             generateCompareSliderUrlParamFromStore,

--- a/tests/cypress/tests-e2e/compareSlider.cy.js
+++ b/tests/cypress/tests-e2e/compareSlider.cy.js
@@ -25,42 +25,42 @@ describe('Testing of the compare slider', () => {
 
                 expectCompareRatioToBe(null)
                 expectCompareSliderToBeActive(false)
-                cy.get('[data-cy="compare_slider"]').should('not.exist')
+                cy.get('[data-cy="compareSlider"]').should('not.exist')
             })
             it('does not shows up with layers and the compare ratio parameter out of bounds or not a number', () => {
                 cy.goToMapView(
                     {
                         layers: ['test-1.wms.layer', 'test-2.wms.layer,,'].join(';'),
-                        compare_ratio: '1.4',
+                        compareRatio: '1.4',
                     },
                     true
                 )
                 expectCompareRatioToBe(null)
                 expectCompareSliderToBeActive(false)
 
-                cy.get('[data-cy="compare_slider"]').should('not.exist')
+                cy.get('[data-cy="compareSlider"]').should('not.exist')
                 cy.goToMapView(
                     {
                         layers: ['test-1.wms.layer', 'test-2.wms.layer,,'].join(';'),
-                        compare_ratio: '-0.3',
+                        compareRatio: '-0.3',
                     },
                     true
                 )
                 expectCompareRatioToBe(null)
                 expectCompareSliderToBeActive(false)
 
-                cy.get('[data-cy="compare_slider"]').should('not.exist')
+                cy.get('[data-cy="compareSlider"]').should('not.exist')
                 cy.goToMapView(
                     {
                         layers: ['test-1.wms.layer', 'test-2.wms.layer,,'].join(';'),
-                        compare_ratio: 'aRandomText',
+                        compareRatio: 'aRandomText',
                     },
                     true
                 )
                 expectCompareRatioToBe(null)
                 expectCompareSliderToBeActive(false)
 
-                cy.get('[data-cy="compare_slider"]').should('not.exist')
+                cy.get('[data-cy="compareSlider"]').should('not.exist')
             })
         })
     })
@@ -71,39 +71,39 @@ describe('Testing of the compare slider', () => {
                 This function moves the slider so the 'left' position of the element will be at x.
                 The slider is 40 px wide and we drag it from the center.
             */
-            cy.get('[data-cy="compare_slider"]').trigger('mousedown', { button: 0 })
-            cy.get('[data-cy="compare_slider"]').trigger('mousemove', {
+            cy.get('[data-cy="compareSlider"]').trigger('mousedown', { button: 0 })
+            cy.get('[data-cy="compareSlider"]').trigger('mousemove', {
                 clientX: Math.abs(x + 20),
                 clientY: 100,
             })
-            cy.get('[data-cy="compare_slider"]').trigger('mouseup', { force: true })
+            cy.get('[data-cy="compareSlider"]').trigger('mouseup', { force: true })
         }
         context('Moving the compare slider', () => {
             it('moves when we click on it and drag the mouse', () => {
                 cy.goToMapView(
                     {
                         layers: 'test-1.wms.layer',
-                        compare_ratio: '0.3',
+                        compareRatio: '0.3',
                     },
                     true
                 )
                 // initial slider position is width * 0.3 -20
-                cy.get('[data-cy="compare_slider"]').then((slider) => {
+                cy.get('[data-cy="compareSlider"]').then((slider) => {
                     cy.readStoreValue('state.ui.width').then((width) => {
                         cy.wrap(slider.position()['left']).should('eq', width * 0.3 - 20)
                     })
                 })
                 expectCompareRatioToBe(0.3)
                 expectCompareSliderToBeActive(true)
-                cy.get('[data-cy="compare_slider"]').should('be.visible')
+                cy.get('[data-cy="compareSlider"]').should('be.visible')
                 moveSlider(73)
-                cy.get('[data-cy="compare_slider"]').then((slider) => {
+                cy.get('[data-cy="compareSlider"]').then((slider) => {
                     cy.wrap(slider.position()['left']).should('be.closeTo', 73.0, 0.2)
                 })
 
                 cy.log('It refuses to get out of bounds when we move around')
                 moveSlider(-10)
-                cy.get('[data-cy="compare_slider"]').then((slider) => {
+                cy.get('[data-cy="compareSlider"]').then((slider) => {
                     //it stops at around 5.999, so we ensure this does not make the test fail, while still being close enough to be relevant
 
                     cy.wrap(slider.position()['left']).should('be.closeTo', -6.0, 0.2)
@@ -114,7 +114,7 @@ describe('Testing of the compare slider', () => {
                     moveSlider(width - 1)
                 })
 
-                cy.get('[data-cy="compare_slider"]').then((slider) => {
+                cy.get('[data-cy="compareSlider"]').then((slider) => {
                     cy.readStoreValue('state.ui.width').then((width) => {
                         cy.wrap(slider.position()['left']).should('be.lte', width - 34.0)
                         cy.wrap(slider.position()['left']).should('be.closeTo', width - 34.0, 0.2)
@@ -172,7 +172,7 @@ describe('Testing of the compare slider', () => {
                 cy.goToMapView(
                     {
                         layers: layerIds.join(';'),
-                        compare_ratio: '0.5',
+                        compareRatio: '0.5',
                     },
                     true
                 )
@@ -234,7 +234,7 @@ describe('Testing of the compare slider', () => {
                     .should('be.visible')
                     .click()
                 cy.closeMenuIfMobile()
-                cy.get('[data-cy="compare_slider"]').should('not.exist')
+                cy.get('[data-cy="compareSlider"]').should('not.exist')
             })
         })
     })
@@ -258,10 +258,10 @@ describe('Testing of the compare slider', () => {
                     cy.readStoreValue('state.ui.isCompareSliderActive').then((isSliderActive) => {
                         expect(isSliderActive).to.eq(true)
                     })
-                    cy.get('[data-cy="compare_slider"]').should('not.exist')
+                    cy.get('[data-cy="compareSlider"]').should('not.exist')
                 })
                 it('stays "active" when we remove the last layer', () => {
-                    cy.goToMapView({ layers: 'test-1.wms.layer', compare_ratio: '0.3' }, true)
+                    cy.goToMapView({ layers: 'test-1.wms.layer', compareRatio: '0.3' }, true)
                     cy.openMenuIfMobile()
                     cy.readStoreValue('state.ui.compareRatio').then((compareRatio) => {
                         expect(compareRatio).to.eq(0.3)
@@ -270,7 +270,7 @@ describe('Testing of the compare slider', () => {
                     cy.readStoreValue('state.ui.isCompareSliderActive').then((isSliderActive) => {
                         expect(isSliderActive).to.eq(true)
                     })
-                    cy.get('[data-cy="compare_slider"]').should('be.visible')
+                    cy.get('[data-cy="compareSlider"]').should('be.visible')
 
                     cy.get(`[data-cy="button-remove-layer-test-1.wms.layer"]`)
                         .should('be.visible')
@@ -283,17 +283,17 @@ describe('Testing of the compare slider', () => {
                     cy.readStoreValue('state.ui.isCompareSliderActive').then((isSliderActive) => {
                         expect(isSliderActive).to.eq(true)
                     })
-                    cy.get('[data-cy="compare_slider"]').should('not.exist')
+                    cy.get('[data-cy="compareSlider"]').should('not.exist')
                 })
                 it('appears and is functional when layers are present in 2d', () => {
                     cy.goToMapView(
                         {
                             layers: ['test-1.wms.layer', 'test-2.wms.layer,,'].join(';'),
-                            compare_ratio: '0.3',
+                            compareRatio: '0.3',
                         },
                         true
                     )
-                    cy.get('[data-cy="compare_slider"]').should('be.visible')
+                    cy.get('[data-cy="compareSlider"]').should('be.visible')
                     cy.openMenuIfMobile()
                     cy.get('[data-cy="menu-tray-tool-section"]').click()
                     cy.get('[data-cy="menu-advanced-tools-compare"]').should('be.visible')
@@ -313,13 +313,13 @@ describe('Testing of the compare slider', () => {
                     cy.readStoreValue('state.ui.isCompareSliderActive').then((isSliderActive) => {
                         expect(isSliderActive).to.eq(false)
                     })
-                    cy.get('[data-cy="compare_slider"]').should('not.exist')
+                    cy.get('[data-cy="compareSlider"]').should('not.exist')
 
                     cy.get('[data-cy="menu-advanced-tools-compare"]').click()
                     cy.readStoreValue('state.ui.compareRatio').then((compareRatio) => {
                         expect(compareRatio).to.eq(0.3)
                     })
-                    cy.get('[data-cy="compare_slider"]').should('be.visible')
+                    cy.get('[data-cy="compareSlider"]').should('be.visible')
                 })
             }
         )
@@ -332,13 +332,13 @@ describe('The compare Slider and the menu elements should not be available in 3d
             cy.goToMapView(
                 {
                     layers: ['test-1.wms.layer', 'test-2.wms.layer,,'].join(';'),
-                    compare_ratio: '0.4',
+                    compareRatio: '0.4',
                     '3d': true,
                     sr: WEBMERCATOR.epsgNumber,
                 },
                 true
             )
-            cy.get('[data-cy="compare_slider"]').should('not.exist')
+            cy.get('[data-cy="compareSlider"]').should('not.exist')
 
             cy.readStoreValue('state.ui.compareRatio').then((compareRatio) => {
                 expect(compareRatio).to.eq(0.4)

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -438,7 +438,7 @@ describe('Test on legacy param import', () => {
                 false
             )
             // initial slider position is width * 0.3 -20
-            cy.get('[data-cy="compare_slider"]').then((slider) => {
+            cy.get('[data-cy="compareSlider"]').then((slider) => {
                 cy.readStoreValue('state.ui.width').should((width) => {
                     expect(slider.position()['left']).to.eq(width * 0.3 - 20)
                 })
@@ -446,7 +446,7 @@ describe('Test on legacy param import', () => {
             cy.readStoreValue('state.ui.compareRatio').should('be.equal', 0.3)
 
             cy.readStoreValue('state.ui.isCompareSliderActive').should('be.equal', true)
-            cy.get('[data-cy="compare_slider"]').should('be.visible')
+            cy.get('[data-cy="compareSlider"]').should('be.visible')
         })
     })
 })


### PR DESCRIPTION
In most of the code, we are using camelCase for our parameters and variables
The compare slider was using snake_case.

We are now using camelCase for the compareRatio parameter, and the compareSlider data-cy

[Test link](https://sys-map.dev.bgdi.ch/preview/compare-slider-case-change/index.html)