### PR TITLE
Let the tippy placement default for the composable

### DIFF
--- a/src/modules/map/components/toolbox/FullScreenButton.vue
+++ b/src/modules/map/components/toolbox/FullScreenButton.vue
@@ -9,7 +9,7 @@ const dispatcher = { dispatcher: 'FullScreenButton.vue' }
 
 const store = useStore()
 
-useTippyTooltip('#fullscreenButton[data-tippy-content]')
+useTippyTooltip('#fullscreenButton[data-tippy-content]', { placement: 'left' })
 
 const isInFullScreenMode = computed(() => store.state.ui.fullscreenMode)
 

--- a/src/modules/map/components/toolbox/GeolocButton.vue
+++ b/src/modules/map/components/toolbox/GeolocButton.vue
@@ -8,7 +8,7 @@ const dispatcher = { dispatcher: 'GeolocButton.vue' }
 
 const store = useStore()
 
-useTippyTooltip('.geoloc-button[data-tippy-content]')
+useTippyTooltip('.geoloc-button[data-tippy-content]', { placement: 'left' })
 
 const isActive = computed(() => store.state.geolocation.active)
 const isDenied = computed(() => store.state.geolocation.denied)

--- a/src/modules/map/components/toolbox/TimeSliderButton.vue
+++ b/src/modules/map/components/toolbox/TimeSliderButton.vue
@@ -7,7 +7,9 @@ import { useTippyTooltip } from '@/utils/useTippyTooltip'
 
 const store = useStore()
 
-const { refreshTippyAttachment } = useTippyTooltip('#timeSlider [data-tippy-content]')
+const { refreshTippyAttachment } = useTippyTooltip('#timeSlider [data-tippy-content]', {
+    placement: 'left',
+})
 
 const showTimeSlider = ref(false)
 

--- a/src/modules/map/components/toolbox/Toggle3dButton.vue
+++ b/src/modules/map/components/toolbox/Toggle3dButton.vue
@@ -9,7 +9,7 @@ const dispatcher = { dispatcher: 'Toggle3dButton.vue' }
 
 const store = useStore()
 
-useTippyTooltip('#threeDButton[data-tippy-content]')
+useTippyTooltip('#threeDButton[data-tippy-content]', { placement: 'left' })
 
 const webGlIsSupported = ref(false)
 

--- a/src/modules/map/components/toolbox/ZoomButtons.vue
+++ b/src/modules/map/components/toolbox/ZoomButtons.vue
@@ -6,7 +6,7 @@ import { useTippyTooltip } from '@/utils/useTippyTooltip'
 const dispatcher = { dispatcher: 'ZoomButtons.vue' }
 
 const store = useStore()
-useTippyTooltip('#zoomButtons [data-tippy-content]')
+useTippyTooltip('#zoomButtons [data-tippy-content]', { placement: 'left' })
 
 function increaseZoom() {
     store.dispatch('increaseZoom', dispatcher)

--- a/src/utils/useTippyTooltip.js
+++ b/src/utils/useTippyTooltip.js
@@ -40,12 +40,15 @@ import { useI18n } from 'vue-i18n'
  */
 export function useTippyTooltip(
     selector,
-    { theme = null, placement = 'left', delay = [300, 0] } = {}
+    { theme = null, placement = null, delay = [300, 0] } = {}
 ) {
     let tooltips = null
-    const options = { placement, delay }
+    const options = { delay }
     if (theme) {
         options.theme = theme
+    }
+    if (placement) {
+        options.placement = placement
     }
 
     const i18n = useI18n()


### PR DESCRIPTION
Make more sense to use the tippy default placement in the composable as using
the one needed for the toolbox.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-tooltip/index.html)