### PR TITLE
PB-294: Avoid reloading the application when entering ENTER in import file

### DIFF
--- a/src/modules/menu/components/advancedTools/ImportFile/ImportFileOnlineTab.vue
+++ b/src/modules/menu/components/advancedTools/ImportFile/ImportFileOnlineTab.vue
@@ -120,7 +120,7 @@ function onEnter() {
         aria-labelledby="nav-online-tab"
         data-cy="import-file-online-content"
     >
-        <form class="needs-validation">
+        <div class="needs-validation">
             <TextInput
                 ref="fileUrlInput"
                 v-model="fileUrl"
@@ -131,9 +131,9 @@ function onEnter() {
                 :form-validated="layerAdded"
                 data-cy="import-file-online-url-input"
                 @input="onUrlChange"
-                @keydown.enter="onEnter"
+                @keydown.enter.prevent="onEnter"
             />
-        </form>
+        </div>
         <ImportFileButtons
             class="mt-2"
             :button-state="buttonState"

--- a/src/modules/menu/components/advancedTools/ImportFile/ImportFileOnlineTab.vue
+++ b/src/modules/menu/components/advancedTools/ImportFile/ImportFileOnlineTab.vue
@@ -97,6 +97,14 @@ function validateForm() {
         isFormValid.value = true
     }
 }
+
+function onEnter() {
+    if (!isFormValid.value) {
+        log.debug(`Cannot load file invalid form`)
+        return
+    }
+    loadFile()
+}
 </script>
 
 <template>
@@ -123,7 +131,7 @@ function validateForm() {
                 :form-validated="layerAdded"
                 data-cy="import-file-online-url-input"
                 @input="onUrlChange"
-                @keydown.enter="loadFile"
+                @keydown.enter="onEnter"
             />
         </form>
         <ImportFileButtons

--- a/tests/cypress/tests-e2e/importToolFile.cy.js
+++ b/tests/cypress/tests-e2e/importToolFile.cy.js
@@ -324,6 +324,12 @@ describe('The Import File Tool', () => {
             .contains('URL is not valid')
         cy.get('[data-cy="import-file-load-button"]:visible').should('be.disabled')
 
+        cy.get('[data-cy="import-file-online-url-input"]').type('{enter}')
+        cy.get('[data-cy="import-file-online-url-input"]')
+            .find('[data-cy="invalid-feedback-error"]')
+            .should('be.visible')
+            .contains('URL is not valid')
+
         //---------------------------------------------------------------------
         cy.log('Test online import url not reachable')
 


### PR DESCRIPTION
In import file when entering enter with an invalid url field, it triggered a
page reload. This was due to the fact that the `loadFile()` was triggered with
an invalid url which triggered a fetch to the current host, reloading the app.

Now we prevent calling loadFile() if the url is not valid.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-294-import/index.html)