### PR TITLE
PB-332: Fixed compare slider with duplicate layers and also visibility flag bugs

### DIFF
--- a/src/modules/map/components/CompareSlider.vue
+++ b/src/modules/map/components/CompareSlider.vue
@@ -4,6 +4,7 @@ import { unByKey } from 'ol/Observable'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useStore } from 'vuex'
 
+import log from '@/utils/logging'
 import { round } from '@/utils/numberUtils'
 
 const dispatcher = { dispatcher: 'CompareSlider.vue' }
@@ -25,13 +26,14 @@ const compareSliderPosition = computed(() => {
     }
 })
 const visibleLayerOnTop = computed(() => store.getters.visibleLayerOnTop)
+const visibleLayers = computed(() => store.getters.visibleLayers)
 
 watch(storeCompareRatio, (newValue) => {
     compareRatio.value = newValue
     slice()
 })
 
-watch(visibleLayerOnTop, () => {
+watch(visibleLayers, () => {
     nextTick(slice)
 })
 
@@ -53,9 +55,11 @@ function slice() {
         preRenderKey.value = null
         postRenderKey.value = null
     }
-    const topVisibleLayer = olMap?.getAllLayers().find((layer) => {
-        return visibleLayerOnTop.value && layer.get('id') === visibleLayerOnTop.value.id
-    })
+    const topVisibleLayer = olMap
+        ?.getAllLayers()
+        .toSorted((a, b) => b.get('zIndex') - a.get('zIndex'))
+        .find((layer) => layer.get('id') === visibleLayerOnTop.value?.id)
+    log.debug(`Compare slider slicing`, topVisibleLayer, visibleLayerOnTop.value)
     if (topVisibleLayer && isCompareSliderActive.value) {
         preRenderKey.value = topVisibleLayer.on('prerender', onPreRender)
         postRenderKey.value = topVisibleLayer.on('postrender', onPostRender)


### PR DESCRIPTION
Because the layers can be duplicate we need to take the one on top of the open layer
list, not that this list is by default not by zindex sorted.

The compare slice needs also to be done each time any layers from the list
changes its visibility otherwise the compare ratio is not applied to the correct
layer.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-332-compare/index.html)