### PR TITLE
PB-166 : use OpenLayers to detect vector features

### DIFF
--- a/src/modules/map/components/common/mouse-click.composable.js
+++ b/src/modules/map/components/common/mouse-click.composable.js
@@ -1,13 +1,7 @@
 import { computed } from 'vue'
 import { useStore } from 'vuex'
 
-import LayerTypes from '@/api/layers/LayerTypes.enum'
 import { ClickInfo, ClickType } from '@/store/modules/map.store'
-import {
-    identifyGeoJSONFeatureAt,
-    identifyGPXFeatureAt,
-    identifyKMLFeatureAt,
-} from '@/utils/identifyOnVectorLayer'
 import log from '@/utils/logging'
 
 const dispatcher = { dispatcher: 'mouse-click.composable' }
@@ -20,26 +14,6 @@ export function useMouseOnMap() {
     let contextMenuTimeout = null
 
     const store = useStore()
-    const isCurrentlyDrawing = computed(() => store.state.ui.showDrawingOverlay)
-    const currentKmlDrawingLayer = computed(() => store.getters.activeKmlLayer)
-    const visibleGeoJsonLayers = computed(() =>
-        store.getters.visibleLayers.filter((layer) => layer.type === LayerTypes.GEOJSON)
-    )
-    const visibleKMLLayers = computed(() =>
-        store.getters.visibleLayers
-            .filter((layer) => layer.type === LayerTypes.KML)
-            .filter(
-                (kmlLayer) =>
-                    // No identification of feature on the active KML layer used in the drawing module
-                    // as this module already does identification of drawn feature itself.
-                    !isCurrentlyDrawing.value || kmlLayer.id !== currentKmlDrawingLayer.value?.id
-            )
-    )
-    const visibleGPXLayers = computed(() =>
-        store.getters.visibleLayers.filter((layer) => layer.type === LayerTypes.GPX)
-    )
-    const currentMapResolution = computed(() => store.getters.resolution)
-    const currentProjection = computed(() => store.state.position.projection)
     const isCurrentlyTrackingGeoLocation = computed(
         () => store.state.geolocation.active && store.state.geolocation.tracking
     )
@@ -62,45 +36,23 @@ export function useMouseOnMap() {
         }, msBeforeTriggeringLocationPopup)
     }
 
-    function onLeftClickUp(screenPosition, coordinate) {
+    /**
+     * Function to be called when a left on the map has occured.
+     *
+     * Vector features found by the mapping framework (not requiring backend interaction) can be
+     * given as param
+     *
+     * @param {[Number, Number]} screenPosition Position of the click on the screen [x, y] in pixels
+     *   (counted from top left corner)
+     * @param {[Number, Number]} coordinate Position of the click expressed in the current mapping
+     *   projection
+     * @param {SelectableFeature[]} features List of vector features found by the mapping framework
+     *   at the click position
+     */
+    function onLeftClickUp(screenPosition, coordinate, features = []) {
         clearTimeout(contextMenuTimeout)
         // if we've already "handled" this click event, we do nothing more
         if (!hasPointerDownTriggeredLocationPopup && isStillOnStartingPosition) {
-            const features = []
-            // if there is a GeoJSON layer currently visible, we will find it and search for features under the mouse cursor
-            visibleGeoJsonLayers.value.forEach((geoJSonLayer) => {
-                features.push(
-                    ...identifyGeoJSONFeatureAt(
-                        geoJSonLayer,
-                        coordinate,
-                        currentProjection.value,
-                        currentMapResolution.value
-                    )
-                )
-            })
-            // same for KML layers
-            visibleKMLLayers.value.forEach((kmlLayer) => {
-                features.push(
-                    ...identifyKMLFeatureAt(
-                        kmlLayer,
-                        coordinate,
-                        currentProjection.value,
-                        currentMapResolution.value
-                    )
-                )
-            })
-            // and lastly for GPX layers
-            visibleGPXLayers.value.forEach((gpxLayer) => {
-                features.push(
-                    ...identifyGPXFeatureAt(
-                        gpxLayer,
-                        coordinate,
-                        currentProjection.value,
-                        currentMapResolution.value
-                    )
-                )
-            })
-            log.debug('vector features found under mouse cursor', features)
             store.dispatch('click', {
                 clickInfo: new ClickInfo({
                     coordinate,

--- a/src/store/modules/map.store.js
+++ b/src/store/modules/map.store.js
@@ -9,12 +9,12 @@ export const ClickType = {
 
 export class ClickInfo {
     /**
-     * @param {Number[]} clickInfo.coordinate Of the last click expressed in the current mapping
-     *   projection
-     * @param {Number[]} [clickInfo.pixelCoordinate=[]] Position of the last click on the screen [x,
-     *   y] in pixels (counted from top left corner). Default is `[]`
-     * @param {Object[]} [clickInfo.features=[]] List of potential features (geoJSON or KML) that
-     *   where under the click. Default is `[]`
+     * @param {[Number, Number]} clickInfo.coordinate Of the last click expressed in the current
+     *   mapping projection
+     * @param {[Number, Number]} [clickInfo.pixelCoordinate=[]] Position of the last click on the
+     *   screen [x, y] in pixels (counted from top left corner). Default is `[]`
+     * @param {SelectableFeature[]} [clickInfo.features=[]] List of potential features (geoJSON or
+     *   KML) that where under the click. Default is `[]`
      * @param {ClickType} [clickInfo.clickType=ClickType.LEFT_SINGLECLICK] Which button of the mouse
      *   has been used to make this click. Default is `ClickType.LEFT_SINGLECLICK`
      */


### PR DESCRIPTION
instead of using our own grown functions, it was very hard to detect shapes such as image from a marker (whereas OL has that built-in right away)

We will have to rework how Cesium does it too

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_pb-166_vector_feature_selection_with_ol/index.html)