### PR TITLE
PB-363 : authorize request in a different projection as the map

### DIFF
--- a/tests/cypress/fixtures/external-wms-getcap-2.fixture.xml
+++ b/tests/cypress/fixtures/external-wms-getcap-2.fixture.xml
@@ -152,8 +152,6 @@
             <KeywordList>
                 <Keyword>BGDI Geodaten</Keyword>
             </KeywordList>
-            <CRS>EPSG:2056</CRS>
-            <CRS>EPSG:21781</CRS>
             <CRS>EPSG:4326</CRS>
             <CRS>EPSG:3857</CRS>
             <CRS>EPSG:3034</CRS>

--- a/tests/cypress/tests-e2e/layers.cy.js
+++ b/tests/cypress/tests-e2e/layers.cy.js
@@ -2,6 +2,7 @@
 
 import { encodeExternalLayerParam } from '@/api/layers/layers-external.api'
 import { encodeLayerParam } from '@/router/storeSync/layersParamParser'
+import { WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems.js'
 
 /**
  * This function is used as a parameter to `JSON.stringify` to remove all properties with the name
@@ -277,6 +278,12 @@ describe('Test of layer handling', () => {
                         'eq',
                         'application/vnd.ogc.gml'
                     )
+                    // this serveur doesn't support LV95 or LV03, so WGS84 or Mercator should be selected to request it instead
+                    cy.wrap(intercept.request.query).should('have.a.property', 'CRS')
+                    cy.wrap(intercept.request.query.CRS).should('be.oneOf', [
+                        WGS84.epsg,
+                        WEBMERCATOR.epsg,
+                    ])
                 })
             })
             it('reads and adds an external WMTS correctly', () => {


### PR DESCRIPTION
For external WMS that do not support the current projection of the map, but can handle another we support, we fallback to that to build the request instead of failing

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_pb-363_getfeatureinfo_mixed_projection/index.html)