### PR TITLE
PB-347: Added support for legacy geoadmin icon url

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,7 +5,7 @@
   "trailingComma": "es5",
   "tabWidth": 4,
   "jsxSingleQuote": false,
-  "plugins": ["prettier-plugin-jsdoc"],
+  "plugins": ["prettier-plugin-jsdoc", "@prettier/plugin-xml"],
   "overrides": [{
     "files": "*.md",
     "options": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
                 "@cypress/vite-dev-server": "^5.0.7",
                 "@cypress/vue": "^6.0.0",
                 "@nuintun/qrcode": "^3.4.0",
+                "@prettier/plugin-xml": "^3.3.1",
                 "@rushstack/eslint-patch": "^1.7.2",
                 "@types/jsdom": "^21.1.6",
                 "@types/node": "^18.19.21",
@@ -1251,6 +1252,18 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
+            }
+        },
+        "node_modules/@prettier/plugin-xml": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.3.1.tgz",
+            "integrity": "sha512-kllNJk6n2pXJjGWdj+HAr1GhOoOTrlmeWkDYCGBzkyZS2l0K6h2gsUQcVif2cNqAE1MNC+nUrzN6QwEsCukPnQ==",
+            "dev": true,
+            "dependencies": {
+                "@xml-tools/parser": "^1.0.11"
+            },
+            "peerDependencies": {
+                "prettier": "^3.0.0"
             }
         },
         "node_modules/@protobufjs/aspromise": {
@@ -2459,6 +2472,15 @@
             "integrity": "sha512-VcZK7MvpjuTPx2w6blwnwZAu5/LgBUtejFOi3pPGQFXQN5Ela03FUtd2Qtg4yWGGissVL0dr6Ro1LfOFh+PCuQ==",
             "dev": true
         },
+        "node_modules/@xml-tools/parser": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
+            "integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
+            "dev": true,
+            "dependencies": {
+                "chevrotain": "7.1.1"
+            }
+        },
         "node_modules/@xmldom/xmldom": {
             "version": "0.8.10",
             "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
@@ -3155,6 +3177,15 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/chevrotain": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
+            "integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
+            "dev": true,
+            "dependencies": {
+                "regexp-to-ast": "0.5.0"
             }
         },
         "node_modules/chokidar": {
@@ -7925,6 +7956,12 @@
             "engines": {
                 "node": ">=8.10.0"
             }
+        },
+        "node_modules/regexp-to-ast": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+            "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
+            "dev": true
         },
         "node_modules/reproject": {
             "version": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
         "@cypress/vite-dev-server": "^5.0.7",
         "@cypress/vue": "^6.0.0",
         "@nuintun/qrcode": "^3.4.0",
+        "@prettier/plugin-xml": "^3.3.1",
         "@rushstack/eslint-patch": "^1.7.2",
         "@types/jsdom": "^21.1.6",
         "@types/node": "^18.19.21",

--- a/src/utils/components/TextInput.vue
+++ b/src/utils/components/TextInput.vue
@@ -99,6 +99,7 @@ function onFocusOut(event) {
 function onClearInput() {
     value.value = ''
     error.value = ''
+    inputElement.value.focus()
     emit('clear')
 }
 

--- a/tests/samples/kml/alpen.kml
+++ b/tests/samples/kml/alpen.kml
@@ -1,0 +1,10521 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <name>Viatimages :  : Alpes [Chaîne montagneuse]</name>
+    <Style id="orange_dot">
+      <IconStyle>
+        <scale>1.0</scale>
+        <Icon>
+          <href>http://maps.google.com/mapfiles/kml/shapes/placemark_circle_highlight.png</href>
+        </Icon>
+        <hotSpot x="10" y="10" xunits="pixels" yunits="pixels"/>
+      </IconStyle>
+    </Style>
+    <Style id="yellow_dot">
+      <IconStyle>
+        <scale>1.2</scale>
+        <Icon>
+          <href>http://maps.google.com/mapfiles/kml/shapes/placemark_circle.png</href>
+        </Icon>
+        <hotSpot x="10" y="10" xunits="pixels" yunits="pixels"/>
+      </IconStyle>
+    </Style>
+    <StyleMap id="dot">
+      <Pair>
+        <key>normal</key>
+        <styleUrl>#orange_dot</styleUrl>
+      </Pair>
+      <Pair>
+        <key>highlight</key>
+        <styleUrl>#yellow_dot</styleUrl>
+      </Pair>
+    </StyleMap>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la côte Orientale du Lac de Genève</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=31"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1779fb_280_t_1_pl_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.124449,46.220448,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue circulaire des Montagnes qu’on découvre du sommet du Glacier de Buet</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=129"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1779fb_280_t_1_pl_08.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.850662,46.021157,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Guide glissant sur la glace]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=135"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1779fb_280_t_1_front_03.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.881218,45.977572,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la montagne du Nant d'Arpenaz entre Maglan et Salanche en Faucigny</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=142"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1779fb_280_t_1_pl_04.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.639641,45.976011,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue circulaire des montagnes à partir du sommet du Glacier de Buet</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=145"><img src="http://www2.unil.ch/viatimages/viatimages/small/vanberchem1790_1c_1467_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.8523788452148,46.022173814455,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue des Alpes prise tout près du Signal (ou Hochwacht) placé au sommet de l’Albis, à trois lieues de Zurich</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=148"><img src="http://www2.unil.ch/viatimages/viatimages/small/viaebel1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.53139877319336,47.2692979535922,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue prise à deux lieux de Neuchâtel, dix minutes de distance du village de Rochefort sur la crête de la colline, à droite du chemin qui mène à la Val-Travers</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=150"><img src="http://www2.unil.ch/viatimages/viatimages/small/viaebel2.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.88430786132812,47.0000334997867,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du fond du Lac de Genève prise au dessus de Cueilly</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=162"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0028.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.725264,46.489869,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bridge of St. Maurice on the Rhône</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=170"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1800_ac_389_16.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.00181,46.228049,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Martigni and the valley of the Rhône</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=171"><img src="http://www2.unil.ch/viatimages/viatimages/small/ac_389_18.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.085237,46.104772,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Summit of the Great St. Bernard including the hospice, or convent.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=172"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1800_ac_389_19.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.168236,45.867627,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Source of the Rhône and glacier of la Furca</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=176"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1800_ac_389_21.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.386774,46.576083,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bey der Saegmühle des Lauterbachs, am Zuger-See</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=177"><img src="http://www2.unil.ch/viatimages/viatimages/small/meyer1793_2c_1493_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.512901,47.172435,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Auf dem Vierwaldstätter-See gegen Tells Capelle</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=178"><img src="http://www2.unil.ch/viatimages/viatimages/small/meyer1793_2c_1493_02.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.61179,46.932593,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bey Ponte Tresa, in der Herrschaft Lauis</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=179"><img src="http://www2.unil.ch/viatimages/viatimages/small/meyer1793_2c_1493_09.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.857985,45.967362,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Via Mala, in Bündten</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=180"><img src="http://www2.unil.ch/viatimages/viatimages/small/meyer1793_2c_1493_11.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.448113,46.66225,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ruinen von Bommerstein, am Wallenstatter-See</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=181"><img src="http://www2.unil.ch/viatimages/viatimages/small/meyer1793_2c_1493_12.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.289616,47.113282,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Coupes scientifiques de profile et de face et vue aérienne du Mont Grimsel et de son glacier]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=182"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1751_mvsrg187_002.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.319396973,46.5637507,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Von Altorf gegen den Eingang ins Reüssthal</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=184"><img src="http://www2.unil.ch/viatimages/viatimages/small/meyer1793_2c_1493_03.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.644352,46.879224,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>1ste Tafel, worauf das hohe Kaltgebirge, aus Schichten bestehend, mit der Gallmeygrube von Auronzo im Cadorinischen von der Südseite vorgestellt ist</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=185"><img src="http://www2.unil.ch/viatimages/viatimages/small/hacquet1785_bcul_1c_1349_08.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>12.439871,46.552529,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>2te Tafel. Das ganze kaltgebürge mit den Gallmey- und Bleygruben von Orgentiva im Cadorinischen, von der Nordseite.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=186"><img src="http://www2.unil.ch/viatimages/viatimages/small/hacquet1785_bcul_1c_1349_09.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>12.733154,46.387612,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ascent of the St. Gothard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=197"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1800ac_389_22.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.559723,46.581215,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Glacier]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=198"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1800_ac_389_17.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.344532,45.873389,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mur de Glace pure du Glacier des Bossons</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=210"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1773_az_2996_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.853065,45.888746,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Unweit Airol, im obern Livener-thal</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=214"><img src="http://www2.unil.ch/viatimages/viatimages/small/meyer1793_2c_1493_04.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.789063,46.498392,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Im mittlern Livenerthal, gegen das Bergdorf Calonico</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=215"><img src="http://www2.unil.ch/viatimages/viatimages/small/meyer1793_2c_1493_05.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.834682,46.452723,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ansicht des Monte Rosa von Macugnaga aus</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=221"><img src="http://www2.unil.ch/viatimages/viatimages/small/welden1824_1c_748_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.966461,45.967856,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Topographische Carte des Monte Rosa und seiner Umgebungen.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=222"><img src="http://www2.unil.ch/viatimages/viatimages/small/welden1824_1c_748_02.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.863092,45.93993,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ansicht des Mte Rosa von Lago d'Orta her, vom Ost nach West.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=223"><img src="http://www2.unil.ch/viatimages/viatimages/small/welden1824_1c_748_07.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.421707,45.802478,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ansicht des Mte Rosa von Turin aus, von West nach Ost.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=224"><img src="http://www2.unil.ch/viatimages/viatimages/small/welden1824_1c_748_06.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.679443359,45.05121047,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ansicht des Monte Rosa von Vercelli aus, von Süd nach Nord.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=225"><img src="http://www2.unil.ch/viatimages/viatimages/small/welden1824_1c_748_05.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.425441,45.331091,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ansicht des Mte Rosa von der Gemmi im Wallis, von Nord nach Süd.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=226"><img src="http://www2.unil.ch/viatimages/viatimages/small/welden1824_1c_748_04.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.608719,46.394306,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la vallée de Chamouni de dessus le glacier des Bossons</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=228"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1773_az_2996_03.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.862679,45.874884,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Aspect de la vallée de glace du Sommet du Montanvert</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=230"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1773_az_2996_02.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.937523,45.926729,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>All Aqua fraggia</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=235"><img src="http://www2.unil.ch/viatimages/viatimages/small/meyer1793_2c_1493_13.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.436955,46.331728,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la partie superieure du Glacier des Bossons</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=240"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1803_1c_733_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.852722,45.893354,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Montanvert sur la mer de glace, du Grand Jorace, du Géant, de l'Aiguille des Charmaux et de l'Hospice</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=241"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1803_1c_733_02.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.907654,45.93205,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de l'Aiguille du Gouté prise de l'intérieur de la voute de glace de l'Arveron</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=242"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit18031c_733_03.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.91658,45.945898,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Mont Blanc sur l'Allée Blanche en descendant du Col de la Seigne a Courmayeur</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=243"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1803_1c_733_04.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.836929,45.771834,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Sion</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=244"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1800_ac_389_20.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.344532,46.23447,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>De Devil's Bridge</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=246"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1800_ac_389_24.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.558778,46.590764,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hospice on the St. Gothard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=247"><img src="http://www2.unil.ch/viatimages/viatimages/small/ac_389_23.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.554831,46.564209,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Versoix</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=249"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1800_ac_389_11.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.166935,46.279979,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Geneva</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=250"><img src="http://www2.unil.ch/viatimages/viatimages/small/ac_389_10.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.118097,46.201026,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lausanne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=252"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1800_ac_389_13.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.634026,46.527775,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vevay</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=253"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1800_ac_389_14.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.852722,46.475311,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Gegend um Zürich</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=274"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_008.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.486251831,47.39851575,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Insel Ufnau</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=275"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_009.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.780651093,47.21813597,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ansicht der Alpenkette, von der Hochwache bey Regensberg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=276"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_010.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.435096741,47.48249189,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Morgarten, am Aegeri-See</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=277"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_011.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.640489578,47.10382574,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Alt. Schweizer Kampf am Schindelleggi</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=278"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_012.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.713188171,47.17476181,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lowärtzer-See</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=279"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_013.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.584098816,47.03628836,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Sempacher Schlacht-Kapelle</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=281"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_016.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.212881088,47.1464362,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Von Stanzstadt gegen Hergiswyl</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=282"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_018.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.33278656,46.97948329,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Rozloch, an der neuen Papiermühle</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=283"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_019.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.331413269,46.96405031,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Winkelrieds Kapelle, nach der Revolution</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=284"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_020.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.361024857,46.96014658,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Stanz, vor der Revolution</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=285"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_021.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.365316391,46.95833057,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der Vier-Waldstädter-See</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=287"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_022.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.343772888,46.99751637,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Gersau</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=288"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_023.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.525476456,46.99153627,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Fluelen, am Vierwaldstädter-See</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=289"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_024.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.625469208,46.90100668,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Altorf, vor dem Brand</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=290"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_025.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.643751144,46.87947973,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Die Teufels Brücke</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=291"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_026.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.590321541,46.64657015,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Das Urner-Loch</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=293"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_028.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.592038155,46.68412019,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Gotthard's Strasse am Tizino</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=295"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_030.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.58083725,46.53745814,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ansicht der Ebene von Bellenzone</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=296"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_031.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.013938904,46.18974622,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Isola Bella</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=297"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_032.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.528308868,45.89498788,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der Rhone-Gletscher, links die Grimsel, rechts die Furka</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=298"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_033.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.392524719,46.58499109,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ansicht der Stadt Sion in Wallis</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=299"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_034.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.367277,46.235292,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der Gemmi</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=300"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_035.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.60974884,46.38574698,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ansicht von Unterseen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=301"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_036.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.849774361,46.68550389,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der Staubbach</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=303"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_037.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.90517807,46.58460717,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Grindelwald-Gletscher</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=304"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_038.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.059844971,46.59442859,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Rosenlawi-Gletscher, und Sennen-Hütten</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=305"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_039.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.157348633,46.68238758,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der Reichenbach</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=307"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_040.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.184299469,46.68858667,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Aar-Brücke, auf der Grimsel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=308"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_041.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.313131332,46.60515291,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Brienzer-See</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=309"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_042.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.034267426,46.75366505,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Brücke und Ansicht von der Rhone zu St.Maurice</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=311"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_045.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.015800476,46.20400425,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Meillerie</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=312"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_046.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.721401215,46.40731047,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chamounix-Thal</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=314"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_048.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.830062866,45.90690444,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Das Eismeer auf dem Montanvert</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=315"><img src="http://www2.unil.ch/viatimages/viatimages/small/reichard1827_1c_1450_049.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.925506592,45.92553497,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Montagne nommée le grand Gletscher, dans le Grindelwald, dans le Canton de Berne en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=318"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_03.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.048859,46.613214,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Sources du Haut et du Bas Rhin</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=322"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_07.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.438285828,46.83444564,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Source du Rhône dans le Mont de la Fourche</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=323"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_08.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.37844848632812,46.5652181356167,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Glacier de Grindelwald]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=338"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1751_mvsrg187_001.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.072205,46.585632,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vallée du Lauterbrounnen, vue du village de même nom</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=339"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_001.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.908096,46.59712,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'amas du Lauter-Aar au canton de Berne, ou le vallon de glace du Grimsel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=342"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_004.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.172454,46.578686,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'amas du Tsinke ou le mur de glace de l'amas du Lauter-Aar</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=343"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_005.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.172454,46.578686,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Amas du Rosenlaui sur le Scheidek</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=344"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_006.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.158722,46.653207,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'amas de Schwartswald, ou Forêt Noire</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=345"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_008.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.156319,46.623505,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue des monts & amas de glace du Grindelwald ou Boisgrindel, au canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=346"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_009.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.047829,46.622798,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Amas inférieur du Grindelwald</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=347"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_010.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.048172,46.612894,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Plan des glaciers du Grindelwald</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=348"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_011.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.075294,46.612422,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le ruisseau de poussière en Lauterbrounnen au canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=349"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_012.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.904363,46.584114,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Les monts et amas de glace du Stroubel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=350"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_013.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.534904,46.415139,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La vallée de Simmen ou l'amas du Roetsliberg, au canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=351"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_014.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.465553,46.417506,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'amas de glace de Ghelten</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=352"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_015.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.338696,46.378616,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'amas du Rhône ou du Fourke</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=353"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_016.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.384628,46.581754,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'amas de Faucigny</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=354"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_017.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.856155,45.918677,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'amas de Glitchenon au canton d'Ouri</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=355"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_018.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.5751,46.8772,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'amas du Rheinwald ou bois du Rhin dans le Paradis en Bunden, près de la source du bras postérieur du Rhin.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=357"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_020.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.108592,46.496704,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'amas de Bernina en Bunden</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=358"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_021.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.901428,46.377728,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'amas du haut Saentis au canton d'Abbentsel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=359"><img src="http://www2.unil.ch/viatimages/viatimages/small/grunner1770_mvsrg154_022.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.342499,47.249407,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Cascade of Nant Arpenaz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=361"><img src="http://www2.unil.ch/viatimages/viatimages/small/seymour1827_mvsrh279_002.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.64052,45.974587,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Blanc from the Bridge of Pellissier</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=362"><img src="http://www2.unil.ch/viatimages/viatimages/small/seymour1827_mvsrh279_002b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.760754585,45.92634046,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Vale of Trient leading to the pass of the Tête Noir.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=363"><img src="http://www2.unil.ch/viatimages/viatimages/small/seymour1827_mvsrh279_005.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.98387146,46.06773543,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chateau de st.Michel Martigny</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=364"><img src="http://www2.unil.ch/viatimages/viatimages/small/seymour1827_mvsrh279_006.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.070818,46.105962,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Liddes</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=365"><img src="http://www2.unil.ch/viatimages/viatimages/small/seymour1827_mvsrh279_007.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.184372,45.991084,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Dead-house at St. Bernard's</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=366"><img src="http://www2.unil.ch/viatimages/viatimages/small/seymour1827_mvsrh279_008.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.199821472,45.90383259,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Courmayeur</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=367"><img src="http://www2.unil.ch/viatimages/viatimages/small/seymour1827_mvsrh279_08b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.967906952,45.79370727,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>A Châlet near the Col du Bonhomme</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=368"><img src="http://www2.unil.ch/viatimages/viatimages/small/seymour1827_mvsrh279_010.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.624755859,45.70220719,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Church of St. Helena in the Valley d'Aoste</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=371"><img src="http://www2.unil.ch/viatimages/viatimages/small/seymour1827_mvsrh279_009.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.03125,45.76050939,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Triumphal Arch in the Cité d'Aoste</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=372"><img src="http://www2.unil.ch/viatimages/viatimages/small/seymour1827_mvsrh279_013.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.328449,45.739437,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>View in the Valley of Chamouny of the Glacier des Bois</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=373"><img src="http://www2.unil.ch/viatimages/viatimages/small/seymour1827_mvsrh279_003.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.898384,45.95768,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Argentièr</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=374"><img src="http://www2.unil.ch/viatimages/viatimages/small/seymour1827_mvsrh279_004.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.927481,45.981917,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>From the window at the Cure's house at Contamine</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=375"><img src="http://www2.unil.ch/viatimages/viatimages/small/seymour1827_mvsrh279_014.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.727753,45.82087,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Glacier de Chermotane</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=378"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1785_mvsrz1202_1_004.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.387962,45.928639,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la vallée de Glace de Chermotane</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=379"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1785_mvsrz1202_1_005.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.427101,45.940578,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Salt-works at Bex</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=380"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1800_ac_389_15.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.026101,46.267529,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Vallais et du Rhône</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=381"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1785_mvsrz1202_1_002.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.408905,46.239397,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du lac de Kandel Steig</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=382"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1785_mvsrz1202_1_003.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.724247,46.498553,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Glacier du Rhône et de la Source de ce Fleuve</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=383"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1785_mvsrz1202_2_007.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.380508,46.571473,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Pont du Diable</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=384"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1785_mvsrz1202_2_008.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.59,46.6475,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Glacier du Grindelvald</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=385"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1785_mvsrz1202_2_006.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.054695,46.60811,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du lac de Chède et du Mont Blanc</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=386"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1785_mvsrz1202_2_009.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.727066,45.934785,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vüe du Glacier des bossons & du Mont Blanc, prise de Chamouny</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=387"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1785_mvsrz1202_3_010.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.850147,45.902877,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vüe de la Vallée de Chamouni, de l'Arvéron & des Aiguilles des Charmos</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=388"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1785_mvsrz1202_3_011.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.903877,45.944909,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vüe de la mer de Glace du montanvert</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=389"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1785_mvsrz1202_3_012.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.939754,45.899532,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vüe de l'amas de Glace et de la source de l'Arveron</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=390"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1785_mvsrz1202_3_013.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.920014,45.942283,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vüe du Glacier de la Valsoret</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=391"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit1785_mvsrz1202_3_014.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.264023,45.919564,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Bourg d'Altdorf, Capitale du Canton d'Uri, en Suisse.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=394"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_22.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.64636898,46.88066139,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Sources de la Reuss et Cache d'une partie du Canton d'Uri</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=395"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_23.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.646240234,46.82235042,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lacus in Monte Gotthardi</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=396"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_24.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.558006287,46.56291567,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bourg de Schwitz en Suisse, Capitale du Canton du même nom: en perspective</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=397"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_25.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.65036,47.020375,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Représentation du Bourg de Schwyts en Suisse & de quelques Lieux voisins</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=398"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_26.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.65139,47.024705,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Einsiedeln ou Nôtre Dame des Hermites, Lieu fameux de Devotion dans le Canton de Schwytz & Monastére dans l'Abbé porte le titre de Prince</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=399"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_27.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.7479496,47.12736482,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Canton d'Unterwald, en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=401"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_29.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.334846497,46.95230507,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Carte du Canton de Glaris</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=404"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_32.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.080886841,47.02226488,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bourg de Glaris, Capitale du Canton de même nom; en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=405"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_33.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.068226814,47.04163615,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bourg d'Appenzell, Capitale du Canton de même nom, en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=413"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_42.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.409747124,47.33089311,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lugano, Bailliage en Italie, appartenant aux Suisses</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=429"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_56.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.950724602,46.00500213,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bellinzone, en allemand Bellentz, Bailliage d'Italie, aux 3 petits Cantons</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=430"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_57.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.023595,46.193816,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Abbaye de Disentis, dans la Ligue haute des Grisons</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=435"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_62.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.855881691,46.70670073,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Coire, Capitale des Grisons</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=436"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_63.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.531240463,46.84879575,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Mont-Jule dans l'Engadine</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=437"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_64.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.728536,46.472206,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Meyenfeld</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=438"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_65.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.530382156,47.00734126,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vuë du Bain de Leuk en Vallais, & du Chemin merveilleux par où l'ong décend du haut du Mont Gemmi; long de dix mille piez</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=439"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_66.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.622966766,46.38161918,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Ville de Sedunum, ou Sion, dans le Païs de Valais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=440"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_67.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.354488373,46.23242558,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Ville de Genève</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=441"><img src="http://www2.unil.ch/viatimages/viatimages/small/altmann1730_aa_1695_68.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.148996353,46.20411464,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pierre des Marmettes</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=444"><img src="http://www2.unil.ch/viatimages/viatimages/small/charpentier1841_mvssn1279_002.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.943703,46.250947,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pierre à Dzo</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=445"><img src="http://www2.unil.ch/viatimages/viatimages/small/charpentier1841_mvssn1279_003.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.946793,46.267088,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pierre du Four</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=446"><img src="http://www2.unil.ch/viatimages/viatimages/small/charpentier1841_mvssn1279_004.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.946106,46.249878,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pierre des Mourguets</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=447"><img src="http://www2.unil.ch/viatimages/viatimages/small/charpentier1841_mvssn1279_005.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.951427,46.253914,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pierre à Milan</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=448"><img src="http://www2.unil.ch/viatimages/viatimages/small/charpentier1841_mvssn1279_006.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.949539,46.254626,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pierre de la Poudrière de Sion du côté de l'Est</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=449"><img src="http://www2.unil.ch/viatimages/viatimages/small/charpentier1841_mvssn1279_007.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.369192,46.236488,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pierre de la Poudrière de Sion du côté du Sud</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=450"><img src="http://www2.unil.ch/viatimages/viatimages/small/charpentier1841_mvssn1279_008.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.369192,46.236488,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier du Rhône</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=451"><img src="http://www2.unil.ch/viatimages/viatimages/small/charpentier1841_mvssn1279_009.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.376216,46.570764,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Blocs erratiques de Monthey]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=452"><img src="http://www2.unil.ch/viatimages/viatimages/small/charpentier1841_mvssn1279_010.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.948681,46.252744,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue des bords du lac de Genève, près St. Gingouph</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=462"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_003.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.815416,46.39008,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de l'extrémité du Lac de Genève, et de l'entrée du Rhône près le Boveret</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=464"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_004.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.850705,46.387223,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le pont de St. Maurice</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=465"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_005.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.002039,46.224384,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Cascade de Pissevache</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=466"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_006.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.029372,46.144122,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Sion prise du côté du couchant</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=467"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_007.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.359295,46.234342,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Sion prise de côté du levant</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=469"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_008.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.372513,46.24016,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Blanc, from St. Martin</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=500"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_003.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.6412353515625,45.9395395731162,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vale of Sallence</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=501"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_005.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.63986206054688,45.9371758744587,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bridge of Pelessier. Near Servos</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=502"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_002.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.76792144775391,45.9302274438336,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Blanc, from the village of Chamouny</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=503"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_006bis.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.86817169189453,45.9240184889253,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier of Mer de Glace. From Montaignvert</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=504"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_006.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.932373046875,45.9155556822586,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mer de glace</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=505"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_007.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.94198608398438,45.9021781481262,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Valais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=506"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_008.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.00618743896484,46.0586364366272,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Old castle, at Martigny</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=507"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_009.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.0725345611572,46.106549348737,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>St. Branchier, in the valley of Bagne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=508"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_011bis.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.15347290039062,46.0765014823079,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Convent on the Grand St. Bernard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=509"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_010.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.1685791015625,45.8678914671368,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Gemmi</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=510"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_011.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.60391235351562,46.39779406517,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Brieg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=513"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_009.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.978758,46.322169,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la Galerie et du Pont de Ganther</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=514"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_010.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.047708,46.296473,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue prise de la sortie de la Galerie de Schalbet, du coté de l'Italie</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=515"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_011.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.045812,46.25845,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la Galerie de Schalbet, prise du côté de l'Italie</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=516"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_012.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.046412,46.257085,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la Galerie des Glaciers</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=517"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_014.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.038216,46.252456,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de l'emplacement de l'Hospice du Simplon, et du Mont Rosa</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=518"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_013.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.027744,46.247165,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Village de Simplon</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=519"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_015.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.053685,46.197649,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la Galerie d'Algaby, prise du côté du Vallais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=520"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_016.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.07255,46.178464,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue prise de l'Intérieur de la Galerie d'Algaby</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=521"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_017.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.072505,46.178623,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ponte Alto</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=522"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_018.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.072655,46.184892,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la nouvelle route près de la grande galerie</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=523"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_019.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.111472,46.194756,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de l'Intérieur de la Grande Galerie</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=524"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_020.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.124626,46.198157,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la Sortie de la Grande Galerie, du côté de l'Italie</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=525"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_021.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.132994,46.199286,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue près de Gondo</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=526"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_022.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.137994,46.19637,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la Galerie d'Issel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=527"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_023.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.191509,46.205222,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Entrée du Vallon de Dovedro</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=528"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_024.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.209019,46.205965,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pont sur la Cherasca</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=529"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_025.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.280516,46.178506,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de l'entrée de la dernière Galerie, dessinée du côté du Simplon</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=530"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_026.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.291245,46.155502,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Pont de Crevola et de la Vallée de Domo D'ossola</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=531"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_027.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.3006,46.151875,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Pont de Crevola</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=532"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_028.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.301864,46.151334,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Villa</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=533"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_029.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.260805,46.070104,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Pont de Baveno et de l'Isola madre</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=534"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_031.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.500761,45.91287,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Lac Majeur et des Isles Boromées</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=535"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_032.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.508697,45.901529,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de l'Isola Bella</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=537"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_033.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.526807,45.895346,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de l'Isola Bella prise de Stresa</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=538"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_034.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.540111,45.885071,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Sesto</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=540"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1811_mvsrh490_036.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.640262,45.722375,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la ville de Genève du côté des Paquis</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=549"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0023.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.15097,46.21019,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la ville de Berne, prise de la Promenade</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=552"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0025.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.44976,46.949266,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la Glacière d'où sort le Trien</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=553"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0026a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.008591,46.031772,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Trien, Torrent qui sort des glaciers du Valais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=554"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0026b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.999836,46.037582,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Lac de Genève et de la côte d'Ouchy, sous Lausanne, Prise du rivage de Morges</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=555"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0027a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.615829,46.509853,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue d'une partie du Lac de Genève, et du fond des Glaciers de Savoye, prise de Genève au Paquis</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=557"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0029.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.151915,46.212507,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la grande glacière du Grindelwald. Prise de Coté</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=567"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0034.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.051605,46.608884,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ruines de la ville de Pleurs. Dans le Comté de Chiavenne renversée par un Tremblement de Terre le 25 Aoust 1618</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=568"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0035.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.431618,46.327234,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue d'une Fabrique. Dans la Montagne de Martigny en Valais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=569"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0036a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.023354,46.074183,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Autre vue de la même Montagne près du Trien</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=570"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0036b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.016487,46.071087,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Genève du côté de la chute du Rhône</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=577"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0040.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.109428406,46.202884,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la Glacière ou l'Aar prend sa source. Dans un Lieu nommé Ospital, au Pied du Mont Grimsel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=588"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0049.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.332443,46.571341,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du roc et du trou de St. Batt sur le Lac de Thun</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=589"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0050a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.79407,46.684452,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Chateau de Spietz à M. le Cte. d'Erlach, Sur le Lac de Thun</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=590"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0050b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.687361,46.68928,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Pont du Diable</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=597"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0055.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.590922,46.647286,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ruines du chateau de la Tour-Chatillon, dans le Haut Valais; au dizain de Rarogne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=599"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0057a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.782108,46.312992,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Rarogne dans le haut Valais, avec les Ruines du Chateau de ce nom</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=600"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0057b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.80349,46.31076,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Martinach ou Martigny, Bourg dans le bas Valais, connu des Romains sous le nom d'Octodurus</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=602"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0060.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.069241,46.105122,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>IIme vue d'une partie de la ville de Fribourg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=608"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0064b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.166541,46.806023,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue prise du pont de péage près d'Interlachen, avec la sortie de l'Aar, du Lac de Brientz pour se jetter dans celui de Thoun, Canton de Berne.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=609"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0065.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.865696,46.690782,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la ville de Coire</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=610"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0066.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.53124,46.848863,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la ville de Gruyères et des montagnes voisines, sur la Rivière de Sane, dans le Canton de Fribourg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=611"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0067.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.083971,46.584734,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Source du Rhône dans les glaces du mont de la Fourche, en Valais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=612"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0068.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.382568,46.578923,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la Cascade de Lauterbrunn, dans le Baillage d'Interlachen, Canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=614"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0070.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.904749,46.583288,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Passage pour aller au Grindelwald, Canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=615"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0071a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.015213,46.625863,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la petite glacière du Grindelwald, dans le Canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=616"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0071b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.090057,46.62044,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cascade du Tesin, A Sa Source au Mont Saint Gothard, dans le Canton d'Uri</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=620"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0074a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.582039,46.539027,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du local voisin de la chute du torrent de Bellegarde, Canton de Fribourg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=630"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0080a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.276736,46.613865,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la cascade formée par le torrent de Bellegarde, Canton de Fribourg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=631"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0080b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.276533,46.613631,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du mont Gemmi, avec le chemin pratiqué dans le roc, pour descendre aux Bains de Leuck dans le Haut Vallais.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=632"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0081.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.614899,46.387438,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue d'une partie du Mont Grimsel, dans le Canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=638"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0085.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.336563,46.562519,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Bellinzone, Capitale de l'un des trois Baillages Italliens, apartenant aux Cantons d'Uri, de Schwies et d'Undervalden. Cette Ville est située près du Confluent de la Moesa et du Tessin.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=640"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0087.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.02308,46.191566,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Iere vue d'un passage du Mont St. Gothard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=643"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0089.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.6695,46.769792,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la source de la Russe au Mont St. Gothard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=645"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0091.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.56041,46.588597,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>IIe. vue d'un passage du mont St. Gothard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=652"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0096.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.64212,46.746683,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue d'un pont sur le Tesin, dans le Mont St. Gothard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=654"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0098.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.578949,46.540444,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la ville de Sion, Capitale du Vallais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=657"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0101.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.363629,46.234626,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Mont St. Gothard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=658"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0102.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.55835,46.563109,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du lac de Lungern, Canton du Haut Undervvald</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=671"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0109a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.155288696,46.78525113,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Bourg de Sarnen, Prise à la gauche du Lac du même nom, dans le Chemin d'Underwwald Superieur ou d'enhaut.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=672"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0109b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.240604,46.890584,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue d'un passage du mont St. Gothard, avec une Cascade sur la Russ</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=673"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0110a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.583412,46.65574,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue d'un autre passage du mont St. Gothard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=674"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0110b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.586674,46.661867,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ière vue de la voute du rocher sous la quele on passe sur le Mont St. Gothard, au dessus du Pont du Diable</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=675"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0111a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.572168,46.61142,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>IIe vue de la voute du rocher, passage du mont St. Gothard, du Coté d'urselen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=676"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0111b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.571997,46.610123,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Pont de Hospital, Dernier Village en montant au St. Gotthard, Canton d'Uri</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=678"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0114a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.569443,46.620897,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Bourg d'Altorf, la Capitale du Canton d'Uri, avec le site des Montagnes de Lucerne, autrement le Lac des quatres Cantons</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=679"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0114b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.643751,46.880362,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Bourg de Gersau, petite République sur le Lac de Lucerne, ou des quatres Cantons</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=680"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0115a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.525047,46.99186,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du château de Buehenas sur le Lac de Zug, appartenant à M. de Schweitzer, Conseiller d'Etat de Lucerne, sous la haute Jurisdiction de la Ville de Zug. </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=695"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0122b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.470459,47.140548,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de l'Aiguille du Midi située au N. E. du Mont Blanc et Vue de l'Aiguille de Bellaval, située au S. O. du Mont Blanc</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=696"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1779fb_280_t_1_pl_06_07.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.890831,45.878951,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue d'une des cascades du Tesin, en descendant le St. Gothard pour arriver à Airolo, dans la Vallée de Livenen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=697"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0123.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.582726,46.536901,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pont sur la Russ prés le village de Multiback, dans le Canton d'Uri</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=705"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0129.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.593025,46.688191,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Lac de Lucerne, prise au dessus de la Ville</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=706"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0130.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.324633,47.048897,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de l'Abbaye de Pfeffers, dans le Comté de Sargans qui appartient aux huit anciens cantons</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=710"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0133a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.501758,46.990294,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cascade des bains de Pfeffers près du Pont de Ragatz, dans le Comté de Sargans</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=711"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0133b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.48781,46.970824,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>IIe vue de la Grande glacière, au Grindelwald, Canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=719"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0139.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.056068,46.596383,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Bourg d'Appenzell, Capitale du Canton de ce nom, prise sur le Haut de la Riviere de Sitter.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=721"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0140b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.410927296,47.33065,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du port de Walenstadt du coté de Naefels</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=724"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0143.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.096165,47.133688,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Source de la Weisluchine, ou Lulchine Blanche, qui sort d'une Grotte de glace au pied du Glacier inférieur au Grindelwald, Canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=725"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0144.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.089371,46.622091,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Lac de Walenstadt et de ses montagnes, prise au dessus du Magasin</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=728"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0146a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.311256,47.125045,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la ville et des montagnes de Walenstadt, du Coté de Sargans</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=729"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0146b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.311256,47.125045,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Bourg de Glaris, Capital du Canton de ce nom</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=733"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0149.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.069214,47.041001,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Rhône près de Sion</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=734"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0150a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.325305939,46.22664046,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la Cascade de Pissevache, dans le Vallais.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=735"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_3_0150b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.02919,46.144518,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Felsenburgh</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=737"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_004.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.673252821,46.5320743,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bridge over the Rhône, at St Maurice</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=738"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_014.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.007904053,46.21773299,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Castle of Chillon</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=739"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_016.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.927567,46.41431,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Village of Bex</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=740"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_015.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.00515747070312,46.2519218839156,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Clarens, on the Lake of Geneva</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=741"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_017.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.890830994,46.44099173,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vevay</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=743"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_019.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.840791702,46.47000991,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lausanne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=744"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_020.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.635828018,46.52439763,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bern, from Enghi</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=748"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_028.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.432079,46.971702,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Thun</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=749"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_025.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.627108097,46.76029695,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cottage at Interlachen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=755"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_033.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.85368,46.685718,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Convent of Engelberg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=762"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_038.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.410634995,46.82041423,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lake of Sarner</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=763"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_040.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.194770813,46.84892147,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>City of Lucerne and mons Pilot</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=764"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_013.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.30845356,47.05299043,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lucerne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=765"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_012.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.304086924,47.05203284,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lake of Zug</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=767"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_042.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.521442413,47.27550217,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lake of Lowertz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=768"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_043.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.597348928,47.03248985,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Fluellen, canton of Uri</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=769"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_044.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.623323441,46.90114058,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Altorf from the Capuchin Convent, pass between the Mountains leads to Italy</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=770"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_045.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.639802933,46.88090437,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Burglen, canton of Uri</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=771"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_046.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.663363457,46.87700289,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Devil's Bridge</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=772"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_051.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.590664864,46.64722664,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Village of Goschenen, between Wasen and the Devil's Bridge</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=773"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_050.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.588197231,46.6683018,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pfaffensprung, a bridge over the Reuss below Wasen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=774"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_049.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.604934216,46.70773488,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Amsteg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=775"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_048.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.671281338,46.76916009,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Trou d'Uri</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=776"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_047.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.590836525,46.64790424,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du premier pont du Tesin, sur le Mont St. Gothard, du coté de l'Italie</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=788"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0010a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.571911,46.550302,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du dernier pont en montant le St. Gotthard, au dessous du Pont du Diable</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=789"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0010b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.556118,46.565293,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bains et auberge de Rosenlaui</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=793"><img src="http://www2.unil.ch/viatimages/viatimages/small/walsh1834_az_426_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.153636456,46.68020541,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du pont du milieu, dans la Via-mala</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=795"><img src="http://www2.unil.ch/viatimages/viatimages/small/walsh1834_az_426_03.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.448242188,46.66510644,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hospice du Grimsel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=796"><img src="http://www2.unil.ch/viatimages/viatimages/small/walsh1834_az_426_04.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.332722,46.571887,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Mont Blanc, Vue du Lac de Chède</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=797"><img src="http://www2.unil.ch/viatimages/viatimages/small/walsh1834_az_426_05.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.72715187072754,45.9351433679251,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Berne, vue de l'Engi</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=800"><img src="http://www2.unil.ch/viatimages/viatimages/small/walsh1834_az_426_08.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.450790405,46.95067238,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la ville de Genève, prise du Lac</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=812"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0013.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.148524284,46.20128007,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Rocher perpendiculaire, Ou l'on a placé des Echelles qui servent de chemin aux habitans d'Albinen, près des Bains de Leuck</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=826"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0020.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.630005,46.32678,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la rivière de la Lint, et des Montagnes de Glaris.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=829"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0022a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.031448,46.95823,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Bourg de Naefels, et des Montagnes du coté du Lac de Wallenstadt</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=830"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0022b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.063635,47.099636,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chaine des Glaciers de l'Oberland, vue depuis les environs de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=862"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyss1817_bpun_55_4_03_3_0002.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.476196,46.961511,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du village et du lac de Brienz, Canton de Berne Bailliage d'Interlachen, à l'endroit ou étoit le Village de Kienholz que les Lavanges ont détruit</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=872"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0024.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.032637,46.754387,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Jonction du haut et du bas Rhin, a Richenau Pays des Grisons</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=873"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0025a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.40773,46.823615,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Roselaui Gletscher, Glacier qui descend du Wetter-horn au Canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=874"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0025b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.163185,46.691135,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pont sur le Trient, il débouche entre deux Rochers ou il s'est creusé son lit, dans le bas Valais.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=875"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0026.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.043009,46.130899,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Renck-loch, dans le Canton de Lucerne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=876"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0027.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.25923,46.981658,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pont sur la rivière d'Aar, entre Ospital et la Source de cette Rivière</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=877"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0028a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.267899,46.564054,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ière vue des cascades du Tesin, en descendant le Mont St. Gothard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=879"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0029a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.581095,46.537905,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>IIème vue des cascades du tesin, en descendant le Mont St.Gothard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=880"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0029b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.573971,46.541506,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hospice du St. Bernard du coté du val d'Aost, dessiné au dela du Lac</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=883"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0032.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.166948,45.868915,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Château de la petite ville de Rheinegg, Capitale du Comté de Rheinstal, appartenant aux huit premiers Cantons et a celui d'Appenzell.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=885"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0033b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.589948654,47.4666288,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Grande chute d'eaux, du fond d'Engelberg, près des Glacieres</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=890"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0036.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.471146,46.792538,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Lac au pied de l'Hospice du St. Bernard, dessiné d'une des Fenêtre de la Maison</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=898"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0041.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.167592,45.868728,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>IIe vue du Pont du Diable</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=899"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0042.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.590665,46.647227,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le fond de la Combe, par lequel on arrive à l'hospice du st.Bernard au Valais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=901"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0044.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.183465,45.877607,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la ville et du château de Sargans, dans le Comté de ce nom appartenant aux huit premiers et anciens Cantons, prise en arrivant de Wallenstadt</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=906"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0048.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.43747,47.050154,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Unter-Gletscher, ou Glacier inférieur de la Vallée du Grindelwald, Canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=909"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0051.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.052979,46.598506,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier du Fischer-Thal dans le Grindelwald, dessiné d'Arnen dans le haut Valais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=910"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0052a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.136063,46.469552,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chute de la Vassorée, A coté du Bourg St. Pierre au pied du Mont St. Bernard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=911"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0052b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.178407,45.871396,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Lac de Lucerne, en partant du Promontoire de Meggen-horn</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=914"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0054.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.36169,47.032329,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Martis-Loch, trou st.Martin, Meridien naturel dans un Rocher percé par lequel le Soleil eclaire en mars et en Septembre le Clocher du Village d'Elm au Canton de Glaris</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=915"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0055.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.217186,46.894689,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du champ de bataille de Naefels, avec la borne ou les Glarnois fixerent la Victoire le 7 Avril 1388</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=917"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0057.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.062476,47.099168,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Lac de Lucerne, prise auprès de la ville</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=920"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0059a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.321199,47.055739,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Lac de Lucerne et du Mont-Pilate, prise de la pointe de L'Isle près la Maison des Baterliers</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=921"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0059b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.253736,46.979667,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier du Rhône au haut du Valais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=922"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0060.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.384628,46.582934,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La montagne de la Gemmi, dans le haut Valais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=923"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0061.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.62331,46.370148,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Rocher dans les montagnes de Lungern, au Canton d'Underwalden d'en haut</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=930"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0067a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.159494,46.773848,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Bourg de Schweitz, la Capitale du Canton de ce nom, prise du coté de Brunnen, et du Lac des quatres Cantons</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=932"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0068.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.653407,47.020905,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Bourg de Stanz, la Vapitale du Canton d'Underwald - le Bas, prise de la Montagne Bloum-Alp</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=938"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0072.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.366947,46.957117,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la cascade de Rotz-Loch, dans le Canton d'Underwalden, qui tombe dans le lac de Lucerne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=939"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0073.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.331585,46.963678,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Lugano, Capitale du Bailliage ultramontain de ce nom, appartenant aux douze premiers Cantons, située sur les bords du Lac</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=943"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0079.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.95021,46.002,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>IIe. vue du Mont Pilate, pres la Ville de Lucerne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=944"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0080a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.255196,46.980369,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de l'Ance, prise à droite du Lac de Lucerne et du Port de Stanz-stad, ou l'on voit sur le devant les restes de l'ancienne Ville de Lucerne et le Rocher ou est la Chapelle du petit St. Nicolas</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=945"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0080b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.33313,46.980721,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Lac d'ou sort la source du Tesin, et de l'hospice des Capucins sur le haut du St. Gothard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=950"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0089a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.565989,46.555319,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du pont aux dessous du pont du diable, en montant le St. Gothard sur la Russ</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=951"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0089b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.583412,46.656094,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Plan perspectif d'une grande partie des cantons de Lucerne, d'Uri, de Schweitz, d'Under-walden, de Zoug, et de Glaris, avec la Frontiere de celui de Berne.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=952"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0091.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.397846,47.015288,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Plan perspectif d'une grande partie des cantons de Lucerne, d'Uri, de Schweitz, d'Under-walden, de Zoug, et de Glaris, avec la Frontiere de celui de Berne. [Explicatif du plan du Général Pfiffer]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=953"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0092.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.398489545,47.0151708,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Saint Paul, dans la Paroisse d'Arbedo, près de la Ville de Bellinzone, Local célèbre par la Victoire des Suisses sur le Duc de Milan en 1422</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=955"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0098.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.044302,46.213472,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Entrée de la vallée Lévontina, En Venant du Mont St. Gothard près d'Airolo</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=956"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0099a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.636112,46.522375,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Sortie de la vallée Lévontina a Pole</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=957"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0099b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.943858,46.364551,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ier vue de la vallée de Hassli, dans le canton de Berne, à la Source de l'Aar sous les Glacières</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=960"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0101a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.324203,46.593788,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>IIe vue de la vallée de Hassli, et de la tête de Lac de Brienz, dans le Canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=961"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0101b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.074608,46.744331,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Leuk, célèbre par ses Bains dans le haut Vallais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=964"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0103.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.627344,46.380925,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du pont de Saint Maurice, sur le Rhône dans le bas Vallais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=969"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0106b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.008634,46.217822,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cascade du Tessein Au Mont St. Gothard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=971"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0107b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.570709,46.544458,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'entrée dans la gorge d'Engelberg, prise de Grafen-ort, Maison de Campagne de l'Abbé d'Engelberg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=972"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0108a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.376989,46.82479,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chute d'eaux sur le haut de la derniere Montagne du Païs d'Engelberg en descendant au Canton d'Uri</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=973"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0108b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.450375,46.794419,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Pont du Diable et de ses rochers, au Mont Saint Gothard, dans le Canton d'Uri</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=974"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0109.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.590879,46.647492,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Vevay ; et du Lac de Genève</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=975"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0110.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.841993,46.462428,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pelerinage de Herrgotts-Wald, la Foret du Seigneur au pied du Mont Pilate avec le Torrent du Reng-bach dans le Canton de Lucerne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=977"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0111b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.239789,47.022046,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>IIe vue du château de Chillon, dans le Canton de Berne, sur le Lac de Genève, prise du côté du Vallais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=984"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0115.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.927631,46.414133,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la premiere cascade de la Russ, sur le Mont S.Gothard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=992"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0120a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.565559,46.600039,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Lac de Luzendro, qui forme l'une des Principales Sources de la Russ, sur le Mont S.Gothard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=993"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0120b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.538437,46.561103,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Croix plantés près d'Ulrichen Dans le haut Vallais, en Mémoire de la Victoire des Vallaisans, sur le Duc de Zeringen en M.CC.XI</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=994"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0121.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.303432,46.504537,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue d'une Fabrique de moulins hors Lucerne, avec le Mont Pilate dans le fond</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=995"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0122a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.278198,47.018653,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cascade du Rossloch, sur le Lac de Lucerne, près de Stanz-stad</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1002"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0125b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.331413,46.962916,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue d'une cascade à la droite du Rhosne, près de sa Source et de sa Chute des Montagnes dans le Fleuve</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1003"><img src="http://www2.unil.ch/viatimages/viatimages/small/zurlauben1780_3c_354_4_0126.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.353987,46.537078,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Auf dem Weg ins Rotthal</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1004"><img src="http://www2.unil.ch/viatimages/viatimages/small/hugi1830_bpun_85_6_04_0001.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.905178,46.529934,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hüttenbau zwischen dem Roth- und Finsteraarhorn</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1005"><img src="http://www2.unil.ch/viatimages/viatimages/small/hugi1830_bpun_85_6_04_0002.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.134346,46.531469,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Profil-Ansicht der Jungfrau, vom Ellstab aus gesehen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1006"><img src="http://www2.unil.ch/viatimages/viatimages/small/hugi1830_bpun_85_6_04_0003.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.942772,46.533831,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Schicktenprofil der Jungfrau von Ost gegen West</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1007"><img src="http://www2.unil.ch/viatimages/viatimages/small/hugi1830_bpun_85_6_04_0004.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.951698,46.535957,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Mettenberg]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1008"><img src="http://www2.unil.ch/viatimages/viatimages/small/hugi1830_bpun_85_6_04_0005.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.081474,46.604875,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Tristenhorn]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1010"><img src="http://www2.unil.ch/viatimages/viatimages/small/hugi1830_bpun_85_6_04_0006.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.20507,46.65627,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Tosenhorn - Engelstock]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1012"><img src="http://www2.unil.ch/viatimages/viatimages/small/hugi1830_bpun_85_6_04_0008.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.173141,46.652736,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Profil-Ansicht der Gebirge von Oberwald bis Brienz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1013"><img src="http://www2.unil.ch/viatimages/viatimages/small/hugi1830_bpun_85_6_04_0009.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.278542,46.660748,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Bützberg im Ursernthal - Kalkthal am Susten]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1015"><img src="http://www2.unil.ch/viatimages/viatimages/small/hugi1830_bpun_85_6_04_0011.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.541183,46.730684,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Titlis - Faulhorn]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1016"><img src="http://www2.unil.ch/viatimages/viatimages/small/hugi1830_bpun_85_6_04_0012.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.437843,46.77326,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Gebirgsprofil vom Lötsch- bis Sefithal</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1017"><img src="http://www2.unil.ch/viatimages/viatimages/small/hugi1830_bpun_85_6_04_0013.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.875481,46.478537,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Profilansicht der Gebirge von Formazza bis Obergestelen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1018"><img src="http://www2.unil.ch/viatimages/viatimages/small/hugi1830_bpun_85_6_04_0014.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.348579,46.442352,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Rigi - Stanserhorn]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1019"><img src="http://www2.unil.ch/viatimages/viatimages/small/hugi1830_bpun_85_6_04_0015.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.377762,47.018419,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Schichtenprofil des Pilatus</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1020"><img src="http://www2.unil.ch/viatimages/viatimages/small/hugi1830_bpun_85_6_04_0016.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.253822,46.97955,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der Unteraargletscher mit seinen Verzweigungen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1022"><img src="http://www2.unil.ch/viatimages/viatimages/small/hugi1830_bpun_85_6_04_0018.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.191681,46.569719,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Fig. 1-4. Desoria glacialis Nic. - Fig. 5. Philodina roseola Ehr.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1025"><img src="http://www2.unil.ch/viatimages/viatimages/small/desor1844_q820a_bpun_q820a_0002.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.251762,46.566414,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hotel des Neuchatelois, sur la Mer de glace du Lauter Aar et du Finster Aar, Côté Méridional</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1026"><img src="http://www2.unil.ch/viatimages/viatimages/small/desor1844_q820a_bpun_q820a_0003.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.185844,46.56901,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Neige rouge</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1027"><img src="http://www2.unil.ch/viatimages/viatimages/small/desor1844_q820a_bpun_q820a_0004.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.181725,46.56901,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Carte du glacier inférieur de l'Aar</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1028"><img src="http://www2.unil.ch/viatimages/viatimages/small/desor1844_q820a_bpun_q820a_0005.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.22052,46.564998,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Les Wetterhörner vus du sommet du Tosenhorn</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1029"><img src="http://www2.unil.ch/viatimages/viatimages/small/desor1844_q820a_bpun_q820a_0006.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.137779,46.632465,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Blanc from the Jura</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1031"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_002.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.102905,46.431232,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Geneva from the ramparts</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1032"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_003.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.152601,46.204428,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cluse, on the Arve-Savoy</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1034"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_005.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.574502,46.059832,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Blanc from above Sallenche</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1035"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_006.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.635742,45.938139,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Baths of St. Gervais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1036"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_007.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.711402,45.892637,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mer de Glace (Chamouni)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1037"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_008.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.917782,45.931214,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The source of the Arveiron, valley of Chamouni</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1038"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_009.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.920185,45.942198,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier of Bossons (Valley of Chamouni)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1039"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_010.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.852036,45.892995,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Blanc, from Chamouni</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1040"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_011.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.871605,45.926319,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Gallery on the "Tête Noire" near Trient</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1041"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_012.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.98679,46.108112,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The col-de-Balme (Looking towards Chamouni)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1042"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_013.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.969444,46.027222,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Rock of Balmarussa, Tete Noire</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1043"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_014.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.974087,46.029866,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Valais & Martigny from the Forclas, pass of the Tete Noire</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1044"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_015.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.000351,46.056675,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pissezache Cascade (Valais)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1045"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_016.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.031937,46.149989,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Batia Castle, Martigny</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1046"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_017.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.076397,46.103233,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Sion, from the W.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1047"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_018.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.356913,46.238218,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ruins of the Episcopal Palace, Sion (Canton Valais)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1052"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_019.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.364616,46.235012,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Street in Sion - Valais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1053"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_020.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.360518,46.233097,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Castle of the Bishops of Sion - Valais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1054"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_021.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.364971,46.234641,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cathedral of Sion, Valais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1055"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_022.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.365464,46.23384,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Viège or Visp - with Monté Rosa</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1056"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_023.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.879515,46.29111,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mount Cervin (From near Stalden)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1057"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_024.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.842522,46.219689,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Scene in the Valley of St. Nicholas</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1058"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_025.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.803984,46.177572,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Brig, with the Ascent of the Simplon</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1059"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_026.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.983627,46.320912,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The bernese Alpes</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1060"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_027.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.022766,46.304015,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Ponte Alto (Simplon)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1061"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_028.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.10482,46.191953,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Gallery of Gondo (Simplon)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1062"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_029.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.150954,46.196438,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Val Vedro-Simplon</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1063"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_030.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.225155,46.205617,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Val d'Ossola. From the Simplon</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1064"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_031.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.303089,46.15094,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lugano (Canton Tessin)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1065"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_032.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.959265,46.009124,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Magadino, Lago Maggiore (Canton Tessin)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1066"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_033.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.85,46.15,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The convent of là Madonna del Sasso - above Locarno (Canton Tessin)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1067"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_034.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.797935,46.17966,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lake of Lugano. Canton Tessin</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1068"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_035.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.971882,46.003282,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lugano (Canton Tessin)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1069"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_036.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.950338,46.002507,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bellinzona (Canton Tessin)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1070"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_037.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.024303,46.192977,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Castle & valley of Misocco looking towards Soazza</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1071"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_038.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.232571,46.379904,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bridge and Avalache Gallery, - St. Bernhardin. Grisons</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1072"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_039.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.171944,46.496944,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hospice, Grand St. Bernard (Vallais)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1073"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_040.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.170556,45.868889,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Village of Splugen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1074"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_041.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.321944,46.554167,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bridge over the Rhine (Near Suvers, Via Mala)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1075"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_042.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.399405,46.566414,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The gorge of the Rhine, Via Mala (Grisons)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1076"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_043.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.447126,46.646196,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The second bridge, Via Mala (Grisons)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1077"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_044.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.448414,46.651911,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Gallery in the "Trou perdu" near Tuses (Grisons)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1078"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_045.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.446011,46.686896,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Fall of the Rhine in the Roffla (Grisons)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1079"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_046.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.388676,46.568538,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Passage of the Cardinells (Mount Splügen)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1080"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_047.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.328938,46.513752,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Scene on the Tessin, at Monte Piotino</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1081"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_048.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.579893,46.523084,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Airolo</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1082"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_049.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.608217,46.528753,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'hôpital</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1083"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_050.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.568392,46.619084,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Devils Bridge (Canton Uri)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1084"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_051.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.591137,46.647403,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Tell's Chapel & the Meadow of Grutli (Lake of Lucerne)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1085"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_052.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.60178,46.995007,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Tell's Chapel (Lake of Uri)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1086"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_053.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.612584,46.93407,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Baths of Pfeffers (Canton of St. Gall)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1088"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_055.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.5,46.983333,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Gorge of the Tamina (Bath of Pfeffers)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1089"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_056.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.488003,46.973569,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Junction of the Rhine & Tamina (Above Ragaz)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1090"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_057.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.510384,46.993309,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Devils Bridge - Scene of Action</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1091"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_058.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.590279,46.647168,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Wildkirchlein, or Hermitage (Canton of Appenzel)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1092"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_059.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.415455,47.284207,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bern (Canton Bern)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1100"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_067.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.449803,46.949149,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Thun, with the Bernese Alps</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1101"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_068.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.625971,46.760797,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Thun, from the cemetery</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1103"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_070.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.631571,46.758584,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Entrance to Simmenthal (Canton Bern)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1104"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_071.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.637815,46.675001,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Castle of Spiez, Lake of Thun. Canton Bern</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1105"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_072.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.687511,46.689413,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Interlacken. Canton Bern</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1106"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_073.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.848701,46.690546,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Unterseen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1107"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_074.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.849731,46.687922,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Fall of the Staubbach (Canton Bern)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1108"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_075.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.908268,46.583491,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The valley of Lauterbrunn (From the Wengern Alp)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1109"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_076.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.929554,46.594698,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The summit of the Jungfrau (Scene from Manfred)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1110"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_077.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.976418,46.547225,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Jungfrau (Bernese Oberland)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1111"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_078.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.907753,46.588361,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The valley of Grindelwald. Canton Bern</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1112"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_079.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.027916,46.620845,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Grindelwald (Canton Bern)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1113"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_080.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.033752,46.623678,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vue du Mont Blanc]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1114"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1786fb_280_t_2_front_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.674194,45.892812,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Montagnes qui bordent au Sud-Est la vallée de Chamouni</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1115"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1786fb_280_t_2_pl_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.866455,45.955653,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Glacier de la Brenva</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1117"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1786fb_280_t_2_pl_03.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.894608,45.830211,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Profil du Mont-Blanc et des Montagnes qui bordent l’Allée-Blanche prise de la Vallée de Ferrez</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1118"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1786fb_280_t_2_pl_04.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.925507,45.805398,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Mont-Blanc vu en face du côté de l’Allée-Blanche</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1119"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1786fb_280_t_2_pl_05.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.976318,45.820984,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L’aiguille du Goûté, vue de Bionnassay</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1120"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1786fb_280_t_2_pl_06.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.82045,45.852175,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vallon du Mont Cenis, son lac son Hospice, et Montagnes qui le dominent</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1121"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1796fb_280_t_3_front.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.928082,45.23981,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Montagne de La Tuile au-dessus de Montmélian</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1122"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1796fb_280_t_3_pl_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.085739,45.512899,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Dernier pont sur le Reuse en montant à l'Hospice du St Gothard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1123"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1796fb_280_t_4_front.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.565044,46.552528,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Rochers de Granit sur la route du St. Gothard à une lieue au dessous du Pont du Diable</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1124"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1796fb_280_t_4_pl_0.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.591083,46.647981,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue des murs de Granit veiné qui bordent le Chemin du St. Gothard à une lieue au Nord de l’Hospice</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1125"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1796fb_280_t_4_pl_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.563049,46.557838,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Mont Blanc et de la Route par laquelle on a atteint sa cime</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1126"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1796fb_280_t_4_pl_02.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.893921,45.969543,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de l’aiguille du Géant prise du côté de l’Ouest derrière les Tentes</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1127"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1796fb_280_t_4_pl_03.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.944561,45.859737,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Mont-Blanc vu du pied de l’Aiguille Marbrée au N. E. de la Cabane</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1128"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1796fb_280_t_4_pl_04.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.940484,45.851274,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Mont Rose vu des environs de Macugnaga</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1129"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1796fb_280_t_4_pl_05.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.963715,45.967785,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Source de l'Arveyron, Glacier des Bois</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1156"><img src="http://www2.unil.ch/viatimages/viatimages/small/toepffer1844_bgecollsuz98_0298.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.918983459,45.94347686,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Prarion, vallée de Chamounix</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1157"><img src="http://www2.unil.ch/viatimages/viatimages/small/toepffer1844_bgecollsuz98_0315.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.752128601,45.89379763,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Montée de la Gemmi</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1158"><img src="http://www2.unil.ch/viatimages/viatimages/small/toepffer1844_bgecollsuz98_0323.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.631378174,46.44394106,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Brunig du côté de la vallée de Meyringen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1159"><img src="http://www2.unil.ch/viatimages/viatimages/small/toepffer1844_bgecollsuz98_0351.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.13949585,46.7607301,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Halte du voyage entre Bonneville et Cluse]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1160"><img src="http://www2.unil.ch/viatimages/viatimages/small/toepffer1844_bgecollsuz98_0307.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.482276917,46.07268679,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La grotte de Balme</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1161"><img src="http://www2.unil.ch/viatimages/viatimages/small/toepffer1844_bgecollsuz98_0309.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.296710968,46.07712665,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Montée du Prarion</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1162"><img src="http://www2.unil.ch/viatimages/viatimages/small/toepffer1844_bgecollsuz98_0317.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.750240326,45.89666494,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'avalanche</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1163"><img src="http://www2.unil.ch/viatimages/viatimages/small/toepffer1844_bgecollsuz98_0318.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.932373047,45.92338561,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La mer de glace (Chamounix)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1164"><img src="http://www2.unil.ch/viatimages/viatimages/small/toepffer1844_bgecollsuz98_0320.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.939582825,45.89997611,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La pierre des anglais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1165"><img src="http://www2.unil.ch/viatimages/viatimages/small/toepffer1844_bgecollsuz98_0321.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.914176941,45.92434089,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Forclaz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1166"><img src="http://www2.unil.ch/viatimages/viatimages/small/toepffer1844_bgecollsuz98_0322.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.998291016,46.05791774,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Château de Sion</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1167"><img src="http://www2.unil.ch/viatimages/viatimages/small/toepffer1844_bgecollsuz98_0327.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.37937927246094,46.2367259330562,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Warren</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1168"><img src="http://www2.unil.ch/viatimages/viatimages/small/toepffer1844_bgecollsuz98_0329a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.607431412,46.31823563,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Oeschi, Lac de Thoune et de Brientz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1169"><img src="http://www2.unil.ch/viatimages/viatimages/small/toepffer1844_bgecollsuz98_0336.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.731285095,46.64041289,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Grindelwald</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1170"><img src="http://www2.unil.ch/viatimages/viatimages/small/toepffer1844_bgecollsuz98_0346.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.059501648,46.59112566,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Wetterhorn, Rosenlaui</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1195"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_081.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.158121,46.675708,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Riale di Buffalora]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1221"><img src="http://www2.unil.ch/viatimages/viatimages/small/storr1784_a12514_07.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.228515625,46.3671709,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Breitlauwinen, contre le Glacier du Breithorn</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1225"><img src="http://www2.unil.ch/viatimages/viatimages/small/wolf1776_bn_kafch20res_03.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.914962769,46.49115008,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vallée de Lauterbrounn, contre les Glaciers Canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1227"><img src="http://www2.unil.ch/viatimages/viatimages/small/wolf1776_bn_kafch20res_04.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.904319763,46.58502452,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de l’aiguille des Charmoz au dessous de Montanvert dans la Vallée de Chamouni </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1228"><img src="http://www2.unil.ch/viatimages/viatimages/small/saussure1779fb_280_t_1_pl_05.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.918855,45.904963,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Schiltwaldbach en hyver vis-a-vis du Staubbach, dans la vallee de Lauterbrounn, Canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1457"><img src="http://www2.unil.ch/viatimages/viatimages/small/wolf1776_bn_kafch20res_05.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.918310165,46.58409739,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Premiere Chûte du Staubbach dans la vallée de Lauterbrounn; Canton de Berne </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1458"><img src="http://www2.unil.ch/viatimages/viatimages/small/wolf1776_bn_kafch20res_06.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.905092239,46.5840384,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Seconde Chûte du Staubbach dans la Vallée de Lauterbroun, Canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1459"><img src="http://www2.unil.ch/viatimages/viatimages/small/wolf1776_bn_kafch20res_07.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.905950546,46.58681089,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Seconde Chûte du Staubbach en hyver du còté opposé à celle d'été, dans la vallée de Lauterbrounn, Canton de Berne.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1460"><img src="http://www2.unil.ch/viatimages/viatimages/small/wolf1776_bn_kafch20res_08.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.907752991,46.58032187,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ansicht von Rigi Scheideck. Kurort</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1475"><img src="http://www2.unil.ch/viatimages/viatimages/small/pfyffer1840_bn_a63558_02.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.520584106,47.02537372,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Panorama von Rigi-Scheideck gegen die Seite des Zugersee's u. des Rigi-Kulm</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1476"><img src="http://www2.unil.ch/viatimages/viatimages/small/pfyffer1840_bn_a63558_47.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.513031006,47.02747999,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Gorge de Cluse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1477"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_10a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.580124,46.05625,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cascade de l'Arpenaz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1478"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_11a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.634227,45.977891,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Environs de Sallenche</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1480"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_12a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.625786,45.936076,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Four Savoyard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1481"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_13a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.647587,45.927718,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Habitation savoyarde</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1482"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_14a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.670418,45.905385,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Mont-Blanc vu de Sallenche</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1483"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_15a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.631622,45.933688,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Upper Cascade of the Reichenbach (Canton Bern)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1581"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_082.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.182948,46.714988,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lake of Brientz, with the Giesbach Cascade (Canton Berne)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1582"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_083.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.024826,46.726297,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lucerne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1587"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_084.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.303261,47.054152,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Hofbrücke, Lucern (Pont de la Cour, Canton Lucern)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1588"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_085.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.307467,47.05151,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Lake of Lucerne from the Righi (Canton Unterwalden)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1589"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_086.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.485556,47.056667,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mount Pilatus - from the Brunig (Canton Unterwalden)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1590"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_087.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.157692,46.776082,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Aar fall at Handek</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1594"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_090.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.310385,46.611412,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lake at the foot of the Blumlis Alp (In the Ascenthal)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1595"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_091.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.716907,46.501374,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Kandersteg, canton Bern (Pass of the Ghemmi)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1597"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_092.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.675323,46.496823,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Monte Rosa, and the Cervin (From the Summit of the Ghemmi)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1598"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_093.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.603226,46.390923,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The pays de Vaud. From above Lausanne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1607"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_098.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.642952,46.534473,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lake of Lausanne above Pandex</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1611"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_102.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.672306,46.509284,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Castle of Chillon</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1612"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_103.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.927845,46.416018,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Castle of Chillon (Moonlight)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1613"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_104.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.927738,46.415071,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chateau Wufflens (Pays de Vaud)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1614"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_105.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.473554,46.525173,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mt. Bernhardin (By Moonlight)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1615"><img src="http://www2.unil.ch/viatimages/viatimages/small/beattie1836_2c_1411_106.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.166562,45.869086,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier du Breithorn, contre le Couchant</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1648"><img src="http://www2.unil.ch/viatimages/viatimages/small/wolf1776_bn_kafch20res_09.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.90397644,46.48549472,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chûte du Myrrenbach, dans la Vallée de Lauterbrounn, Canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1649"><img src="http://www2.unil.ch/viatimages/viatimages/small/wolf1776_bn_kafch20res_10.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.885437012,46.55825438,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier du Breithorn, contre la Vallée de Lauterbroun</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1650"><img src="http://www2.unil.ch/viatimages/viatimages/small/wolf1776_bn_kafch20res_11.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.906036377,46.48691305,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Herrenbaechli, pris en hyver</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1651"><img src="http://www2.unil.ch/viatimages/viatimages/small/wolf1776_bn_kafch20res_12.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.91015625,46.57288902,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La cascade du Bonnant, derrière les bains de St. Gervais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1652"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_17a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.715736,45.883253,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lac de Chède</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1658"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_19a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.726465,45.935561,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Mont Blanc vu de Servoz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1659"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_20a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.764832,45.931377,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Environs de Servoz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1661"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_22a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.762085,45.931181,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Aux Montées</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1662"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_23a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.800022,45.888976,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier des Bossons</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1663"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_24b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.863022,45.882293,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Eglise de Chamonix</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1664"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_25a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.868429,45.924145,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Prieuré et le Mont Blanc</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1665"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_27a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.876411,45.932221,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Mer de Glace vue du Montanvert</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1666"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_29a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.918297,45.923624,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue prise du jardin</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1667"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_31a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.935463,45.891135,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Source de l'Arveron</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1668"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_32a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.897697,45.941533,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier des Bois</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1669"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_34a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.896882,45.943443,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>À la Flégère</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1670"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_35a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.874352,45.963732,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Col de Balme vu de la Vallée d'Argentiére</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1671"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_36a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.923103,45.978526,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Chamonix vu du Col de Balme</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1673"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_39a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.941299,46.051656,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Panorama du Bréven, ou esquisse de la Chaîne du Mont Blanc vue de cette sommité</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1674"><img src="http://www2.unil.ch/viatimages/viatimages/small/birmann1826_bn_kaf_e_2_res_40a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.830921,45.931778,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue sur le Lac de Brientz, et le petit Lac de Goldswil, près de Rickenberg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1675"><img src="http://www2.unil.ch/viatimages/viatimages/small/zehender1797_bn_kaqch25res_b05a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.883806229,46.69729972,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la Vallée d'Oberhasli, prise au bas de la Tour Resti</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1690"><img src="http://www2.unil.ch/viatimages/viatimages/small/zehender1797_bn_kaqch25res_b09a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.20653,46.728322,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le port de Fluelen dans le Canton d'Ury</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1693"><img src="http://www2.unil.ch/viatimages/viatimages/small/zehender1797_bn_kaqch25res_b19a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.622207642,46.90200363,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Burgle, lieu de naissance de Guillaume Tell, dans le Canton d'Ury</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1694"><img src="http://www2.unil.ch/viatimages/viatimages/small/zehender1797_bn_kaqch25res_b19b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.661174774,46.87519677,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Staeg près de Zwing Uri, sur la Route du St-Gotthardt</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1695"><img src="http://www2.unil.ch/viatimages/viatimages/small/zehender1797_bn_kaqch25res_b23a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.671302795,46.78782035,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Pont du Diable sur le Mont St-Gotthardt dans le Canton d'Ury</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1696"><img src="http://www2.unil.ch/viatimages/viatimages/small/zehender1797_bn_kaqch25res_b25a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.588905334,46.64959623,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Brounnen et d'une partie du Lac des Quatres Cantons prise à Wyl</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1697"><img src="http://www2.unil.ch/viatimages/viatimages/small/zehender1797_bn_kaqch25res_b29a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.603668,46.999189,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Schweiz, chef-lieu du Canton, ainsi nommé</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1698"><img src="http://www2.unil.ch/viatimages/viatimages/small/zehender1797_bn_kaqch25res_b31a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.654651642,47.02224733,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de l'Isle de Schwanau, sur le Lac de Lowerz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1699"><img src="http://www2.unil.ch/viatimages/viatimages/small/zehender1797_bn_kaqch25res_b31b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.59770298,47.03224755,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Curieuse Eremitage auf dem Rigiberg, rings umher zwischen felsen gelegen = Hermitage très curieux sur le Rigiberg, placé entre les rochers.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1704"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_1_0005.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.483741283,47.04286334,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Prospect in welchem der Berühmte Pilatus-See liget = Vuë du fameux Lac de Pilate et des Environs</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1705"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_1_0006.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.203804493,46.96944316,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Tüfelsbrugg = Tüfelsbrougg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1708"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_1_0009.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.587532043,46.65000866,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Gletschers, im Berner Gebiet = Glettschers, C'est à dire Glaces eternelles, au Canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1727"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_1_0021.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.028259277,46.6255941,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Klus, In Reteien, auf der Strass in Italien über den S.Bernhards-Berg = Clus, .Ecluse dans les Grisons: Passage fameux en Italie par le Mont St. Bernhard.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1728"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_1_0022.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.188690186,46.46421539,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pantenbrugg, im Glarner Gebiet = Pantenbrougg, Pont dans le Canton de Glarus</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1729"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_1_0023.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.936347961,46.83640872,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Trostburg, Schloss im Berner Gebiet = Trostburg, Château dans le Canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1734"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_1_0028.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.118681908,47.33034047,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Breitlauwinen, contre le Glacier du Breithorn</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1773"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.90775299072265,46.4862708710106,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Schiltwaldbach contre le Staubbach, pris en hyver</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1788"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t3.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.91736602783203,46.5843166417955,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Première Chûte du Staubbach dans la Vallée de Lauterbrounn</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1789"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t4.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.9050064086914,46.5858503669142,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Seconde Chûte du Staubbach prise de sa gauche dans la Vallée de Lauterbrounn</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1790"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t5.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.90397644042968,46.5865582254106,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Seconde Chûte du Staubbach en hyver, de sa droite</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1791"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t6.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.90706634521484,46.5805411335586,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier du Breithorn contre le couchant</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1792"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t7.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.91084289550781,46.4872499010881,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chûte du Myrrenbach</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1793"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t8.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.88749694824218,46.5578825626542,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier du Breithorn contre la Vallée de Lauterbrounn ver le Sud</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1794"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t9.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.91530609130859,46.4900864255441,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Herrenbaechli, pris en hyver</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1795"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t10.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.90260314941406,46.585260477773,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du château de Worb dans le Canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1796"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t11.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.56451606750488,46.9294418380299,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Blonay, Schloss im Berner Gebiet. = Blonay, Château dans le Canton de Bern.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1797"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_1_0048.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.89117431640625,46.4641007851129,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vûe de Thoun du côté de l'occident</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1803"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t12.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.63403892517089,46.7596629019945,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Schadau sur le Lac de Thun</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1818"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t14.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.6349401473999,46.7465868274138,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue depuis le haut du Niesen sur les Lacs de Thoun et de Brienz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1819"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t15.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.65300750732421,46.6449247150459,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Caverne de St. Beat au bord du Lac de Thoun</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1820"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t16.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.79720306396484,46.7000664044758,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La vallée du Lauterbrunnen avec le Staubbach</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1821"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t17.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.90715217590332,46.5856901147526,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Rinkenberg sur le Lac de Brienz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1822"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t18.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.89672374725341,46.7009177214121,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Lutschinen sortant du Glacier inférieur du Grindelwald</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1823"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t19.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.051605,46.606375,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier superieur de la vallée du Gindelwald</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1824"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t20.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.01984787,46.62524043,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier inférieur de la vallée du Grindelwald</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1825"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t21.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.039417267,46.63078104,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bachalp au haut du Grindelwald</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1826"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t22.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.02585601806641,46.668212468891,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chute de l'Aar au dessus de Gutdannen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1828"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t24.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.30137252807617,46.6462229990572,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'Hôpital sur le Grimsel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1829"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t25.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.323517,46.570065,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Lauteraar Canton de Berne Province d'Oberhasli</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1830"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t26.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.17726135253906,46.5750838814907,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La grosse pierre sur le glacier de Vorderaar</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1831"><img src="http://www2.unil.ch/viatimages/viatimages/small/wyttenbach1789_bbb_muels125_t27.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.196831,46.568507,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Die Gegend des Leukerbades = Les environs des bains du Valais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=1992"><img src="http://www2.unil.ch/viatimages/viatimages/small/haller1773_bbb_hallera51_t41b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.64112,46.386045,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Blanc from Sallenche</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2018"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.65702819824219,45.9186955473763,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Guide, Couttet, ascending the Ice Cliff to gain the Grand Mulet Rock, below him a Chasm of unknown depth</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2019"><img src="http://www2.unil.ch/viatimages/viatimages/small/barry1836fb_1106_pl_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.8611764907837,45.867428283032,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Guides, Couttet and Balmat,- having gained the Grand Mulet Rock - drawing up the rest of the party</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2020"><img src="http://www2.unil.ch/viatimages/viatimages/small/barry1836fb_1106_pl_2.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.8611764907837,45.867428283032,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Rapperswyl. Stadt am Zürich See. = Rappersweil. Ville sur le bord du Lac de Zurich.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2022"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_1_0052.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.81755828857422,47.2255683138881,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier-Table on the Mer de Glace</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2026"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes1843fb_325_pl_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.948509,45.902759,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mer de Glace of Chamouni, from Les Charmoz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2028"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes1843fb_325_pl_02.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.90731048583984,46.047243457635,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Contact of the Ice and Rock at the Angle, Mer de Glace</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2029"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes1843fb_325_pl_03_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.932373046875,45.90791574869,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Glacier of La Brenva in the Allée Blanche, from Entreves</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2030"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes1843fb_325_pl_04.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.899757,45.829625,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Glacier of La Brenva, showing the Structure of the Ice</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2031"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes1843fb_325_pl_05.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.891174,45.83171,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Collon, and the Glacier of Arolla; Vallée d’Erin</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2032"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes1843fb_325_pl_06.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.51808166503906,45.9718413325899,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Cervin, from the Riffelberg near Monte Rosa</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2033"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes1843fb_325_pl_07.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.75394439697266,46.0044243370541,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Monte Rosa from Alagna</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2034"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes1843fb_325_pl_08.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.93487548828125,45.850437287315,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glaciers of the Second Order, near Macugnaga</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2035"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes1843fb_325_pl_09.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.96646118164062,45.9651040710729,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[paysage du Saint Gothard]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2036"><img src="http://www2.unil.ch/viatimages/viatimages/small/mechel1795_mvsta13364_001.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.567962,46.648493,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Topographical sketch n. I. Eye sketch of the Glacier of Miage </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2037"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes1843fb_325_sk_01a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.849604,45.797727,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Rhône près de sa source</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2043"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_000a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.362355,46.562604,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Source du Rhône</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2044"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_00a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.383255,46.576547,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue générale des glaciers du Rhône</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2045"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_04a_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.373642,46.569593,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cascade de la Toccia</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2046"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_08a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.413467,46.408688,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vallée d'Obergestelen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2048"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_12a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.32592,46.51387,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Viesch</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2054"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_14a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.133874,46.403717,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Brieg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2055"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_16a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.983413,46.319622,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont-Cervin</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2057"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_20a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.772141,46.051965,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Châlet valaisan</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2060"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_24a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.957106,46.094186,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Rosa </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2062"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_26a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.863465,45.937781,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Visp</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2064"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_30a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.87945,46.291784,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Louesch</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2065"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_34a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.638931,46.317177,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Empfinden. Niderteuffen. Schloss im Zürich Gebiet. = Château dans le Canton de Zurich. </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2066"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_1_0072.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.57439994812012,47.5437063439623,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bains de Louesch</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2067"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_38a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.631518,46.375041,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Sion</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2071"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_42a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.334758,46.230671,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cascade de Pissevache</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2072"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_44a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.030048,46.145053,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Aigle</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2075"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_46a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.966856,46.317711,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Saint-Maurice</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2076"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_48a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.004245,46.228029,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chain of Mont Blanc from the Summit of the Bréven</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2083"><img src="http://www2.unil.ch/viatimages/viatimages/small/barry_1836_fb_1106_p120.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.83658599853516,45.9334192134715,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Boveret</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2084"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369_02a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.838431,46.386579,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Saint-Gingouph</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2085"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369__04a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.795945,46.392618,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Château de Chatelard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2086"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369__08a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.899146,46.44749,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Meillerie</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2087"><img src="http://www2.unil.ch/viatimages/viatimages/small/sauvan1829_mvs_rh369__10a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.718558,46.406921,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Sargans. Schloss und Stättli unweit Wallenstat. = Sargans. Château et Petite ville près de Wallenstatt.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2099"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_1_0094.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.437814,47.049902,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Map of the Mer De Glace of Chamouni And of the Adjoining Mountains Laid down from a detailed Survey in 1842 by Professor Forbes</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2170"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes_fb_325_map.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.96395874023438,45.8806717850342,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Topographical sketch n. II. Eye sketch and sections of the Glacier de la Brenva</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2171"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes1843fb_325_sk_ii.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.910715,45.821777,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Topographical sketch n. VI. Eye sketch of the Pass of the Mont Collon </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2173"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes1843fb_325_sk_vi.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.46829986572266,45.9785300548462,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Topographical sketch n. VII. Eye sketch and magnetic bearings from the Col d’Erin between Evolena and Zermatt </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2174"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes1843fb_325_sk_vii_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.61146545410156,46.0261628384322,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Topographical sketch n. VIII. Eye sketch of the Glacier of Macugnaga </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2175"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes1843fb_325_sk_viii.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.91187286376953,45.9570532817339,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Topographical sketch n. IX. Eye sketch of the Glacier of Allalein in the Valley of Saas </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2176"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes1843fb_325_sk_ix.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.927222,46.044444,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Topographical sketch n. III. Eye sketch of the environs of Courmayeur with the boundaries of Granite And a Section of the Chain of Alps from Courmayeur to Chamouni</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2177"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes_1843fb_325_sk_iii.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.962585,45.815512,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Topographical sketch n. IV. Eye sketch of the Glacier of Argentière </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2178"><img src="http://www2.unil.ch/viatimages/viatimages/small/forbes1843fb_325_sk_iv.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.96104049682617,45.9735672730701,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lac de Chede</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2179"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_2.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.72689437866211,45.935072731272,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ponte alto, an der Simplonstrasse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2189"><img src="http://www2.unil.ch/viatimages/viatimages/small/meisner1822_1827_bpun_zr873_4_0001_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.07263374328613,46.184525092557,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Isola Bella</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2190"><img src="http://www2.unil.ch/viatimages/viatimages/small/meisner1822_1827_bpun_zr873_4_0002.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.52674782276154,45.8953734260115,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Gallerie von Algaby, an der Simplonstrasse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2193"><img src="http://www2.unil.ch/viatimages/viatimages/small/meisner1822_1827_bpun_zr873_4_0003.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.07254791259766,46.1788795365058,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Brunnen]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2202"><img src="http://www2.unil.ch/viatimages/viatimages/small/meisner1822_1827_bpun_zr873_3_0003.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.59514951705933,46.9951825653115,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Panorama des glaciers du Mont-Rose, partie orientale de la chaine</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2203"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0001.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.877541,45.920826,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Panorama des glaciers du Mont-Rose, partie orientale de la chaine</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2204"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0002.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.878227,45.920587,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Panorama des glaciers du Mont-Rose. Partie occidentale de la chaine.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2205"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0003.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.744675,45.941362,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Panorama des glaciers du Mont-Rose. Partie occidentale de la chaine. </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2206"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0004.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.736092,45.940885,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Zermatt. Partie supérieure, prise au-dessous du Riffelhorn</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2207"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0005.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.747507,45.993145,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Zermatt. Partie supérieure, prise au-dessous du Riffelhorn</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2208"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0006.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.755833,45.989925,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Zermatt. Partie moyenne. </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2209"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0007.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.778664,45.971285,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Zermatt. Partie moyenne.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2210"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0008.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.765961,45.972979,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Zermatt. Partie inférieure, vue de côté, au dernier contour du glacier</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2211"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0009.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.730942,45.987747,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Zermatt. Partie inférieure, vue de côté, au dernier contour du glacier.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2212"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0010.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.728882,45.992366,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Zermatt. Extrémité inférieure.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2213"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0011.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.726221,45.993607,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Zermatt. Extrémité inférieure.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2214"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0012_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.726479,45.995857,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Zermatt. Flanc de l'Extrémité inférieure.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2215"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0013.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.730598,45.993352,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Zermatt. Flanc de l'Extrémité inférieure. </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2216"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0014.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.72768,45.997645,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Roches polies des bords du glacier de Zermatt.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2217"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0015.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.741241,45.96714,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Roches polies des bords du glacier de Zermatt.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2218"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0016.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.734375,45.970895,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Viesch. Extrémité inférieure. </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2219"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0017.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.138466,46.444891,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Viesch. Moraine Terminale. </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2220"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0018.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.139839,46.439213,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Viesch. </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2221"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0019.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.147736,46.487866,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Viesch.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2222"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0020.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.148422,46.498329,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Finelen.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2223"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0021.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.893677,45.997614,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Finelen.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2224"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0022.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.866898,45.997852,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier et lac d'Aletsch.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2225"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0023.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.062592,46.426373,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier et lac d'Aletsch.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2226"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0024.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.058472,46.42022,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Stratification du glacier de St. Theodule.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2227"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0025a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.738152,45.960872,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Stratification du glacier de St. Théodule.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2228"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0026a.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.737808,45.962455,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de l'Aar, partie Supérieure avec la cabane de Mr Hugi.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2229"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0027.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.187561,46.568774,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de l'Aar. Partie Supérieure avec la cabane de Mr Hugi.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2230"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0028.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.204212,46.568035,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Domes arrondis, polis et striés, au dessus de la Handeck.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2231"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0030.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.308239,46.611715,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hoellen-Platte à la Handeck.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2232"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0032.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.309698,46.611522,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Glacier de Chermotane</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2236"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit_1781_fb_285_t_1_pl_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.381439,45.924409,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la Vallée de Glace de Chermotane</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2237"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit_1781_fb_285_t_1_pl_2.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.386246,45.92823,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Vallais et du Rhône</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2238"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit_1781_fb_285_t_1_pl_3.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.413197,46.237862,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Lac du Kandel Steig</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2239"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit_1781_fb_285_t_1_pl_4.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.724762,46.498392,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Glacier du Rhône et de la Source de ce Fleuve</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2240"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit_1781_fb_285_t_2_pl_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.381882,46.574203,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Pont du Diable</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2241"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit_1781_fb_285_t_2_pl_2.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.59,46.6475,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Glacier du Grindelvald</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2242"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit_1781_fb_285_t_2_pl_3.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.059674,46.595557,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Lac de Chéde et du Mont Blanc</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2243"><img src="http://www2.unil.ch/viatimages/viatimages/small/bourrit_1781_fb_285_t_2_pl_4.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.726894,45.934905,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>View of the Ice Valley, & Mountains that Surround it, from Mount Anver</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2244"><img src="http://www2.unil.ch/viatimages/viatimages/small/widham1744fb_1677_pl_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.934433,45.918533,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Cluse]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2248"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1787fa_2156_res_pl_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.579502,46.056406,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Saint Martin]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2249"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1787fa_2156_res_pl_02.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.64175,45.9407,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Sallanches]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2250"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1787fa_2156_res_pl_03.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.624392,45.935961,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Lac de Chède]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2251"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1787fa_2156_res_pl_04.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.727324,45.935024,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>View of Mont Blanc from Servoz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2252"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_3.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.7650032043457,45.9305358828014,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Blanc and the Valley of Chamonix from the Col de Balme</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2253"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_4.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.96636199951172,46.0323245958572,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Blanc & the Priory of Chamonix</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2254"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_5.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.88465118408203,45.9421419146417,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Scaling a Wall of Ice</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2256"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_8.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.86233520507812,45.8597149826788,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Grand Mulet</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2257"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_9.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.86851501464844,45.8611495401057,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Passage of a block of Ice in a Crevice</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2258"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_10.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.86439514160156,45.8633889701376,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>A dangerous Part of the Glacier</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2260"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_11.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.85237884521484,45.850955410212,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bridge of Snow where the Party breakfasted</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2261"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_12.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.85186386108398,45.8444226925406,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Passing a Cliff</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2262"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_13.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.8613052368164,45.834301244592,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Blanc from the Couvercle</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2263"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_06.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.96510672569275,45.9104434322155,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Blanc from the Valley of Courmayeur</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2264"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_07.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.96172714233398,45.8082217645531,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Map of 60 Leagues round Mont Blanc showing also the Extent of the visible Horizon: the Red line enclosing the space to which the actual range of sight is limited by the different Mountain Chains within view</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2265"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_14bis.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.932373046875,45.9358706211905,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Le Pont du Diable]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2266"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_001.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.590879,46.647492,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Abbaye de Pfefers</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2286"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_019.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.501457,46.989123,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vuë du Bain de Pfeffers, en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2287"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_020.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.488186,46.973459,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Sources jaillissant des montagnes]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2288"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_021.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.418888,46.882547,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Montagne engendrant des nuages]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2290"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_022_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.386702,46.856611,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vue du château de Hohenrätien]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2291"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_023.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.444133,46.691326,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Gros Bourg de PLURS, en Suisse, avec sa Ruine</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2293"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_026.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.421651,46.33046,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[La cataracte d'Acquafraggia]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2294"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_027.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.437245,46.331202,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Trois montagnes proches de Soglio]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2295"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_028.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.537506,46.341477,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vues des colonnes juliennes]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2296"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_029.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.72444534301758,46.4704976034201,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vue du Martinsloch]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2298"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_031.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.237785,46.909819,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vue d'aqueducs et de ponts destinés aux bains de Pfäfers (1)]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2307"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_040.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.48750972747803,46.973195648107,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vue des bains de Pfäfers]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2308"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_041.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.48802471160889,46.9734061183531,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vue d'aqueducs et de ponts destinés aux bains de Pfäfers (2)]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2309"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_042.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.48798179626465,46.9734335709328,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vue d'aqueducs et de ponts destinés aux bains de Pfäfers (3)]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2310"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_043.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.48803007602692,46.9735580224507,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vue d'aqueducs et de ponts destinés aux bains de Pfäfers (4)]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2311"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_044.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.48858261108398,46.9734006278354,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vue d'aqueducs et de ponts destinés aux bains de Pfäfers (5)]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2312"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_045.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.48823928833008,46.9746597717875,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vue d'aqueducs et de ponts destinés aux bains de Pfäfers (6)]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2313"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_046.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.48836803436279,46.9744255146923,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Source d'eau thermale des bains de Pfäfers]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2314"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_047_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.48635101318359,46.9678658993998,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Voie romaine de Baden et spécimens de pseudo-diamants]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2316"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_1_1c_1345_049.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.25708389282227,47.5366741201253,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bourg de GLARIS, en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2319"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_2_1c_1345_050.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.06766891479492,47.0419953768847,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>MAPPA TERRITORII GLARONENSIS</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2323"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_2_1c_1345_052.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.06543731689453,47.0413519790076,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lacus in Monte GOTTHARDI</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2327"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_2_1c_1345_056.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.55766296386719,46.5834062186124,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>RHENI, RHODANI, TICINI, URSAE PRIMA STAMINA IN SUMIS ALPIBUS HELVETICUS</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2328"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_2_1c_1345_057.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.50067138671875,46.5975622706182,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Sources de la Reuss et Cache d'une partie du Canton d'Uri</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2329"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_2_1c_1345_058.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.64383697509766,46.8226166688049,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Sources du Rhône dans le Mont de la FOURCHE</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2330"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_2_1c_1345_059.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.37844848632812,46.5652338680502,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Ville de BERN, en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2331"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_2_1c_1345_060.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.44894504547119,46.9480943365053,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Bain de WALTERSWYL, au Canton de Zug</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2334"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_063.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.557448387146,47.2104003676811,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Ville de ZUG, en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2335"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_064.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.51371765136719,47.1666094626574,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Dragon vu au lieu-dit In der Hauwelen, Frumsenberg, canton de Zurich] </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2337"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_066.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.269717,47.082954,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Dragon vu au lieu-dit Erlawäldli, Frumsenberg, canton de Zurich]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2338"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_067.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.269717,47.082954,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Dragon vu a lieu-dit Am Soolbrunnen, canton de Zurich]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2339"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_068.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.462135,47.315591,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Dragon observé au mont Pilate, région de Lucerne]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2340"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_069.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.256011,46.9794,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Dragon brodé sur une chasuble, église de Saint Leodegar, Lucerne]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2341"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_070.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.313688,47.055722,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Dragon observé sur la montagne de Flue, région de Lucerne]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2342"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_071.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.119702,47.052425,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Dragon vu au pont sur la Reuss, Lucerne]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2343"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_072.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.307535,47.051651,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Dragon vu au Wellerscher Gang, Appenzell]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2344"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_073.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.485337,47.299335,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Dragon vu sur la montagne de Joppatsch, dans les Grisons]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2345"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_074.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.727734,46.652468,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Dragon vu au village de Quinten, pays de Gaster, région de Saint-Gall]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2346"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_075.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.215813,47.139737,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Ville de FREYBURG, en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2347"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_076.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.16514587402344,46.8025271037451,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Ville de MURTEN, en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2348"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_077.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.1161365509033,46.930923766323,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Ville de BIENNE, ou BIEL, en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2350"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_079.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.24411010742188,47.1383588086431,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vue de la vallée d'Amden et spécimens de fossiles]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2355"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_084.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.13616180419922,47.1376581884198,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>RHENI POSTERIORIS ET MUESAE PRIMA STAMINA</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2356"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_085.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.44373607635498,46.6340854912075,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Ville de CHUR, ou COIRE, en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2358"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_086.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.53338623046875,46.847982235309,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>MAIRAE Ortus et Progressus</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2359"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_087.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.51891303062439,46.3336618397356,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>ALBULAE FLUVII Prima Stamina et Progressus</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2361"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_089.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.73800659179688,46.6334077219971,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>PROSPECTUS MONTIUM GLACIALIUM GRINDELIANORUM (1)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2364"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_092.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.041306,46.618318,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Canton d'UNDERWALD, en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2365"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_093.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.403854,47.006012,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>PROSPECTUS MONTIUM GLACIALUM GRINDELIANORUM (2)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2366"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_094.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.04885864257812,46.6093561563266,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>EXQUISITA SALINARUM BERNENSIUM DELINEATIO</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2368"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_096.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.03090667724609,46.2587250585899,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Château de FORSTECK, en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2376"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_4_1c_1345_102_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.4974607229233,47.250528500827,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Ville de St. Gal, en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2377"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_4_1c_1345_103_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.37700271606445,47.4259387850482,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Bourg d'HERISSAW, en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2378"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_4_1c_1345_104.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.27883923053742,47.3858501752231,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Rosenburg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2380"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_4_1c_1345_105.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.25440430641174,47.3884406503517,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>KYBURG, en Suisse.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2381"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_4_1c_1345_106_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.74700546264648,47.4619577233662,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Païs de Toggenbourg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2382"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_4_1c_1345_107.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.08466339111328,47.3057751172513,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Ville de SOLOTHURN, en Suisse. comme elle a été ci-devant.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2387"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_4_1c_1345_112.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.53353118896484,47.2065666436636,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Ville de THUN, en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2388"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_4_1c_1345_113.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.63601303100586,46.7456835434569,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Ville de SITTEN, ou SION, dans le Païs de Valais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2392"><img src="http://www2.unil.ch/viatimages/viatimages/small/scheuchzer1723_vol_3_1c_1345_095_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.3683500289917,46.233112316144,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vieille neige fissurée avec des traces de neige fraiche.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2398"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0025b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.735577,45.958756,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Veille neige fissurée avec des traces de neige fraiche.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2399"><img src="http://www2.unil.ch/viatimages/viatimages/small/agassiz1840_bpun_zf147_0026b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.736435,45.960665,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Map of Mont Blanc and Surrounding Mountains </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2402"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_15.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.86465263366699,45.8326816020013,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Plan of Plateau]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2403"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_17.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.85812950134277,45.8388599114702,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Sliding down a Snow Hill</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2404"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_18.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.85976028442383,45.8433464543017,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chain of Mont Blanc from Breven</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2408"><img src="http://www2.unil.ch/viatimages/viatimages/small/auldjo1828fb_1103_pl_16_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.83710098266602,45.933819165512,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la Cascade de Nant d’Arpenas</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2418"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1815rec_est_249_grav_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.641493,45.976043,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Mont Blanc prise de St. Martin</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2419"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1815rec_est_249_grav_2.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.641879,45.940405,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Lac de Chêde</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2420"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1815rec_est_249_grav_3.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.726723,45.935203,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Glacier des Bois et de la Source de l’Arveiron</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2421"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1815rec_est_249_grav_4.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.904221,45.943161,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la Mer de Glace prise de Montanvert</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2422"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1815rec_est_249_grav_5.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.917009,45.933254,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue prise de la Flégère</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2424"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1815rec_est_249_grav_6.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.880918,45.955782,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Panorama du Breven</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2436"><img src="http://www2.unil.ch/viatimages/viatimages/small/pictet_1829_carte_2.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.837358,45.9337,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Les Alpes Bernoises vues des environs de Berne /The BERNES ALPS as seen from the neighbourhood of Berne - Route 24</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2437"><img src="http://www2.unil.ch/viatimages/viatimages/small/murry1844s_5732_p_112.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.555847,46.894986,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Chain of Mont Blanc as seen from the Brevent / La Chaîne du Mont Blanc vue du Brévent</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2439"><img src="http://www2.unil.ch/viatimages/viatimages/small/murry1844s_5732_p_468.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.838303,45.933976,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vue de Chamouni]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2442"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1787fa_2156_res_pl_05.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.86977,45.922922,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vue de la Mer de Glace]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2443"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1787fa_2156_res_pl_06.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.91711664199829,45.932903348253,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Source de l’Arveiron]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2444"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1787fa_2156_res_pl_08.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.918941,45.943112,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Chute de la Mer de Glace]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2445"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1787fa_2156_res_pl_07.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.90353393554688,45.9558121477795,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vue du village des Bois]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2446"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1787fa_2156_res_pl_09.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.897182,45.942882,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vue des Montagnes à Genève]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2449"><img src="http://www2.unil.ch/viatimages/viatimages/small/albanis1787fa_2156_res_pl_12.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.135864,46.290463,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Eigentliche Vorstellung, des Schönen Flecken Plurs, und wie derselbe nach seinem schroeklichen Untergang A 1618. erbaermlich ausgesehen habe. = Representation du beau Bourg de Plours, ou Pleurs, en Grisons, et de sa Ruine terrible, arriveè en 1618.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2454"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_1_0114.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.42300796508789,46.3283956237703,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Notre Dame des Neiges sur le Rigi.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2550"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin_1835_2c_2504_013.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.485556,47.056667,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cours de la Linth.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2556"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin_1835_2c_2504_016.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.031448364,46.95823001,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Trou Saint-Martin à Elme.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2558"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin_1835_2c_2504_017.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.17152404785156,46.9118128376096,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Rapperschwyl.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2585"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin_1835_2c_2504_030_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.816667,47.226667,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>St-Gall.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2587"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin_1835_2c_2504_031.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.37477111816406,47.4259968531381,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Galerie du Trou-Perdu - Via-Mala. </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2590"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin_1835_2c_2504_032b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.44446563720703,46.6867585147242,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Entrée de la Via-Mala. </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2593"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin_1835_2c_2504_034.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.44317817687988,46.6904579333701,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Via-Mala - Pont du milieu.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2595"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin_1835_2c_2504_035b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.43519592285156,46.6626324907917,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Route du Simplon. </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2613"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin_1835_2c_2504_044.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.0385160446167,46.2157434592979,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lac de Genève. </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2623"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin_1835_2c_2504_049.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.55059814453125,46.4473199834169,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hospice du Grand Saint Bernard.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2633"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin_1835_2c_2504_055.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.170556,45.868889,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Mont-Blanc, vu du lac de Chède.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2634"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin_1835_2c_2504_055b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.72706604003906,45.9355612163493,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Panorama de la vallée de Chamouny. </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2635"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin_1835_2c_2504_055c.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.87190532684326,45.9124962499569,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier du Valsoret.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2636"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin_1835_2c_2504_056.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.26934432983398,45.9099363122104,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mer de glace du Montanvert.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2637"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin_1835_2c_2504_056b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.90010070800781,45.9234532798291,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Courmayeur.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2638"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin_1835_2c_2504_057.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.9717264175415,45.7926340435377,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vallée de Chamouny.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2639"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin_1835_2c_2504_057b.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.91400527954102,45.9559235310971,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Altorff Haupt flecken des Lands Ury</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2704"><img src="http://www2.unil.ch/viatimages/viatimages/small/merian1654_bbb_muel_s_108_altdorf.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.602982,46.88812,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Burgdorf</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2720"><img src="http://www2.unil.ch/viatimages/viatimages/small/merian1654_bbb_muel_s_108_burgdorf.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.622452,47.056386,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Engelberg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2725"><img src="http://www2.unil.ch/viatimages/viatimages/small/merian1654_bbb_muel_s_108_engelberg.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.406816,46.820139,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Fischbach</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2726"><img src="http://www2.unil.ch/viatimages/viatimages/small/merian1654_bbb_muel_s_108_fischbach.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.882778,46.292222,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glarona. Glaris. </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2732"><img src="http://www2.unil.ch/viatimages/viatimages/small/merian1654_bbb_muel_s_108_glarus.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.073334,47.033927,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Plursium</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2755"><img src="http://www2.unil.ch/viatimages/viatimages/small/merian1654_bbb_muel_s_108_plurs.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.41940307617188,46.3290001563091,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Thun</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2762"><img src="http://www2.unil.ch/viatimages/viatimages/small/merian1654_bbb_muel_s_108_thun.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.638931,46.744974,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Svitia, Schweÿtz.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2768"><img src="http://www2.unil.ch/viatimages/viatimages/small/merian1654_bbb_muel_s_108_schwyz_von_sueden.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.647398,47.019835,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Prospect des Haubt Fleckens Schwÿtz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2769"><img src="http://www2.unil.ch/viatimages/viatimages/small/merian1654_bbb_muel_s_108_schwyz_von_osten.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.627701,47.008993,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vue de Lucerne] </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2785"><img src="http://www2.unil.ch/viatimages/viatimages/small/businger1815_1c_403b_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.308883,47.052722,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ansicht der Gebirgskette von dem Rossberge an bis Ende des Pilatusberges, gezeichnet mitten auf der Hofbrücke der Stadt Luzern.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2786"><img src="http://www2.unil.ch/viatimages/viatimages/small/businger1815_1c_403b_03.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.307509,47.051637,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Lucerne prise à la Colline du Gütsch. Aussicht der Stadt Luzern gezeichnet auf dem Gütsch.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2787"><img src="http://www2.unil.ch/viatimages/viatimages/small/businger1815_1c_403b_04.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.295064,47.051417,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Carte du Lac de Lucerne ou des Quatre Cantons. Karte des Vier Waldstaedter See's</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2788"><img src="http://www2.unil.ch/viatimages/viatimages/small/businger1815_1c_403b_05.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.418274,47.011927,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ury</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2789"><img src="http://www2.unil.ch/viatimages/viatimages/small/tassin1635_1c_333_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.640575,46.88058,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Schwitz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2790"><img src="http://www2.unil.ch/viatimages/viatimages/small/tassin1635_1c_333_02.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.65345,47.021163,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Undervald </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2791"><img src="http://www2.unil.ch/viatimages/viatimages/small/tassin1635_1c_333_03.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.244821,46.896579,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glaris</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2795"><img src="http://www2.unil.ch/viatimages/viatimages/small/tassin1635_1c_333_07.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.067283,47.041844,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2796"><img src="http://www2.unil.ch/viatimages/viatimages/small/tassin1635_1c_333_08.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.457228,46.950872,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chur</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2803"><img src="http://www2.unil.ch/viatimages/viatimages/small/tassin1635_1c_333_15.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.530897,46.848617,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pleurs abifmée</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2804"><img src="http://www2.unil.ch/viatimages/viatimages/small/tassin1635_1c_333_16.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.422793,46.331367,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Syon</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2805"><img src="http://www2.unil.ch/viatimages/viatimages/small/tassin1635_1c_333_17.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.361827,46.230643,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Klinguenau</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2811"><img src="http://www2.unil.ch/viatimages/viatimages/small/tassin1635_1c_333_21.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.25,47.583333,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Burgdorf</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2819"><img src="http://www2.unil.ch/viatimages/viatimages/small/tassin1635_1c_333_29.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.629833,47.05778,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Canton de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2830"><img src="http://www2.unil.ch/viatimages/viatimages/small/duvotenay1837_2c_2444_004.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.525634765625,46.7990566993024,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de l'Eiger, du Moench et de la Jungfrau</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2857"><img src="http://www2.unil.ch/viatimages/viatimages/small/dora18561c_136_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.634726,46.747697,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de l'Eiger, du Moench et de la Jungfrau du côté de la Wengernalp</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2863"><img src="http://www2.unil.ch/viatimages/viatimages/small/dora18561c_136_02.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.947634,46.586049,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du Mettenberg et du mont Eiger dans la vallée de Grindelwald</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2864"><img src="http://www2.unil.ch/viatimages/viatimages/small/dora18561c_136_03_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.044739,46.620719,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Grindelwald</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2866"><img src="http://www2.unil.ch/viatimages/viatimages/small/dora18561c_136_04_2.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.039932,46.625738,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pointe de Sales et col d'Anterne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2876"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin1821_1p_3490_15_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.790753,45.980361,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'Abaye de Sixte</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2877"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin1821_1p_3490_15_02.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.77393,46.054341,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Fer à cheval, de la vallée de Sixt</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2878"><img src="http://www2.unil.ch/viatimages/viatimages/small/martin1821_1p_3490_15_03.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.853409,46.075049,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Stockhorn</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2881"><img src="http://www2.unil.ch/viatimages/viatimages/small/latrobe_1829_az_2991_03.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.537222,46.693832,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La ville de Berne vers le couchant (Suisse)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2914"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_1_009.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.43928909301758,46.9655893685545,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chute du Staubach, Vallée de Lauterbrunen. Suisse. (Canton de Berne).</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2915"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_1_010.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.9046630859375,46.5834008110506,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'hospice sur le Grimsel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2917"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_1_012.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.331515,46.571499,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Village du Simplon</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2920"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_1_018.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.05860042572021,46.193967227235,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'hospice Napoléon (non achevé) au Simplon</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2921"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_1_019.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.02879571914673,46.2467781380451,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le village de Visp</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2922"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_1_021.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.87947177886963,46.2933060258958,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'ancienne porte du Bourg St-Pierre</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2923"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_1_022.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.20834016799927,45.9533698241137,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La ville de Berne vers le couchant (Suisse)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2929"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_005.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.44040489196777,46.9638428563416,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chute du Staubach, vallée de Lauterbrunen, Suisse. (Canton de Berne)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2930"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_006.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.904577255249,46.583371315413,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'hospice sur le Grimsel. Suisse (Canton de Berne)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2931"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_007.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.332127,46.571625,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'ancienne porte du Bourg St-Pierre, sur la route du St. Bernard, Suisse (Canton du Valais)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2932"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_008.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.20788955688477,45.9520338734243,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'hospice, la chapelle Notre Dame à la neige et les auberges sur le mont Righi. Suisse (Canton de Schwytz)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2934"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_010.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.48934173583984,47.0428620020044,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lucerne. Suisse.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2935"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_011.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.28678131103516,47.0560682513402,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le château d'Oberhofen sur le lac de Thoun. Suisse (Canton Berne)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2936"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_012.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.66784012317657,46.7304036544635,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hilterfingen près Thoun Suisse. (Canton de Berne)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2937"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_013.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.65755653381348,46.7379167826114,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le hameau de Frutval. Piémont (Vallée de Formazza).</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2938"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_014.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.40876817703247,46.4093218992794,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Entrée d'une galerie au Simplon à demie lieue de l'hospice au nord-est. Suisse (Canton du Valais)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2939"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_015.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.08490753173828,46.1859997747112,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Carte des cantons de Bâle, Berne, Soleure, Argovie et Lucerne. Suisse.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2940"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_016.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.6409912109375,46.9478873143145,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Carte du canton du Valais. Suisse.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2941"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_017.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.3773193359375,46.2244394765529,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Carte des cantons de Neuchâtel, Fribourg, Vaud et Genève. Suisse.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2942"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_018.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.665955,46.607689,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Carte des cantons de Schaffhouse, Zurich, Thurgovie, St-Gall, Appenzell, Schwyz, Zug et Glaris. Suisse.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2943"><img src="http://www2.unil.ch/viatimages/viatimages/small/snoeck1824_ab_2560_019.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.14337158203125,47.2899111542936,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pont de St-Maurice en Valais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2947"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_04.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.0081615447998,46.2202786961581,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cascade de Pissevache en Valais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2948"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_05.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.0301342010498,46.1490618847788,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vu du Rhône dans le bas Valais prise au-dessus des Ruines de Bex vieux.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2949"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_06.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.03433990478516,46.2382556097973,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pont sur la route de Chillon, Lac de Genève</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2951"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_08.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.93067789077759,46.4232571045192,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Rochers de Meillerie, Lac de Genève</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2954"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_11.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.72740936279297,46.4065953403729,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pont dans le haut Valais sur la route du Simplon</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2957"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_14.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.03512573242188,46.2172499694562,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Château d'Aigle bas Valais</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2958"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_15.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.98361396789551,46.3131941944717,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La cathédrale de Lausanne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2960"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_17.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.63042068481445,46.5273247352943,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Genève</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2965"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_22.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.15114212036133,46.2101090292534,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Promenade pittoresque. Un chasseur engagé dans un précipice de la vallée de Sallanches échappe au danger d'y périr.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2970"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_27.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.62647247314453,45.9336579918087,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chasse du chamois au Nant d'Enfer en Doran, vallée de Sallenche</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2971"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_28.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.58244132995605,45.9722002427311,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cascade du Chède route de Chamounie</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2972"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_29.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.7166805267334,45.9332684831149,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Caverne de Balme en Savoie</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2973"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_30.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>5.33862590789795,45.8523229394377,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Grotte de Bonant, vallée de St-Gervais, Mont-blanc</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2975"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_32.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.70839786529541,45.8947817909821,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Tour du port d'Ouchi sous Lausanne, lac de Genève</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2977"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_34.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.62501335144043,46.5071627717189,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Mont Blanc et la vallée de Sallanche</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2979"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_36.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.64329528808594,45.9405184511762,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Voute de glace de la source de l'Aveiron à Chamounie</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2980"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_37.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.96258544921875,45.9754482507542,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Fabrique à Pont de Royan en Dauphiné</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2981"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_38.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>5.34570693969727,45.0612591943971,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Pont de Royan en Dauphiné</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2982"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_39.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>5.34618437290192,45.0602743201943,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Nant noir, route de Chamounie</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2984"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_41.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.67337894439697,45.9522780417879,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ruine d'un château antique appelé la Tour de Chrest, département de la Drôme.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2985"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_42.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>5.03036499023438,44.7269628457195,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la vallée de Six en Savoie</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2986"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_43.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.77101135253906,46.0333971724013,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Notre Dame de la Gorge, dans la vallée de Bonant, au pied de la route du Bonhomme, dans la chaine du Mont-blanc.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2989"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_46.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.71878337860107,45.7944837551205,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Village de St-Nicolas-la-Chapelle, sur les rochers du torrent de la gietta en Savoie.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2991"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_48.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.50699615478516,45.8086784597809,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Torrent de la Roche Baudin, près Montélimar. Dauphiné.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2992"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_49.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>5.03363728523254,44.5791797193944,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Grenoble, rive gauche de l'Isère</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2993"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_50.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>5.69332122802734,45.2094742816128,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Grenoble, rive droite de l'Isère</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=2996"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_53.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>5.73263168334961,45.195575761423,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ruines de St. Barthelemi de Vals</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3000"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_57.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>4.88295078277588,45.178885290898,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cascade du torrent de la Frasse près de Sallanches en Savoie</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3002"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_59.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.6412353515625,45.9432560325151,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cascade près d'Exille en Piémont</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3003"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_60.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.93301677703857,45.0967859099386,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La ville de Briançon en Dauphiné</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3004"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_61.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.64398193359375,44.8960394218134,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La grotte du Luira dans les montagnes de Vercorps en Dauphiné</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3008"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_65.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>5.42261123657227,44.8907950547164,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Arburg, Stadt und Berg-Vestung. In dem Canton Bern, von Mitternacht anzusehen. = Arbourg, Ville et Fortresse. dans le Canton de Berne, du Côté du Septentrion.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3010"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_2_0002.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.89831161499023,47.3287864856879,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Guggi. Sonst genannt Recken Bühl. Ein Lufthaus im Canton Lucern. = Gouggi. Nommé Recken Buhl. Maison de Campagne dans le Canton de Lucerne.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3011"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_2_0003.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.30085754394531,47.044479210305,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der Stutz. = Le Stoutz.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3013"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_2_0005.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.32454681396484,47.0309941561233,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Staubbach. Im Lauterbrunn Canton Bern. = Staubbach. à Lauterbrunn, dans le Canton de Berne.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3036"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_2_0028.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.90775299072266,46.5932529316561,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Habspurg. = Habspourg.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3041"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_2_0031bis.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.37578773498535,47.0426816596394,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Trüpschen. = Trupschen.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3042"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_2_0033.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.32926750183105,47.0415703454555,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Altenryf. Ein Gotts-Haus Cistercienser Ordens in dem Canton Freÿburg. gegen Mitternacht anzusehen. = Hauterive. Abbaye de l'ordre de Cisteaux située dans le Canton de Fribourg. du Côté du Septentrion.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3048"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_2_0039.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.09630966186523,46.7608476930551,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Altishofen. Schloss und Herrschaft im Adelboden Canton Lucern. = Altishofen. Chateau et Seigneurie dans l'Adelboden du Canton de Lucerne.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3055"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_2_0046.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.96062469482422,47.2015945374085,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Das Heilige Thal = La Valsainte</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3058"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_2_0049.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.18969345092773,46.6492702069459,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Das Heilige Thal. = La Valsainte</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3059"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_2_0050.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.18703269958496,46.6478296050625,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Part Dieu Chartreuse à deux lieuës de Gruyére dans le Canton de Fribourg. = Theil Gottes Carthaus zwei Stund von Griers in dem Canton Freyburg.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3061"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_2_0052.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.01803207397461,46.5967051486713,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Richensee und Grünenberg. Zweÿ alte BurgStähle im Oberen Freÿen Amt. = Richensee et Grunenberg. Deux vieux Châteaux dans les Baillages Libres.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3081"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_2_0072.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.25186967849731,47.2200543909374,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Das Schloss Boll. in dem Canton Freÿburg. = Château de Bulle. dans le Canton de Fribourg.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3086"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_2_0077.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.05792188644409,46.6173706018352,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Willisauw. Statt im Lucerner Gebiet. = Willisauw. Ville au Canton de Lucerne.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3087"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_2_0078.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.99289703369141,47.1218178161311,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hunnenfluh. Im Lauterbrunnen im Canton Bern. = Hunnenfluh. à Lauterbrunnen, dans le Canton de Berne.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3093"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_2_0084.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.90775299072266,46.5739038624934,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der Gletscher. Auf dem Hohen Säntis in dem Canton Abbenzell. = Gletscher. C'est à dire Glaciers éternelles au Haut Saentis dans le Canton d'Appenzell.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3103"><img src="http://www2.unil.ch/viatimages/viatimages/small/herrliberger1754_bpun_zr6005_2_0092.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.34867858886719,47.2454760289692,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pont des Prêtres sur la route d'Ivrée en Piemont.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3114"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_66.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.87702560424805,45.4663592059197,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ruines du château de Crussol dans l'Ardèche</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3115"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_67.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>4.85251307487488,44.9391370849376,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Embrun, Dauphiné</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3116"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_68.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.49500131607056,44.5624476881055,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ruines d'un château près de la route de Montmeillan à Conflans en Savoie.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3117"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_69.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.05415344238281,45.5019716213192,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La ville de Die, sur la Dromme, ancienne colonie Romaine.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3118"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_70.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>5.37334442138672,44.7508132959996,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Monastère de Belmonte en Piémont</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3122"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_74.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.63206481933594,45.3702053853847,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Château de Tournon sur le Rhône.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3123"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_75.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>4.83346939086914,45.0670265079502,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La cascade de Val-orsina. Savoie.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3129"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_81.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.93305969238281,46.0327099317927,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Aloës-Pitte en fleurs, sur les rochers du chemin appelé la Corniche, entre Nice et Savone</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3134"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_86.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.46246337890625,43.7447758267016,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chemin du Col de Tondé, taillé dans les rochers des Gorges de Saorgio, Comté de Nice.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3137"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_89.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.5519847869873,43.9892164886871,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Pas des brigands, dans les vallées de Rocabigliera, Comté de Nice.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3138"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_90.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.30831146240234,44.0120111892453,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Poste d'observation, pendant le blocus du Fort de Saorgio.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3139"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_91.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.55155563354492,43.989710507837,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Prise des défilés de Succarello, Etat de Gènes.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3148"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_100.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.11511993408203,44.1113690079284,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Avant-poste français devant Savonne.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3149"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_101.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.45157623291016,44.3311505351979,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L'entrée dans le monde. (Montagnes du Mont blanc.)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3153"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_105.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.87538146972656,45.9085169511673,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La sortie du monde. (Montagnes du Mont-blanc).</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3154"><img src="http://www2.unil.ch/viatimages/viatimages/small/baclerbs1818_kaf_ch_82_res_106.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.8719482421875,45.898355403331,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Der Adrius oder heutige Dinariberg]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3155"><img src="http://www2.unil.ch/viatimages/viatimages/small/hacquet1785_bcul_1c_1349_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>16.313324,44.103102,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hôtel des Alpes aux Bains de Loëche tenu par le propriétaire Hyacinthe Beeger</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3165"><img src="http://www2.unil.ch/viatimages/viatimages/small/grillet1845_mvs_rh_328_00008.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.629832,46.379968,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue des environs des bains de Loëche</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3167"><img src="http://www2.unil.ch/viatimages/viatimages/small/grillet1845_mvs_rh_328_00009.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.616314,46.366348,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bains de Louëche et passage de la Gemmi</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3168"><img src="http://www2.unil.ch/viatimages/viatimages/small/grillet1845_mvs_rh_328_00011.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.630563,46.375438,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hôtel de France aux bains de Loësche, près du passage de la Gemmi, canton du Valais, en Suisse</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3169"><img src="http://www2.unil.ch/viatimages/viatimages/small/grillet1845_mvs_rh_328_00164.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.630132,46.378999,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hôtel des Alpes aux bains de Loëche, canton du Valais. M. Beeguer propriétaire</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3170"><img src="http://www2.unil.ch/viatimages/viatimages/small/grillet1845_mvs_rh_328_00168.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.629832,46.379968,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Panorama de la sommité du Galm près des bains de Loëche</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3171"><img src="http://www2.unil.ch/viatimages/viatimages/small/grillet1845_mvs_rh_328_00174.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.670902,46.370967,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Vue du lac Majeur et des îles Borromées] </h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3173"><img src="http://www2.unil.ch/viatimages/viatimages/small/malo1824_mvs_rh_4_00011.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.520068,45.888714,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du pont de St Maurice</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3174"><img src="http://www2.unil.ch/viatimages/viatimages/small/malo1824_mvs_rh_4_00058.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.001595,46.227522,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Sion (côté de l'Orient)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3175"><img src="http://www2.unil.ch/viatimages/viatimages/small/malo1824_mvs_rh_4_00100.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.366739,46.236487,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la galerie des Glaciers</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3176"><img src="http://www2.unil.ch/viatimages/viatimages/small/malo1824_mvs_rh_4_00138.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.035469,46.297137,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du village de Simplon</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3177"><img src="http://www2.unil.ch/viatimages/viatimages/small/malo1824_mvs_rh_4_00144.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.054394,46.196815,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Perspective de l'intérieur de la galerie d'Algaby</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3178"><img src="http://www2.unil.ch/viatimages/viatimages/small/malo1824_mvs_rh_4_00150.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.077312,46.185327,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue prise de l'intérieur de la galerie d'Algaby</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3179"><img src="http://www2.unil.ch/viatimages/viatimages/small/malo1824_mvs_rh_4_00156.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.076668,46.185238,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de l'intérieur de la grande galerie</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3180"><img src="http://www2.unil.ch/viatimages/viatimages/small/malo1824_mvs_rh_4_00163.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.104906,46.191477,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la nouvelle route près de la grande galerie</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3181"><img src="http://www2.unil.ch/viatimages/viatimages/small/malo1824_mvs_rh_4_00169.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.124561,46.198013,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue près de Gondo</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3182"><img src="http://www2.unil.ch/viatimages/viatimages/small/malo1824_mvs_rh_4_00175.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.139452,46.195835,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la galerie d'Issel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3183"><img src="http://www2.unil.ch/viatimages/viatimages/small/malo1824_mvs_rh_4_00180.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.196831,46.206626,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Villa</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3184"><img src="http://www2.unil.ch/viatimages/viatimages/small/malo1824_mvs_rh_4_00192.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.259014,46.06947,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pass near La Tuille</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3186"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.946442,45.723918,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Vale of Gresivaudan from the terrace of the Chateau Bayard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3187"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_2.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.018533,45.423546,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Roche Blanche</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3188"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_3.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.818184,45.633741,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Scene from the Little St Bernard looking towards the Tarantaise</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3189"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_4.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.833231,45.648428,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Colonne de Joux and Hospice of the Little St Bernard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3190"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_5.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.882853,45.679249,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Blanc from the baths of St Didier</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3196"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_6.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.989839,45.763669,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la ville de Berne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3197"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_002_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.440491,46.966665,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue d'une partie des environs de Thoune</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3199"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_004.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.633009,46.757445,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue d'une partie du lac de Thoune</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3200"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_005.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.63155,46.736919,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Maison de pêcheurs à Scherzligen près de Thoune</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3201"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_006.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.622945,46.761289,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue prise dans le petit bois nommé le Bächihölzli près de Thoune</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3202"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_007.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.655582,46.741508,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la caverne de St Beat audessus du lac de Thoune</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3203"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_009.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.797632,46.690723,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue sur le lac de Thoune prise de la colline du Rugen près d'Interlaken</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3204"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_010.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.8475,46.674412,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue d'Unterseen et d'Interlaken</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3205"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_011.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.84956,46.691253,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue sur le lac de Brientz prise sur le Hohbuhl</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3206"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_012.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.852478,46.702673,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La cascade du Giessbach</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3207"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_013.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.964702,46.706146,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Maison de paysan près d'Unterseen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3208"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_014.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.846127,46.688191,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue du château d'Unspunnen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3209"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_016.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.868443,46.67188,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la Jungfrau dans la vallée de Lauterbrunnen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3210"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_017.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.91153,46.59426,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Blanc and the Valley of Aosta from Fort Roc</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3214"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_7.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.000437,45.763182,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ascent of the Little St Bernard from the Tarantaise</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3215"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_8.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.819804,45.638107,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Fall of the Romanche near Villard d'Arene</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3217"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_10.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.315629,45.047875,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The fort of Fenestrelles</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3218"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_11.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.061198,45.027648,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Scene from the Ascent to the Mont Genèvre</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3219"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_12.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.774395,44.951072,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Briançon</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3220"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_13.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.637326,44.906362,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont d'Arcines, and the val de Guisanne. From the col of Lautaret</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3221"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_14.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.416266,45.042205,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Scene in the val Romanche</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3222"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_15.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.283493,45.042114,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chûte du Staubbach prise à l'entrée du village de Lauterbrunnen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3223"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_018.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.907238,46.598565,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chute supérieure du Staubbach</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3224"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_019.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.893233,46.588125,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de la cascade du Schmadribach au fond de la vallée de Lauterbrunnen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3225"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_020.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.908056,46.511333,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Passage de la Wengernalp</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3226"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_021.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.939682,46.581518,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Grindelwald</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3228"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_023.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.010235,46.626099,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le glacier inférieur de Grindelwald</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3229"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_024.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.047142,46.617611,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue des montagnes de Wetter-horn, Well-horn, et du glacier de Rosenlaui</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3230"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_025.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.138916,46.677857,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La cascade supérieure du Reichenbach</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3231"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_026.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.183056,46.713611,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La cascade inférieure du Reichenbach</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3232"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_027.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.183056,46.713611,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Les cascades de Dorfbach et Alpbach à Meyringen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3233"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_028.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.185877,46.727391,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue prise du fond du Hasli im Grund, sur la route du Grimsel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3234"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_029.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.250732,46.680066,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La chute de l'Aar à Handeck</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3235"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_030.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.308325,46.611685,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pont sur l'Aar au passage du Grimsel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3236"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_031.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.33758,46.5614,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Les pierres sur le glacier de l'Aar</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3237"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_032.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.184814,46.566414,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue prise du pied du Finsteraarhorn</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3238"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_033.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.12621,46.5373,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de l'hospice du Grimsel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3239"><img src="http://www2.unil.ch/viatimages/viatimages/small/lory1822_bn_guggelmann_034.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.33758,46.5614,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Grenoble from the road to Vizille</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3240"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_16.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>5.782156,45.113178,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The lake & the plain of Mont Cenis</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3243"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_19.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.901045,45.259664,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lyons, from the confluence of Rhone and Saone</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3244"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_20.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>4.814549,45.728079,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Montmélian</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3245"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_21.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.070075,45.495308,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Fort Lesseillon near Bramante</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3246"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_22.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.746678,45.212611,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ascent to the Grand Croix from the plain of St. Nicolas</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3247"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_23.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.95941,45.209156,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Monastery of St. Michel above St. Ambrogio</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3248"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_24.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.362084,45.097579,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Turin and the Alps from the Mont Superga</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3249"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_25.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.739396,45.083112,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Valley of the Arc from above St. Michel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3250"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_26.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.478844,45.211537,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Devils Bridge</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3252"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_28.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.590381,46.64768,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bellinzona, from Sementina</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3253"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_29.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.999863,46.181168,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Airolo and the Val Levantine</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3254"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_30.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.583831,46.526944,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ponte Tremola</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3255"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_31.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.580698,46.540038,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The summit of the pass of the Saint Gothard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3256"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_32.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.563907,46.558314,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Scene in the valley of the Reuss above Goschenen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3257"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_33.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.585687,46.650261,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Tell's chapel, from the lake of Uri</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3258"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_34.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.604355,46.936081,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Tell's Tower, Altdorf</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3259"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_35.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.643968,46.881634,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hospice of the Great St. Bernard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3261"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_37.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.165264,45.86812,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The valley of the Rhône above Martigny</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3263"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_38.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.068533,46.10507,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Scene in the forest of Saint Pierre</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3264"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_39.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.213554,45.95126,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La ville de Syon avec ses deux chasteaux & l'eglise cathedrale appellée Valeria</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3273"><img src="http://www2.unil.ch/viatimages/viatimages/small/munster1575_mvs_bcv_rz_1688_0503_0504.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.354252,46.231064,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Octodur qui est auiourdhuy appellée Martinach]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3274"><img src="http://www2.unil.ch/viatimages/viatimages/small/munster1575_mvs__bcv_rz_1688_0505.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.071075,46.105732,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The lake of the Great St. Bernard from the hospice</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3277"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_40.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.170446,45.869311,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Descent from the Great St. Bernard on the side of Italy</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3278"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_41.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.158279,45.868736,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The valley and the city of Aosta from the chateau Quart</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3279"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_42.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.401888,45.747971,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Les baings de Brig]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3283"><img src="http://www2.unil.ch/viatimages/viatimages/small/munster1575_mvs_bcv_rz_1688_0511.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.918054,46.299742,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Des bains de Leuck]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3284"><img src="http://www2.unil.ch/viatimages/viatimages/small/munster1575_mvs_bcv_rz_1688_0512.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.628385,46.379229,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Guillaume Tell]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3294"><img src="http://www2.unil.ch/viatimages/viatimages/small/munster1575_mvs_bcv_rz_1688_0528.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.640549,46.877893,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[La premiere alliance des Suysses]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3296"><img src="http://www2.unil.ch/viatimages/viatimages/small/munster1575_mvs_bcv_rz_1688_0532.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.593022,46.968965,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chateau of St. Germain from the defile of Mont Jovet</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3297"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_43.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.66438,45.727244,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Gate of Bourg St. Pierre</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3298"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_44.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.208657,45.727244,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Galleries in the Wurmser Loch</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3300"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_46.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>10.393581,46.510208,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Vale of Meran from the old castle of Tyrol</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3301"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_47.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>11.144385,46.694962,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Ortler-Spitz, from the summit of the Stelvio Pass</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3302"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_48.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>11.144385,46.694962,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The baths of Bormio</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3303"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_49.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>10.364318,46.490282,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Sondrio</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3304"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_50.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.869682,46.17067,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Como, from the road to Erba</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3305"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_52.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.129303,45.797019,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The chateau of Gastenbell</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3323"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_53.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>10.899532,46.627897,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pont Saint Louis near Menton</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3325"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_55.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.529084,43.785824,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Les baings de Pfaeuers]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3327"><img src="http://www2.unil.ch/viatimages/viatimages/small/munster1575_mvs_bcv_rz_1688_0554.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.500542,46.990498,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bordighera from the Capo Noro</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3338"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_57.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.734976,43.799474,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lecco</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3339"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t1_51_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.387045,45.850924,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ventimiglia</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3357"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_58.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.653179,43.78132,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mortole</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3358"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_59.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.548316,43.785456,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ruins of the Trophœa Augusti</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3359"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_60.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.401432,43.745061,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Nice</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3360"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_61.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.401432,43.745061,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Scene from the top of the Aar-fall near Handek</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3363"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_64.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.308089,46.613218,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vale of Meyringen from the Brunig</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3364"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_65.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.143887,46.750509,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Fall of the Toccia, near Fractval</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3365"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_66.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.413918,46.407268,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Formazza</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3366"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_67.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.420185,46.396894,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bridge near Fopiano. Val Formazza</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3367"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_68.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.419991,46.336232,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Stratification du Lauter-Aar</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3368"><img src="http://www2.unil.ch/viatimages/viatimages/small/bpun_unine_igh_agassiz_2_3.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.166962,46.580103,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Rive gauche du glacier de l'Aar</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3369"><img src="http://www2.unil.ch/viatimages/viatimages/small/bpun_unine_igh_agassiz_2_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.20816,46.570899,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Auberge du Schwarzwald sur la route de la Grande Scheidegg]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3370"><img src="http://www2.unil.ch/viatimages/viatimages/small/bpun_55_4_03_1_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.134089,46.675296,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Hospice du Grimsel]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3371"><img src="http://www2.unil.ch/viatimages/viatimages/small/bpun_wyss_55_4_03_3_0001_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.339481,46.572905,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chateau of Scherylingen, Lake of Thun</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3373"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_027_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.641163,46.741155,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chateau of Scherylingen, Lake of Thun</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3374"><img src="http://www2.unil.ch/viatimages/viatimages/small/cockburn1820_mvsrh200_026_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.640305,46.746448,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Scene near Rocco. Val Formazzo</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3375"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_69.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.39078,46.327053,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Domo d'Ossola, from Saint Marco</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3376"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_70.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.319979,46.17624,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glaciers and source of the Rhone</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3377"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_71.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.358321,46.563936,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Gallery in the Verlohren Loch</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3379"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_73.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.4524,46.67978,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Coire</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3380"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_74.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.534502,46.853764,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lake on the summit of the Bernardin</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3381"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_75.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.19034,46.45571,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue depuis le Faulhorn sur les plus hautes Montagnes de l'Oberland Bernois</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3382"><img src="http://www2.unil.ch/viatimages/viatimages/small/bpun_55_4_03_3_0010.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.991867,46.674177,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue depuis le Hohbuhl près d'Interlacken</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3383"><img src="http://www2.unil.ch/viatimages/viatimages/small/bpun_55_4_03_3_0007.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.851706,46.697434,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Plan du vallon d'Unterseen et d'Interlacken, entre les lacs de Thoun et de Brienz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3386"><img src="http://www2.unil.ch/viatimages/viatimages/small/bpun_55_4_03_3_0006.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.881145,46.680772,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Karte vom Thunersee. Carte du Lac de Thoun</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3387"><img src="http://www2.unil.ch/viatimages/viatimages/small/bpun_55_4_03_3_0005.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.724762,46.689486,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Fall of the Moesa</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3389"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_76.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.226761,46.414684,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The castle and valley of Misocco</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3390"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_77.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.232292,46.382284,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Matterhorn (from the Riffelberg)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3391"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.755209,45.992858,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The valley of St. Nicholas (Route to Zermatt)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3392"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_2.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.801844,46.175726,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Monte Rosa and the Lyskam (From the Gorner glacier)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3393"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_3.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.789831,45.972415,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Châlets at Zermatt (Valais)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3394"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_4.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.747937,46.021073,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The lake of Lucerne I. Lucerne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3395"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_5.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.315613,47.050335,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The lake of Lucerne II. Gersau</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3396"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_6.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.523756,46.993428,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mount Pilatus (From the lake of Lucerne)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3397"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_7.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.308706,47.052726,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lugano</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3402"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_78.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.969307,46.028912,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Scene on the descent from the Splugen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3403"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_79.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.336389,46.455374,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Covered bridge across the Rhine at Splugen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3404"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_80.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.323316,46.552818,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Scene near Primolano, Val-Sugana</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3406"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_82.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>11.726704,45.945898,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Valley of Stubay, from the Schonberg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3407"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_83.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>11.726704,45.945898,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Post house on the Brenner</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3408"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_84.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>11.504703,47.001827,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Chateau of Trostberg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3409"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_85.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>11.527855,46.59395,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Trent</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3410"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_86.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>11.127809,46.074518,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Weggis (Lake of the four forest-cantons)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3411"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_12.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.433333,47.033333,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bridge on the Mayenbach (Pass of St. Gothard)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3412"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_13.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.563843,46.596619,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pass of St. Gothard I. The valley of the Reuss</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3413"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_14.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.563843,46.596619,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pass of St. Gothard II. Gorge of the Ticino, Dazio Grande</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3414"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_15.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.752969,46.489311,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Wetterhorn (From Grindelwald)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3417"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_18.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.030959,46.624893,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The valley of Lauterbrunnen (Bernese Oberland)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3418"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_19.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.903313,46.596329,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Mer the Glace (Chamouni, Savoy)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3419"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_20.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.919842,45.928349,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Crevasses in the Mer de Glace</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3420"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_21.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.940956,45.913183,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Aiguille du Dru (From Montanvert)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3422"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_22.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.919498,45.931214,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Gorge of the Tamina (Ragatz and the "Falkniss")</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3423"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_23.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.498882,46.998314,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Gorge of the Tamina (Car road to Pfeffers)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3424"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_24.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.499199,46.998896,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The baths of Pfeffers I. The old baths</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3425"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_25.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.492166,46.991245,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The baths of Pfeffers II. Gorge and source of the hot springs</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3426"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_26.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.489119,46.989504,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>An Alpine Village in the Grisons</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3427"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_27.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.482716,46.968638,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Gorge of the Via Mala - Pass of the Splügen I. The Middle Bridge</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3428"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_28.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.443607,46.659752,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Gorge of the Via Mala - Pass of the Splügen II. The lost Gulph</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3429"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_29.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.4481,46.6616,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>II. Lago Maggiore and the Borromean islands</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3431"><img src="http://www2.unil.ch/viatimages/viatimages/small/thompson1868_bn_kach65_31.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.50668,45.904464,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Scene from the Monte Porgine</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3432"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_87.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>11.171251,46.083933,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bassano</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3433"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_88.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>11.740909,45.776383,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Castle of Salurn</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3434"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_89.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>11.20142,46.235576,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Defile of Saorgio</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3436"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_91.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.540913,43.976603,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Saorgio</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3437"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_92.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.547092,43.983243,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Tende</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3438"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_93.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.593205,44.082684,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Ca on the Mont de Tende</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3439"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_94.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.565417,44.140758,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Valley of the Stura, from Venadio</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3440"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_95.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.179651,44.306898,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Scene in the Valley of the Ubaye</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3441"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_96.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.426584,44.434868,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Dauphin and the upper valley of the Durance, from the ascent to Vars</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3442"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_97.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.670616,44.62817,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Scene near Zambucco, Val Stura</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3443"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_98.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.054185,44.346133,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Entrance to the great gallery near Gondo</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3447"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_100.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.137951,46.196379,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Bernoise Alps from the Simplon</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3448"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_101.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.033656,46.251182,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lucerne and her beautiful Lake, Switzerland (6) 1741</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3454"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_6.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.297081,47.052932,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lucerne and the lofty Pilatus, Switzerland (9) 1744</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3457"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_9.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.313716,47.056618,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Summit of Historic Pilatus, Switzerland (11) 1746</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3458"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_11.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.257813,46.980721,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Backbone of Europe, from the Summit of Pilatus (7000 feet), Switzerland (12) 1747</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3459"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_12.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.257813,46.980721,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Lake of Lucerne from the Axenstein, Switzerland. The most beautiful country in the world (13) 1748</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3460"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_13.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.623761,46.98224,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Defile of the Dovedro near Gondo</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3461"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_102.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.15155,46.196509,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Val d'Ossola from the defile of the Dovedro</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3462"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_103.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.298755,46.153274,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Lake of Orta</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3463"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_104.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.298755,46.153274,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lago Maggiore</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3464"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_105.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.541988,45.770097,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Sisikon and the Mighty Uri-Rothstock (9020 feet), Switzerland (14) 1749</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3465"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_14.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.622937,46.950409,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Monte Rosa and the Alps from the strada Sempione near Somma</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3466"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_106.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.713864,45.681921,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Bold Axenstrasse, hewn from the Cliffs, 360 feet above Lake Lucerne, Switzerland (15) 1750</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3467"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_15.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.611908,46.928345,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Pisse-Vache from the village of Mieville</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3474"><img src="http://www2.unil.ch/viatimages/viatimages/small/brockedon1828_mvs_cb60_t2_107.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.029608,46.148525,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ancient Thun and its Lake, from the Castel (22) 1757</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3477"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_22_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.631013,46.760076,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Interlaken and Jungfrau (13,670 feet) (23) 1758</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3478"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_23.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.849903,46.685247,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Grindelwald Valley, the Wetterhorn and Schreckhorn from Schynige Platte, Switzerland (24) 1759</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3479"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_24.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.9105,46.653207,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Staubbach Waterfall (nearly 1,000 feet), in beautiful, from Schynige Platte (25) 1760</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3480"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_25.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.907238,46.596737,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cloud-hidden heights and appalling depths - the Mönch, Eiger and Lauterbrunnen Valley (26) 1761</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3481"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_26.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.89917,46.579159,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mürren, the loftiest of Switzerland's Hamlets, and the Monch and Eiger (27) 1762</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3482"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_27.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.892644,46.559373,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Breithorn (12,400 feet) and Tschingelhorn (11,748 feet), Upper Lauterbrunnen (28) 1763</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3484"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_28.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.943115,46.585058,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Jungfrau (13,670 feet), from the Summit of Scheidegg (29) 1764</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3485"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_29.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.96011,46.58494,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Grindelwald Valley and the Wetterhorn from the Summit of Scheidegg (30) 1765</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3486"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_30.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.961397,46.585707,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Immense Glacier Basin beneath the Fiescherhorn, looking through Grindelwald Gorge (31) 1766</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3487"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_31.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.075638,46.633408,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Ascent of Jungfrau - Crossing the Glacier, Switzerland (32) 1767</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3488"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_32.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.091431,46.566178,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>A Country Road, Switzerland - "Old summer pictures of the quiet hills" (33) 1768</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3489"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_33.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.046284,46.619379,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Upper Grindelwald Glacier, Switzerland (34) 1769</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3490"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_34.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.085251,46.62268,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>"Youthful years and maiden beauty" - the same in all the World, Switzerland included (35) 1770</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3491"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_35.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.185877,46.727391,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Wonderful Gorge of the River Aare, Switzerland (36) 1771</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3492"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_36.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.215132,46.711582,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Looking east down the Rhine valley from Disentis, Switzerland (37) 1772</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3493"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_37.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.854531,46.704564,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Looking N. down the profound gorge Via Mala toward Thusis and the Rhine Valley, Switzerland (38) 1773</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3494"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_38.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.4481,46.6616,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Nature's Cathedrals, Piz Bernina and Roseg, Roseg Valley, Engadine, Switzerland (39) 1774</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3495"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_39.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.849243,46.420346,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bella Vista, Piz Bernina and the Morteratsch Glacier, Engadine, Switzerland (40) 1775</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3496"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_40.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.948807,46.449685,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Peaks of Palu - wrapped in eternal snows - Bernina Group, Engadine, Switzerland (41) 1776</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3497"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_41.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.976273,46.404013,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Upper Engadine, the most admired of Swiss Valleys, notheast from the Hahnensee (42) 1777</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3498"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_42.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.828644,46.467128,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The beauty and splendor of the Engadine, looking southwest from Hahnensee to the Maloja, Switzerland (43) 1778</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3499"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_43.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.828532,46.467711,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The descent to Italy - Road winding down from the Maloja Pass, Engadine, Switzerland (44) 1779</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3500"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_44.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.69575,46.4,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The gates of the hills</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3501"><img src="http://www2.unil.ch/viatimages/viatimages/small/ruskin1903_bg_t7076_t6_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.778808,46.487174,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Engineering feats on the St. Gotthard Railroad - Circular Tunnels at Giornico, Italian side, Alps. (45) 1780</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3502"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_45.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.866667,46.4,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>St. Gotthard Railroad at Wassen (north side of Alps), Windgalle in distance, Switzerland (46) 1781</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3503"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_46.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.599075,46.706332,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Grimsel Pass, Oberaarhorn and Finsteraarhorn - west from the Furka Pass, Switzerland (47) 1782</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3504"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_47.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.357506,46.567299,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Magnificent view of Rhone Valley with Weisshorn and Monte Rosa Group. S.W. from Furka Pass, Switzerland (48) 1783</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3505"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_48.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.357506,46.567299,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Looking south from the Eggishorn over Rhone Valley to Monte Leone and Fletschhorn Switzerland (49) 1784</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3506"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_49.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.094311,46.431358,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Huge Bed and Banks of an Ice River - Fiescher Glacier and Oberaarhorn, northeast from the Eggishorn, Switzerland (50) 1785</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3507"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_50.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.11409,46.43833,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The great Aletsch Glacier and Marjelen Lake, west from the Eggishorn, Switzerland (51) 1786</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3508"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_51.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.091992,46.440767,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Edge of Aletsch Glacier - showing the treacherous Crevasses - and Marjelen Lake (looking west), Switzerland (52) 1787</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3509"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_52.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.091992,46.440767,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>An ocean of Ice - great Aletsch Glacier (looking south) with Weisshorn in distance, Switzerland (53) 1788</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3510"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_53.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.077698,46.444481,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pass of Faido (1st. simple topography)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3511"><img src="http://www2.unil.ch/viatimages/viatimages/small/ruskin1903_bg_t7076_t6_2.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.786855,46.48557,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pass of Faido (2nd. Turnerian topography)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3512"><img src="http://www2.unil.ch/viatimages/viatimages/small/ruskin1903_bg_t7076_t6_3.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.778808,46.487174,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Aiguille Charmoz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3515"><img src="http://www2.unil.ch/viatimages/viatimages/small/ruskin1903_bg_t7076_t6_6.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.918889,45.904444,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Aiguille Blaitiere</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3516"><img src="http://www2.unil.ch/viatimages/viatimages/small/ruskin1903_bg_t7076_t6_7.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.913056,45.899167,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Aiguille Drawing</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3517"><img src="http://www2.unil.ch/viatimages/viatimages/small/ruskin1903_bg_t7076_t6_8.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.918889,45.904444,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Looking down (noth) the Visp Valley from near Stalden - Bernese Alps in distance -  Switzerland (54) 1789</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3518"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_54.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.86976,46.23304,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The "Alpine Spirit's Sanctuary" - Zermatt and the Matterhorn, Switzerland (55) 1790</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3519"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_55.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.747937,46.021073,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>From Verdure to Eternal Snow; the Matterhorn from pathway above Zermatt,  Switzerland (56) 1791</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3520"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_56.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.740383,46.022476,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Matterhorn seen from the Schwarzsee, Switzerland (57) 1792</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3521"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_57.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.709998,45.991511,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Wonderful frozen cataract, the Gorner Glacier, Monte Rosa, Switzerland (58) 1793</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3522"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_58.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.73901,46.009601,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Zermatt, from the Schwarzsee, Switzerland (59) 1794</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3523"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_59.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.709998,45.991511,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>"Lion of the Alps", the Matterhorn, Switzerland (60) 1795</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3524"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_60.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.755318,46.005309,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Breithorn, Monte Rosa group, from the Gornergrat, Switzerland (61) 1796</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3525"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_61.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.76685,46.01142,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lyskamm, Monte Rosa group, from the Gornergrat, Switzerland (62) 1797</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3526"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_62.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.839088,46.014131,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Summit of the Mt. Rosa (15,217 feet), from Gornergrat, birthplace Gorner Glacier (63) 1798</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3527"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_63.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.862499,45.937945,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The charming Resort, Zermatt, Valley of Visp, beneath the mighty Weisshorn, Switzerland (64) 1799</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3528"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_64.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.749481,46.010555,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Swiss Hamlet near Eternal Snows - Saas Fee, the Fee Glacier and the Alphubel, Switzerland (65) 1800</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3529"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_65.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.92983,46.110604,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Life in Switzerland; a Typical Home in Saas Fee (66) 1801</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3530"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_66.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.92983,46.110604,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Sion with its medieval Homes and Castles, Rhone Valley,  Switzerland (68) 1803</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3531"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_68.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.362049,46.229352,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Leading contours of Aiguille Bouchard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3532"><img src="http://www2.unil.ch/viatimages/viatimages/small/ruskin1903_bg_t7076_t6_9.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.918889,45.904444,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cleavages of Aiguille Bouchard</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3533"><img src="http://www2.unil.ch/viatimages/viatimages/small/ruskin1903_bg_t7076_t6_10.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.918889,45.904444,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Crests of La Côte and Taconay</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3534"><img src="http://www2.unil.ch/viatimages/viatimages/small/ruskin1903_bg_t7076_t6_11.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.851805,45.908582,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Crest of La Côte</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3535"><img src="http://www2.unil.ch/viatimages/viatimages/small/ruskin1903_bg_t7076_t6_12.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.852148,45.913598,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Cervin, from the East, and North East</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3536"><img src="http://www2.unil.ch/viatimages/viatimages/small/ruskin1903_bg_t7076_t6_13.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.658315,45.976327,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Cervin, from the North West</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3537"><img src="http://www2.unil.ch/viatimages/viatimages/small/ruskin1903_bg_t7076_t6_14.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.658315,45.976327,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Mountains of Villeneuve</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3538"><img src="http://www2.unil.ch/viatimages/viatimages/small/ruskin1903_bg_t7076_t6_15.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.919832,46.395979,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Buttresses of an Alp</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3539"><img src="http://www2.unil.ch/viatimages/viatimages/small/ruskin1903_bg_t7076_t6_16.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.071076,46.103709,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Goldau</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3540"><img src="http://www2.unil.ch/viatimages/viatimages/small/ruskin1903_bg_t7076_t6_17.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.55054,47.05018,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>World-famed Monastery and Dogs - Great St. Bernard Pass, Switzerland (70) 1805</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3543"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_70.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.17051,45.8689,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Great St. Bernard pass, Lake and Monastery - looking northeast, Switzerland (71) 1806</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3544"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_71.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.17051,45.8689,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Eastern side Mt. Blanc range, from Col de Fenêtre, near Great St. Bernard Pass, Switzerland (72) 1807</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3545"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_72.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.35638,45.9102,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Balmat, first to ascend Mt. Blanc, pointing out his route to Saussure, Chamonix (78) 1813</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3550"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_78.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.869743,45.923201,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Frightful Alpine Precipices - looking from Aiguille Rouge (Brévent) to Mt. Blanc, Alps (79) 1814</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3551"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_79.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.837519,45.933854,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Blanc, Monarch of European mountains, from the Brévent, Alps (80) 1815</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3552"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_80.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.837519,45.933854,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Climbing the heights above Valley of Chamonix, Aiguille Verte in the distance, Alps (81) 1816</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3553"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_81.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.837519,45.933854,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ascent of Mt. Blanc - cutting steps in the crystal ice of the Bossons Glacier, Alps (82) 1817</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3554"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_82.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.866112,45.871365,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Tunnel in the Glacier des Bossons, Mt. Blanc, Alps (83) 1818</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3555"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_83.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.863135,45.867115,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ascent of Mt. Blanc - halting with guides at Pierre Pointue - looking up Bossons Glacier, Alps (84) 1819</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3556"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_84.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.872098,45.883078,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ascent of Mt. Blanc, crossing Bossons Glacier crevasses - Grands Mulets in distance, Alps (85) 1820</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3557"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_85.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.860104,45.858217,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ascent of Mt. Blanc - Ice Cliffs on the Bossons Glacier (looking southwest), Alps (86) 1821</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3558"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_86.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.844482,45.850804,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ascent of the Mt. Blanc - looking from Grand Mulets hut to Dôme du Goûter (87) 1822</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3559"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_87.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.861111,45.866667,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ascent of the Mt. Blanc - looking back (north) to Grand Mulet hut (10,007 feet) and Chamonix Valley, Alps (88) 1823</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3560"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_88.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.861111,45.866667,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ascent of Mt. Blanc - Dôme du Goûter, between the Petit and Grand Plateau, Alps (89) 1824</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3561"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_89.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.858044,45.862281,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ascent of Mt. Blanc - Party resting on Grand Plateau (13,000 feet), Mt. Blanc in distance, Alps (90) 1825</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3562"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_90.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.861649,45.841238,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ascent of Mt. Blanc - Vallot refuge hut to Bernese Alps, 50 miles away (91) 1826</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3563"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_91.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.851944,45.839444,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Summit of Mt. Blanc, highest point in Europe, N. E. past Observatory to the Bernese Alps (92) 1827</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3564"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_92.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.864594,45.833642,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Descent of Mt. Blanc - enormous crevasses near the summit, Alps (93) 1828</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3565"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_93.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.864594,45.833642,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>A Remnant of the Glacial Period - huge Mer de Glace and Grandes Jorasses, Alps (94) 1829</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3566"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_94.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.917953,45.933184,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ascent of Aig. du Tacul - looking to Tour Ronde and Mt. Blanc from the Glacier des Periades, Alps (95) 1830</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3567"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_95.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.951427,45.875668,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ascent of Aig. du Tacul - S.W. to Aig. du Géant (left) and Tour Ronde (right), Alps (96) 1831</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3568"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_96.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.960864,45.884873,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ascent of Aig. du Tacul - amid dizzy heights, looking north to Aig. du Dru and Verte, Alps (97) 1832</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3569"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_97.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.960864,45.884873,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The "Mauvais Pas" and Mer de Glace, Aig. du Géant in the distance, Alps (98) 1833</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3570"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_98.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.935806,45.921065,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mer de Glace with Aiguille du Géant, Charmoz and Montanvert in distance, Alps (99) 1834</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3571"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_99.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.837519,45.933854,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Great Ice Fall at the end of the Mer de Glace, Alps (100) 1835</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3572"><img src="http://www2.unil.ch/viatimages/viatimages/small/emery1901_bn_klff2230_100.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.926537,45.922976,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Upper ice-fall of the Ober Grindelwald glacier</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3573"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.081338,46.630255,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>On the Unter Grindelwald Glacier</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3587"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_4.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.05658,46.58531,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier motion-ice and rock</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3588"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_5.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.05658,46.58531,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Rhone Glacier. To face page 23</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3589"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_6.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.379035,46.569837,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Waved surface of the Aar glacier</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3590"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_7.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.219147,46.564998,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ice neddles, unter Grindelwald Glacier. To face page 27</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3591"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_8.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.05658,46.58531,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Jungfrau Joch. To face page 37</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3592"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_9.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.971568,46.560601,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>A dirt cone</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3593"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_10.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.05658,46.58531,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>A glacier table</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3594"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_11.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.05658,46.58531,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Medial moraine on the ober Aletsch glacier. To face page 57</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3595"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_12.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.949747,46.423065,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>An active moulin</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3596"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_13.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.05658,46.58531,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>An extinct moulin</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3597"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_14.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.05658,46.58531,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>A glacier remanié</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3598"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_15.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.193541,46.568892,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Viescherhörner, from the Eismeer Path. To face page 78</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3599"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_16.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.065459,46.595687,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Mont Blanc 4810M., pris du Buet.</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3600"><img src="http://www2.unil.ch/viatimages/viatimages/small/civiale_1882_bge_t_9235_front.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.885853,46.025694,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Roches argilo-calcaires de Prégentil</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3601"><img src="http://www2.unil.ch/viatimages/viatimages/small/civiale_1882_bge_t_9235_p097_ht.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.033726,45.063337,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Mer de glace, prise du Montenvers</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3602"><img src="http://www2.unil.ch/viatimages/viatimages/small/civiale_1882_bge_t_9235_p174_ht.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.917267,45.93408,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Mont Blanc 4810M, pris du Carmel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3603"><img src="http://www2.unil.ch/viatimages/viatimages/small/civiale_1882_bge_t_9235_p218_ht.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.002068,45.811093,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Weisshorn 4510M pris de la Bella Tola</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3604"><img src="http://www2.unil.ch/viatimages/viatimages/small/civiale_1882_bge_t_9235_p258_ht.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.653795,46.239069,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Glacier de Gétroz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3605"><img src="http://www2.unil.ch/viatimages/viatimages/small/civiale_1882_bge_t_9235_p270_ht.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.364616,46.014251,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>La Grivola 4010M, prise du Pic Carrel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3606"><img src="http://www2.unil.ch/viatimages/viatimages/small/civiale_1882_bge_t_9235_p282_ht.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.366,45.687,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Grand Cervin 4482M, pris du Riffelberg</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3607"><img src="http://www2.unil.ch/viatimages/viatimages/small/civiale_1882_bge_t_9235_p298_ht.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.755209,45.992858,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Mont Rose 4638M, pris du Monte Moro
+
+</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3608"><img src="http://www2.unil.ch/viatimages/viatimages/small/civiale_1882_bge_t_9235_p324_ht.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.98349,45.9972,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L’Aletschhorn 4207M, pris de l’Eggischhorn
+
+
+</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3609"><img src="http://www2.unil.ch/viatimages/viatimages/small/civiale_1882_bge_t_9235_p346_ht.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.094311,46.431358,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Grindelwald au mois de février
+
+
+</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3610"><img src="http://www2.unil.ch/viatimages/viatimages/small/civiale_1882_bge_t_9235_p358_ht.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.030959,46.624893,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Les roches polies à la source de l’Aare
+
+</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3611"><img src="http://www2.unil.ch/viatimages/viatimages/small/civiale_1881_bge_p_370_12.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.271675,46.560041,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Le Bernina, 4052M, pris du Corvatsch
+
+
+</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3612"><img src="http://www2.unil.ch/viatimages/viatimages/small/civiale_1882_bge_p426_13.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.816083,46.408347,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>L’Örtler 3905M, pris de Minschuns
+
+</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3613"><img src="http://www2.unil.ch/viatimages/viatimages/small/civiale_1882_bge_p450_14.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>10.483528,46.580772,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Final fall of Unter Grindelwald glacier</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3614"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_17.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.05658,46.58531,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Lauteraar Joch from the Abschwung. To face page 109</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3615"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_18.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.16547,46.56593,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>A glacier fountain</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3616"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_19.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.05658,46.58531,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Ober Aletsch glacier, from the Sparrenhorn. To face page 141</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3617"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_20.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.98012,46.406229,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Oberland Mountains. From the Torrenthorn. To face page 143</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3618"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_21.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.68105,46.377833,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Nesthorn, from the Ober Aletsch glacier. To face page 154</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3619"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_22.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.96203,46.42586,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The gorge of the Massa</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3620"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_23.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.01336,46.39331,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ice-peak - Ober Aletsch glacier</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3621"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_24.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.959907,46.422969,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Oeschinen See and Blümlis Alp. To face page 202</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3622"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_25.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.96203,46.42586,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Striations opposite the Grimsel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3623"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_26.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.3327,46.57142,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Striations beside the Unter Grindelwald glacier</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3624"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_27.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.05838,46.59224,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier stream on the Eismeer</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3625"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_28.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.05169,46.57325,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Terminal cave of the Unter Grindelwald glacier</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3626"><img src="http://www2.unil.ch/viatimages/viatimages/small/brooke1866_bns_aq13303res_29.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.05376,46.60176,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Nebelbild, vom Matterhorn aus gesehen (14. Juli 1865)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3627"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_01.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.658448,45.976433,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Maulthiere</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3632"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_05.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.6145,46.3984,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Wer ist das Thieß?</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3634"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_07.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.747937,46.021073,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Briançon</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3637"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_10.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.643179,44.899416,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Pelvoux von oberhalb La Bessée gesehen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3638"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_11_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.559093,44.792924,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Im Val d'Alefred</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3639"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_12.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.494293,44.841751,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der Grand Pelvoux des Val Louise</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3640"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_13.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.399898,44.898813,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Reichenbach</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3644"><img src="http://www2.unil.ch/viatimages/viatimages/small/coxe1802_bge_fb296_t2_2.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.183056,46.713611,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Pelvoux und der Alefroide, von einem Punkte nahe beim Mont Dauphin, im Thale des Durance gesehen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3645"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_15.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.624536,44.669762,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mein Schlafsack</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3646"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_16.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>5.959015,44.971454,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Natürlicher Pfeiler bei Moulines</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3647"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_17.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.827478,44.746015,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Fahrt über den Mont Cenis</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3648"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_18.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.900838,45.259859,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der kleine Postillon</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3649"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_19.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.900838,45.259859,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Staubbach</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3651"><img src="http://www2.unil.ch/viatimages/viatimages/small/coxe1802_bge_fb296_t2_3.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.909218,46.592087,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lake of Lawerz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3652"><img src="http://www2.unil.ch/viatimages/viatimages/small/coxe1802_bge_fb296_t2_4.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.612053,47.026356,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Die bedeckten Wege der Bahn</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3654"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_20.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.900838,45.259859,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lake of Brientz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3655"><img src="http://www2.unil.ch/viatimages/viatimages/small/coxe1802_bge_fb296_t2_5.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.036476,46.75358,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Die Mont-Cenis-Bahn und die Fellsche Bahn in der Nähe des Pass Spitze</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3656"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_21.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.900838,45.259859,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier of Grindelwald</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3657"><img src="http://www2.unil.ch/viatimages/viatimages/small/coxe1802_bge_fb296_t2_6.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.046307,46.599256,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der vorgeschobene Gang auf der französischen Seite des Mont-Cenis-Tunnels mit den arbeitenden Bohrmaschinen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3659"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_22.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.900838,45.259859,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Fortschaffung von Trümmern nach dem Sprengen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3662"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_23.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.900838,45.259859,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Lake of the Four Cantons</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3664"><img src="http://www2.unil.ch/viatimages/viatimages/small/coxe1802_bge_fb296_t2_7.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.406366,46.986745,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Genève</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3665"><img src="http://www2.unil.ch/viatimages/viatimages/small/wetzel1820_bge_pfy59_1_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.119371,46.22289,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Das Matterhorn von einem Punkte nahe beim Theodule Pass gesehen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3667"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_25.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.703819,45.946495,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der Col du Lion: Aussicht auf den Tête du Lion</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3670"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_28.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.6449,45.9717,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der Schornstein. Auf dem Südwestlichen Grat des Matterhorn</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3677"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_32.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.658448,45.976433,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Als ich versuchte, um die Ecke zu gehen, glitt ich aus und fiel</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3678"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_33.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.658448,45.976433,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Im Breil (Giomein)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3679"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_34.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.633655,45.934359,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ein Steinfall auf der Matterhorn im Jahre 1862</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3680"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_35.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.658448,45.976433,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Das Matterhorn von Breil gesehen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3681"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_36.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.633655,45.934359,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vue de Glerole et de St. Saphorin vers Vevey</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3682"><img src="http://www2.unil.ch/viatimages/viatimages/small/wetzel1820_bge_pfy59_5.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.784951,46.473986,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vevey</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3683"><img src="http://www2.unil.ch/viatimages/viatimages/small/wetzel1820_bge_pfy59_6.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.839492,46.468718,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Montreux</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3685"><img src="http://www2.unil.ch/viatimages/viatimages/small/wetzel1820_bge_pfy59_7.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.918333,46.431965,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vom Wasser ausgewaschene Felsen in der Schlucht unter dem Gorner-Gletscher</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3686"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_38.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.789831,45.972415,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Streifen im Gestein, durch Gletscher entstanden (bei Grindelwald)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3687"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_39.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.030959,46.624893,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Carrel lässt mich hinab</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3689"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_40.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.686996,45.858456,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Die Matterhorn-Klippen bei dem Gewitter um Mitternacht des 10. August 1863</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3690"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_41.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.664337,45.975015,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Eine Schneerinne</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3707"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_56.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.333947,44.867732,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Die Aiguilles d'Arve, oberhalb der Sennhütten von Rieu Blanc gesehen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3710"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_46.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.315765,45.133618,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Das Vallon des Etançons (gegenüber la Bérarde)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3712"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_49.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.306324,44.980342,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Die Pointe des Ecrins</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3714"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_51.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.359444,44.921944,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Bruchstück von der Spitze des Pointe des Ecrins</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3716"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_53.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.356134,44.922864,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hinabsteigen von westlichten Grat des Pointe des Ecrins</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3717"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_54.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.356134,44.922864,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Eine Nacht mit Croz</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3718"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_55.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.356134,44.922864,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Weg zu einer Spitze</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3719"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_52.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.359444,44.921944,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Reynaud's luftreise</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3720"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_57.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.333947,44.867732,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hospice du Grimsel. Altitude 1880 Mètres. 1849</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3722"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_02.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.33758,46.5614,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier inférieur de l'Aar. Finsteraarhorn, Agassizhorn, Mittelgrat. 22 août 1850</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3725"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_04.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.205805,46.568164,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier du Finsteraar. Finsteraarhorn, Agassizhorn, Mittelgrat. 22 août 1850</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3726"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_05.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.155743,46.545665,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier inférieur de l'Aar. Moraine médiane et Abschwung. Août 1849</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3727"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_06.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.205805,46.568164,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hospice du Grimsel. Famille Zibach, intendant et maître d'Hôtel de l'hospice. 1850</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3728"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_07.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.33758,46.5614,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Hospice du Grimsel. Famille Zibach. 1850</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3729"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_08.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.33758,46.5614,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier inférieur de l'Aar. Partie entre le Pavillon et la pente terminale. 19 août 1850</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3730"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_09.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.205805,46.568164,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier inférieur de l'Aar. Confluent du glacier du Finsteraar et du Lauteraar, blocs Hugi et Hôtel des Neuchâtelois. 20 août 1850</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3731"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_10.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.205805,46.568164,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier inférieur de l'Aar. Moraine médiane près de l'Abschwung en amont de l'Hôtel des Neuchâtelois. 20 août 1849</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3732"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_11.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.205805,46.568164,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier inférieur de l'Aar. Abschwung. 20 août 1849</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3733"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_12.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.187561,46.567358,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pavillon Dollfus-Ausset. Au glacier de l'Aar. Altitude 2404m. Schreckhorn et Hugihoerner. Août 1850</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3734"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_13.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.187561,46.567358,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Pavillon Dollfus-Ausset. Au glacier de l'Aar, Dollfus-Ausset, Hogard, un guide. Août 1849</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3735"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_14.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.187561,46.567358,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Escherhorn. Vue prise du Pavillon. 19 août 1850</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3736"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_15.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.187561,46.567358,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier inférieur de l'Aar. Bande transeversale du glacier à la hauteur du Pavillon. 19 août 1850</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3737"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_16.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.187561,46.567358,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Scheuchzerhorn et glacier du Tierberg. Vue prise du Pavillon. 19 août 1850 à 3 heures du soir</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3738"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_17.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.19047,46.543953,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier du Lauteraar. Schreckhorn 4082m. 26 août 1850 à 9 heures du matin</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3739"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_18.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.148766,46.59426,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Nachtlager auf dem Miage-Gletscher]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3740"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_58.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.840556,45.804167,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Unser Lager auf Mont Suc</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3741"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_59.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.84854,45.77859,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Eine Eislawine auf dem Moming-Pass</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3742"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_60.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.69815,46.07575,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Cirque du glacier du Lauteraar. 26 août 1850</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3743"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_19.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.161459,46.586547,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier du Rhône. Août 1849</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3744"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_20.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.38246,46.5941,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Viesch (partie supérieure). Oberaarhorn. Septembre 1850</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3745"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_21.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.143822,46.499628,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Viesch (partie inférieure). Septembre 1850</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3746"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_22.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.143822,46.499628,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier de Viesch. Pente terminale. Août 1849</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3747"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_23.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.143822,46.499628,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier d'Aletsch. Lac de Maerjelen, Jungfrau et Moench. 4 septembre 1850</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3748"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_24.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.091992,46.440767,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier d'Aletsch. Jungfrau et Olmenhorn. Septembre 1850</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3749"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_25.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.085938,46.444954,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier d'Aletsch. Pente terminale rive droite. 6 septembre 1850</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3750"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_26.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.033752,46.401408,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Glacier d'Aletsch. Pente terminale. 6 septembre 1850</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3751"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_27.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>8.033752,46.401408,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Mont Cervin (Matterhorn). Vue prise de la moraine du glacier de St Théodule. Août 1849</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3752"><img src="http://www2.unil.ch/viatimages/viatimages/small/dollus1893_bn_28.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.714171,45.963054,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der Gilfel des Moming-Passes im Jahre 1864</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3753"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_61.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.69815,46.07575,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der Alpenclub in Zermatt im Jahre 1864</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3754"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_62.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.746434,46.020142,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ein Theil des südlichen Grats des Grand Cornier</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3755"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_63.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.611667,46.052222,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Ein Theil des nördlichen Grats des Grand Cornier</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3756"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_64.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.611667,46.052222,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der Bergschrund auf dem Dent Blanche im Jahre 1865</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3758"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_66.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.602696,46.038446,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Das Matterhorn vom Riffelberg gesehen</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3760"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_68.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.758358,45.981397,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[regelmässig geschichteten Felsen]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3761"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_69.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.660217,45.976542,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Das Matterhorn von Nordosten</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3762"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_70.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.630348,45.988936,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Das Matterhorn von Gipfel des Theodule-Passes (10899 Fuss)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3763"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_71.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.709194,45.94342,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Die Grandes Jorasses und der Doire-Fluss im Val Ferret (Italien)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3767"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_75.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.9685,45.820175,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der Gilfel des Col Dolent</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3768"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_76.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.040974,45.92288,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Auf dem Mer de Glace</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3774"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_82.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.93924,45.912681,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Auf dem Mer de Glace</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3775"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_83.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.93924,45.912681,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Westliche Seite des Col de Talèfre</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3776"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_84.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.996482,45.909099,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Croz, Croz, kommen Sie hierher!</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3780"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_88.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.658468,45.976452,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der Gipfel des Matterhorns im Jahre 1865 (Nördliches Ende)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3781"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_89.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.658468,45.976452,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Der Gipfel des Matterhorns (1865)</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3782"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_90.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.658468,45.976452,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[gestorbenen Mann]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3787"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_95.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.658468,45.976452,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Geologischer Durchschnitt des Matterhorns, von F. Giordano</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3788"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_96.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.658468,45.976452,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Felsnadeln in der Nähe von Sachas im Thal der Durance; von einer alten Moräne gebildet</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3789"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_97.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.58703,44.871443,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Das Matterhorn und seine Gletscher</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3790"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_98.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.658468,45.976452,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Vertical-Durchschnitt des Schnees auf dem Gipfel des Col de Valpelline, August 1866</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3791"><img src="http://www2.unil.ch/viatimages/viatimages/small/whymper1872_mvs_ta__2182_99.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>7.57854,45.98564,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>Baths of Brida in the Tarantaise</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3792"><img src="http://www2.unil.ch/viatimages/viatimages/small/bakwell_frontispice.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>6.571562,45.45441,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>[Dragon du Wangserberg, Pays de Sargans, Grisons]</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3803"><img src="http://www2.unil.ch/viatimages/viatimages/small/bcv_rg_157_dragon_10.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>9.385414,47.016874,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name/>
+      <description><![CDATA[<h3>The Stelvio pass, austrian side</h3><p><a href="http://www2.unil.ch/viatimages/index.php?projet=viaticalpes&module=image&action=detail&IDImage=3852"><img src="http://www2.unil.ch/viatimages/viatimages/small/bn_a_2604_1.jpg" /></a></p>]]></description>
+      <styleUrl>#dot</styleUrl>
+      <Point>
+        <coordinates>10.488287,46.532823,0</coordinates>
+      </Point>
+    </Placemark>
+  </Document>
+</kml>

--- a/tests/samples/kml/atomGeneratorGlacier.kml
+++ b/tests/samples/kml/atomGeneratorGlacier.kml
@@ -1,0 +1,3294 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+  <Document id="spreadsheet_to_kml"><!-- Atom Feed information -->
+    <atom:author>
+      <atom:name>geo.admin.ch</atom:name>
+    </atom:author>
+    <atom:link href="www,geo.admin.ch" />
+    <atom:generator
+      url="https://docs.google.com/spreadsheet/pub?key=0Alq30s3mf7gPdFpWZU0yY1BUYmgtQlBENHZFSmphZ0E&amp;output=txt&amp;gid=1&amp;range=kml_output"
+      version="">Google Earth Outreach - Spreadsheet Mapper 2.0 -
+      http://earth.google.com/outreach/tutorial_mapper.html</atom:generator><!-- Document tags -->
+    <name><![CDATA[Glaciers of Switzerland]]></name>
+    <Snippet />
+    <description><![CDATA[As time goes by - 150 yrs aof glacier mapping]]></description>
+    <visibility>1</visibility>
+    <open>1</open><!-- Backwards compatibility with Google Maps and Earth < 4.2?TRUEend comment --><!-- LookAt tags --><!-- Custom KML --><!-- Template 1 not in use --><!-- Template 2 not in use -->
+    <StyleMap id="style3_Text_Photo_Banner">
+      <Pair>
+        <key>normal</key>
+        <styleUrl>#style3_Text_Photo_Banner_normal</styleUrl>
+      </Pair>
+      <Pair>
+        <key>highlight</key>
+        <styleUrl>#style3_Text_Photo_Banner_highlight</styleUrl>
+      </Pair>
+    </StyleMap>
+    <Style id="style3_Text_Photo_Banner_normal">
+      <IconStyle>
+        <color>FF0000FF</color>
+        <scale>0.1</scale>
+        <Icon>
+          <href>http://maps.google.com/mapfiles/kml/paddle/red-blank.png</href>
+        </Icon>
+        <hotSpot x="0.5" y="0" xunits="fraction" yunits="fraction" />
+      </IconStyle>
+      <LabelStyle>
+        <color>FFFFFFFF</color>
+        <scale>1</scale>
+      </LabelStyle>
+      <BalloonStyle>
+        <bgColor>FFCBE9E8</bgColor>
+        <text><![CDATA[$[description]]]></text>
+      </BalloonStyle>
+    </Style>
+    <Style id="style3_Text_Photo_Banner_highlight">
+      <IconStyle>
+        <color>FFFFFFFF</color>
+        <scale>1</scale>
+        <Icon>
+          <href>http://maps.google.com/mapfiles/kml/paddle/red-blank.png</href>
+        </Icon>
+        <hotSpot x="0.5" y="0" xunits="fraction" yunits="fraction" />
+      </IconStyle>
+      <LabelStyle>
+        <color>FFFFFFFF</color>
+        <scale>1</scale>
+      </LabelStyle>
+      <BalloonStyle>
+        <bgColor>FFCBE9E8</bgColor>
+        <text><![CDATA[$[description]]]></text>
+      </BalloonStyle>
+    </Style><!-- Template 4 not in use --><!-- Template 5 not in use --><!-- Template 6 not in use -->
+    <Placemark id="p1">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Albignagletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Albignagletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Albignagletscher 19th century and today Vicosoprano, GR, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=131000&Y=770000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=131000&Y=770000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>          <td width="99%" align="right" valign="middle">            <table border="0" cellpadding="0" cellspacing="0">              </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Albignagletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Albignagletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Albignagletscher 19th century and today Vicosoprano, GR, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=131000&Y=770000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=131000&Y=770000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>9.645695,46.30888</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p2">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Aletschgletscher_Märjelensee_.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Aletschgletscher (Märjelensee)</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Aletschgletscher (Märjelensee) 19th century and today Fieschertal, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=143500&Y=650000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=143500&Y=650000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>          <td width="99%" align="right" valign="middle">            <table border="0" cellpadding="0" cellspacing="0">          <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Aletschgletscher_Märjelensee_.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Aletschgletscher (Märjelensee)]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Aletschgletscher (Märjelensee) 19th century and today Fieschertal, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=143500&Y=650000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=143500&Y=650000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.089271,46.440975</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p3">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Allalingletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Allalingletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Allalingletscher 19th century and today Saas Almagell, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=100000&Y=639000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=100000&Y=639000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>          <td width="99%" align="right" valign="middle">            <table border="0" cellpadding="0" cellspacing="0">                </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Allalingletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Allalingletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Allalingletscher 19th century and today Saas Almagell, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=100000&Y=639000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=100000&Y=639000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.942499,46.050404</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p4">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Altels.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Altels</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Altels 19th century and today Kandersteg, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=142800&Y=617200&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=142800&Y=617200&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>          <td width="99%" align="right" valign="middle">            <table border="0" cellpadding="0" cellspacing="0">              <tr>                               </tr>              <tr align="right" valign="top">                <td>                  <a href="http://geo.admin.ch"> </a>                </td>              </tr>            </table>          </td>          <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Altels.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Altels]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Altels 19th century and today Kandersteg, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=142800&Y=617200&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=142800&Y=617200&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.662433,46.436324</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p5">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Balmhorngletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Balmhorngletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Balmhorngletscher 19th century and today Kandersteg, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=143600&Y=619000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=143600&Y=619000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>          <td width="99%" align="right" valign="middle">            <table border="0" cellpadding="0" cellspacing="0">              <tr>                               </tr>              <tr align="right" valign="top">                <td>                  <a href="http://geo.admin.ch"> </a>                </td>              </tr>            </table>          </td>          <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Balmhorngletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Balmhorngletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Balmhorngletscher 19th century and today Kandersteg, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=143600&Y=619000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=143600&Y=619000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.685886,46.443471</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p6">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Bidergletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Bidergletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Bidergletscher 19th century and today Saas Balen, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=109500&Y=635500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=109500&Y=635500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>          <td width="99%" align="right" valign="middle">            <table border="0" cellpadding="0" cellspacing="0">              <tr>                               </tr>              <tr align="right" valign="top">                <td>                  <a href="http://geo.admin.ch"> </a>                </td>              </tr>            </table>          </td>          <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Bidergletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Bidergletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Bidergletscher 19th century and today Saas Balen, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=109500&Y=635500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=109500&Y=635500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.898002,46.136054</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p7">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Bifertengletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Bifertengletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Bifertengletscher 19th century and today Linthal, GL, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=186400&Y=715800&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=186400&Y=715800&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>          <td width="99%" align="right" valign="middle">            <table border="0" cellpadding="0" cellspacing="0">              <tr>                               </tr>              <tr align="right" valign="top">                <td>                  <a href="http://geo.admin.ch"> </a>                </td>              </tr>            </table>          </td>          <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Bifertengletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Bifertengletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Bifertengletscher 19th century and today Linthal, GL, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=186400&Y=715800&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=186400&Y=715800&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.956158,46.818676</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p8">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Birchgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Birchgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Birchgletscher 19th century and today Blatten (Lötschen), VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=139000&Y=631000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=139000&Y=631000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>          <td width="99%" align="right" valign="middle">            <table border="0" cellpadding="0" cellspacing="0">              <tr>                               </tr>              <tr align="right" valign="top">                <td>                  <a href="http://geo.admin.ch"> </a>                </td>              </tr>            </table>          </td>          <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Birchgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Birchgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Birchgletscher 19th century and today Blatten (Lötschen), VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=139000&Y=631000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=139000&Y=631000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.841736,46.401645</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p9">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Bisgletscher_Weisshorn_.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Bisgletscher (Weisshorn)</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Bisgletscher (Weisshorn) 19th century and today Randa, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=105500&Y=622000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=105500&Y=622000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Bisgletscher_Weisshorn_.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Bisgletscher (Weisshorn)]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Bisgletscher (Weisshorn) 19th century and today Randa, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=105500&Y=622000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=105500&Y=622000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.723129,46.100647</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p10">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Breitlouwenengletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Breitlouwenengletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Breitlouwenengletscher 19th century and today Lauterbrunnen, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=150800&Y=637200&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=150800&Y=637200&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Breitlouwenengletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Breitlouwenengletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Breitlouwenengletscher 19th century and today Lauterbrunnen, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=150800&Y=637200&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=150800&Y=637200&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.923301,46.507475</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p11">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Chaltwassergletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Chaltwassergletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Chaltwassergletscher 19th century and today Ried-Brig, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=122000&Y=649000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=122000&Y=649000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Chaltwassergletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Chaltwassergletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Chaltwassergletscher 19th century and today Ried-Brig, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=122000&Y=649000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=122000&Y=649000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.073993,46.247649</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p12">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Doldenhorn_Fründen_unterenundoberenOeschinengletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Doldenhorn-, Fründen-, unteren und oberen  Oeschinengletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Doldenhorn-, Fründen-, unteren und oberen  Oeschinengletscher 19th century and today Kandersteg, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=148200&Y=622300&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=148200&Y=622300&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Doldenhorn_Fründen_unterenundoberenOeschinengletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Doldenhorn-, Fründen-, unteren und oberen  Oeschinengletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Doldenhorn-, Fründen-, unteren und oberen  Oeschinengletscher 19th century and today Kandersteg, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=148200&Y=622300&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=148200&Y=622300&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.729051,46.484748</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p13">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Dossengrat_SEgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Dossengrat-SEgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Dossengrat-SEgletscher 19th century and today Innertkirchen, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=166900&Y=655700&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=166900&Y=655700&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Dossengrat_SEgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Dossengrat-SEgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Dossengrat-SEgletscher 19th century and today Innertkirchen, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=166900&Y=655700&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=166900&Y=655700&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.166267,46.651015</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p14">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Eigerhängegletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Eigerhängegletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Eigerhängegletscher 19th century and today Lauterbrunnen, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=158200&Y=642650&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=158200&Y=642650&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Eigerhängegletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Eigerhängegletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Eigerhängegletscher 19th century and today Lauterbrunnen, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=158200&Y=642650&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=158200&Y=642650&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.99499,46.573716</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p15">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Feegletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Feegletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Feegletscher 19th century and today Saas Fee, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=102000&Y=634000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=102000&Y=634000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Feegletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Feegletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Feegletscher 19th century and today Saas Fee, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=102000&Y=634000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=102000&Y=634000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.878048,46.068666</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p16">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Festigletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Festigletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Festigletscher 19th century and today Randa, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=105500&Y=629500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=105500&Y=629500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Festigletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Festigletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Festigletscher 19th century and today Randa, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=105500&Y=629500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=105500&Y=629500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.820112,46.100361</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p17">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Findelengletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Findelengletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Findelengletscher 19th century and today Zermatt, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=95500&Y=630000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=95500&Y=630000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Findelengletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Findelengletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Findelengletscher 19th century and today Zermatt, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=95500&Y=630000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=95500&Y=630000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.825939,46.010385</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p18">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Fletschhorngletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Fletschhorngletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Fletschhorngletscher 19th century and today Saas Grund, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=112000&Y=643500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=112000&Y=643500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Fletschhorngletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Fletschhorngletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Fletschhorngletscher 19th century and today Saas Grund, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=112000&Y=643500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=112000&Y=643500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.001749,46.158073</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p19">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Gauligletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Gauligletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Gauligletscher 19th century and today Innertkirchen, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=162600&Y=659400&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=162600&Y=659400&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Gauligletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Gauligletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Gauligletscher 19th century and today Innertkirchen, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=162600&Y=659400&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=162600&Y=659400&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.214043,46.612018</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p20">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Gebidumsee.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Gebidumsee</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Gebidumsee 19th century and today Visperterminen, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=123100&Y=638800&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=123100&Y=638800&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Gebidumsee.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Gebidumsee]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Gebidumsee 19th century and today Visperterminen, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=123100&Y=638800&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=123100&Y=638800&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.941829,46.25821</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p21">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GhiacciaiodiPesciora.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Ghiacciaio di Pesciora</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Ghiacciaio di Pesciora 19th century and today Bedretto, TI, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=152650&Y=679550&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=152650&Y=679550&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GhiacciaiodiPesciora.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Ghiacciaio di Pesciora]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Ghiacciaio di Pesciora 19th century and today Bedretto, TI, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=152650&Y=679550&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=152650&Y=679550&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.475336,46.520424</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p22">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Giesengletscher_Silberhorngletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Giesengletscher,  Silberhorngletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Giesengletscher,  Silberhorngletscher 19th century and today Lauterbrunnen, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=155000&Y=640000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=155000&Y=640000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Giesengletscher_Silberhorngletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Giesengletscher,  Silberhorngletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Giesengletscher,  Silberhorngletscher 19th century and today Lauterbrunnen, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=155000&Y=640000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=155000&Y=640000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.960144,46.545094</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p23">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierBasdArolla.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier Bas d'Arolla</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier Bas d'Arolla 19th century and today Evolène, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=93500&Y=604500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=93500&Y=604500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierBasdArolla.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier Bas d'Arolla]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier Bas d'Arolla 19th century and today Evolène, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=93500&Y=604500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=93500&Y=604500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.496714,45.993046</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p24">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdeCorbassiere.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier de Corbassière</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier de Corbassière 19th century and today Bagnes, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=95500&Y=588500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=95500&Y=588500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdeCorbassiere.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier de Corbassière]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier de Corbassière 19th century and today Bagnes, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=95500&Y=588500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=95500&Y=588500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.290174,46.010953</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p25">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdeFerpecle_GlacierdeMontMine.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier de Ferpècle, Glacier de Mont Miné</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier de Ferpècle, Glacier de Mont Miné 19th century and today Evolène, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=100000&Y=609000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=100000&Y=609000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdeFerpecle_GlacierdeMontMine.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier de Ferpècle, Glacier de Mont Miné]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier de Ferpècle, Glacier de Mont Miné 19th century and today Evolène, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=100000&Y=609000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=100000&Y=609000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.554916,46.05147</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p26">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdeGietro.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier de Giétro</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier de Giétro 19th century and today Bagnes, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=94500&Y=594500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=94500&Y=594500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdeGietro.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier de Giétro]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier de Giétro 19th century and today Bagnes, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=94500&Y=594500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=94500&Y=594500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.367646,46.002034</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p27">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdelANeuve.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier de l'A Neuve</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier de l'A Neuve 19th century and today Orsières, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=87300&Y=571000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=87300&Y=571000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdelANeuve.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier de l'A Neuve]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier de l'A Neuve 19th century and today Orsières, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=87300&Y=571000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=87300&Y=571000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.064753,45.936667</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p28">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdePierredar.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier de Pierredar</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier de Pierredar 19th century and today Ormont-Dessus, VD, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=128300&Y=580300&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=128300&Y=580300&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdePierredar.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier de Pierredar]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier de Pierredar 19th century and today Ormont-Dessus, VD, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=128300&Y=580300&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=128300&Y=580300&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.182929,46.305818</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p29">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdePlan_Neve.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier de Plan-Névé</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier de Plan-Névé 19th century and today Mex, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=113200&Y=562000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=113200&Y=562000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdePlan_Neve.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier de Plan-Névé]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier de Plan-Névé 19th century and today Mex, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=113200&Y=562000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=113200&Y=562000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>6.946628,46.1692</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p30">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdeSaleina.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier de Saleina</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier de Saleina 19th century and today Orsières, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=93000&Y=572000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=93000&Y=572000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdeSaleina.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier de Saleina]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier de Saleina 19th century and today Orsières, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=93000&Y=572000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=93000&Y=572000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.077307,45.987982</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p31">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdeTortin.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier de Tortin</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier de Tortin 19th century and today Nendaz, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=104500&Y=589700&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=104500&Y=589700&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdeTortin.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier de Tortin]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier de Tortin 19th century and today Nendaz, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=104500&Y=589700&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=104500&Y=589700&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.305468,46.091932</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p32">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdeTsijioreNouve.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier de Tsijiore Nouve</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier de Tsijiore Nouve 19th century and today Evolène, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=96000&Y=602500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=96000&Y=602500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdeTsijioreNouve.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier de Tsijiore Nouve]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier de Tsijiore Nouve 19th century and today Evolène, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=96000&Y=602500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=96000&Y=602500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.470916,46.015544</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p33">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdeValsorey.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier de Valsorey</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier de Valsorey 19th century and today Bourg-St-Pierre, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=83600&Y=586600&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=83600&Y=586600&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdeValsorey.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier de Valsorey]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier de Valsorey 19th century and today Bourg-St-Pierre, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=83600&Y=586600&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=83600&Y=586600&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.265982,45.903874</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p34">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdeZinal.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier de Zinal</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier de Zinal 19th century and today Ayer, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=99500&Y=616500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=99500&Y=616500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdeZinal.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier de Zinal]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier de Zinal 19th century and today Ayer, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=99500&Y=616500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=99500&Y=616500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.651795,46.046832</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p35">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdEpicoune.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier d'Epicoune</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier d'Epicoune 19th century and today Bagnes, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=85500&Y=597500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=85500&Y=597500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdEpicoune.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier d'Epicoune]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier d'Epicoune 19th century and today Bagnes, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=85500&Y=597500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=85500&Y=597500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.406416,45.921094</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p36">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdesGrands_GlacierdesBerons.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier des Grands, Glacier des Berons</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier des Grands, Glacier des Berons 19th century and today Trient, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=95500&Y=566500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=95500&Y=566500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdesGrands_GlacierdesBerons.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier des Grands, Glacier des Berons]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier des Grands, Glacier des Berons 19th century and today Trient, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=95500&Y=566500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=95500&Y=566500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.006155,46.01022</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p37">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdesRosses.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier des Rosses</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier des Rosses 19th century and today Salvan, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=105500&Y=558000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=105500&Y=558000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdesRosses.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier des Rosses]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier des Rosses 19th century and today Salvan, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=105500&Y=558000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=105500&Y=558000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>6.89553,46.099697</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p38">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdOrny.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier d'Orny</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier d'Orny 19th century and today Orsières, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=94500&Y=571500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=94500&Y=571500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdOrny.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier d'Orny]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier d'Orny 19th century and today Orsières, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=94500&Y=571500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=94500&Y=571500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.070764,46.001454</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p39">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdOtemma_CreteSeche.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier d'Otemma, Crête Sèche</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier d'Otemma, Crête Sèche 19th century and today Bagnes, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=87000&Y=598000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=87000&Y=598000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierdOtemma_CreteSeche.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier d'Otemma, Crête Sèche]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier d'Otemma, Crête Sèche 19th century and today Bagnes, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=87000&Y=598000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=87000&Y=598000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.412854,45.934589</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p40">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierduDar.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier du Dar</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier du Dar 19th century and today Ormont-Dessus, VD, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=131050&Y=582100&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=131050&Y=582100&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierduDar.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier du Dar]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier du Dar 19th century and today Ormont-Dessus, VD, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=131050&Y=582100&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=131050&Y=582100&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.206186,46.330606</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p41">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierduDolent.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier du Dolent</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier du Dolent 19th century and today Orsières, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=85000&Y=571500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=85000&Y=571500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierduDolent.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier du Dolent]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier du Dolent 19th century and today Orsières, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=85000&Y=571500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=85000&Y=571500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.071339,45.915999</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p42">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierduTrient.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier du Trient</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier du Trient 19th century and today Trient, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=96500&Y=568000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=96500&Y=568000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierduTrient.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier du Trient]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier du Trient 19th century and today Trient, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=96500&Y=568000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=96500&Y=568000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.025451,46.019288</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p43">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierGrandDesert.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Glacier Grand Désert</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Glacier Grand Désert 19th century and today Nendaz, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=103000&Y=592500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=103000&Y=592500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_GlacierGrandDesert.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Glacier Grand Désert]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Glacier Grand Désert 19th century and today Nendaz, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=103000&Y=592500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=103000&Y=592500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.341694,46.078475</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p44">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Gornergletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Gornergletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Gornergletscher 19th century and today Zermatt, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=91000&Y=628500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=91000&Y=628500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Gornergletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Gornergletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Gornergletscher 19th century and today Zermatt, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=91000&Y=628500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=91000&Y=628500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.806301,45.969971</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p45">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Griesgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Griesgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Griesgletscher 19th century and today Ulrichen, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=145000&Y=671000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=145000&Y=671000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Griesgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Griesgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Griesgletscher 19th century and today Ulrichen, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=145000&Y=671000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=145000&Y=671000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.362748,46.452573</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p46">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Griessernuhorngletscher_Sirvoltsee_.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Griessernuhorngletscher (Sirvoltsee)</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Griessernuhorngletscher (Sirvoltsee) 19th century and today Simplon, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=117000&Y=643100&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=117000&Y=643100&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Griessernuhorngletscher_Sirvoltsee_.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Griessernuhorngletscher (Sirvoltsee)]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Griessernuhorngletscher (Sirvoltsee) 19th century and today Simplon, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=117000&Y=643100&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=117000&Y=643100&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.997032,46.203076</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p47">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Grubengletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Grubengletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Grubengletscher 19th century and today Saas Balen, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=113500&Y=641500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=113500&Y=641500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Grubengletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Grubengletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Grubengletscher 19th century and today Saas Balen, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=113500&Y=641500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=113500&Y=641500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.975992,46.171693</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p48">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Gruebengletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Gruebengletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Gruebengletscher 19th century and today Guttannen, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=161500&Y=662800&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=161500&Y=662800&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Gruebengletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Gruebengletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Gruebengletscher 19th century and today Guttannen, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=161500&Y=662800&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=161500&Y=662800&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.258274,46.601812</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p49">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Gutzgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Gutzgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Gutzgletscher 19th century and today Grindelwald, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=165800&Y=651200&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=165800&Y=651200&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Gutzgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Gutzgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Gutzgletscher 19th century and today Grindelwald, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=165800&Y=651200&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=165800&Y=651200&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.107362,46.64148</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p50">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Hangendgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Hangendgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Hangendgletscher 19th century and today Innertkirchen, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=164600&Y=657900&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=164600&Y=657900&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Hangendgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Hangendgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Hangendgletscher 19th century and today Innertkirchen, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=164600&Y=657900&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=164600&Y=657900&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.194715,46.63014</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p51">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Hangfirn.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Hangfirn</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Hangfirn 19th century and today Silenen, UR, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=183600&Y=705500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=183600&Y=705500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Hangfirn.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Hangfirn]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Hangfirn 19th century and today Silenen, UR, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=183600&Y=705500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=183600&Y=705500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.820564,46.795204</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p52">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Hobärggletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Hobärggletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Hobärggletscher 19th century and today Randa, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=107000&Y=630000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=107000&Y=630000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Hobärggletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Hobärggletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Hobärggletscher 19th century and today Randa, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=107000&Y=630000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=107000&Y=630000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.826674,46.113833</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p53">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Hochfirngletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Hochfirngletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Hochfirngletscher 19th century and today Lauterbrunnen, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=154000&Y=639500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=154000&Y=639500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Hochfirngletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Hochfirngletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Hochfirngletscher 19th century and today Lauterbrunnen, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=154000&Y=639500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=154000&Y=639500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.95354,46.536128</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p54">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Hohbalmgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Hohbalmgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Hohbalmgletscher 19th century and today Saas Fee, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=106800&Y=643500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=106800&Y=643500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Hohbalmgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Hohbalmgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Hohbalmgletscher 19th century and today Saas Fee, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=106800&Y=643500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=106800&Y=643500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.001266,46.111297</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p55">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Hohlaubgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Hohlaubgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Hohlaubgletscher 19th century and today Saas Almagell, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=100500&Y=638000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=100500&Y=638000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Hohlaubgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Hohlaubgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Hohlaubgletscher 19th century and today Saas Almagell, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=100500&Y=638000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=100500&Y=638000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.92962,46.054959</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p56">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Homattugletscher_Balmengletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Homattugletscher, Balmengletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Homattugletscher, Balmengletscher 19th century and today Zwischbergen, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=121000&Y=649000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=121000&Y=649000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Homattugletscher_Balmengletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Homattugletscher, Balmengletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Homattugletscher, Balmengletscher 19th century and today Zwischbergen, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=121000&Y=649000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=121000&Y=649000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.073887,46.238654</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p57">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Innre_UistreStampbachgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Innre / Uistre Stampbachgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Innre / Uistre Stampbachgletscher 19th century and today Blatten, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=139500&Y=632500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=139500&Y=632500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Innre_UistreStampbachgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Innre / Uistre Stampbachgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Innre / Uistre Stampbachgletscher 19th century and today Blatten, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=139500&Y=632500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=139500&Y=632500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.861275,46.406071</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p58">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Kingletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Kingletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Kingletscher 19th century and today Randa, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=104000&Y=630000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=104000&Y=630000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Kingletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Kingletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Kingletscher 19th century and today Randa, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=104000&Y=630000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=104000&Y=630000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.826481,46.086846</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p59">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_LePleureur_W.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Le Pleureur-W</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Le Pleureur-W 19th century and today Bagnes, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=96300&Y=594500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=96300&Y=594500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_LePleureur_W.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Le Pleureur-W]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Le Pleureur-W 19th century and today Bagnes, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=96300&Y=594500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=96300&Y=594500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.367625,46.018225</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p60">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Loibinbachgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Loibinbachgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Loibinbachgletscher 19th century and today Blatten, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=142500&Y=633500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=142500&Y=633500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Loibinbachgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Loibinbachgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Loibinbachgletscher 19th century and today Blatten, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=142500&Y=633500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=142500&Y=633500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.874495,46.433009</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p61">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Minstigergletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Minstigergletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Minstigergletscher 19th century and today Münster, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=152000&Y=660000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=152000&Y=660000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Minstigergletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Minstigergletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Minstigergletscher 19th century and today Münster, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=152000&Y=660000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=152000&Y=660000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.220494,46.516615</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p62">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Mönch_Süd.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Mönch-Süd</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Mönch-Süd 19th century and today Fieschertal, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=156000&Y=642600&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=156000&Y=642600&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Mönch_Süd.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Mönch-Süd]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Mönch-Süd 19th century and today Fieschertal, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=156000&Y=642600&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=156000&Y=642600&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.994134,46.55393</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p63">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Nestgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Nestgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Nestgletscher 19th century and today Wiler (Lötschen), VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=138800&Y=629800&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=138800&Y=629800&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Nestgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Nestgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Nestgletscher 19th century and today Wiler (Lötschen), VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=138800&Y=629800&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=138800&Y=629800&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.82612,46.3999</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p64">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_OberHüfifirn.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Ober Hüfifirn</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Ober Hüfifirn 19th century and today Silenen, UR, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=184100&Y=705800&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=184100&Y=705800&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_OberHüfifirn.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Ober Hüfifirn]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Ober Hüfifirn 19th century and today Silenen, UR, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=184100&Y=705800&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=184100&Y=705800&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.824608,46.799653</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p65">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_ObererGrindelwaldgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Oberer Grindelwaldgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Oberer Grindelwaldgletscher 19th century and today Grindelwald, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=162500&Y=652500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=162500&Y=652500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_ObererGrindelwaldgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Oberer Grindelwaldgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Oberer Grindelwaldgletscher 19th century and today Grindelwald, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=162500&Y=652500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=162500&Y=652500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.123963,46.611696</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p66">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Rhonegletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Rhonegletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Rhonegletscher 19th century and today Oberwald, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=159500&Y=672500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=159500&Y=672500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Rhonegletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Rhonegletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Rhonegletscher 19th century and today Oberwald, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=159500&Y=672500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=159500&Y=672500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.384547,46.58284</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p67">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Rinderhorn_Gemmi_.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Rinderhorn (Gemmi)</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Rinderhorn (Gemmi) 19th century and today Leukerbad, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=140800&Y=616000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=140800&Y=616000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Rinderhorn_Gemmi_.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Rinderhorn (Gemmi)]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Rinderhorn (Gemmi) 19th century and today Leukerbad, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=140800&Y=616000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=140800&Y=616000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.64675,46.418362</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p68">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Rosenlauigletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Rosenlauigletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Rosenlauigletscher 19th century and today Schattenhalb, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=168300&Y=655500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=168300&Y=655500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Rosenlauigletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Rosenlauigletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Rosenlauigletscher 19th century and today Schattenhalb, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=168300&Y=655500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=168300&Y=655500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.163824,46.663624</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p69">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Rossbodengletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Rossbodengletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Rossbodengletscher 19th century and today Simplon, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=114500&Y=644000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=114500&Y=644000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Rossbodengletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Rossbodengletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Rossbodengletscher 19th century and today Simplon, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=114500&Y=644000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=114500&Y=644000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.008456,46.18053</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p70">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Rottalgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Rottalgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Rottalgletscher 19th century and today Saas Almagell, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=107000&Y=645000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=107000&Y=645000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Rottalgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Rottalgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Rottalgletscher 19th century and today Saas Almagell, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=107000&Y=645000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=107000&Y=645000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.020686,46.112998</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p71">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Rottalgletscher_Stuefesteigletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Rottalgletscher,  Stuefesteigletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Rottalgletscher,  Stuefesteigletscher 19th century and today Lauterbrunnen, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=152300&Y=637800&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=152300&Y=637800&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Rottalgletscher_Stuefesteigletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Rottalgletscher,  Stuefesteigletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Rottalgletscher,  Stuefesteigletscher 19th century and today Lauterbrunnen, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=152300&Y=637800&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=152300&Y=637800&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.931241,46.520934</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p72">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Sidelengletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Sidelengletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Sidelengletscher 19th century and today Oberwald, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=150500&Y=675500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=150500&Y=675500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Sidelengletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Sidelengletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Sidelengletscher 19th century and today Oberwald, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=150500&Y=675500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=150500&Y=675500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.42221,46.501554</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p73">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_SillereGletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Sillere Gletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Sillere Gletscher 19th century and today Kandersteg, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=146000&Y=621750&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=146000&Y=621750&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_SillereGletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Sillere Gletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Sillere Gletscher 19th century and today Kandersteg, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=146000&Y=621750&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=146000&Y=621750&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.721785,46.464977</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p74">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Steingletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Steingletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Steingletscher 19th century and today Gadmen, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=175300&Y=676000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=175300&Y=676000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Steingletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Steingletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Steingletscher 19th century and today Gadmen, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=175300&Y=676000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=175300&Y=676000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.432821,46.724569</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p75">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Tennbachgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Tennbachgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Tennbachgletscher 19th century and today Blatten, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=141850&Y=626180&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=141850&Y=626180&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Tennbachgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Tennbachgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Tennbachgletscher 19th century and today Blatten, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=141850&Y=626180&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=141850&Y=626180&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.779222,46.427488</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p76">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Titlisgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Titlisgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Titlisgletscher 19th century and today Engelberg, OW, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=181460&Y=675300&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=181460&Y=675300&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Titlisgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Titlisgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Titlisgletscher 19th century and today Engelberg, OW, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=181460&Y=675300&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=181460&Y=675300&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.424678,46.780057</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p77">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_TournelonBlanc.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Tournelon Blanc</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Tournelon Blanc 19th century and today Bagnes, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=91500&Y=591000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=91500&Y=591000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_TournelonBlanc.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Tournelon Blanc]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Tournelon Blanc 19th century and today Bagnes, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=91500&Y=591000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=91500&Y=591000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.322524,45.97501</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p78">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Triftgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Triftgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Triftgletscher 19th century and today Saas Grund, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=109000&Y=643500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=109000&Y=643500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Triftgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Triftgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Triftgletscher 19th century and today Saas Grund, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=109000&Y=643500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=109000&Y=643500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.00147,46.131087</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p79">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Triftgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Triftgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Triftgletscher 19th century and today Gadmen, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=171800&Y=670300&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=171800&Y=670300&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Triftgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Triftgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Triftgletscher 19th century and today Gadmen, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=171800&Y=670300&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=171800&Y=670300&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.357728,46.693713</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p80">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Tschierva_Roseggletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Tschierva/Roseggletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Tschierva/Roseggletscher 19th century and today Samedan, GR, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=141700&Y=787300&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=141700&Y=787300&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Tschierva_Roseggletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Tschierva/Roseggletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Tschierva/Roseggletscher 19th century and today Samedan, GR, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=141700&Y=787300&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=141700&Y=787300&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>9.874472,46.400489</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p81">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Turtmann_Diablonsgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Turtmann-, Diablonsgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Turtmann-, Diablonsgletscher 19th century and today Oberems, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=112000&Y=619500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=112000&Y=619500&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Turtmann_Diablonsgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Turtmann-, Diablonsgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Turtmann-, Diablonsgletscher 19th century and today Oberems, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=112000&Y=619500&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=112000&Y=619500&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.69107,46.159194</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p82">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_UntererGrindelwaldgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Unterer Grindelwaldgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Unterer Grindelwaldgletscher 19th century and today Grindelwald, BE, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=161300&Y=647100&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=161300&Y=647100&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_UntererGrindelwaldgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Unterer Grindelwaldgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Unterer Grindelwaldgletscher 19th century and today Grindelwald, BE, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=161300&Y=647100&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=161300&Y=647100&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>8.053353,46.601303</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p83">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_VadretdalAlpOta.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Vadret da l'Alp Ota</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Vadret da l'Alp Ota 19th century and today Pontresina, GR, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=143100&Y=784000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=143100&Y=784000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_VadretdalAlpOta.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Vadret da l'Alp Ota]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Vadret da l'Alp Ota 19th century and today Pontresina, GR, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=143100&Y=784000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=143100&Y=784000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>9.832137,46.413991</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p84">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Weingartengletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Weingartengletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Weingartengletscher 19th century and today Täsch, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=102500&Y=631000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=102500&Y=631000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Weingartengletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Weingartengletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Weingartengletscher 19th century and today Täsch, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=102500&Y=631000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=102500&Y=631000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.83931,46.073308</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="p85">
+      <name><![CDATA[]]></name>
+      <Snippet />
+      <description><![CDATA[<table width="100" border="0" cellpadding="5" cellspacing="0">  <tr>    <td>      <img src="https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Zmuttgletscher.gif" width="400" align="left" />    </td>  </tr>  <tr>    <td>      <h2><font color="#FF0000">Zmuttgletscher</font></h2>    </td>  </tr>  <tr>    <td>      <p>        <p>Zmuttgletscher 19th century and today Zermatt, VS, Switzerland, move the red slider below to see changes</p>        <p><iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=94500&Y=616000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe></p>        <p>          <a href="https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=94500&Y=616000&zoom=7&time=1864&swipe_ratio=0.5">Large map ...</a>        </p>      </p>    </td>  </tr>  <tr>    <td>&nbsp;</td>  </tr>  <tr>    <td>      <table width="100%" border="0" cellpadding="0" cellspacing="0">        <tr>                    <td width="1%" align="right" valign="middle">            <img src="https://pbs.twimg.com/profile_images/1190442843/logo_geoportal_bigger.png" width="32" />          </td>        </tr>      </table>    </td>  </tr></table>]]></description>
+      <styleUrl>#style3_Text_Photo_Banner</styleUrl>
+      <ExtendedData>
+        <Data name="TemplateName">
+          <value>Text_Photo_Banner</value>
+        </Data>
+        <Data name="Top_Photo_URL">
+          <value><![CDATA[https://dav0.bgdi.admin.ch/swisstopo/geoadmin/gletscher/Anim_Zmuttgletscher.gif]]></value>
+        </Data>
+        <Data name="Title_Text">
+          <value><![CDATA[Zmuttgletscher]]></value>
+        </Data>
+        <Data name="Paragraph_1_Text">
+          <value><![CDATA[Zmuttgletscher 19th century and today Zermatt, VS, Switzerland, move the red slider below to see changes]]></value>
+        </Data>
+        <Data name="Paragraph_2_Text">
+          <value><![CDATA[<iframe src='https://map.geo.admin.ch/embed.html?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=94500&Y=616000&zoom=7&time=1864&swipe_ratio=0.5' width='100%' height='300' frameborder='0' style='border:0'></iframe>]]></value>
+        </Data>
+        <Data name="Read_More_Link_URL">
+          <value><![CDATA[https://map.geo.admin.ch/?topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen&layers_timestamp=18641231&X=94500&Y=616000&zoom=7&time=1864&swipe_ratio=0.5]]></value>
+        </Data>
+        <Data name="ge4x_1">
+          <value><![CDATA["/><!--]]></value>
+        </Data>
+        <Data name="ge4x_2">
+          <value><![CDATA[-->]]></value>
+        </Data>
+        <Data name="ge4x_3">
+          <value><![CDATA[<!--]]></value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>7.645165,46.001867</coordinates>
+      </Point>
+    </Placemark>
+  </Document>
+</kml>

--- a/tests/samples/kml/externalContent.kml
+++ b/tests/samples/kml/externalContent.kml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <name>PunkteFilmSlidesPhoto</name>
+    <description><![CDATA[Beispiele, wie Information und Media in ein KML eingebettet werden können und üb https://help.geo.admin.ch/?id=64&lang=de in map.geo.admin.ch genutzt werden können]]></description>
+    <Style id="style1">
+      <IconStyle>
+        <Icon>
+          <href>https://maps.gstatic.com/mapfiles/ms2/micons/tree.png</href>
+        </Icon>
+      </IconStyle>
+    </Style>
+    <Style id="style2">
+      <IconStyle>
+        <Icon>
+          <href>https://maps.gstatic.com/mapfiles/ms2/micons/electronics.png</href>
+        </Icon>
+      </IconStyle>
+    </Style>
+    <Style id="style3">
+      <IconStyle>
+        <Icon>
+          <href>https://maps.gstatic.com/mapfiles/ms2/micons/movies.png</href>
+        </Icon>
+      </IconStyle>
+    </Style>
+    <Style id="style4">
+      <IconStyle>
+        <Icon>
+          <href>https://maps.gstatic.com/mapfiles/ms2/micons/camera.png</href>
+        </Icon>
+      </IconStyle>
+    </Style>
+    <Placemark>
+      <name>Bild + Text</name>
+      <description><![CDATA[<img src="https://www.lfi.ch/resultate/images/sommerlinde.jpg"><br>Die Sommerlinde bevorzugt sommerwarme kolline und submontane Laubmischwälder. Ihr Areal reicht weniger weit nach Norden, dafür
+weiter nach Süden als dasjenige der Winterlinde. Da die Sommerlinde eine höhere Luftfeuchtigkeit benötigt als die
+Winterlinde, findet man sie vorwiegend im Jura, im Chablais und im Tessin. Nur gerade im Jura ist sie häufiger,
+als die Winterlinde; an den übrigen Standorten dominiert diese.<br><br><a href="https://www.lfi.ch/resultate/daten/trees/sommerlinde1.php" target="_blank">Link&nbsp; hier</a><br>]]></description>
+      <styleUrl>#style1</styleUrl>
+      <Point>
+        <coordinates>6.998291,46.897739,0.000000</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name>"Film + Text" </name>
+      <description><![CDATA[<iframe src="https://www.youtube.com/embed/6AAMh8zBSwY" width="240" height="180" frameborder="0"></iframe> <br>
+oder auch <a href="https://www.bafu.ch" target="_blank">hier </a>gibt es noch mehr<br>
+
+]]></description>
+      <styleUrl>#style3</styleUrl>
+      <Point>
+        <coordinates>8.000793,46.997112,0.000000</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name>Slides Google Drive</name>
+      <description><![CDATA[<iframe src="https://docs.google.com/presentation/d/1nmhfwWdORCZ8oMDejHjPnluPQqUnhU3NzDKxC9bmcFI/embed?start=false&loop=false&delayms=3000" frameborder="0" width="342" height="291" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe><div style="margin-bottom:5px"> <strong> <a href="https://www.bafu.admin.ch" title="Hier ein BAFU LINK" target="_blank">Hier ein BAFU LINK</a>  </div>]]></description>
+      <styleUrl>#style2</styleUrl>
+      <Point>
+        <coordinates>7.995737,47.311631,0.000000</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name>Slides Slideshare</name>
+      <description><![CDATA[<iframe src="https://www.slideshare.net/slideshow/embed_code/30393407?rel=0" width="342" height="291" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px 1px 0; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe> <div style="margin-bottom:5px"> <strong> <a href="https://www.slideshare.net/swiss_geoportal/kolloquium-swisstopo-mapgeoadminch-version-3" title="Kolloquium swisstopo: map.geo.admin.ch Version 3" target="_blank">Kolloquium swisstopo: map.geo.admin.ch Version 3</a>  </div>]]></description>
+      <styleUrl>#style2</styleUrl>
+      <Point>
+        <coordinates>7.595737,46.511631,0.000000</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name>Photos Flickr/Picasa</name>
+      <description><![CDATA[<object width="240" height="180"> <param name="flashvars" value="offsite=true&lang=en-us&page_show_url=%2Fphotos%2F60755934%40N06%2Fsets%2F72157633559612172%2Fshow%2Fwith%2F8765029782%2F&page_show_back_url=%2Fphotos%2F60755934%40N06%2Fsets%2F72157633559612172%2Fwith%2F8765029782%2F&set_id=72157633559612172&jump_to=8765029782"></param> <param name="movie" value="https://www.flickr.com/apps/slideshow/show.swf?v=140556"></param> <param name="allowFullScreen" value="true"></param><embed type="application/x-shockwave-flash" src="https://www.flickr.com/apps/slideshow/show.swf?v=140556" allowFullScreen="true" flashvars="offsite=true&lang=en-us&page_show_url=%2Fphotos%2F60755934%40N06%2Fsets%2F72157633559612172%2Fshow%2Fwith%2F8765029782%2F&page_show_back_url=%2Fphotos%2F60755934%40N06%2Fsets%2F72157633559612172%2Fwith%2F8765029782%2F&set_id=72157633559612172&jump_to=8765029782" width="400" height="300"></embed></object><br/><small>Achtung: funktioniert nicht auf iOS: <a href="https://en.wikipedia.org/wiki/Apple_and_Adobe_Flash_controversy" title=" iOS + Flash"> iOS + Flash</a> </small>]]></description>
+      <styleUrl>#style4</styleUrl>
+      <Point>
+        <coordinates> 7.44415, 46.9470,0.000000</coordinates>
+      </Point>
+    </Placemark>
+  </Document>
+</kml>

--- a/tests/samples/kml/legacy-chsdi3-icon-urls.kml
+++ b/tests/samples/kml/legacy-chsdi3-icon-urls.kml
@@ -1,0 +1,135 @@
+<?xml version="1.0"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd">
+  <Document>
+    <Placemark id="marker_1452588951386">
+      <Style>
+        <IconStyle>
+          <scale>0.25</scale>
+          <Icon>
+            <href>http://map.geo.admin.ch/1417604350/img/maki/restaurant-24@2x.png</href>
+          </Icon>
+          <hotSpot x="24" y="24" xunits="pixels" yunits="pixels" />
+        </IconStyle>
+      </Style>
+      <Point>
+        <coordinates>8.573768593248698,47.384306884970954</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="marker_1452588951387">
+      <Style>
+        <IconStyle>
+          <scale>0.25</scale>
+          <Icon>
+            <href>http://map.geo.admin.ch/1417604350/img/maki/bus-24@2x.png</href>
+          </Icon>
+          <hotSpot x="24" y="24" xunits="pixels" yunits="pixels" />
+        </IconStyle>
+      </Style>
+      <Point>
+        <coordinates>8.574025952364934,47.38395354434705</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="marker_1452588951388">
+      <Style>
+        <IconStyle>
+          <scale>0.25</scale>
+          <Icon>
+            <href>http://map.geo.admin.ch/1417604350/img/maki/car-24@2x.png</href>
+          </Icon>
+          <hotSpot x="24" y="24" xunits="pixels" yunits="pixels" />
+        </IconStyle>
+      </Style>
+      <Point>
+        <coordinates>8.576817994101736,47.38414645260196</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="marker_1452588951389">
+      <Style>
+        <IconStyle>
+          <scale>0.25</scale>
+          <Icon>
+            <href>http://map.geo.admin.ch/1417604350/img/maki/car-24@2x.png</href>
+          </Icon>
+          <hotSpot x="24" y="24" xunits="pixels" yunits="pixels" />
+        </IconStyle>
+      </Style>
+      <Point>
+        <coordinates>8.577184522139419,47.38363461353094</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="marker_14525889513810">
+      <Style>
+        <IconStyle>
+          <scale>0.25</scale>
+          <Icon>
+            <href>http://map.geo.admin.ch/1417604350/img/maki/toilets-24@2x.png</href>
+          </Icon>
+          <hotSpot x="24" y="24" xunits="pixels" yunits="pixels" />
+        </IconStyle>
+      </Style>
+      <Point>
+        <coordinates>8.574805266605779,47.384786931215785</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="linepolygon_1452588951386">
+      <Style>
+        <LineStyle>
+          <color>ffff0000</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>66ff0000</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.577442791807954,47.384370161536694 8.57793979075316,47.3839110330132
+              8.578355626470515,47.384122014363065 8.578507049172773,47.38402125160151
+              8.579741965274337,47.38465028124408 8.578997256316782,47.38533089471021
+              8.577771113918006,47.384705154207744 8.577885309740342,47.38455148902867
+              8.577540254722178,47.384369902519715 8.577509319542195,47.38442352446814
+              8.577442791807954,47.384370161536694</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="annotation_1452588951386">
+      <name>MASOALA Regenwald</name>
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+          <!-- NOTE the empty Icon tag is needed otherwise open layer won't print
+               the label if any -->
+          <!-- <Icon></Icon> -->
+        </IconStyle>
+        <LabelStyle>
+          <color>ff008000</color>
+        </LabelStyle>
+      </Style>
+      <Point>
+        <coordinates>8.578637237401265,47.38463616948473</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="linepolygon_1452588951387">
+      <Style>
+        <LineStyle>
+          <color>ff00a5ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>6600a5ff</color>
+        </PolyStyle>
+      </Style>
+      <LineString>
+        <coordinates>8.574294678237534,47.38423101447371 8.574537059476459,47.38410719677265
+          8.574722632811747,47.384114367192076 8.57517246170744,47.38409195241952
+          8.575782435988177,47.38412642830969 8.57612086323247,47.38415907735783
+          8.576225451789089,47.38409508131821 8.577167722318235,47.38449507951347
+          8.577492324584878,47.384190541735435</coordinates>
+      </LineString>
+    </Placemark>
+  </Document>
+</kml>

--- a/tests/samples/kml/print.kml
+++ b/tests/samples/kml/print.kml
@@ -1,0 +1,1728 @@
+<?xml version="1.0"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd">
+  <Document>
+    <name>Drawing</name>
+    <Placemark id="annotation_1448263222238">
+      <name>Dusch-WAgen</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.649730458643704,46.83347437022299,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448262738316">
+      <name>Behinderten</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.649457242380227,46.83381139102615,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448263040814">
+      <name>Bike-Rep-Service, Speaker, Infostand, etc.</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.651114360549518,46.83719250428629,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448262424010">
+      <name>Zelt f&#xFC;r 2000 Pers.</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.649620583219677,46.82142782697658,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1452588920914">
+      <name>Samariter, Sanit&#xE4;t</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ffffffff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>ffffffff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.649183055688201,46.822157483662636,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="linepolygon_1452588892439">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.649326782766625,46.82213192019825,0
+              8.649400956000859,46.822025930641544,0 8.649865429845503,46.82216910234604,0
+              8.64979270694582,46.82227689960652,0 8.649326782766625,46.82213192019825,0
+              8.649326782766625,46.82213192019825,0 8.649326782766625,46.82213192019825,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="linepolygon_1452588951386">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.649923068707107,46.821949293608725,0
+              8.649983618537502,46.82172783462111,0 8.650239624187966,46.82172102785288,0
+              8.650221202301844,46.82196246230972,0 8.649923068707107,46.821949293608725,0
+              8.649923068707107,46.821949293608725,0 8.649923068707107,46.821949293608725,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="annotation_1448263271953">
+      <name>Wasch-Tr&#xF6;ge</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.649748289628583,46.83260026957262,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="linepolygon_1452588973018">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <LineString>
+        <coordinates>8.650230468642176,46.82184101932524,0 8.651456900868714,46.821810362630345,0
+          8.651415415897593,46.82181894456439,0</coordinates>
+      </LineString>
+    </Placemark>
+    <Placemark id="annotation_1452588956184">
+      <name>ST. Galler</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ffffffff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>ffffffff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.651754915289512,46.82181534187212,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448260491924">
+      <name>Parking Sponsoren und Organisation</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff000000</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff000000</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>66000000</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.652322618340752,46.82210660236295,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448263246517">
+      <name>WC-Anlagen</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.649851401226325,46.83302326830515,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="linepolygon_1448262599954">
+      <description />
+      <Style>
+        <LineStyle>
+          <color>ff808080</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>66808080</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.649237113586,46.82030007272352,0 8.649058601396694,46.82040452259723,0
+              8.64906079177473,46.8206186143859,0 8.649130138792754,46.820671858537686,0
+              8.64945133598149,46.820501572678815,0 8.649237113586,46.82030007272352,0
+              8.649237113586,46.82030007272352,0 8.649237113586,46.82030007272352,0
+              8.649237113586,46.82030007272352,0 8.649237113586,46.82030007272352,0
+              8.649237113586,46.82030007272352,0 8.649237113586,46.82030007272352,0
+              8.649237113586,46.82030007272352,0 8.649237113586,46.82030007272352,0
+              8.649237113586,46.82030007272352,0 8.649237113586,46.82030007272352,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="annotation_1448262327140">
+      <name>Speaker, Ton, Technik</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.648328187958219,46.81968556884933,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1449223992022">
+      <name>Wechselzone Inline-Velo</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.64828844979231,46.8198871329116,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448261948972">
+      <name>Produktion</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.648377694889665,46.81899161401329,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448262603162">
+      <name>Parkpl&#xE4;tze Medien</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff808080</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.648910966227076,46.820696572030954,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448261883426">
+      <name>Check-In</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.648064741704725,46.81863397549835,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448261486113">
+      <name>Zufahrt Produktion</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.649819724516501,46.81860427212141,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="linepolygon_1448261209924">
+      <description />
+      <Style>
+        <LineStyle>
+          <color>ff808080</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>66808080</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.649326782766625,46.82213192019825,0 8.649968036687065,46.82121558744503,0
+              8.650273723003348,46.8212879174045,0 8.650239684792172,46.82163913895418,0
+              8.649936504899232,46.821678337982085,0 8.649842972781947,46.82171531485106,0
+              8.65024351333663,46.82210061511917,0 8.6501767724388,46.82239640541887,0
+              8.649326782766625,46.82213192019825,0 8.649326782766625,46.82213192019825,0
+              8.649326782766625,46.82213192019825,0 8.649326782766625,46.82213192019825,0
+              8.649326782766625,46.82213192019825,0 8.649326782766625,46.82213192019825,0
+              8.649326782766625,46.82213192019825,0 8.649326782766625,46.82213192019825,0
+              8.649326782766625,46.82213192019825,0 8.649326782766625,46.82213192019825,0
+              8.649326782766625,46.82213192019825,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="linepolygon_1452588607809">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.649670762370208,46.82164038793139,0 8.649968036687065,46.82121558744503,0
+              8.650273723003348,46.8212879174045,0 8.650239684792172,46.82163913895418,0
+              8.649951317083315,46.821617340877104,0 8.649842972781947,46.82171531485106,0
+              8.649580781264678,46.8220416701192,0 8.64942343973231,46.82199380250806,0
+              8.649670762370208,46.82164038793139,0 8.649670762370208,46.82164038793139,0
+              8.649670762370208,46.82164038793139,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="annotation_1448262034836">
+      <name>VIP</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.647288775542001,46.819825438705514,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="linepolygon_1448262226570">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.64701778934709,46.82001408013892,0 8.647064511798346,46.81987684053455,0
+              8.647438158212841,46.81994126234087,0 8.647370553366641,46.82008232152809,0
+              8.64701778934709,46.82001408013892,0 8.64701778934709,46.82001408013892,0
+              8.64701778934709,46.82001408013892,0 8.64701778934709,46.82001408013892,0
+              8.64701778934709,46.82001408013892,0 8.64701778934709,46.82001408013892,0
+              8.64701778934709,46.82001408013892,0 8.64701778934709,46.82001408013892,0
+              8.64701778934709,46.82001408013892,0 8.64701778934709,46.82001408013892,0
+              8.64701778934709,46.82001408013892,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="linepolygon_1448262017808">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.64752367295273,46.820101843773905,0 8.647571884095933,46.81991420819778,0
+              8.647703717282382,46.819948799426115,0 8.64768142911753,46.8201235658424,0
+              8.64752367295273,46.820101843773905,0 8.64752367295273,46.820101843773905,0
+              8.64752367295273,46.820101843773905,0 8.64752367295273,46.820101843773905,0
+              8.64752367295273,46.820101843773905,0 8.64752367295273,46.820101843773905,0
+              8.64752367295273,46.820101843773905,0 8.64752367295273,46.820101843773905,0
+              8.64752367295273,46.820101843773905,0 8.64752367295273,46.820101843773905,0
+              8.64752367295273,46.820101843773905,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="annotation_1448262948947">
+      <name>WZ-Bike-Laufen</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.648134937989811,46.83829238372222,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448261006390">
+      <name>Zielverpflegung</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.647695053901806,46.820205064363044,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448262245637">
+      <name>Info-Zentrale</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.64722463973509,46.82005409502443,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448262934236">
+      <name>WZ Velo-Bike</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.64782225618845,46.837752083268704,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448262230485">
+      <name>OK-B&#xFC;ros</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.647197757015691,46.820119316126906,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448263076760">
+      <name>Bike-Waschanlage</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.648419262390581,46.83879542344363,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="linepolygon_1448262373720">
+      <description />
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.647472218772087,46.81944429940648,0 8.647514869561334,46.81935928188766,0
+              8.647859364511953,46.81940961633811,0 8.647837718616402,46.81949621103058,0
+              8.647472218772087,46.81944429940648,0 8.647472218772087,46.81944429940648,0
+              8.647472218772087,46.81944429940648,0 8.647472218772087,46.81944429940648,0
+              8.647472218772087,46.81944429940648,0 8.647472218772087,46.81944429940648,0
+              8.647472218772087,46.81944429940648,0 8.647472218772087,46.81944429940648,0
+              8.647472218772087,46.81944429940648,0 8.647472218772087,46.81944429940648,0
+              8.647472218772087,46.81944429940648,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="annotation_1448262377265">
+      <name>B&#xFC;hne</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.647636703919246,46.81941557037303,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="linepolygon_1448262491141">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.646706978316316,46.819595883161305,0
+              8.646718224761235,46.819512997206765,0 8.647015187746175,46.81954764299542,0
+              8.646959776761265,46.81964808910938,0 8.646706978316316,46.819595883161305,0
+              8.646706978316316,46.819595883161305,0 8.646706978316316,46.819595883161305,0
+              8.646706978316316,46.819595883161305,0 8.646706978316316,46.819595883161305,0
+              8.646706978316316,46.819595883161305,0 8.646706978316316,46.819595883161305,0
+              8.646706978316316,46.819595883161305,0 8.646706978316316,46.819595883161305,0
+              8.646706978316316,46.819595883161305,0 8.646706978316316,46.819595883161305,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="linepolygon_1449223972889">
+      <description />
+      <Style>
+        <LineStyle>
+          <color>ff00a5ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>6600a5ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.646937124947797,46.81975281827399,0
+              8.646916457464524,46.819675709456014,0 8.64732874842315,46.81970595594864,0
+              8.64865294384834,46.819908689691324,0 8.648670463340678,46.81992256564192,0
+              8.64866831406279,46.81995115205508,0 8.648631326164203,46.819981906570284,0
+              8.648267162852514,46.819925825922304,0 8.646937124947797,46.81975281827399,0
+              8.647576139395113,46.81980112717508,0 8.647576139395113,46.81980112717508,0
+              8.647576139395113,46.81980112717508,0 8.646937124947797,46.81975281827399,0
+              8.646937124947797,46.81975281827399,0 8.646937124947797,46.81975281827399,0
+              8.646937124947797,46.81975281827399,0 8.646937124947797,46.81975281827399,0
+              8.646937124947797,46.81975281827399,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="annotation_1448261120130">
+      <name>Zieleinlauf</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff008000</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.64699565942697,46.81972867759268,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="linepolygon_1448261058576">
+      <description />
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.6468199843647,46.819765547664566,0 8.647326075614707,46.819764768240866,0
+              8.647576139395113,46.81980112717508,0 8.647571318812367,46.819889024155685,0
+              8.647703717282382,46.819948799426115,0 8.64777739571271,46.81978661399887,0
+              8.647343127234227,46.81970701077959,0 8.646823289539886,46.81966887425909,0
+              8.6468199843647,46.819765547664566,0 8.6468199843647,46.819765547664566,0
+              8.6468199843647,46.819765547664566,0 8.6468199843647,46.819765547664566,0
+              8.6468199843647,46.819765547664566,0 8.6468199843647,46.819765547664566,0
+              8.6468199843647,46.819765547664566,0 8.6468199843647,46.819765547664566,0
+              8.6468199843647,46.819765547664566,0 8.6468199843647,46.819765547664566,0
+              8.6468199843647,46.819765547664566,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="linepolygon_1448262321281">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.647521996737262,46.819706018748164,0
+              8.647562430767683,46.81963901754934,0 8.647764935906861,46.81966926259876,0
+              8.647727324480307,46.8197452304395,0 8.647521996737262,46.819706018748164,0
+              8.647521996737262,46.819706018748164,0 8.647521996737262,46.819706018748164,0
+              8.647521996737262,46.819706018748164,0 8.647521996737262,46.819706018748164,0
+              8.647521996737262,46.819706018748164,0 8.647521996737262,46.819706018748164,0
+              8.647521996737262,46.819706018748164,0 8.647521996737262,46.819706018748164,0
+              8.647521996737262,46.819706018748164,0 8.647521996737262,46.819706018748164,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="linepolygon_1448262029303">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.647124903761955,46.81985236147819,0
+              8.647149444978167,46.819765040521936,0 8.647507413746973,46.81979113461848,0
+              8.647456420070915,46.819908232235875,0 8.647124903761955,46.81985236147819,0
+              8.647124903761955,46.81985236147819,0 8.647124903761955,46.81985236147819,0
+              8.647124903761955,46.81985236147819,0 8.647124903761955,46.81985236147819,0
+              8.647124903761955,46.81985236147819,0 8.647124903761955,46.81985236147819,0
+              8.647124903761955,46.81985236147819,0 8.647124903761955,46.81985236147819,0
+              8.647124903761955,46.81985236147819,0 8.647124903761955,46.81985236147819,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="annotation_1448260944088">
+      <name>Ziel</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.647545249641824,46.81976690351707,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448261602856">
+      <name>Partner-Park</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.647568705647284,46.818488083251616,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="linepolygon_1448261908580">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.647728938621305,46.81897062098973,0 8.64758444964416,46.818955955789285,0
+              8.647638142652001,46.81877905787916,0 8.647393471278796,46.81873846286239,0
+              8.647424913106943,46.81862117678062,0 8.647469995588725,46.818644540527224,0
+              8.647489404876132,46.81857506271062,0 8.647762617785465,46.81860276060106,0
+              8.647787494125005,46.81866007458754,0 8.647881337808264,46.81869551732466,0
+              8.647789401020265,46.81897852794636,0 8.647728938621305,46.81897062098973,0
+              8.647728938621305,46.81897062098973,0 8.647728938621305,46.81897062098973,0
+              8.647728938621305,46.81897062098973,0 8.647728938621305,46.81897062098973,0
+              8.647728938621305,46.81897062098973,0 8.647728938621305,46.81897062098973,0
+              8.647728938621305,46.81897062098973,0 8.647728938621305,46.81897062098973,0
+              8.647728938621305,46.81897062098973,0 8.647728938621305,46.81897062098973,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="linepolygon_1448261879355">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.647832527679661,46.81897312366822,0 8.647881337808264,46.81869551732466,0
+              8.648179849719504,46.81874093938325,0 8.64810225638489,46.81902064976118,0
+              8.647832527679661,46.81897312366822,0 8.647832527679661,46.81897312366822,0
+              8.647832527679661,46.81897312366822,0 8.647832527679661,46.81897312366822,0
+              8.647832527679661,46.81897312366822,0 8.647832527679661,46.81897312366822,0
+              8.647832527679661,46.81897312366822,0 8.647832527679661,46.81897312366822,0
+              8.647832527679661,46.81897312366822,0 8.647832527679661,46.81897312366822,0
+              8.647832527679661,46.81897312366822,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="linepolygon_1452589076972">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.64664669303814,46.81906134384446,0 8.646698357067334,46.818709127532124,0
+              8.647080051758164,46.818729607575854,0 8.64699757410213,46.81903721275107,0
+              8.64664669303814,46.81906134384446,0 8.64664669303814,46.81906134384446,0
+              8.64664669303814,46.81906134384446,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="linepolygon_1448262264942">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.647216061599461,46.81892116712326,0 8.647267660130959,46.81876768224299,0
+              8.647541439161708,46.818820564709135,0 8.647492138793824,46.81895963114295,0
+              8.647216061599461,46.81892116712326,0 8.647216061599461,46.81892116712326,0
+              8.647216061599461,46.81892116712326,0 8.647216061599461,46.81892116712326,0
+              8.647216061599461,46.81892116712326,0 8.647216061599461,46.81892116712326,0
+              8.647216061599461,46.81892116712326,0 8.647216061599461,46.81892116712326,0
+              8.647216061599461,46.81892116712326,0 8.647216061599461,46.81892116712326,0
+              8.647216061599461,46.81892116712326,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="annotation_1448262268200">
+      <name>Helferzentrale</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.64723511704661,46.8188644849363,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1452589083848">
+      <name>Bike-Park</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ffffffff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>ffffffff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.6464256724198,46.81876927153691,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448263314755">
+      <name>Festwirtschaft</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.64701635286151,46.81915893149215,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="linepolygon_1448263312051">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.646797914161275,46.81932637869099,0 8.646834800265978,46.81921803167611,0
+              8.64714610377932,46.81924937678361,0 8.647106436389291,46.81935055614326,0
+              8.646797914161275,46.81932637869099,0 8.646797914161275,46.81932637869099,0
+              8.646797914161275,46.81932637869099,0 8.646797914161275,46.81932637869099,0
+              8.646797914161275,46.81932637869099,0 8.646797914161275,46.81932637869099,0
+              8.646797914161275,46.81932637869099,0 8.646797914161275,46.81932637869099,0
+              8.646797914161275,46.81932637869099,0 8.646797914161275,46.81932637869099,0
+              8.646797914161275,46.81932637869099,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="linepolygon_1449226681016">
+      <description />
+      <Style>
+        <LineStyle>
+          <color>ff000000</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>66000000</color>
+        </PolyStyle>
+      </Style>
+      <LineString>
+        <coordinates>8.644659903962876,46.83645048539558,0 8.644823212752566,46.83605535272734,0
+          8.645291552409167,46.83612270801035,0 8.645694767556326,46.83607724829197,0
+          8.64602030633954,46.835736445864335,0 8.645877898676714,46.835231902000864,0
+          8.644893011102617,46.83515175970723,0 8.643325523942023,46.835121511037045,0
+          8.63990873492,46.83474604520246,0 8.639896861344034,46.834676949502104,0
+          8.639974225079866,46.83461672612794,0 8.640281520461147,46.83446939968036,0
+          8.640467836881553,46.83448677056215,0</coordinates>
+      </LineString>
+    </Placemark>
+    <Placemark id="linepolygon_1448263972481">
+      <description />
+      <Style>
+        <LineStyle>
+          <color>ff000000</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>66000000</color>
+        </PolyStyle>
+      </Style>
+      <LineString>
+        <coordinates>8.644365358474193,46.83749844743985,0 8.644823212752566,46.83605535272734,0
+          8.64602030633954,46.835736445864335,0 8.645877898676714,46.835231902000864,0
+          8.644893011102617,46.83515175970723,0 8.643325523942023,46.835121511037045,0
+          8.63990873492,46.83474604520246,0 8.64027334869501,46.83451039854402,0</coordinates>
+      </LineString>
+    </Placemark>
+    <Placemark id="linepolygon_1448263874052">
+      <description />
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <LineString>
+        <coordinates>8.645808431209443,46.83590889340504,0 8.646011970211558,46.83538621224849,0
+          8.645702090663356,46.835258616715805,0 8.645388235442846,46.83512938269067,0
+          8.64265772429553,46.83511895462152,0 8.640875613223347,46.834918196025974,0
+          8.64002737815493,46.834722247232975,0 8.640256247240596,46.83459619866532,0</coordinates>
+      </LineString>
+    </Placemark>
+    <Placemark id="linepolygon_1448260117762">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.637426562659946,46.839687861192175,0
+              8.637188196218955,46.83722535052212,0 8.637072720445941,46.835571225603736,0
+              8.637761636146793,46.834718342214025,0 8.638570456151965,46.83571745182749,0
+              8.638274177229952,46.83771775894423,0 8.638758704660791,46.83945797346759,0
+              8.637426562659946,46.839687861192175,0 8.637426562659946,46.839687861192175,0
+              8.637426562659946,46.839687861192175,0 8.637426562659946,46.839687861192175,0
+              8.637426562659946,46.839687861192175,0 8.637426562659946,46.839687861192175,0
+              8.637426562659946,46.839687861192175,0 8.637426562659946,46.839687861192175,0
+              8.637426562659946,46.839687861192175,0 8.637426562659946,46.839687861192175,0
+              8.637426562659946,46.839687861192175,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="linepolygon_1450711034329">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <LineString>
+        <coordinates>8.642326275144695,46.83542378064677,0 8.646606181872226,46.83757582988136,0
+          8.646310626550294,46.83772082864591,0 8.646997881101883,46.83738366074897,0
+          8.646929710716978,46.83775179432001,0 8.646310626550294,46.83772082864591,0
+          8.646929710716978,46.83775179432001,0 8.646310626550294,46.83772082864591,0</coordinates>
+      </LineString>
+    </Placemark>
+    <Placemark id="annotation_1448262944929">
+      <name>6'500 m2</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.64198620316295,46.83463527093687,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="linepolygon_1448260076955">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.634951926404642,46.841013755555764,0
+              8.633789261423832,46.84061208071984,0 8.634056569170292,46.83729861956471,0
+              8.635019512615208,46.8357951475145,0 8.635484279661485,46.83901098863866,0
+              8.634951926404642,46.841013755555764,0 8.634951926404642,46.841013755555764,0
+              8.634951926404642,46.841013755555764,0 8.634951926404642,46.841013755555764,0
+              8.634951926404642,46.841013755555764,0 8.634951926404642,46.841013755555764,0
+              8.634951926404642,46.841013755555764,0 8.634951926404642,46.841013755555764,0
+              8.634951926404642,46.841013755555764,0 8.634951926404642,46.841013755555764,0
+              8.634951926404642,46.841013755555764,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="annotation_1448260125161">
+      <name>Parkplatz (2. Prio)</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.638063498230046,46.838853513759936,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448260083181">
+      <name>Parkplatz (1. Prio)</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.633337085693108,46.83914140027807,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="linepolygon_1448260582980">
+      <description />
+      <Style>
+        <LineStyle>
+          <color>ff808080</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>66808080</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.64189646857094,46.82510542517351,0 8.642720071856407,46.82442382109035,0
+              8.643059790129214,46.82461096603548,0 8.642180786546776,46.82524785032961,0
+              8.64189646857094,46.82510542517351,0 8.64189646857094,46.82510542517351,0
+              8.64189646857094,46.82510542517351,0 8.64189646857094,46.82510542517351,0
+              8.64189646857094,46.82510542517351,0 8.64189646857094,46.82510542517351,0
+              8.64189646857094,46.82510542517351,0 8.64189646857094,46.82510542517351,0
+              8.64189646857094,46.82510542517351,0 8.64189646857094,46.82510542517351,0
+              8.64189646857094,46.82510542517351,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="linepolygon_1448260187980">
+      <description />
+      <Style>
+        <LineStyle>
+          <color>ff008000</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>66008000</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.643656259908034,46.83275812472842,0 8.64502171545113,46.82934308264045,0
+              8.646364058335075,46.82958080838336,0 8.645988253558862,46.83035846916737,0
+              8.645366867354283,46.83070689380673,0 8.644684144800496,46.832999185274176,0
+              8.643656259908034,46.83275812472842,0 8.643656259908034,46.83275812472842,0
+              8.643656259908034,46.83275812472842,0 8.643656259908034,46.83275812472842,0
+              8.643656259908034,46.83275812472842,0 8.643656259908034,46.83275812472842,0
+              8.643656259908034,46.83275812472842,0 8.643656259908034,46.83275812472842,0
+              8.643656259908034,46.83275812472842,0 8.643656259908034,46.83275812472842,0
+              8.643656259908034,46.83275812472842,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="linepolygon_1449502021667">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.640801756298461,46.832265603002604,0
+              8.641016089904685,46.83169059316198,0 8.641455470939654,46.83179842623044,0
+              8.641227703239881,46.832361613017795,0 8.640801756298461,46.832265603002604,0
+              8.640801756298461,46.832265603002604,0 8.640801756298461,46.832265603002604,0
+              8.640801756298461,46.832265603002604,0 8.640801756298461,46.832265603002604,0
+              8.640801756298461,46.832265603002604,0 8.640801756298461,46.832265603002604,0
+              8.640801756298461,46.832265603002604,0 8.640801756298461,46.832265603002604,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="linepolygon_1448262903376">
+      <description />
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.640236183714801,46.83469685951311,0 8.640245287740079,46.83465118369501,0
+              8.640300081509751,46.83437627613606,0 8.641434063152635,46.83447389519388,0
+              8.642419718561258,46.83455873612393,0 8.642353884738941,46.83489769382201,0
+              8.640236183714801,46.83469685951311,0 8.640236183714801,46.83469685951311,0
+              8.640236183714801,46.83469685951311,0 8.640236183714801,46.83469685951311,0
+              8.640236183714801,46.83469685951311,0 8.640236183714801,46.83469685951311,0
+              8.640236183714801,46.83469685951311,0 8.640236183714801,46.83469685951311,0
+              8.640236183714801,46.83469685951311,0 8.640236183714801,46.83469685951311,0
+              8.640236183714801,46.83469685951311,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="linepolygon_1450766035567">
+      <description />
+      <Style>
+        <LineStyle>
+          <color>ff008000</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>66008000</color>
+        </PolyStyle>
+      </Style>
+      <LineString>
+        <coordinates>8.640227920653403,46.834456623206734,0 8.639900934500616,46.834611873430575,0
+          8.639836448610147,46.834659399688725,0 8.639023457750404,46.83457610769471,0
+          8.637957378887062,46.83441110149231,0 8.637771104975515,46.83438494162671,0
+          8.637496524512823,46.83414755005316,0 8.637244722116623,46.8342457768173,0
+          8.637326418346012,46.83435737518111,0 8.637117373480112,46.83441392742639,0
+          8.63648202261387,46.83436022003837,0 8.636545853826792,46.834160888462044,0
+          8.636288579515271,46.83413547009114,0 8.636265370641574,46.83431939693275,0
+          8.636178527428313,46.83434466435679,0 8.636186570451407,46.83470630241423,0
+          8.636273159190272,46.8355300717066,0 8.636353322715592,46.83606339241581,0</coordinates>
+      </LineString>
+    </Placemark>
+    <Placemark id="annotation_1448260192729">
+      <name>Camp</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff008000</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.645887045899927,46.83169100685594,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="linepolygon_1448263033688">
+      <description />
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.640284041765916,46.834315449157494,0
+              8.640300560094061,46.83426849428647,0 8.641738987665757,46.83436876095982,0
+              8.641747974300205,46.834404269606594,0 8.640284041765916,46.834315449157494,0
+              8.640284041765916,46.834315449157494,0 8.640284041765916,46.834315449157494,0
+              8.640284041765916,46.834315449157494,0 8.640284041765916,46.834315449157494,0
+              8.640284041765916,46.834315449157494,0 8.640284041765916,46.834315449157494,0
+              8.640284041765916,46.834315449157494,0 8.640284041765916,46.834315449157494,0
+              8.640284041765916,46.834315449157494,0 8.640284041765916,46.834315449157494,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="annotation_1449502026344">
+      <name>Camper</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ffffffff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>ffffffff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.640666760491898,46.83189668560704,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="linepolygon_1449224331627">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <LineString>
+        <coordinates>8.644518114213255,46.83319534048437,0 8.648056386055122,46.833145010382225,0
+          8.647714113893561,46.83291742306465,0 8.64761115849938,46.83332964760592,0
+          8.647925619168708,46.833159348494824,0</coordinates>
+      </LineString>
+    </Placemark>
+    <Placemark id="linepolygon_1452588988281">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.645780907065988,46.81971742398893,0 8.645478565388359,46.81978197212575,0
+              8.64545527546214,46.81954093418305,0 8.645734934429477,46.819525700741515,0
+              8.645780907065988,46.81971742398893,0 8.645780907065988,46.81971742398893,0
+              8.645780907065988,46.81971742398893,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="linepolygon_1449226851541">
+      <description />
+      <Style>
+        <LineStyle>
+          <color>ff008000</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>66008000</color>
+        </PolyStyle>
+      </Style>
+      <LineString>
+        <coordinates>8.635116169330125,46.8338036684089,0 8.638520462950781,46.82920974252072,0
+          8.63821382742425,46.82735701859067,0 8.641121404983792,46.82633370184381,0
+          8.643766803965943,46.824373053909284,0 8.64518106964231,46.823163824248695,0
+          8.645397736821094,46.82225758540055,0 8.645874644456871,46.82095614778897,0
+          8.64586208106152,46.820501969809996,0 8.64582250618206,46.820094332562455,0
+          8.645778845942631,46.81978386349895,0 8.646746907203555,46.8197451668445,0
+          8.64777739571271,46.81978661399887,0</coordinates>
+      </LineString>
+    </Placemark>
+    <Placemark id="linepolygon_1448263585892">
+      <description />
+      <Style>
+        <LineStyle>
+          <color>ff00a5ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>6600a5ff</color>
+        </PolyStyle>
+      </Style>
+      <LineString>
+        <coordinates>8.638543712169164,46.83781164181066,0 8.638355239212813,46.83717048936037,0
+          8.63859534106705,46.83615756372874,0 8.638607235869592,46.83586775508246,0
+          8.63860329006406,46.83551423834917,0 8.638456730808807,46.83529086671952,0
+          8.638119478706542,46.834981330984654,0 8.637910894024225,46.83459217612332,0
+          8.637871432530534,46.83446843982772,0 8.637730898949726,46.83389729355781,0
+          8.637881800265564,46.833403608143016,0 8.640793542702407,46.827719240209284,0
+          8.642453081520797,46.8265520350983,0 8.644201396547071,46.82595784001951,0
+          8.645948058565553,46.824823850165544,0 8.646275379900037,46.82400058258606,0
+          8.646431427696626,46.823608087201684,0 8.646515414191222,46.82276540476108,0
+          8.646330468875017,46.822028303032425,0 8.646654388694846,46.820893287395194,0
+          8.64670410626997,46.820563762681424,0 8.6465722146829,46.82021398123226,0
+          8.646688186970383,46.819710291742034,0 8.647211075534786,46.81973368747296,0
+          8.647917118519766,46.81981849599928,0</coordinates>
+      </LineString>
+    </Placemark>
+    <Placemark id="linepolygon_1449224037272">
+      <description />
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <LineString>
+        <coordinates>8.648670463340678,46.81992256564192,0 8.649552211515745,46.81878060284361,0
+          8.650881503688237,46.81721010268269,0 8.653227612097907,46.8162068316131,0
+          8.654494474555958,46.81681744447502,0 8.654483300989571,46.81704814220048,0
+          8.654131380431435,46.817057463176816,0 8.653906162553564,46.816879929328834,0
+          8.652590975171437,46.81812533875696,0 8.650434219006687,46.820964135100375,0
+          8.650415247198312,46.82147231964206,0 8.650398583835233,46.82264524825028,0
+          8.65037742855967,46.82282924704676,0 8.649902380316554,46.825301281800264,0
+          8.647729363878051,46.82691791280216,0 8.64668458179754,46.830006360672264,0
+          8.644786971624148,46.83617311364054,0 8.644254572483612,46.83733524982004,0</coordinates>
+      </LineString>
+    </Placemark>
+    <Placemark id="annotation_1452588991839">
+      <name>Versammlungsort ToF</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ffffffff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>ffffffff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.645131319283432,46.819597118161596,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1449224576983">
+      <name>L&#xE4;ufer</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff008000</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ffffffff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>ffffffff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.64573647741777,46.81993105641823,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="annotation_1448260483495">
+      <name>Parking</name>
+      <description />
+      <Style>
+        <IconStyle>
+          <scale>0</scale>
+        </IconStyle>
+        <LabelStyle>
+          <color>ff0000ff</color>
+        </LabelStyle>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>1</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Point>
+        <coordinates>8.64454992112743,46.82328347938875,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark id="linepolygon_1448260478293">
+      <Style>
+        <LineStyle>
+          <color>ff0000ff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>660000ff</color>
+        </PolyStyle>
+      </Style>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>8.643628070402037,46.823766061353005,0
+              8.644136559433263,46.823998205181546,0 8.644913432051504,46.82310476208613,0
+              8.645397736821094,46.82225758540055,0 8.64562093457079,46.82145634674274,0
+              8.645756721151158,46.82096550753206,0 8.645297595085653,46.8214147785272,0
+              8.645040855335628,46.82165499401791,0 8.644898284812479,46.82231143788504,0
+              8.64466540493132,46.822680949139595,0 8.644265616511973,46.8226203924386,0
+              8.643628070402037,46.823766061353005,0 8.643628070402037,46.823766061353005,0
+              8.643628070402037,46.823766061353005,0 8.643628070402037,46.823766061353005,0
+              8.643628070402037,46.823766061353005,0 8.643628070402037,46.823766061353005,0
+              8.643628070402037,46.823766061353005,0 8.643628070402037,46.823766061353005,0
+              8.643628070402037,46.823766061353005,0 8.643628070402037,46.823766061353005,0
+              8.643628070402037,46.823766061353005,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="linepolygon_1449646591125">
+      <description />
+      <Style>
+        <LineStyle>
+          <color>ffffffff</color>
+          <width>3</width>
+        </LineStyle>
+        <PolyStyle>
+          <color>66ffffff</color>
+        </PolyStyle>
+      </Style>
+      <LineString>
+        <coordinates>8.64393129922751,46.83128419750794,0 8.644693088866237,46.82944323512212,0
+          8.645119767567592,46.82801046260543,0 8.646817700484003,46.827270073032224,0
+          8.647053334247481,46.82701263015878,0 8.646707999044066,46.82672411548804,0
+          8.646277060329444,46.82590503995558,0 8.64667028833065,46.82579758364662,0
+          8.646845758495311,46.82539588335959,0 8.645948058565553,46.824823850165544,0
+          8.646347141225504,46.82404083347311,0 8.646436623921422,46.823849298890416,0
+          8.647196582819276,46.82396775613389,0 8.647351609086827,46.82357535734932,0
+          8.647488551820885,46.82277885038165,0 8.648246070444994,46.82287820893197,0
+          8.648601837943877,46.82194164915189,0 8.648734004843243,46.82144544656667,0
+          8.649115970817815,46.820699526799096,0 8.649393264792268,46.8205323598398,0
+          8.650353016426065,46.82098913412863,0 8.650892804419173,46.820224336513355,0
+          8.650623146392456,46.820072592545024,0</coordinates>
+      </LineString>
+    </Placemark>
+  </Document>
+</kml>


### PR DESCRIPTION
Some kml out there could still be on legacy version icon url that are not anymore
reachable. mf-geoadmin3 was already dynamically changing those legacy url format
to a new format (which is now with the new viewer also legacy) and would therefore
still support such kml.

Now in the new viewer we also support all type of legacy icon urls and dynamically
change the url to the new format, so that only the new format will be fetched.

NOTE: Some internal openlayer still first try to fetch old urls format but I
could not figure out why.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-347-kml-samples/index.html)