### PR TITLE
Move "print" job logic and management out of area composable

### DIFF
--- a/src/api/shortlink.api.js
+++ b/src/api/shortlink.api.js
@@ -7,26 +7,33 @@ import log from '@/utils/logging'
  * Generates a short link from the given URL
  *
  * @param {String} url The URL we want to shorten
+ * @param {Boolean} withCrosshair If a cross-hair should be placed at the center of the map in the
+ *   shortlink
  * @returns {Promise<String>} A promise that will resolve with the short link
  */
-export function createShortLink(url) {
+export function createShortLink(url, withCrosshair = false) {
     return new Promise((resolve, reject) => {
+        // we do not want the geolocation of the user clicking the link to kick in, so we force the flag out of the URL
+        let sanitizedUrl = url.replace('&geolocation', '')
+        if (withCrosshair) {
+            sanitizedUrl += '&crosshair=marker'
+        }
         try {
-            new URL(url)
+            new URL(sanitizedUrl)
         } catch (e) {
             const errorMessage = 'Invalid URL, no short link generated'
-            log.error(errorMessage, url)
+            log.error(errorMessage, sanitizedUrl)
             reject(errorMessage)
         }
         axios
             .post(API_SERVICE_SHORTLINK_BASE_URL, {
-                url: url,
+                url: sanitizedUrl,
             })
             .then((response) => {
                 resolve(response.data.shorturl)
             })
             .catch((error) => {
-                log.error('Error while retrieving short link for', url, error)
+                log.error('Error while retrieving short link for', sanitizedUrl, error)
                 reject(error)
             })
     })

--- a/src/modules/map/components/openlayers/utils/usePrint.composable.js
+++ b/src/modules/map/components/openlayers/utils/usePrint.composable.js
@@ -1,0 +1,99 @@
+import { computed, ref } from 'vue'
+import { useStore } from 'vuex'
+
+import { abortPrintJob, createPrintJob, waitForPrintJobCompletion } from '@/api/print.api.js'
+import { getGenerateQRCodeUrl } from '@/api/qrcode.api.js'
+import log from '@/utils/logging'
+
+const dispatcher = { dispatcher: 'usePrint.composable' }
+
+/** @enum */
+export const PrintStatus = {
+    IDLE: 'IDLE',
+    PRINTING: 'PRINTING',
+    FINISHED_SUCCESSFULLY: 'FINISHED_SUCCESSFULLY',
+    FINISHED_FAILED: 'FINISHED_FAILED',
+}
+
+/**
+ * Gathering of all the logic that will trigger and manage a print request to service-print3
+ *
+ * @param {Map} map
+ */
+export function usePrint(map) {
+    const currentJobReference = ref(null)
+    /** @type {PrintStatus} */
+    const printStatus = ref(PrintStatus.IDLE)
+
+    const store = useStore()
+    const printLayout = computed(() => store.state.print.selectedLayout)
+    const printScale = computed(() => store.state.print.selectedScale)
+    const attributions = computed(() =>
+        store.getters.visibleLayers
+            .map((layer) => layer.attributions)
+            .map((attribution) => attribution.name)
+            .filter((attribution, index, self) => self.indexOf(attribution) === index)
+    )
+    const layersWithLegends = computed(() =>
+        store.getters.visibleLayers.filter((layer) => layer.hasLegend)
+    )
+    const lang = computed(() => store.state.i18n.lang)
+    const projection = computed(() => store.state.map.projection)
+
+    /**
+     * @param {Boolean} printGrid Print the coordinate grid on the finished PDF, true or false
+     * @param {Boolean} printLegend Print all visible layer legend (if they have one) on the map,
+     *   true or false
+     * @returns {Promise<String | null>}
+     */
+    async function print(printGrid = false, printLegend = false) {
+        try {
+            if (currentJobReference.value) {
+                await abortCurrentJob()
+            }
+            printStatus.value = PrintStatus.PRINTING
+            await store.dispatch('generateShortLinks', dispatcher)
+            const shortLink = store.state.share.shortLink
+            const qrCodeUrl = getGenerateQRCodeUrl(shortLink)
+            const printJob = await createPrintJob(map, {
+                layout: printLayout.value,
+                scale: printScale.value,
+                attributions: attributions.value,
+                qrCodeUrl,
+                shortLink,
+                layersWithLegends: printLegend ? layersWithLegends.value : [],
+                lang: lang.value,
+                printGrid: printGrid,
+                projection: projection.value,
+            })
+            currentJobReference.value = printJob.ref
+            const result = await waitForPrintJobCompletion(printJob)
+            printStatus.value = PrintStatus.FINISHED_SUCCESSFULLY
+            return result
+        } catch (error) {
+            log.error('Error while printing', error)
+            printStatus.value = PrintStatus.FINISHED_FAILED
+            return null
+        } finally {
+            currentJobReference.value = null
+        }
+    }
+
+    async function abortCurrentJob() {
+        try {
+            if (currentJobReference.value) {
+                await abortPrintJob(currentJobReference.value)
+                log.debug('Job', currentJobReference.value, 'successfully aborted')
+                currentJobReference.value = null
+            }
+        } catch (error) {
+            log.error('Could not abort job', currentJobReference.value, error)
+        }
+    }
+
+    return {
+        print,
+        abortCurrentJob,
+        printStatus,
+    }
+}

--- a/src/modules/map/components/openlayers/utils/usePrint.composable.js
+++ b/src/modules/map/components/openlayers/utils/usePrint.composable.js
@@ -1,11 +1,12 @@
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
 import { useStore } from 'vuex'
 
 import { abortPrintJob, createPrintJob, waitForPrintJobCompletion } from '@/api/print.api.js'
 import { getGenerateQRCodeUrl } from '@/api/qrcode.api.js'
+import { createShortLink } from '@/api/shortlink.api.js'
 import log from '@/utils/logging'
 
-const dispatcher = { dispatcher: 'usePrint.composable' }
+// const dispatcher = { dispatcher: 'usePrint.composable' }
 
 /** @enum */
 export const PrintStatus = {
@@ -26,19 +27,6 @@ export function usePrint(map) {
     const printStatus = ref(PrintStatus.IDLE)
 
     const store = useStore()
-    const printLayout = computed(() => store.state.print.selectedLayout)
-    const printScale = computed(() => store.state.print.selectedScale)
-    const attributions = computed(() =>
-        store.getters.visibleLayers
-            .map((layer) => layer.attributions)
-            .map((attribution) => attribution.name)
-            .filter((attribution, index, self) => self.indexOf(attribution) === index)
-    )
-    const layersWithLegends = computed(() =>
-        store.getters.visibleLayers.filter((layer) => layer.hasLegend)
-    )
-    const lang = computed(() => store.state.i18n.lang)
-    const projection = computed(() => store.state.map.projection)
 
     /**
      * @param {Boolean} printGrid Print the coordinate grid on the finished PDF, true or false
@@ -48,23 +36,30 @@ export function usePrint(map) {
      */
     async function print(printGrid = false, printLegend = false) {
         try {
+            // TODO PB-362 : show laoding bar
             if (currentJobReference.value) {
                 await abortCurrentJob()
             }
             printStatus.value = PrintStatus.PRINTING
-            await store.dispatch('generateShortLinks', dispatcher)
-            const shortLink = store.state.share.shortLink
+            const shortLink = await createShortLink(window.location.href)
             const qrCodeUrl = getGenerateQRCodeUrl(shortLink)
+            // using store values directly (instead of going through computed) so that it is a bit more performant
+            // (we do not need to have reactivity on these values, if they change while printing we do nothing)
             const printJob = await createPrintJob(map, {
-                layout: printLayout.value,
-                scale: printScale.value,
-                attributions: attributions.value,
+                layout: store.state.print.selectedLayout,
+                scale: store.state.print.selectedScale,
+                attributions: store.getters.visibleLayers
+                    .map((layer) => layer.attributions)
+                    .map((attribution) => attribution.name)
+                    .filter((attribution, index, self) => self.indexOf(attribution) === index),
                 qrCodeUrl,
                 shortLink,
-                layersWithLegends: printLegend ? layersWithLegends.value : [],
-                lang: lang.value,
+                layersWithLegends: printLegend
+                    ? store.getters.visibleLayers.filter((layer) => layer.hasLegend)
+                    : [],
+                lang: store.state.i18n.lang,
                 printGrid: printGrid,
-                projection: projection.value,
+                projection: store.state.map.projection,
             })
             currentJobReference.value = printJob.ref
             const result = await waitForPrintJobCompletion(printJob)
@@ -75,6 +70,7 @@ export function usePrint(map) {
             printStatus.value = PrintStatus.FINISHED_FAILED
             return null
         } finally {
+            // TODO PB-362 : hide laoding bar
             currentJobReference.value = null
         }
     }

--- a/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
+++ b/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
@@ -1,10 +1,3 @@
-import {
-    BaseCustomizer,
-    cancelPrint,
-    getDownloadUrl,
-    MFPEncoder,
-    requestReport,
-} from '@geoblocks/mapfishprint'
 import { Feature } from 'ol'
 import { Polygon } from 'ol/geom'
 import * as olHas from 'ol/has'
@@ -13,14 +6,6 @@ import VectorSource from 'ol/source/Vector'
 import { Fill, Style } from 'ol/style'
 import { computed, watch } from 'vue'
 import { useStore } from 'vuex'
-
-import { getGenerateQRCodeUrl } from '@/api/qrcode.api'
-import { createShortLink } from '@/api/shortlink.api'
-import { API_BASE_URL, API_SERVICES_BASE_URL, WMS_BASE_URL } from '@/config'
-import i18n from '@/modules/i18n'
-import store from '@/store'
-import CustomCoordinateSystem from '@/utils/coordinates/CustomCoordinateSystem.class'
-import log from '@/utils/logging'
 
 const dispatcher = { dispatcher: 'print-area-renderer.composable' }
 
@@ -55,62 +40,6 @@ function createWorldPolygon() {
     return vectorLayer
 }
 
-function encodeGraticule(dpi, projection) {
-    let gridLayer = 'org.epsg.grid_4326'
-    if (projection instanceof CustomCoordinateSystem) {
-        gridLayer = 'org.epsg.grid_2056'
-    }
-    return {
-        baseURL: WMS_BASE_URL,
-        opacity: 1,
-        singleTile: true,
-        type: 'WMS',
-        layers: [gridLayer],
-        format: 'image/png',
-        styles: [''],
-        customParams: {
-            TRANSPARENT: true,
-            MAP_RESOLUTION: dpi,
-        },
-    }
-}
-
-function encodeLegend() {
-    // const icons = []
-    const visibleLayers = store.getters.visibleLayers
-    const classes = []
-
-    for (const layer of visibleLayers) {
-        // There are some layers that do not have legend but the hasLegend is set to True
-        // It might give a blank legend in the print
-        if (layer.hasLegend) {
-            classes.push({
-                name: layer.name,
-                icons: [
-                    `${API_BASE_URL}static/images/legends/${layer.id}_${store.state.i18n.lang}.png`,
-                ],
-            })
-        }
-    }
-    return {
-        name: i18n.global.t('legend'),
-        classes: classes,
-    }
-}
-
-function encodeAttributions() {
-    const visibleLayers = store.getters.visibleLayers
-    const attributions = new Set()
-
-    for (const layer of visibleLayers) {
-        const layerAttributions = layer.attributions
-        for (const layerAttribution of layerAttributions) {
-            attributions.add(layerAttribution.name)
-        }
-    }
-    return Array.from(attributions).join(', ')
-}
-
 export default function usePrintAreaRenderer(map) {
     const store = useStore()
 
@@ -118,26 +47,12 @@ export default function usePrintAreaRenderer(map) {
     const POINTS_PER_INCH = 72 // PostScript points 1/72"
     const MM_PER_INCHES = 25.4
     const UNITS_RATIO = 39.37 // inches per meter
-    const POLL_INTERVAL = 2000 // interval for multi-page prints (ms)
-    const POLL_MAX_TIME = 600000 // ms (10 minutes)
     let worldPolygon = null
     let printRectangle = []
 
-    const isActive = computed(() => {
-        return store.state.print.printSectionShown
-    })
-
-    const selectedLayoutName = computed(() => {
-        return store.state.print.selectedLayout.name
-    })
-
-    const selectedScale = computed(() => {
-        return store.state.print.selectedScale
-    })
-
-    const printingStatus = computed(() => {
-        return store.state.print.printingStatus
-    })
+    const isActive = computed(() => store.state.print.printSectionShown)
+    const selectedLayoutName = computed(() => store.state.print.selectedLayout.name)
+    const selectedScale = computed(() => store.state.print.selectedScale)
 
     watch(isActive, (newValue) => {
         if (newValue) {
@@ -146,99 +61,6 @@ export default function usePrintAreaRenderer(map) {
             deactivatePrintArea()
         }
     })
-
-    watch(printingStatus, async (newValue) => {
-        if (newValue) {
-            startPrinting()
-        } else {
-            abortPrinting()
-        }
-    })
-
-    async function startPrinting() {
-        const mapFishPrintUrl = API_SERVICES_BASE_URL + 'print3/print/default'
-
-        const layout = store.state.print.selectedLayout.name
-
-        const encoder = new MFPEncoder(mapFishPrintUrl)
-        const customizer = new BaseCustomizer([0, 0, 10000, 10000])
-        // Generate QR code url from current shortlink (similar as in share.store.js avoding dispatch)
-        const urlWithoutGeolocation =
-            // we do not want the geolocation of the user clicking the link to kick in, so we force the flag out of the URL
-            window.location.href.replace('&geolocation', '')
-        const shortLink = await createShortLink(urlWithoutGeolocation)
-        const qrCodeUrl = getGenerateQRCodeUrl(shortLink)
-
-        const mapConfig = {
-            map,
-            scale: selectedScale.value,
-            printResolution: 96,
-            dpi: 96,
-            customizer: customizer,
-        }
-
-        const mapSpec = await encoder.encodeMap(mapConfig)
-
-        const spec = {
-            attributes: {
-                map: mapSpec,
-                copyright: `© ${encodeAttributions()}`,
-                url: store.state.ui.hostname,
-                qrimage: qrCodeUrl,
-            },
-            format: 'pdf',
-            layout: layout,
-        }
-        if (store.state.print.useGraticule) {
-            const legend = encodeLegend()
-            if (legend.classes.length > 0) {
-                spec.attributes.legend = legend
-            } else {
-                spec.attributes.printLegend = 0
-            }
-        } else {
-            spec.attributes.printLegend = 0
-        }
-
-        if (store.state.print.useGraticule) {
-            // Put the graticule in the first layer so it's drawn at the top
-            spec.attributes.map.layers.unshift(encodeGraticule(96, store.state.position.projection))
-        }
-
-        const report = await requestReport(mapFishPrintUrl, spec)
-        store.dispatch('setCurrentPrintReference', { reference: report.ref, ...dispatcher })
-
-        try {
-            const url = await getDownloadUrl(mapFishPrintUrl, report, POLL_INTERVAL, POLL_MAX_TIME)
-            downloadUrl(url)
-        } catch (error) {
-            log.error('result', 'error', error)
-        } finally {
-            store.dispatch('setPrintStatusAndReference', {
-                isPrinting: false,
-                reference: null,
-                ...dispatcher,
-            })
-        }
-    }
-
-    function abortPrinting() {
-        if (store.getters.currentPrintReference) {
-            const printReference = store.getters.currentPrintReference
-            const mapFishPrintUrl = API_SERVICES_BASE_URL + 'print3/print/default'
-            cancelPrint(mapFishPrintUrl, printReference)
-
-            store.dispatch('setCurrentPrintReference', { reference: null, ...dispatcher })
-        }
-    }
-
-    function downloadUrl(url) {
-        if (window.navigator.userAgent.indexOf('MSIE ') > -1) {
-            window.open(url)
-        } else {
-            window.location = url
-        }
-    }
 
     function activatePrintArea() {
         if (!worldPolygon) {

--- a/src/modules/menu/components/print/MenuPrintSection.vue
+++ b/src/modules/menu/components/print/MenuPrintSection.vue
@@ -1,96 +1,100 @@
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, inject, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 
+import {
+    PrintStatus,
+    usePrint,
+} from '@/modules/map/components/openlayers/utils/usePrint.composable'
 import MenuSection from '@/modules/menu/components/menu/MenuSection.vue'
-import { formatThousand } from '@/utils/numberUtils.js'
+import log from '@/utils/logging'
+import { formatThousand } from '@/utils/numberUtils'
 
 const dispatcher = { dispatcher: 'MapPrintSection.vue' }
 
 const emits = defineEmits(['openMenuSection'])
 
 const isSectionShown = ref(false)
-const selectedLayoutName = ref(null)
+const printGrid = ref(false)
+const printLegend = ref(false)
+
+const olMap = inject('olMap')
+const { printStatus, print, abortCurrentJob } = usePrint(olMap)
 
 const i18n = useI18n()
 const store = useStore()
-const printLayouts = computed(() => store.state.print.layouts)
-const selectedLayout = computed(() =>
-    printLayouts.value.find((layout) => layout.name === selectedLayoutName.value)
-)
+const availablePrintLayouts = computed(() => store.state.print.layouts)
+const selectedLayout = computed(() => store.state.print.selectedLayout)
 const scales = computed(() => selectedLayout.value?.scales || [])
-const printStatus = computed(() => store.state.print.printingStatus)
+
+const selectedLayoutName = computed({
+    get() {
+        return store.state.print.selectedLayout?.name
+    },
+    set(value) {
+        store.dispatch('setSelectedLayout', {
+            layout: availablePrintLayouts.value.find((layout) => layout.name === value),
+            ...dispatcher,
+        })
+    },
+})
 
 const selectedScale = computed({
     get() {
-        return store.getters.getSelectedScale
+        return store.state.print.selectedScale
     },
     set(value) {
         store.dispatch('setSelectedScale', { scale: value, ...dispatcher })
     },
 })
 
-const useGraticule = computed({
-    get() {
-        return store.getters.getUseGraticule
-    },
-    set(value) {
-        store.dispatch('setUseGraticule', { useGraticule: value, ...dispatcher })
-    },
-})
-
-const useLegend = computed({
-    get() {
-        return store.getters.getUseLegend
-    },
-    set(value) {
-        store.dispatch('setUseLegend', { useLegend: value, ...dispatcher })
-    },
-})
-
-watch(selectedLayout, () => {
-    store.dispatch('setSelectedLayout', { layout: selectedLayout.value, ...dispatcher })
-})
-
 watch(isSectionShown, () => {
     store.dispatch('setPrintSectionShown', { show: isSectionShown.value, ...dispatcher })
 })
 
-watch(printLayouts, () => {
+watch(availablePrintLayouts, () => {
     // whenever layouts are loaded form the backend, we select the first one as default value
-    if (printLayouts.value.length > 0) {
-        selectLayout(printLayouts.value[0])
+    if (availablePrintLayouts.value.length > 0) {
+        selectLayout(availablePrintLayouts.value[0])
     }
 })
 
 function togglePrintMenu() {
     // load print layouts from the backend if they were not yet loaded
-    if (printLayouts.value.length === 0) {
+    if (availablePrintLayouts.value.length === 0) {
         store.dispatch('loadPrintLayouts', dispatcher).then(() => {
             isSectionShown.value = !isSectionShown.value
         })
     } else {
         // if layouts are already present, we select the first one as default value
-        selectLayout(printLayouts.value[0])
+        selectLayout(availablePrintLayouts.value[0])
         isSectionShown.value = !isSectionShown.value
     }
 }
 function selectLayout(layout) {
     selectedLayoutName.value = layout.name
-    selectedScale.value = layout.scales[0]
 }
 
 function close() {
     isSectionShown.value = false
 }
 
-function printMap() {
-    store.dispatch('setPrintingStatus', { isPrinting: true, ...dispatcher })
-}
-
-function abortPrinting() {
-    store.dispatch('setPrintingStatus', { isPrinting: false, ...dispatcher })
+async function printMap() {
+    try {
+        const documentUrl = await print(printGrid.value, printLegend.value)
+        if (documentUrl) {
+            if (window.navigator.userAgent.indexOf('MSIE ') > -1) {
+                window.open(documentUrl)
+            } else {
+                window.location = documentUrl
+            }
+        } else {
+            log.error('Print failed, received null')
+        }
+    } catch (error) {
+        log.error('Print failed', error)
+    }
 }
 
 defineExpose({
@@ -114,7 +118,7 @@ defineExpose({
             }}</label>
             <select id="print-layout-selector " v-model="selectedLayoutName" class="form-select">
                 <option
-                    v-for="layout in printLayouts"
+                    v-for="layout in availablePrintLayouts"
                     :key="layout.name"
                     :value="layout.name"
                     @click="selectLayout(layout)"
@@ -133,7 +137,7 @@ defineExpose({
             <div class="form-check">
                 <input
                     id="checkboxLegend"
-                    v-model="useLegend"
+                    v-model="printLegend"
                     class="form-check-input"
                     type="checkbox"
                 />
@@ -141,32 +145,27 @@ defineExpose({
             </div>
             <div class="form-check">
                 <input
-                    id="checkboxGraticule"
-                    v-model="useGraticule"
+                    id="checkboxGrid"
+                    v-model="printGrid"
                     class="form-check-input"
                     type="checkbox"
                 />
-                <label class="form-check-label" for="checkboxGraticule">{{
-                    i18n.t('graticule')
-                }}</label>
+                <label class="form-check-label" for="checkboxGrid">{{ i18n.t('graticule') }}</label>
             </div>
             <div class="full-width justify-content-center">
                 <button
-                    v-if="!printStatus"
-                    type="button"
-                    class="btn btn-light w-100"
-                    @click="printMap"
-                >
-                    {{ i18n.t('print_action') }}
-                </button>
-                <button
-                    v-if="printStatus"
+                    v-if="printStatus === PrintStatus.PRINTING"
                     type="button"
                     class="btn btn-danger w-100 text-white"
-                    @click="abortPrinting"
+                    @click="abortCurrentJob"
                 >
                     {{ i18n.t('abort') }}
                 </button>
+                <button v-else type="button" class="btn btn-light w-100" @click="printMap">
+                    {{ i18n.t('print_action') }}
+                </button>
+                <!-- TODO: manage failing print job-->
+                <!-- TODO: give a UI feedback for a print success-->
             </div>
         </div>
     </MenuSection>

--- a/src/store/modules/print.store.js
+++ b/src/store/modules/print.store.js
@@ -4,34 +4,20 @@ import log from '@/utils/logging.js'
 export default {
     state: {
         layouts: [],
-        selectedLayout: {},
+        selectedLayout: null,
         selectedScale: 0,
         printSectionShown: false,
-        printingStatus: false,
-        useGraticule: false,
-        useLegend: false,
-        currentPrintReference: null,
     },
     getters: {
         mapSize(state) {
-            const mapAttributes = state.selectedLayout.attributes.find((atr) => atr.name === 'map')
+            const mapAttributes = state.selectedLayout.attributes.find(
+                (attribute) => attribute.name === 'map'
+            )
 
             return {
                 width: mapAttributes?.clientParams?.width?.default,
                 height: mapAttributes?.clientParams?.height?.default,
             }
-        },
-        getSelectedScale(state) {
-            return state.selectedScale
-        },
-        useGraticule(state) {
-            return state.useGraticule
-        },
-        useLegend(state) {
-            return state.useLegend
-        },
-        currentPrintReference(state) {
-            return state.currentPrintReference
         },
     },
     actions: {
@@ -48,25 +34,10 @@ export default {
         },
         setSelectedLayout({ commit }, { layout, dispatcher }) {
             commit('setSelectedLayout', { layout, dispatcher })
+            commit('setSelectedScale', { scale: layout.scales[0], dispatcher })
         },
         setPrintSectionShown({ commit }, { show, dispatcher }) {
             commit('setPrintSectionShown', { show, dispatcher })
-        },
-        setPrintingStatus({ commit }, { isPrinting, dispatcher }) {
-            commit('setPrintingStatus', { isPrinting, dispatcher })
-        },
-        setUseGraticule({ commit }, { useGraticule, dispatcher }) {
-            commit('setUseGraticule', { useGraticule, dispatcher })
-        },
-        setUseLegend({ commit }, { useLegend, dispatcher }) {
-            commit('setUseLegend', { useLegend, dispatcher })
-        },
-        setCurrentPrintReference({ commit }, { reference, dispatcher }) {
-            commit('setCurrentPrintReference', { reference, dispatcher })
-        },
-        setPrintStatusAndReference({ commit }, { isPrinting, reference, dispatcher }) {
-            commit('setPrintingStatus', { isPrinting, dispatcher })
-            commit('setCurrentPrintReference', { reference, dispatcher })
         },
     },
     mutations: {
@@ -74,10 +45,5 @@ export default {
         setSelectedLayout: (state, { layout }) => (state.selectedLayout = layout),
         setSelectedScale: (state, { scale }) => (state.selectedScale = scale),
         setPrintSectionShown: (state, { show }) => (state.printSectionShown = show),
-        setPrintingStatus: (state, { isPrinting }) => (state.printingStatus = isPrinting),
-        setUseGraticule: (state, { useGraticule }) => (state.useGraticule = useGraticule),
-        setUseLegend: (state, { useLegend }) => (state.useLegend = useLegend),
-        setCurrentPrintReference: (state, { reference }) =>
-            (state.currentPrintReference = reference),
     },
 }

--- a/src/store/modules/share.store.js
+++ b/src/store/modules/share.store.js
@@ -28,21 +28,16 @@ export default {
     getters: {},
     actions: {
         async generateShortLinks({ commit }, { withCrosshair = false, dispatcher }) {
-            const urlWithoutGeolocation =
-                // we do not want the geolocation of the user clicking the link to kick in, so we force the flag out of the URL
-                window.location.href.replace('&geolocation', '') +
-                // if the geolocation was being tracked by the user generating the link, we place a balloon (dropped pin) marker at his position (center of the screen, so no need to change any x/y position)
-                (withCrosshair ? '&crosshair=marker' : '')
             try {
-                const shortLink = await createShortLink(urlWithoutGeolocation)
+                const shortLink = await createShortLink(window.location.href, withCrosshair)
                 if (shortLink) {
                     commit('setShortLink', { shortLink, dispatcher })
                 }
             } catch (err) {
-                log.error('Error while creating short link for', urlWithoutGeolocation, err)
-                commit('setShortLink', { shortLink: urlWithoutGeolocation, dispatcher })
+                log.error('Error while creating short link for', window.location.href, err)
+                commit('setShortLink', { shortLink: window.location.href, dispatcher })
             }
-            const embedUrl = transformUrlMapToEmbed(urlWithoutGeolocation)
+            const embedUrl = transformUrlMapToEmbed(window.location.href)
             try {
                 const embeddedShortLink = await createShortLink(embedUrl)
                 if (embeddedShortLink) {

--- a/src/store/plugins/loading-bar-management.plugin.js
+++ b/src/store/plugins/loading-bar-management.plugin.js
@@ -10,7 +10,7 @@ const loadingBarManagementPlugin = (store) => {
         const isLoadingBarVisible = state.ui.showLoadingBar
         // for now, we only check if app is ready and printing status
         // TODO: any pending request to the backend should trigger the loading bar
-        const shouldLoadingBarBeVisible = !state.app.isReady || state.print.printingStatus
+        const shouldLoadingBarBeVisible = !state.app.isReady
         if (isLoadingBarVisible !== shouldLoadingBarBeVisible) {
             store.dispatch('toggleLoadingBar', dispatcher)
         }


### PR DESCRIPTION
The print area preview composable was doing the preview, the printing and also coffee. It is now only responsible for the preview area. I also took the opportunity to remove from the store things that weren't making much sense being there, as no one else as the print menu section was using them (and as the menu section is now the one triggering the print job, it's much clearer this way)

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_split_print_functions/index.html)