### PR TITLE
Fix import tool local file tabindex

### DIFF
--- a/src/modules/menu/components/advancedTools/ImportFile/ImportFileLocalTab.vue
+++ b/src/modules/menu/components/advancedTools/ImportFile/ImportFileLocalTab.vue
@@ -116,7 +116,7 @@ function validateForm() {
         aria-labelledby="nav-local-tab"
         data-cy="import-file-local-content"
     >
-        <form class="needs-validation">
+        <div class="needs-validation">
             <div class="input-group rounded needs-validation mb-2">
                 <button
                     class="btn btn-outline-secondary"
@@ -141,6 +141,7 @@ function validateForm() {
                     :value="filePathInfo"
                     readonly
                     required
+                    tabindex="-1"
                     data-cy="import-file-local-input-text"
                     @click="importFileLocalInput.click()"
                 />
@@ -152,7 +153,7 @@ function validateForm() {
                     {{ i18n.t(errorMessage) }}
                 </div>
             </div>
-        </form>
+        </div>
         <ImportFileButtons
             class="mt-2"
             :button-state="buttonState"


### PR DESCRIPTION
On the import tool local file, the input had a tabindex but the user could
do nothing with its focus because this field is readonly. Moreover due to the
form, when pressing enter on this input field it reloaded the page.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-import-file-tool/index.html)