### PR TITLE
Fix two bugs regarding selected features

### DIFF
--- a/src/router/storeSync/layersParamParser.js
+++ b/src/router/storeSync/layersParamParser.js
@@ -1,3 +1,4 @@
+import LayerFeature from '@/api/features/LayerFeature.class.js'
 import { ActiveLayerConfig } from '@/utils/layerUtils'
 import { isNumber } from '@/utils/numberUtils'
 
@@ -121,12 +122,14 @@ export function transformLayerIntoUrlString(layer, defaultLayerConfig, featuresI
 export function orderFeaturesByLayers(selectedFeatures) {
     const layersFeatures = {}
 
-    selectedFeatures.forEach((feature) => {
-        if (!layersFeatures[feature.layer.id]) {
-            layersFeatures[feature.layer.id] = []
-        }
+    selectedFeatures
+        .filter((feature) => feature instanceof LayerFeature)
+        .forEach((feature) => {
+            if (!layersFeatures[feature.layer.id]) {
+                layersFeatures[feature.layer.id] = []
+            }
 
-        layersFeatures[feature.layer.id].push(feature.id)
-    })
+            layersFeatures[feature.layer.id].push(feature.id)
+        })
     return layersFeatures
 }

--- a/src/utils/geoJsonUtils.js
+++ b/src/utils/geoJsonUtils.js
@@ -52,7 +52,13 @@ export function reprojectGeoJsonData(geoJsonData, toProjection, fromProjection =
         toProjection instanceof CoordinateSystem
     ) {
         if (matchingProjection.epsg !== toProjection.epsg) {
-            reprojectedGeoJSON = reproject(geoJsonData, matchingProjection.epsg, toProjection.epsg)
+            reprojectedGeoJSON = reproject(
+                // (deep) cloning the geom before reprojecting it, because reproject function might alter something in the geom
+                // and the geom comes sometimes directly from the Vuex store (ending in an error when that happen)
+                JSON.parse(JSON.stringify(geoJsonData)),
+                matchingProjection.epsg,
+                toProjection.epsg
+            )
         } else {
             // it's already in the correct projection, we don't re-project
             reprojectedGeoJSON = geoJsonData


### PR DESCRIPTION
The new @features param wasn't checking that it was looping over features with layer, creating error when selecting drawing features

The geometry of a feature came sometimes directly from the store, and was shallow-cloned only by reproject utils. Vuex was then raising an error because reproject attempted to modify something coming from the store. We now deep-clone the geometry before passing it to reproject

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_fix_geom_vuex_and_feature_no_layer/index.html)