### PR TITLE
PB-370: Clear preview layer on selection

### DIFF
--- a/src/modules/menu/components/search/SearchResultListEntry.vue
+++ b/src/modules/menu/components/search/SearchResultListEntry.vue
@@ -43,6 +43,7 @@ const layerName = computed(() => {
 function selectItem() {
     emits('entrySelected')
     store.dispatch('selectResultEntry', { entry: entry.value, ...dispatcher })
+    store.dispatch('clearPreviewLayer', dispatcher)
 }
 
 function goToFirst() {


### PR DESCRIPTION
The preview layer was not clear when selecting the layer, which let the layer
on top of the stack until a new layer preview was set. Due to this the user
had the impression that it could not changed its active layer configuration
because the preview was still on top.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-370-preview-layer/index.html)