### PR TITLE
PB-111: Update geoblocks/mapfishprint to v0.2.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@fortawesome/free-solid-svg-icons": "^6.5.1",
                 "@fortawesome/vue-fontawesome": "^3.0.6",
                 "@geoblocks/cesium-compass": "^0.5.0",
-                "@geoblocks/mapfishprint": "github:geoblocks/mapfishprint#4c47539f391af3c641f9455efe0d31ebdc145cfe",
+                "@geoblocks/mapfishprint": "^0.2.11",
                 "@geoblocks/ol-maplibre-layer": "^0.1.3",
                 "@ivanv/vue-collapse-transition": "^1.0.2",
                 "@mapbox/togeojson": "^0.16.2",
@@ -806,10 +806,9 @@
             }
         },
         "node_modules/@geoblocks/mapfishprint": {
-            "version": "0.2.10",
-            "resolved": "git+ssh://git@github.com/geoblocks/mapfishprint.git#4c47539f391af3c641f9455efe0d31ebdc145cfe",
-            "integrity": "sha512-1T6jA/Uz07CtLO9vXq4EwnD1LhWUBuRz3FnzCv1hPKQa5VNLOD8Ye1GaNG+/YDuWgR/DY2U9RcZBMpZS7gwRIg==",
-            "license": "BSD-3-Clause",
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/@geoblocks/mapfishprint/-/mapfishprint-0.2.11.tgz",
+            "integrity": "sha512-wcmoUHJ/O5iUYWHI6Rf665OaRpzE1j2pSxxveXmolhh6/2OiiLYZC8TSztIma/RW/u47fcvaq6cBR+2QZea55Q==",
             "optionalDependencies": {
                 "@geoblocks/print": "0.7.8"
             },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.5.1",
         "@fortawesome/vue-fontawesome": "^3.0.6",
         "@geoblocks/cesium-compass": "^0.5.0",
-        "@geoblocks/mapfishprint": "github:geoblocks/mapfishprint#4c47539f391af3c641f9455efe0d31ebdc145cfe",
+        "@geoblocks/mapfishprint": "^0.2.11",
         "@geoblocks/ol-maplibre-layer": "^0.1.3",
         "@ivanv/vue-collapse-transition": "^1.0.2",
         "@mapbox/togeojson": "^0.16.2",


### PR DESCRIPTION


[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-111-upgrade-mapfishprint/index.html)