### PR TITLE
Fix GPX local file import

### DIFF
--- a/src/api/layers/GPXLayer.class.js
+++ b/src/api/layers/GPXLayer.class.js
@@ -46,7 +46,7 @@ export default class GPXLayer extends AbstractLayer {
             hasDescription: false,
             hasLegend: false,
             isExternal: true,
-            isLoading: !!gpxData && !!gpxMetadata,
+            isLoading: !gpxData,
         })
         this.gpxFileUrl = gpxFileUrl
         this.gpxData = gpxData

--- a/src/store/plugins/external-layers.plugin.js
+++ b/src/store/plugins/external-layers.plugin.js
@@ -28,26 +28,28 @@ export default function loadExternalLayerAttributes(store) {
                     layer instanceof ExternalGroupOfLayers ||
                     layer instanceof ExternalWMTSLayer)
         )
-        // We get first the capabilities
-        const wmsCapabilities = getWMSCababilitiesForLayers(externalLayers)
-        const wmtsCapabilities = getWMTSCababilitiesForLayers(externalLayers)
-        const updatedLayers = []
-        externalLayers.forEach((layer) => {
-            updatedLayers.push(
-                updateExternalLayer(
-                    store,
-                    layer instanceof ExternalWMTSLayer
-                        ? wmtsCapabilities[layer.baseUrl]
-                        : wmsCapabilities[layer.baseUrl],
-                    layer,
-                    state.position.projection
+        if (externalLayers.length > 0) {
+            // We get first the capabilities
+            const wmsCapabilities = getWMSCababilitiesForLayers(externalLayers)
+            const wmtsCapabilities = getWMTSCababilitiesForLayers(externalLayers)
+            const updatedLayers = []
+            externalLayers.forEach((layer) => {
+                updatedLayers.push(
+                    updateExternalLayer(
+                        store,
+                        layer instanceof ExternalWMTSLayer
+                            ? wmtsCapabilities[layer.baseUrl]
+                            : wmsCapabilities[layer.baseUrl],
+                        layer,
+                        state.position.projection
+                    )
                 )
-            )
-        })
-        store.dispatch('updateLayers', {
-            layers: (await Promise.all(updatedLayers)).filter((layer) => !!layer),
-            ...dispatcher,
-        })
+            })
+            store.dispatch('updateLayers', {
+                layers: (await Promise.all(updatedLayers)).filter((layer) => !!layer),
+                ...dispatcher,
+            })
+        }
     }
     store.subscribe((mutation, state) => {
         if (mutation.type === 'addLayer') {

--- a/src/store/plugins/load-geojson-style-and-data.plugin.js
+++ b/src/store/plugins/load-geojson-style-and-data.plugin.js
@@ -144,17 +144,19 @@ export default function loadGeojsonStyleAndData(store) {
                         // we are currently looping through, filtering it out otherwise (it's a duplicate)
                         self.indexOf(self.find((layer) => layer.id === geoJsonLayer.id)) === index
                 )
-            const requester = 'load-geojson-style-and-data'
-            store.dispatch('setLoadingBarRequester', { requester, ...dispatcher })
-            const updatedLayers = await Promise.all(
-                geoJsonLayers
-                    .filter((layer) => layer.isLoading)
-                    .map((layer) => loadDataAndStyle(layer).clone)
-            )
-            if (updatedLayers.length > 0) {
-                store.dispatch('updateLayers', { layers: updatedLayers, ...dispatcher })
+
+            const geoJsonLayersLoading = geoJsonLayers.filter((layer) => layer.isLoading)
+            if (geoJsonLayersLoading.length > 0) {
+                const requester = 'load-geojson-style-and-data'
+                store.dispatch('setLoadingBarRequester', { requester, ...dispatcher })
+                const updatedLayers = await Promise.all(
+                    geoJsonLayersLoading.map((layer) => loadDataAndStyle(layer).clone)
+                )
+                if (updatedLayers.length > 0) {
+                    store.dispatch('updateLayers', { layers: updatedLayers, ...dispatcher })
+                }
+                store.dispatch('clearLoadingBarRequester', { requester, ...dispatcher })
             }
-            store.dispatch('clearLoadingBarRequester', { requester, ...dispatcher })
 
             // after the initial load is done,
             // going through all layers that have an update delay and launching the routine to reload their data

--- a/src/store/plugins/load-gpx-data.plugin.js
+++ b/src/store/plugins/load-gpx-data.plugin.js
@@ -17,7 +17,7 @@ const dispatcher = { dispatcher: 'load-gpx-data.plugin' }
  * @returns {Promise<void>}
  */
 async function loadGpx(store, gpxLayer) {
-    log.debug(`Loading data/metadata for added GPX layer`, gpxLayer)
+    log.debug(`Loading data for added GPX layer`, gpxLayer)
     try {
         const response = await axios.get(gpxLayer.gpxFileUrl)
         const gpxContent = response.data
@@ -30,7 +30,12 @@ async function loadGpx(store, gpxLayer) {
             ...dispatcher,
         })
     } catch (error) {
-        log.error(`Error while fetching GPX data/metadata for layer ${gpxLayer?.id}`)
+        log.error(`Error while fetching GPX data for layer ${gpxLayer?.id}`)
+        store.dispatch('setLayerErrorKey', {
+            layerId: gpxLayer.id,
+            errorKey: `loading_error_network_failure`,
+            ...dispatcher,
+        })
     }
 }
 
@@ -43,7 +48,7 @@ async function loadGpx(store, gpxLayer) {
 export default function loadGpxDataAndMetadata(store) {
     store.subscribe((mutation) => {
         const addLayerSubscriber = (layer) => {
-            if (layer instanceof GPXLayer && (!layer?.gpxData || !layer?.gpxMetadata)) {
+            if (layer instanceof GPXLayer && !layer?.gpxData) {
                 loadGpx(store, layer)
             }
         }


### PR DESCRIPTION
Some GPX file might not have metadata and it is ok to have it null. Due to this GPX file without metadata could not be loaded correctly. When no metadata was present, even if the file was a local file, the load gpx data plugin was triggered. On a deployment we could see an error on HTTP where the plugin tried to load GPX file on https://sys-map.dev.bgdi.ch/FILE_NAME while on localhost it tried to do on localhost which gave a differant answer.
    
So this triggered some weird bug. Now we allow GPX without metadata and only trigger the GPX load plugin when no data is present regardless of the metadata
    
Also make sure to set the layer error in case of GPX load failure

Also Avoid unnecessary store dispatch in layers plugins

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-gpx-local/index.html)