### PR TITLE
PB-390, PB-391: Change the pdf print file name and fixed print lang parameter

### DIFF
--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -196,6 +196,8 @@ export class PrintError extends Error {
  *   the grid is to be printed (it can otherwise be null). Default is `null`
  * @param {String[]} [config.excludedLayerIDs=[]] List of the IDs of OpenLayers layer to exclude
  *   from the print. Default is `[]`
+ * @param {String | null} [config.outputFilename=null] Output file name, without extension. When
+ *   null, let the server decide. Default is `null`
  */
 async function transformOlMapToPrintParams(olMap, config) {
     const {
@@ -209,6 +211,7 @@ async function transformOlMapToPrintParams(olMap, config) {
         printGrid = false,
         projection = null,
         excludedLayerIDs = [],
+        outputFilename = null,
     } = config
 
     if (!qrCodeUrl) {
@@ -267,6 +270,8 @@ async function transformOlMapToPrintParams(olMap, config) {
             },
             format: 'pdf',
             layout: layout.name,
+            lang,
+            outputFilename,
         }
         if (layersWithLegends.length > 0) {
             spec.attributes.legend = {
@@ -309,6 +314,8 @@ async function transformOlMapToPrintParams(olMap, config) {
  *   the grid is to be printed (it can otherwise be null). Default is `null`
  * @param {String[]} [config.excludedLayerIDs=[]] List of IDs of OpenLayers layer to exclude from
  *   the print. Default is `[]`
+ * @param {String | null} [config.outputFilename=null] Output file name, without extension. When
+ *   null, let the server decide. Default is `null`
  * @returns {Promise<MFPReportResponse>} A job running on our printing backend (needs to be polled
  *   using {@link waitForPrintJobCompletion} to wait until its completion)
  */
@@ -324,6 +331,7 @@ export async function createPrintJob(map, config) {
         printGrid = false,
         projection = null,
         excludedLayerIDs = [],
+        outputFilename = null,
     } = config
     try {
         const printingSpec = await transformOlMapToPrintParams(map, {
@@ -337,6 +345,7 @@ export async function createPrintJob(map, config) {
             printGrid,
             projection,
             excludedLayerIDs,
+            outputFilename,
         })
         log.debug('Starting print for spec', printingSpec)
         return await requestReport(SERVICE_PRINT_URL, printingSpec)

--- a/src/modules/map/components/openlayers/utils/usePrint.composable.js
+++ b/src/modules/map/components/openlayers/utils/usePrint.composable.js
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useStore } from 'vuex'
 
 import { abortPrintJob, createPrintJob, waitForPrintJobCompletion } from '@/api/print.api.js'
@@ -30,6 +30,8 @@ export function usePrint(map) {
 
     const store = useStore()
 
+    const hostname = computed(() => store.state.ui.hostname)
+
     /**
      * @param {Boolean} printGrid Print the coordinate grid on the finished PDF, true or false
      * @param {Boolean} printLegend Print all visible layer legend (if they have one) on the map,
@@ -49,6 +51,11 @@ export function usePrint(map) {
             // using store values directly (instead of going through computed) so that it is a bit more performant
             // (we do not need to have reactivity on these values, if they change while printing we do nothing)
             const printJob = await createPrintJob(map, {
+                // NOTE: below we use the '-' instead of ':' for hours, minutes and seconds separator
+                // because chrome and firefox will anyway replace the ':' characters to either space
+                // or '_'. The ${yyyy-MM-dd'T'HH-mm-ss'Z'} placeholder is used by mapfish print see
+                // https://mapfish.github.io/mapfish-print-doc/configuration.html
+                outputFilename: `${hostname.value}_\${yyyy-MM-dd'T'HH-mm-ss'Z'}`,
                 layout: store.state.print.selectedLayout,
                 scale: store.state.print.selectedScale,
                 attributions: store.getters.visibleLayers


### PR DESCRIPTION
Now we set the pdf file name to HOSTNAME_DATETIME.pdf

Also fixed lang parameter that was not sent to print server. This parameter is
used to translate the disclaimer see also PB-383.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-390-file-name-pdf/index.html)