### PR TITLE
PB-296: Add failOnError to all layers

### DIFF
--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -179,6 +179,23 @@ export class PrintError extends Error {
 }
 
 /**
+ * @typedef {Object} PrintSpecAttributes
+ * @param {MFPMap} map
+ * @param {String} copyright
+ * @param {String} url
+ * @param {String} qrimage URL of the qrcode image to use
+ */
+
+/**
+ * @typedef {Object} PrintSpec
+ * @param {PrintSpecAttributes} attributes
+ * @param {String} format
+ * @param {String} layout
+ * @param {String} lang
+ * @param {String} outputFilename
+ */
+
+/**
  * @param {Map} olMap OL map
  * @param {String[]} [config.attributions=[]] List of all attributions of layers currently visible
  *   on the map. Default is `[]`
@@ -198,6 +215,7 @@ export class PrintError extends Error {
  *   from the print. Default is `[]`
  * @param {String | null} [config.outputFilename=null] Output file name, without extension. When
  *   null, let the server decide. Default is `null`
+ * @returns {PrintSpec} Print spec to pass to the /report print endpoint
  */
 async function transformOlMapToPrintParams(olMap, config) {
     const {
@@ -286,6 +304,11 @@ async function transformOlMapToPrintParams(olMap, config) {
         } else {
             spec.attributes.printLegend = 0
         }
+
+        // Add the failOnError flag to all layers
+        spec.attributes.map.layers.map((layer) => {
+            layer.failOnError = true
+        })
         return spec
     } catch (error) {
         log.error("Couldn't encode map to print request", error)


### PR DESCRIPTION
This is needed to avoid having red square for tiles that failed.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-296-print-flag/index.html)