### PR TITLE
PB-398: Improve print UI user feedback

### DIFF
--- a/src/modules/i18n/locales/de.json
+++ b/src/modules/i18n/locales/de.json
@@ -190,7 +190,6 @@
     "feedback_description": "1. Melden Sie uns in diesem Feld Änderungen in der Karte, Verbesserungen der Daten oder Fragen zu dieser Website (erforderlich) :",
     "feedback_disclaimer": "Mit dem Absenden Ihrer Meldung erklären Sie sich mit den <a href='https://www.geo.admin.ch/de/ueber-geo-admin/impressum.html#feedback' target='_blank'>Nutzungsbedingungen</a> einverstanden.",
     "feedback_drawing": "2. Markieren Sie den betroffenen Ort in der Karte :",
-    "feedback_empty_warning": "Die Berichtsnachricht darf nicht leer sein",
     "feedback_error_message": "Problem: Meldung konnte nicht übermittelt werden",
     "feedback_kml_attached": "Die aktuelle Zeichung wird übermittelt. ",
     "feedback_mail": "3. Ihre E-Mail Adresse :",
@@ -465,7 +464,8 @@
     "swisstopo": "swisstopo",
     "swisstopo_service_link_href": "https://www.swisstopo.admin.ch/de/home.html",
     "swisstopo_service_link_label": "Bundesamt für Landestopografie swisstopo",
-    "test_host_warning": "TESTSEITE – NICHT TEILEN -  NICHT FÜR PRODUKTIVEN GEBRAUCH<br/>Diese Seite dient ausschliesslich Testzwecken und sollte nicht operativ eingesetzt werden. Es gibt seitens Betreiber dieser Seite keine Garantie für fehlerfreien Inhalt und störungsfreien Betrieb.",
+    "test_host_warning": "TESTSEITE – NICHT TEILEN -  NICHT FÜR PRODUKTIVEN GEBRAUCH",
+    "test_host_full_disclaimer": "Diese Seite dient ausschliesslich Testzwecken und sollte nicht operativ eingesetzt werden. Es gibt seitens Betreiber dieser Seite keine Garantie für fehlerfreien Inhalt und störungsfreien Betrieb.",
     "text_to_display": "Link Beschreibung",
     "third_party_data_warning": "Warnung: diese Daten kommen von einem Drittanbieter. Dieser Permalink zeigt möglicherweise auf Daten eines Drittanbieters. Wollen Sie diese Daten dennoch laden?",
     "tile": "Kartenblatt",
@@ -653,5 +653,9 @@
     "kml_gpx_file_empty": "Die KML/GPX-Datei ist leer",
     "large_size": "Gross",
     "extra_large_size": "Extra Gross",
-    "duplicate_layer": "Karte duplizieren"
+    "duplicate_layer": "Karte duplizieren",
+    "feedback_empty_warning": "Die Berichtsnachricht darf nicht leer sein",
+    "operation_successful": "Erfolg!",
+    "operation_failed": "Hoppla! Etwas ist schiefgegangen. Bitte versuchen Sie es erneut.",
+    "operation_aborted": "Operation abgebrochen"
 }

--- a/src/modules/i18n/locales/en.json
+++ b/src/modules/i18n/locales/en.json
@@ -190,7 +190,6 @@
     "feedback_description": "1. Report in this field changes in the map, improvements to the data or questions about this website (required) :",
     "feedback_disclaimer": "By submitting your message, you agree to the <a href='https://www.geo.admin.ch/en/about-swiss-geoportal/responsabilities-and-contacts.html#feedback' target='_blank'>terms of use</a>.",
     "feedback_drawing": "2. Indicate the appropriate location on the map :",
-    "feedback_empty_warning": "Report message can not be empty",
     "feedback_error_message": "Problem: Your message could not be sent",
     "feedback_kml_attached": "The current drawing will be transferred. ",
     "feedback_mail": "3. Your Email :",
@@ -465,7 +464,8 @@
     "swisstopo": "swisstopo",
     "swisstopo_service_link_href": "https://www.swisstopo.admin.ch/en/home.html",
     "swisstopo_service_link_label": "Federal Office of Topography swisstopo",
-    "test_host_warning": "TESTSITE – DO NOT-SHARE -  NOT FOR OPERATIONAL USE<br/>This site is for testing purposes only. It's not for operational use and there's no guarantee by the provider of this site.",
+    "test_host_warning": "TESTSITE – DO NOT-SHARE -  NOT FOR OPERATIONAL USE",
+    "test_host_full_disclaimer": "This site is for testing purposes only. It's not for operational use and there's no guarantee by the provider of this site.",
     "text_to_display": "Link description",
     "third_party_data_warning": "Warning: Third party data and/or style shown. The permalink you use contains possibly reference to third party data. Would your really load these data?",
     "tile": "Sheet",
@@ -653,5 +653,9 @@
     "kml_gpx_file_empty": "KML/GPX file is empty",
     "large_size": "Large",
     "extra_large_size": "Extra Large",
-    "duplicate_layer": "Duplicate map"
+    "duplicate_layer": "Duplicate map",
+    "feedback_empty_warning": "Report message can not be empty",
+    "operation_successful": "Operation successful!",
+    "operation_failed": "Oops! Something went wrong. Please try again.",
+    "operation_aborted": "Operation aborted"
 }

--- a/src/modules/i18n/locales/fr.json
+++ b/src/modules/i18n/locales/fr.json
@@ -190,7 +190,6 @@
     "feedback_description": "1. Faites-nous part de modifications de la carte, d’amélioration des données ou posez des questions sur ce site dans ce champ (obligatoire) :",
     "feedback_disclaimer": "En envoyant votre message, vous acceptez les <a href='https://www.geo.admin.ch/fr/geo-admin-ch/impressum.html#feedback' target='_blank'>conditions d'utilisation</a>.",
     "feedback_drawing": "2. Situez le lieu concerné dans la carte :",
-    "feedback_empty_warning": "Le message de rapport ne peut pas être vide",
     "feedback_error_message": "Problème lors de l'envoi",
     "feedback_kml_attached": "Le dessin actuel va être envoyé. ",
     "feedback_mail": "3. Votre email :",
@@ -465,7 +464,8 @@
     "swisstopo": "swisstopo",
     "swisstopo_service_link_href": "https://www.swisstopo.admin.ch/fr/home.html",
     "swisstopo_service_link_label": "Office fédéral de topographie swisstopo",
-    "test_host_warning": "TESTSITE – DO NOT-SHARE -  NOT FOR OPERATIONAL USE<br/>This site is for testing purposes only. It's not meant for operational use and there's no guarantee whatsoever.",
+    "test_host_warning": "SITE DE TEST - NE PAS PARTAGER - NE PAS UTILISER À DES FINS OPÉRATIONNELLES",
+    "test_host_full_disclaimer": "Ce site est destiné à être testé uniquement. Il n'est pas destiné à une utilisation opérationnelle et il n'y a aucune garantie.",
     "text_to_display": "Description du lien",
     "third_party_data_warning": "Mise en garde données tierces. Le permalien que vous utilisez contient peut-être des références à des données tierces ne provenant pas de map.geo.admin.ch. Voulez-vous également visualiser ces données sachant que map.geo.admin.ch ne prend aucune responsabilité quant à ces données?",
     "tile": "Feuille",
@@ -653,5 +653,9 @@
     "kml_gpx_file_empty": "Le fichier KML/GPX est vide",
     "large_size": "Grande",
     "extra_large_size": "Très Grande",
-    "duplicate_layer": "Duplication de carte"
+    "duplicate_layer": "Duplication de carte",
+    "feedback_empty_warning": "Le message ne peut pas être vide",
+    "operation_successful": "Succès !",
+    "operation_failed": "Oups ! Quelque chose s'est mal passé. Veuillez réessayer.",
+    "operation_aborted": "Opération annulée"
 }

--- a/src/modules/i18n/locales/it.json
+++ b/src/modules/i18n/locales/it.json
@@ -190,7 +190,6 @@
     "feedback_description": "1. Ci comunichi in questo campo cambiamenti nella carta, miglioramenti dei dati o domande su questo sito (obbligatorio) :",
     "feedback_disclaimer": "Inviando un messaggio, l’utente accetta le <a href='https://www.geo.admin.ch/it/geo-admin-ch/colophon.html#feedback' target='_blank'>condizioni d'uso</a>.",
     "feedback_drawing": "2. Indichi il luogo corrispondente nella carta :",
-    "feedback_empty_warning": "Il messaggio di segnalazione non può essere vuoto",
     "feedback_error_message": "Errore! Messaggio non trasmesso",
     "feedback_kml_attached": "Il disegno attuale verrà inviato.",
     "feedback_mail": "3. La sua email :",
@@ -465,7 +464,8 @@
     "swisstopo": "swisstopo",
     "swisstopo_service_link_href": "https://www.swisstopo.admin.ch/it/home.html",
     "swisstopo_service_link_label": "Ufficio federale di topografia swisstopo ",
-    "test_host_warning": "TESTSITE – DO NOT-SHARE -  NOT FOR OPERATIONAL USE<br/>This site is for testing purposes only. It's not meant for operational use and there's no guarantee whatsoever.",
+    "test_host_warning": "SITO DI PROVA - NON CONDIVIDERE - NON PER USO OPERATIVO",
+    "test_host_full_disclaimer": "Questo sito è solo a scopo di test. Non è destinato all'uso operativo e non vi è alcuna garanzia.",
     "text_to_display": "Descrizione del link",
     "third_party_data_warning": "Attenzione: questi dati provengono da terze parti. Il permalink usato fa riferimento probabilmente a dati di terze parti. Volete veramente caricare questi dati?",
     "tile": "Foglio",
@@ -653,5 +653,9 @@
     "kml_gpx_file_empty": "Il file KML/GPX è vuoto",
     "large_size": "Grande",
     "extra_large_size": "Extra Grande",
-    "duplicate_layer": "Mappa duplicata"
+    "duplicate_layer": "Mappa duplicata",
+    "feedback_empty_warning": "Il messaggio di segnalazione non può essere vuoto",
+    "operation_successful": "Successo!",
+    "operation_failed": "Oops! Qualcosa è andato storto. Si prega di riprovare.",
+    "operation_aborted": "Operazione annullata."
 }

--- a/src/modules/i18n/locales/rm.json
+++ b/src/modules/i18n/locales/rm.json
@@ -188,7 +188,6 @@
     "feedback_description": "1. Rapport charta actual (necessari) :",
     "feedback_disclaimer": " <a href='https://www.geo.admin.ch/en/about-swiss-geoportal/responsabilities-and-contacts.html#feedback' target='_blank'>Cundiziuns d'utilisaziun</a>",
     "feedback_drawing": "2. Voss dissegn :",
-    "feedback_empty_warning": "La messadi dal raport po betg esser vegnida lasciada basa",
     "feedback_error_message": "Problem: rapport na tramess cun success",
     "feedback_kml_attached": "Trametter dissegn actual",
     "feedback_mail": "3. Voss e-mail:",
@@ -463,7 +462,8 @@
     "swisstopo": "swisstopo",
     "swisstopo_service_link_href": "https://www.swisstopo.admin.ch/de/home.html",
     "swisstopo_service_link_label": "Uffizi federal da topografia swisstopo",
-    "test_host_warning": "PAGINA DA TEST ? BETG PARTER – BETG PER IL DIEVER PRODUCTIV<br/>Questa pagina è fatga mo per intents da test e na duess betg vegnir duvrada en conturns productivs. I na dat absolutamain nagina garanzia per il diever.",
+    "test_host_warning": "PAGINA DA TEST ? BETG PARTER – BETG PER IL DIEVER PRODUCTIV",
+    "test_host_full_disclaimer": "Questa pagina è fatga mo per intents da test e na duess betg vegnir duvrada en conturns productivs. I na dat absolutamain nagina garanzia per il diever.",
     "text_to_display": "Descripziun link",
     "third_party_data_warning": "Attenziun: questas datas e/u stil derivan d'in terz purschider. Quest permalink va eventualmain sin datas d'in terz purschider. Vulais Vus tuttina chargiar questas datas?",
     "tile": "Fegl da la charta",
@@ -651,5 +651,9 @@
     "kml_gpx_file_empty": "La datoteca KML/GPX è vegnida empruva",
     "large_size": "Grond",
     "extra_large_size": "Extra Grond",
-    "duplicate_layer": "Mapa duplicada"
+    "duplicate_layer": "Mapa duplicada",
+    "feedback_empty_warning": "La messadi dal raport po betg esser vegnida lasciada basa",
+    "operation_successful": "Success! ",
+    "operation_failed": "Oops! Qualche cosa è andada schabetg. Per favur, retentas.",
+    "operation_aborted": "Operaziun avorta"
 }

--- a/src/modules/menu/components/print/MenuPrintSection.vue
+++ b/src/modules/menu/components/print/MenuPrintSection.vue
@@ -49,6 +49,12 @@ const selectedScale = computed({
     },
 })
 
+const printErrorMessage = computed(() =>
+    printStatus.value === PrintStatus.FINISHED_ABORTED
+        ? i18n.t('operation_aborted')
+        : i18n.t('operation_failed')
+)
+
 watch(isSectionShown, () => {
     store.dispatch('setPrintSectionShown', { show: isSectionShown.value, ...dispatcher })
 })
@@ -97,6 +103,13 @@ async function printMap() {
     }
 }
 
+function onOpenMenuSection(id) {
+    if (printStatus.value !== PrintStatus.PRINTING) {
+        printStatus.value = PrintStatus.IDLE
+    }
+    emits('openMenuSection', id)
+}
+
 defineExpose({
     close,
 })
@@ -110,7 +123,7 @@ defineExpose({
         data-cy="menu-print-section"
         secondary
         @click:header="togglePrintMenu"
-        @open-menu-section="(id) => emits('openMenuSection', id)"
+        @open-menu-section="onOpenMenuSection"
     >
         <div class="p-2 d-grid gap-2 menu-print-settings mx-4" data-cy="menu-print-form">
             <label for="print-layout-selector" class="col-form-label fw-bold me-2">{{
@@ -166,6 +179,20 @@ defineExpose({
                 />
                 <label class="form-check-label" for="checkboxGrid">{{ i18n.t('graticule') }}</label>
             </div>
+            <div class="full-width">
+                <input
+                    hidden
+                    :class="{
+                        'is-invalid': [
+                            PrintStatus.FINISHED_FAILED,
+                            PrintStatus.FINISHED_ABORTED,
+                        ].includes(printStatus),
+                        'is-valid': printStatus === PrintStatus.FINISHED_SUCCESSFULLY,
+                    }"
+                />
+                <div class="invalid-feedback">{{ printErrorMessage }}</div>
+                <div class="valid-feedback">{{ i18n.t('operation_successful') }}</div>
+            </div>
             <div class="full-width justify-content-center">
                 <button
                     v-if="printStatus === PrintStatus.PRINTING"
@@ -175,6 +202,7 @@ defineExpose({
                     @click="abortCurrentJob"
                 >
                     {{ i18n.t('abort') }}
+                    <font-awesome-icon spin :icon="['fa', 'spinner']" class="ms-2" />
                 </button>
                 <button
                     v-else
@@ -185,8 +213,6 @@ defineExpose({
                 >
                     {{ i18n.t('print_action') }}
                 </button>
-                <!-- TODO: manage failing print job-->
-                <!-- TODO: give a UI feedback for a print success-->
             </div>
         </div>
     </MenuSection>


### PR DESCRIPTION
Now provide a success, aborted or failure feedback

NOTE currently the failure feedback can be tested using a KML layer with a measure which is currently failing.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-398-print-error-mgmt/index.html)