### PR TITLE
PB-319: Alter year picker css when time slider is active

### DIFF
--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItemTimeSelector.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItemTimeSelector.vue
@@ -129,8 +129,16 @@ function hidePopover() {
                 :key="timeEntry.timestamp"
                 class="btn mb-1 me-1"
                 :class="{
-                    'btn-primary': timeEntry.timestamp === timeConfig.currentTimestamp,
-                    'btn-light': timeEntry.timestamp !== timeConfig.currentTimestamp,
+                    'btn-primary':
+                        previewYear === timeEntry.year ||
+                        (!previewYear && timeConfig.currentTimestamp === timeEntry.timestamp),
+                    'btn-outline-primary':
+                        previewYear &&
+                        timeConfig.currentTimestamp === timeEntry.timestamp &&
+                        timeEntry.year !== previewYear,
+                    'btn-light':
+                        timeEntry.timestamp !== timeConfig.currentTimestamp &&
+                        previewYear !== timeEntry.year,
                 }"
                 :data-cy="`time-select-${timeEntry.timestamp}`"
                 @click="handleClickOnTimestamp(timeEntry.year)"


### PR DESCRIPTION
Issue : we want to see the previewed year in the year picker when the time slider is active, while still giving the information about each layer individual year.

Fix :
 - In PB-318 : we already made the button which open the year picker show the previewed year
 - Now we show the previewed year in $primary in the year picker, and show the outline of the layer's selected year in primary too.

[Test link](https://sys-map.dev.bgdi.ch/preview/pb-319-timeselector-css/index.html)