### PR TITLE
PB-396: Make search result dropdown disappear when going to location

### DIFF
--- a/src/modules/menu/components/search/SearchBar.vue
+++ b/src/modules/menu/components/search/SearchBar.vue
@@ -68,7 +68,6 @@ const clearSearchQuery = () => {
 
 const closeSearchResults = () => {
     showResults.value = false
-    searchInput.value.focus()
 }
 
 const goToFirstResult = () => {

--- a/src/modules/menu/components/search/SearchResultList.vue
+++ b/src/modules/menu/components/search/SearchResultList.vue
@@ -138,7 +138,6 @@ defineExpose({ focusFirstEntry })
                 'border rounded-bottom': !isPhoneMode,
             }"
             data-cy="search-results"
-            @keydown.esc.prevent="emit('close')"
         >
             <div class="search-results-inner">
                 <SearchResultCategory

--- a/src/modules/menu/components/search/SearchResultList.vue
+++ b/src/modules/menu/components/search/SearchResultList.vue
@@ -148,6 +148,7 @@ defineExpose({ focusFirstEntry })
                     :title="i18n.t(`${category.id}_results_header`)"
                     :results="category.results"
                     :data-cy="`search-results-${category.id}`"
+                    @entry-selected="emit('close')"
                     @first-entry-reached="onFirstEntryReached(index)"
                     @last-entry-reached="onLastEntryReached(index)"
                     @set-preview="setPreview"

--- a/tests/cypress/tests-e2e/search/search-results.cy.js
+++ b/tests/cypress/tests-e2e/search/search-results.cy.js
@@ -307,6 +307,9 @@ describe('Test the search bar result handling', () => {
             checkLocation(expectedCenterDefaultProjection, center)
         )
 
+        cy.log('Search bar dropdown should be hidden after centering on the feature')
+        cy.get('@locationSearchResults').should('not.be.visible')
+
         // checking that the zoom level corresponds to the extent of the feature
         // TODO: this somehow fail on the desktop viewport, see https://jira.swisstopo.ch/browse/BGDIINF_SB-2156
         const width = Cypress.config('viewportWidth')
@@ -324,6 +327,7 @@ describe('Test the search bar result handling', () => {
         )
 
         cy.log('It hides the results when the user clicks on the map')
+        cy.get(searchbarSelector).focus()
         cy.get('@locationSearchResults').should('be.visible')
         cy.get('[data-cy="map"]').click(viewportWidth * 0.5, viewportHeight * 0.75)
         cy.get('@locationSearchResults').should('not.be.visible')


### PR DESCRIPTION


[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-396-make-search-result-dropdown-disappear/index.html)