### PR TITLE
Fix codebuid engine npm and node version error

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,10 +131,6 @@
         "write-yaml-file": "^5.0.0",
         "yargs": "^17.7.2"
     },
-    "engines": {
-        "node": ">=18",
-        "npm": "9.*.*"
-    },
     "type": "module",
     "engineStrict": true
 }


### PR DESCRIPTION


[Test link](https://sys-map.dev.bgdi.ch/preview/fix_codebuid_engine_npm_node_version_error/index.html)