### PR TITLE
PB-404 bugfix: removing error on drawing selection

### DIFF
--- a/src/api/features/SelectableFeature.class.js
+++ b/src/api/features/SelectableFeature.class.js
@@ -42,7 +42,9 @@ export default class SelectableFeature extends EventEmitter {
         } = featureData
         this.id = id
         // using the setter for coordinate (see below)
-        this.coordinates = coordinates
+
+        // if coordinates are not defined, we set them to null
+        this.coordinates = coordinates ? coordinates : null
         this.title = title
         this.description = description
         this.geometry = geometry

--- a/src/modules/map/components/openlayers/utils/useMapInteractions.composable.js
+++ b/src/modules/map/components/openlayers/utils/useMapInteractions.composable.js
@@ -128,7 +128,7 @@ export default function useMapInteractions(map) {
                                             title: olFeature.get('name'),
                                             description: olFeature.get('description'),
                                         },
-                                        coordinates: olFeature.getGeometry().coordinates,
+                                        coordinates: olFeature.getGeometry().getCoordinates(),
                                         geometry: new GeoJSON().writeGeometryObject(
                                             olFeature.getGeometry()
                                         ),


### PR DESCRIPTION
Issue : When selecting a drawing feature outside of the drawing mode, an error log would appear in the console explaining there were no coordinates.

Second Issue : when creating a drawing feature, an error log would appear in the console log explaining the same issue

Fix : We use 'getCoordinates()' instead of 'coordinates' in the map interactions composable.
Second Fix : when creating a Feature with no coordinates (undefined), we set them to null in the constructor.
[Test link](https://sys-map.dev.bgdi.ch/preview/pb-404-log-error-on-selecting-drawing-feature/index.html)