### PR TITLE
PB-396: Updated search bar e2e tests

### DIFF
--- a/src/modules/menu/components/search/SearchBar.vue
+++ b/src/modules/menu/components/search/SearchBar.vue
@@ -52,8 +52,12 @@ const updateSearchQuery = (event) => {
     }, 100)
 }
 
-const onSearchInputFocus = () => {
-    if (hasResults.value) {
+const onSearchInputFocus = (event) => {
+    // When the focus event is due to a programatic focus event, the relatedTarget is not null
+    // and in this case we don't want to show the result. For example when selecting a result value
+    // we want to close the result and focus on the input, so that the user can directly change
+    // the search.
+    if (!event.relatedTarget && hasResults.value) {
         showResults.value = true
     }
 }
@@ -68,6 +72,7 @@ const clearSearchQuery = () => {
 
 const closeSearchResults = () => {
     showResults.value = false
+    searchInput.value.focus()
 }
 
 const goToFirstResult = () => {
@@ -100,6 +105,12 @@ const onClickOutside = (event) => {
 const focusSearchInput = () => {
     searchInput.value.focus()
 }
+
+const toggleResults = () => {
+    if (hasResults.value) {
+        showResults.value = !showResults.value
+    }
+}
 </script>
 
 <template>
@@ -130,7 +141,8 @@ const focusSearchInput = () => {
             @input="updateSearchQuery"
             @focus="onSearchInputFocus"
             @keydown.down.prevent="goToFirstResult"
-            @keydown.esc.prevent="closeSearchResults"
+            @keydown.esc.prevent="toggleResults"
+            @keyup.enter.stop.prevent="goToFirstResult"
         />
         <button
             v-show="searchValue"

--- a/src/router/storeSync/abstractParamConfig.class.js
+++ b/src/router/storeSync/abstractParamConfig.class.js
@@ -82,6 +82,8 @@ export default class AbstractParamConfig {
                 (typeof queryValue === 'string' && queryValue === 'true') ||
                 (typeof queryValue === 'boolean' && !!queryValue)
             )
+        } else if (queryValue === null) {
+            return this.defaultValue
         }
         return this.valueType(queryValue)
     }

--- a/src/router/storeSync/storeSync.routerPlugin.js
+++ b/src/router/storeSync/storeSync.routerPlugin.js
@@ -152,7 +152,7 @@ function urlQueryWatcher(store, to) {
                     setValueInStore(
                         paramConfig,
                         store,
-                        paramConfig.valueType === Boolean ? false : null
+                        paramConfig.valueType === Boolean ? false : paramConfig.defaultValue
                     )
                 )
                 delete newQuery[paramConfig.urlParamName]

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -490,9 +490,7 @@ const actions = {
             } else {
                 clone = getters.getLayerConfigById(layer)?.clone()
                 if (!clone) {
-                    throw new Error(
-                        `Failed to setPreviewLayer: layer ${layer.id} not found in config`
-                    )
+                    throw new Error(`Failed to setPreviewLayer: layer ${layer} not found in config`)
                 }
             }
             clone.visible = true

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -23,6 +23,16 @@ export function isValidUrl(urlToCheck) {
 }
 
 /**
+ * Escape all RegExp special character from string
+ *
+ * @param {String} string
+ * @returns {String} New string with all special RegExp character escaped
+ */
+export function escapeRegExp(string) {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
  * Segmentation of text based on a search string
  *
  * @param {String} text Text to segmentize
@@ -38,7 +48,7 @@ export function segmentizeMatch(text, search) {
     if (search instanceof RegExp) {
         regex = new RegExp(`(${search.source})`, search.flags)
     } else {
-        regex = new RegExp(`(${search})`, 'gi')
+        regex = new RegExp(`(${escapeRegExp(search)})`, 'gi')
     }
 
     return text.split(regex).map((segment) => {

--- a/tests/cypress/tests-e2e/search/search-results.cy.js
+++ b/tests/cypress/tests-e2e/search/search-results.cy.js
@@ -88,8 +88,8 @@ describe('Test the search bar result handling', () => {
                     layer: expectedLayerId,
                 },
             },
-            { attrs: { label: 'Test layer #2' } },
-            { attrs: { label: 'Test layer #3' } },
+            { id: 4322, weight: 1, attrs: { layer: 'test-2.wms.layer', label: 'Test layer #2' } },
+            { id: 4323, weight: 1, attrs: { layer: 'test-3.wms.layer', label: 'Test layer #3' } },
         ],
     }
     const layerFeatureResponse = {

--- a/tests/cypress/tests-e2e/search/search-results.cy.js
+++ b/tests/cypress/tests-e2e/search/search-results.cy.js
@@ -211,9 +211,13 @@ describe('Test the search bar result handling', () => {
         cy.get(searchbarSelector).paste('test')
         cy.wait(`@search-locations`)
 
+        cy.log('Toggling the search result with ESC')
         cy.get(searchbarSelector).trigger('keydown', { key: 'Escape' })
         cy.get('[data-cy="search-results"]').should('not.be.visible')
+        cy.get(searchbarSelector).trigger('keydown', { key: 'Escape' })
+        cy.get('[data-cy="search-results"]').should('be.visible')
 
+        cy.log('Navigating with arrow UP/DOWN')
         cy.get(searchbarSelector).trigger('keydown', { key: 'ArrowDown' })
         cy.get('[data-cy="search-results"]').should('be.visible')
 
@@ -301,14 +305,11 @@ describe('Test the search bar result handling', () => {
         })
 
         cy.log('Clicking on the first entry to test handling of zoom/extent/position')
-        cy.get('@locationSearchResults').first().click()
+        cy.get('@locationSearchResults').first().realClick()
         // checking that the view has centered on the feature
         cy.readStoreValue('state.position.center').should((center) =>
             checkLocation(expectedCenterDefaultProjection, center)
         )
-
-        cy.log('Search bar dropdown should be hidden after centering on the feature')
-        cy.get('@locationSearchResults').should('not.be.visible')
 
         // checking that the zoom level corresponds to the extent of the feature
         // TODO: this somehow fail on the desktop viewport, see https://jira.swisstopo.ch/browse/BGDIINF_SB-2156
@@ -326,8 +327,18 @@ describe('Test the search bar result handling', () => {
             checkLocation(expectedCenterDefaultProjection, pinnedLocation)
         )
 
+        cy.log('Search bar dropdown should be hidden after centering on the feature')
+        cy.get('@locationSearchResults').should('not.be.visible')
+
+        cy.log(`Search input should be focused`)
+        cy.focused().should('have.attr', 'data-cy', 'searchbar')
+
+        cy.log(`Pressing enter should re-open the result`)
+        cy.focused().trigger('keyup', { key: 'enter' })
+        cy.get('@locationSearchResults').should('be.visible')
+        cy.focused().should('have.attr', 'data-cy', 'search-result-entry')
+
         cy.log('It hides the results when the user clicks on the map')
-        cy.get(searchbarSelector).focus()
         cy.get('@locationSearchResults').should('be.visible')
         cy.get('[data-cy="map"]').click(viewportWidth * 0.5, viewportHeight * 0.75)
         cy.get('@locationSearchResults').should('not.be.visible')


### PR DESCRIPTION
When clicking on a search bar result make sure to set the focus back on the search bar, so the user can quickly edit the search if needed.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-396-search-focus/index.html)