### PR TITLE
PB-432: Added link detection in layer description and made text selectable

### DIFF
--- a/src/modules/menu/components/LayerDescriptionPopup.vue
+++ b/src/modules/menu/components/LayerDescriptionPopup.vue
@@ -115,6 +115,10 @@ $spacing: 8px;
     line-height: 1.42857143;
     line-break: auto;
     text-align: start;
+
+    // allow user selection
+    user-select: text;
+    -webkit-user-select: text;
 }
 
 .legend-header {

--- a/src/modules/menu/components/LayerDescriptionPopup.vue
+++ b/src/modules/menu/components/LayerDescriptionPopup.vue
@@ -6,6 +6,7 @@ import { useStore } from 'vuex'
 import AbstractLayer from '@/api/layers/AbstractLayer.class'
 import { getLayerDescription } from '@/api/layers/layers.api'
 import ModalWithBackdrop from '@/utils/components/ModalWithBackdrop.vue'
+import { segmentizeMatch } from '@/utils/utils'
 
 const props = defineProps({
     layer: {
@@ -31,6 +32,7 @@ const htmlContent = ref('')
 const currentLang = computed(() => store.state.i18n.lang)
 const title = computed(() => layer.value?.name ?? layerName.value)
 const body = computed(() => layer.value?.abstract ?? '')
+const bodyLinkSegments = computed(() => segmentizeMatch(body.value, /https?:\/\/\S+/))
 
 const attributionName = computed(() => layer.value?.attributions[0].name ?? '')
 const attributionUrl = computed(() => layer.value?.attributions[0].url ?? '')
@@ -68,7 +70,22 @@ onMounted(async () => {
                 <h6 v-if="body" data-cy="layer-description-popup-description-title">
                     {{ i18n.t('description') }}
                 </h6>
-                <div v-if="body" data-cy="layer-description-popup-description-body">{{ body }}</div>
+                <div v-if="body" data-cy="layer-description-popup-description-body">
+                    <template
+                        v-for="(segment, index) in bodyLinkSegments"
+                        :key="`${segment.text}-${index}`"
+                    >
+                        <a
+                            v-if="segment.match"
+                            class="link-primary link-offset-2 link-underline-opacity-0 link-underline-opacity-75-hover"
+                            :href="segment.text"
+                            target="_blank"
+                            :data-cy="`layer-description-popup-description-body-link-${segment.text}-${index}`"
+                            >{{ segment.text }}</a
+                        >
+                        <span v-else>{{ segment.text }}</span>
+                    </template>
+                </div>
                 <div v-if="legends.length" class="mt-4">
                     <h6 data-cy="layer-description-popup-legends-title">{{ i18n.t('legend') }}</h6>
                     <div

--- a/tests/cypress/fixtures/import-tool/wms-geo-admin-get-capabilities.xml
+++ b/tests/cypress/fixtures/import-tool/wms-geo-admin-get-capabilities.xml
@@ -350,7 +350,7 @@
                 <Layer queryable="1" opaque="0" cascaded="1">
                     <Name>ch.swisstopo-vd.official-survey-3</Name>
                     <Title>OpenData-AV 3</Title>
-                    <Abstract>OpenData-AV 3 abstract</Abstract>
+                    <Abstract>OpenData-AV 3 abstract https://www.example.com</Abstract>
                     <Style>
                         <Name>default</Name>
                         <Title>default</Title>

--- a/tests/cypress/tests-e2e/importToolMaps.cy.js
+++ b/tests/cypress/tests-e2e/importToolMaps.cy.js
@@ -185,7 +185,13 @@ describe('The Import Maps Tool', () => {
         cy.get(`[data-cy="layer-description-popup-description-title"]`).should('be.visible')
         cy.get(`[data-cy="layer-description-popup-description-body"]`)
             .should('be.visible')
-            .contains('OpenData-AV 3 abstract')
+            .contains('OpenData-AV 3 abstract https://www.example.com')
+        cy.get(
+            '[data-cy="layer-description-popup-description-body-link-https://www.example.com-1"]'
+        )
+            .should('be.visible')
+            .should('have.attr', 'href', 'https://www.example.com')
+            .should('have.attr', 'target', '_blank')
         cy.get(`[data-cy="layer-description-popup-legends-title"]`).should('be.visible')
         cy.get(`[data-cy^="layer-description-popup-legends-body-"]`).should('be.visible')
         cy.get('[data-cy="modal-close-button"]').click()


### PR DESCRIPTION
Now any link is detected and made an hyperlink in the layer description. Useful
for external layers.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-432-layer-legend/index.html)