### PR TITLE
PB-418: bugfix opacity in WMS layers

### DIFF
--- a/src/modules/map/components/openlayers/OpenLayersExternalWMTSLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersExternalWMTSLayer.vue
@@ -32,7 +32,7 @@ const projection = computed(() => store.state.position.projection)
 
 // extracting useful info from what we've linked so far
 const layerId = computed(() => externalWmtsLayerConfig.value.id)
-const opacity = computed(() => parentLayerOpacity.value || externalWmtsLayerConfig.value.opacity)
+const opacity = computed(() => parentLayerOpacity.value ?? externalWmtsLayerConfig.value.opacity)
 const options = computed(() => externalWmtsLayerConfig.value.options)
 
 const layer = new TileLayer({

--- a/src/modules/map/components/openlayers/OpenLayersGPXLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersGPXLayer.vue
@@ -34,7 +34,7 @@ const projection = computed(() => store.state.position.projection)
 
 // extracting useful info from what we've linked so far
 const layerId = computed(() => gpxLayerConfig.value.id)
-const opacity = computed(() => parentLayerOpacity.value || gpxLayerConfig.value.opacity)
+const opacity = computed(() => parentLayerOpacity.value ?? gpxLayerConfig.value.opacity)
 const url = computed(() => gpxLayerConfig.value.baseUrl)
 const gpxData = computed(() => gpxLayerConfig.value.gpxData)
 

--- a/src/modules/map/components/openlayers/OpenLayersGeoJSONLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersGeoJSONLayer.vue
@@ -35,7 +35,7 @@ const projection = computed(() => store.state.position.projection)
 
 // extracting useful info from what we've linked so far
 const layerId = computed(() => geoJsonConfig.value.technicalName)
-const opacity = computed(() => parentLayerOpacity.value || geoJsonConfig.value.opacity)
+const opacity = computed(() => parentLayerOpacity.value ?? geoJsonConfig.value.opacity)
 const geoJsonData = computed(() => geoJsonConfig.value.geoJsonData)
 const geoJsonStyle = computed(() => geoJsonConfig.value.geoJsonStyle)
 const isLoading = computed(() => geoJsonConfig.value.isLoading)

--- a/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
@@ -39,7 +39,7 @@ const iconsArePresent = computed(() => availableIconSets.value.length > 0)
 
 // extracting useful info from what we've linked so far
 const layerId = computed(() => kmlLayerConfig.value.id)
-const opacity = computed(() => parentLayerOpacity.value || kmlLayerConfig.value.opacity)
+const opacity = computed(() => parentLayerOpacity.value ?? kmlLayerConfig.value.opacity)
 const url = computed(() => kmlLayerConfig.value.baseUrl)
 const kmlData = computed(() => kmlLayerConfig.value.kmlData)
 

--- a/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
@@ -36,7 +36,7 @@ const { vectorLayerConfig, parentLayerOpacity, zIndex } = toRefs(props)
 
 // extracting useful info from what we've linked so far
 const layerId = computed(() => vectorLayerConfig.value.id)
-const opacity = computed(() => parentLayerOpacity.value, vectorLayerConfig.value.opacity)
+const opacity = computed(() => parentLayerOpacity.value ?? vectorLayerConfig.value.opacity)
 const styleUrl = computed(
     () => `${vectorLayerConfig.value.baseUrl}styles/${layerId.value}/style.json`
 )

--- a/src/modules/map/components/openlayers/OpenLayersWMSLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersWMSLayer.vue
@@ -42,7 +42,7 @@ const layerId = computed(() => wmsLayerConfig.value.technicalName || wmsLayerCon
 const wmsVersion = computed(() => wmsLayerConfig.value.wmsVersion || '1.3.0')
 const format = computed(() => wmsLayerConfig.value.format || 'png')
 const gutter = computed(() => wmsLayerConfig.value.gutter || -1)
-const opacity = computed(() => parentLayerOpacity.value || wmsLayerConfig.value.opacity)
+const opacity = computed(() => parentLayerOpacity.value ?? wmsLayerConfig.value.opacity)
 const url = computed(() => wmsLayerConfig.value.baseUrl)
 const isTimeSliderActive = computed(() => store.state.ui.isTimeSliderActive)
 const timestamp = computed(() =>

--- a/tests/cypress/tests-e2e/layers.cy.js
+++ b/tests/cypress/tests-e2e/layers.cy.js
@@ -282,6 +282,36 @@ describe('Test of layer handling', () => {
                         WEBMERCATOR.epsg,
                     ])
                 })
+                cy.openMenuIfMobile()
+                // we play with the transparency to ensure nothing goes wrong
+                cy.log('We ensure transparency works as expected for external layers too')
+                cy.openLayerSettings(fakeWmsLayerId1)
+
+                cy.get(`[data-cy^="slider-opacity-layer-${fakeWmsLayerId1}-"]`)
+                    .should('be.visible')
+                    .realClick({ position: 'left' })
+                cy.openLayerSettings(fakeWmsLayerId4)
+
+                cy.get(`[data-cy^="slider-opacity-layer-${fakeWmsLayerId4}-"]`)
+                    .should('be.visible')
+                    .realClick({ position: 'right' })
+
+                // we had some issues with wms transparency reverting back to default when reaching 0
+                // we test layer 1 and 3 for transparency 0, since that's both our wms fixtures tested
+                // this way
+                cy.openLayerSettings(fakeWmsLayerId3)
+
+                cy.get(`[data-cy^="slider-opacity-layer-${fakeWmsLayerId3}-"]`)
+                    .should('be.visible')
+                    .realClick({ position: 'left' })
+
+                cy.checkOlLayer([
+                    bgLayer,
+                    { id: fakeWmsLayerId1, visible: true, opacity: 0.0 },
+                    { id: fakeWmsLayerId2, visible: false, opacity: 0.8 },
+                    { id: fakeWmsLayerId3, visible: true, opacity: 0.0 },
+                    { id: fakeWmsLayerId4, visible: false, opacity: 1.0 },
+                ])
             })
             it('reads and adds an external WMTS correctly', () => {
                 const layers = [

--- a/tests/cypress/tests-e2e/layers.cy.js
+++ b/tests/cypress/tests-e2e/layers.cy.js
@@ -754,6 +754,20 @@ describe('Test of layer handling', () => {
                     const layer = visibleLayers.find((layer) => layer.id === layerId)
                     expect(layer.opacity).to.eq(initialOpacity - step * repetitions)
                 })
+
+                cy.log(
+                    'Check that, for both WMS and WMTS, sliding all the way left gets us an opacity of 0'
+                )
+                visibleLayerIds.forEach((layerId, index) => {
+                    cy.openLayerSettings(layerId)
+                    cy.get(`[data-cy="slider-opacity-layer-${layerId}-${index}"]`)
+                        .should('be.visible')
+                        .realClick({ position: 'left' })
+                    cy.readStoreValue('getters.visibleLayers').should((visibleLayers) => {
+                        const layer = visibleLayers.find((layer) => layer.id === layerId)
+                        expect(layer.opacity).to.eq(0.0)
+                    })
+                })
             })
             it('reorders visible layers when corresponding buttons are pressed', () => {
                 const [firstLayerId, secondLayerId] = visibleLayerIds


### PR DESCRIPTION
Issue : when modyfing the opacity of an external WMS layer and setting it to 0, it would instead revert to its default config value (1 in most cases)

Cause : Opacity of a layer could be set by its parent (parentLayerOpacity). When this was set to 0, the computed check `parentLayerOpacity.value || wmsLayerConfig.value.opacity` would consider the 0 to be a 'false' and use the config value instead.

Fix : We switch the || operator to the ?? operator, which will only use the config value if the parentLayerOpacity is null. We did this change in all layers type to be on the safe side.

[Test link](https://sys-map.dev.bgdi.ch/preview/pb-418-bugfix-transparency-external-layers/index.html)