### PR TITLE
PB-389: Fix print attributions and duplicate legends

### DIFF
--- a/src/modules/map/components/openlayers/utils/usePrint.composable.js
+++ b/src/modules/map/components/openlayers/utils/usePrint.composable.js
@@ -70,7 +70,13 @@ export function usePrint(map) {
                 qrCodeUrl,
                 shortLink,
                 layersWithLegends: printLegend
-                    ? store.getters.visibleLayers.filter((layer) => layer.hasLegend)
+                    ? store.getters.visibleLayers
+                          .filter((layer) => layer.hasLegend)
+                          // remove duplicate layers for the legends to avoid duplicate legends
+                          .filter(
+                              (layer, index, self) =>
+                                  self.findIndex((l) => l.id === layer.id) === index
+                          )
                     : [],
                 lang: store.state.i18n.lang,
                 printGrid: printGrid,

--- a/src/modules/map/components/openlayers/utils/usePrint.composable.js
+++ b/src/modules/map/components/openlayers/utils/usePrint.composable.js
@@ -61,7 +61,10 @@ export function usePrint(map) {
                 layout: store.state.print.selectedLayout,
                 scale: store.state.print.selectedScale,
                 attributions: store.getters.visibleLayers
+                    .concat([store.state.layers.currentBackgroundLayer])
+                    .filter((layer) => !!layer)
                     .map((layer) => layer.attributions)
+                    .flat()
                     .map((attribution) => attribution.name)
                     .filter((attribution, index, self) => self.indexOf(attribution) === index),
                 qrCodeUrl,


### PR DESCRIPTION
The attribution (copyright) on the pdf was empty.
    
Also add the background layer attribution if any background.

Fix duplicate print legends. We could duplicate some layers with different opacity, but when printing we need to make sure to have their legend only once.

Added attribution, language and filename tests. Also tested duplicate layer
in print.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-389-print-attributions/index.html)