### PR TITLE
PB-438: Fix transparency of external WMS layers in print

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@fortawesome/free-solid-svg-icons": "^6.5.2",
                 "@fortawesome/vue-fontawesome": "^3.0.6",
                 "@geoblocks/cesium-compass": "^0.5.0",
-                "@geoblocks/mapfishprint": "^0.2.11",
+                "@geoblocks/mapfishprint": "^0.2.12",
                 "@geoblocks/ol-maplibre-layer": "^0.1.3",
                 "@ivanv/vue-collapse-transition": "^1.0.2",
                 "@mapbox/togeojson": "^0.16.2",
@@ -806,9 +806,9 @@
             }
         },
         "node_modules/@geoblocks/mapfishprint": {
-            "version": "0.2.11",
-            "resolved": "https://registry.npmjs.org/@geoblocks/mapfishprint/-/mapfishprint-0.2.11.tgz",
-            "integrity": "sha512-wcmoUHJ/O5iUYWHI6Rf665OaRpzE1j2pSxxveXmolhh6/2OiiLYZC8TSztIma/RW/u47fcvaq6cBR+2QZea55Q==",
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/@geoblocks/mapfishprint/-/mapfishprint-0.2.12.tgz",
+            "integrity": "sha512-kg1iPhnvEp2flo3bsTpfiS9wMcMhWzdpeZewxgOnclg2pi+gnzcLpiIOQApOSGeiLo372Zv7qczxsziyBqZPxg==",
             "optionalDependencies": {
                 "@geoblocks/print": "0.7.8"
             },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@fortawesome/vue-fontawesome": "^3.0.6",
         "@geoblocks/cesium-compass": "^0.5.0",
-        "@geoblocks/mapfishprint": "^0.2.11",
+        "@geoblocks/mapfishprint": "^0.2.12",
         "@geoblocks/ol-maplibre-layer": "^0.1.3",
         "@ivanv/vue-collapse-transition": "^1.0.2",
         "@mapbox/togeojson": "^0.16.2",


### PR DESCRIPTION
WMS layer based on the WMS specification, prints background in white unless
the query parameter TRANSPARENT is set to true.

Geoadmin layers have a bug and their default behavior is transparent=true instead
of false, see https://jira.swisstopo.ch/browse/PB-439

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-438-print-transparent/index.html)