### PR TITLE
PB-360: Update gpx line style and adjust line stroke width for printing.

### DIFF
--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -10,7 +10,7 @@ import axios from 'axios'
 import { API_BASE_URL, API_SERVICES_BASE_URL, WMS_BASE_URL } from '@/config'
 import i18n from '@/modules/i18n'
 import log from '@/utils/logging'
-import { adjustDistance } from '@/utils/styleUtils'
+import { adjustWidth } from '@/utils/styleUtils'
 
 const PRINTING_DEFAULT_POLL_INTERVAL = 2000 // interval between each polling of the printing job status (ms)
 const PRINTING_DEFAULT_POLL_TIMEOUT = 600000 // ms (10 minutes)
@@ -70,7 +70,7 @@ class GeoAdminCustomizer extends BaseCustomizer {
             symbolizer.strokeDashstyle = 'dash'
         }
         if (symbolizer.strokeWidth) {
-            symbolizer.strokeWidth = adjustDistance(symbolizer.strokeWidth, this.printResolution)
+            symbolizer.strokeWidth = adjustWidth(symbolizer.strokeWidth, this.printResolution)
         }
     }
 }

--- a/src/modules/map/components/openlayers/utils/usePrint.composable.js
+++ b/src/modules/map/components/openlayers/utils/usePrint.composable.js
@@ -82,6 +82,7 @@ export function usePrint(map) {
                 printGrid: printGrid,
                 projection: store.state.position.projection,
                 excludedLayerIDs: [PRINT_AREA_LAYER_ID],
+                dpi: store.getters.selectedDPI,
             })
             currentJobReference.value = printJob.ref
             const result = await waitForPrintJobCompletion(printJob)

--- a/src/store/modules/print.store.js
+++ b/src/store/modules/print.store.js
@@ -19,6 +19,12 @@ export default {
                 height: mapAttributes?.clientParams?.height?.default,
             }
         },
+        selectedDPI(state) {
+            const mapAttributes = state.selectedLayout.attributes.find(
+                (attribute) => attribute.name === 'map'
+            )
+            return mapAttributes?.clientInfo?.maxDPI
+        },
     },
     actions: {
         async loadPrintLayouts({ commit }, { dispatcher }) {

--- a/src/utils/styleUtils.js
+++ b/src/utils/styleUtils.js
@@ -136,13 +136,10 @@ export const highlightPointStyle = new Style({
     }),
 })
 
-// Change a distance according to the change of DPI
+// Change a distance according to the change of DPI (from the old geoadmin)
 export function adjustDistance(dist, dpi) {
     if (!dist) {
         return
     }
-    // Taken from the old geoadmin where the distance is calculated based on the DPI used.
-    // In the old geoadmin we use (dist * 90) / dpi. With dpi either 150 (A3) or 254 (A4).
-    // I use 34 as a constant to have a similar result (i.e. 90/254 * 96 = 34)
-    return (dist * 34) / dpi
+    return (dist * 90) / dpi
 }

--- a/src/utils/styleUtils.js
+++ b/src/utils/styleUtils.js
@@ -41,6 +41,8 @@ export const dashedRedStroke = new Stroke({
     lineDash: [8],
 })
 
+export const gpxStrokeStyle = new Stroke({ width: 1.5, color: hexToRgba(red, 1) })
+
 export const pointStyle = {
     radius: 7,
     stroke: new Stroke({
@@ -59,6 +61,7 @@ export const redCircleStyle = new Circle({
     fill: new Fill({
         color: hexToRgba(red),
     }),
+    stroke: gpxStrokeStyle,
 })
 /** Style for grabbing points when editing a feature */
 export const sketchPointStyle = new Circle({
@@ -68,8 +71,8 @@ export const sketchPointStyle = new Circle({
 
 export const gpxStyles = {
     Point: new Style({ image: redCircleStyle }),
-    LineString: new Style({ stroke: redStroke, fill: redFill }),
-    MultiLineString: new Style({ stroke: redStroke, fill: redFill }),
+    LineString: new Style({ stroke: gpxStrokeStyle, fill: redFill }),
+    MultiLineString: new Style({ stroke: gpxStrokeStyle, fill: redFill }),
 }
 
 export const geolocationPointStyle = new Style({
@@ -132,3 +135,14 @@ export const highlightPointStyle = new Style({
         stroke: highlightedStroke,
     }),
 })
+
+// Change a distance according to the change of DPI
+export function adjustDistance(dist, dpi) {
+    if (!dist) {
+        return
+    }
+    // Taken from the old geoadmin where the distance is calculated based on the DPI used.
+    // In the old geoadmin we use (dist * 90) / dpi. With dpi either 150 (A3) or 254 (A4).
+    // I use 34 as a constant to have a similar result (i.e. 90/254 * 96 = 34)
+    return (dist * 34) / dpi
+}

--- a/src/utils/styleUtils.js
+++ b/src/utils/styleUtils.js
@@ -136,10 +136,13 @@ export const highlightPointStyle = new Style({
     }),
 })
 
-// Change a distance according to the change of DPI (from the old geoadmin)
-export function adjustDistance(dist, dpi) {
-    if (!dist) {
+// Change a width according to the change of DPI (from the old geoadmin)
+// Originally introduced here https://github.com/geoadmin/mf-geoadmin3/pull/3280
+export function adjustWidth(width, dpi) {
+    if (!width) {
         return
     }
-    return (dist * 90) / dpi
+    // 90 is choosen to compensate the difference DPI between the WMTS or WMS and the print DPI used.
+    // The number is from the old geoadmin (see the link above)
+    return (width * 90) / dpi
 }

--- a/tests/cypress/fixtures/print/capabilities.json
+++ b/tests/cypress/fixtures/print/capabilities.json
@@ -1,21 +1,17 @@
 {
-    "app": "default",
+    "app": "mapviewer",
     "layouts": [
         {
             "name": "1. A4 landscape",
             "attributes": [
-                {
-                    "name": "name",
-                    "type": "String",
-                    "default": "this is a name"
-                },
                 {
                     "name": "url",
                     "type": "String"
                 },
                 {
                     "name": "copyright",
-                    "type": "String"
+                    "type": "String",
+                    "default": "© swisstopo"
                 },
                 {
                     "name": "qrimage",
@@ -170,32 +166,12 @@
                         }
                     },
                     "clientInfo": {
-                        "dpiSuggestions": [
-                            72,
-                            91,
-                            128,
-                            254,
-                            300,
-                            400
-                        ],
+                        "dpiSuggestions": [254],
                         "scales": [
-                            2500000,
-                            1500000,
-                            1000000,
-                            500000,
-                            300000,
-                            200000,
-                            100000,
-                            50000,
-                            25000,
-                            20000,
-                            10000,
-                            5000,
-                            2500,
-                            1000,
-                            500
+                            2500000, 1500000, 1000000, 500000, 300000, 200000, 100000, 50000, 25000,
+                            20000, 10000, 5000, 2500, 1000, 500
                         ],
-                        "maxDPI": 400,
+                        "maxDPI": 254,
                         "width": 802,
                         "height": 514
                     }
@@ -310,17 +286,13 @@
             "name": "2. A4 portrait",
             "attributes": [
                 {
-                    "name": "name",
-                    "type": "String",
-                    "default": "this is a name"
-                },
-                {
                     "name": "url",
                     "type": "String"
                 },
                 {
                     "name": "copyright",
-                    "type": "String"
+                    "type": "String",
+                    "default": "© swisstopo"
                 },
                 {
                     "name": "qrimage",
@@ -475,32 +447,12 @@
                         }
                     },
                     "clientInfo": {
-                        "dpiSuggestions": [
-                            72,
-                            91,
-                            128,
-                            254,
-                            300,
-                            400
-                        ],
+                        "dpiSuggestions": [254],
                         "scales": [
-                            2500000,
-                            1500000,
-                            1000000,
-                            500000,
-                            300000,
-                            200000,
-                            100000,
-                            50000,
-                            25000,
-                            20000,
-                            10000,
-                            5000,
-                            2500,
-                            1000,
-                            500
+                            2500000, 1500000, 1000000, 500000, 300000, 200000, 100000, 50000, 25000,
+                            20000, 10000, 5000, 2500, 1000, 500
                         ],
-                        "maxDPI": 400,
+                        "maxDPI": 254,
                         "width": 555,
                         "height": 752
                     }
@@ -615,17 +567,13 @@
             "name": "3. A3 landscape",
             "attributes": [
                 {
-                    "name": "name",
-                    "type": "String",
-                    "default": "this is a name"
-                },
-                {
                     "name": "url",
                     "type": "String"
                 },
                 {
                     "name": "copyright",
-                    "type": "String"
+                    "type": "String",
+                    "default": "© swisstopo"
                 },
                 {
                     "name": "qrimage",
@@ -780,32 +728,12 @@
                         }
                     },
                     "clientInfo": {
-                        "dpiSuggestions": [
-                            72,
-                            91,
-                            128,
-                            254,
-                            300,
-                            400
-                        ],
+                        "dpiSuggestions": [150],
                         "scales": [
-                            2500000,
-                            1500000,
-                            1000000,
-                            500000,
-                            300000,
-                            200000,
-                            100000,
-                            50000,
-                            25000,
-                            20000,
-                            10000,
-                            5000,
-                            2500,
-                            1000,
-                            500
+                            2500000, 1500000, 1000000, 500000, 300000, 200000, 100000, 50000, 25000,
+                            20000, 10000, 5000, 2500, 1000, 500
                         ],
-                        "maxDPI": 400,
+                        "maxDPI": 150,
                         "width": 1151,
                         "height": 751
                     }
@@ -920,17 +848,13 @@
             "name": "4. A3 portrait",
             "attributes": [
                 {
-                    "name": "name",
-                    "type": "String",
-                    "default": "this is a name"
-                },
-                {
                     "name": "url",
                     "type": "String"
                 },
                 {
                     "name": "copyright",
-                    "type": "String"
+                    "type": "String",
+                    "default": "© swisstopo"
                 },
                 {
                     "name": "qrimage",
@@ -1085,32 +1009,12 @@
                         }
                     },
                     "clientInfo": {
-                        "dpiSuggestions": [
-                            72,
-                            91,
-                            128,
-                            254,
-                            300,
-                            400
-                        ],
+                        "dpiSuggestions": [150],
                         "scales": [
-                            2500000,
-                            1500000,
-                            1000000,
-                            500000,
-                            300000,
-                            200000,
-                            100000,
-                            50000,
-                            25000,
-                            20000,
-                            10000,
-                            5000,
-                            2500,
-                            1000,
-                            500
+                            2500000, 1500000, 1000000, 500000, 300000, 200000, 100000, 50000, 25000,
+                            20000, 10000, 5000, 2500, 1000, 500
                         ],
-                        "maxDPI": 400,
+                        "maxDPI": 150,
                         "width": 802,
                         "height": 1100
                     }
@@ -1225,17 +1129,13 @@
             "name": "5. A6 landscape",
             "attributes": [
                 {
-                    "name": "name",
-                    "type": "String",
-                    "default": "this is a name"
-                },
-                {
                     "name": "url",
                     "type": "String"
                 },
                 {
                     "name": "copyright",
-                    "type": "String"
+                    "type": "String",
+                    "default": "© swisstopo"
                 },
                 {
                     "name": "qrimage",
@@ -1390,32 +1290,12 @@
                         }
                     },
                     "clientInfo": {
-                        "dpiSuggestions": [
-                            72,
-                            91,
-                            128,
-                            254,
-                            300,
-                            400
-                        ],
+                        "dpiSuggestions": [254],
                         "scales": [
-                            2500000,
-                            1500000,
-                            1000000,
-                            500000,
-                            300000,
-                            200000,
-                            100000,
-                            50000,
-                            25000,
-                            20000,
-                            10000,
-                            5000,
-                            2500,
-                            1000,
-                            500
+                            2500000, 1500000, 1000000, 500000, 300000, 200000, 100000, 50000, 25000,
+                            20000, 10000, 5000, 2500, 1000, 500
                         ],
-                        "maxDPI": 400,
+                        "maxDPI": 254,
                         "width": 380,
                         "height": 240
                     }
@@ -1530,15 +1410,5 @@
     "smtp": {
         "enabled": false
     },
-    "formats": [
-        "bmp",
-        "gif",
-        "jpeg",
-        "jpg",
-        "pdf",
-        "png",
-        "svg",
-        "tif",
-        "tiff"
-    ]
+    "formats": ["bmp", "gif", "jpeg", "jpg", "pdf", "png", "svg", "tif", "tiff"]
 }

--- a/tests/cypress/tests-e2e/print.cy.js
+++ b/tests/cypress/tests-e2e/print.cy.js
@@ -116,7 +116,7 @@ describe('Testing print', () => {
 
                 const mapAttributes = attributes.map
                 expect(mapAttributes['scale']).to.equals(1500000)
-                expect(mapAttributes['dpi']).to.equals(96)
+                expect(mapAttributes['dpi']).to.equals(254)
                 expect(mapAttributes['projection']).to.equals('EPSG:2056')
 
                 const layers = mapAttributes.layers
@@ -159,7 +159,7 @@ describe('Testing print', () => {
 
                 const mapAttributes = attributes.map
                 expect(mapAttributes['scale']).to.equals(500000)
-                expect(mapAttributes['dpi']).to.equals(96)
+                expect(mapAttributes['dpi']).to.equals(254)
                 expect(mapAttributes['projection']).to.equals('EPSG:3857')
 
                 const layers = mapAttributes.layers
@@ -241,7 +241,7 @@ describe('Testing print', () => {
 
                 const mapAttributes = attributes.map
                 expect(mapAttributes['scale']).to.equals(1500000)
-                expect(mapAttributes['dpi']).to.equals(96)
+                expect(mapAttributes['dpi']).to.equals(254)
                 expect(mapAttributes['projection']).to.equals('EPSG:2056')
 
                 const layers = mapAttributes.layers
@@ -328,7 +328,7 @@ describe('Testing print', () => {
 
                 const mapAttributes = attributes.map
                 expect(mapAttributes['scale']).to.equals(10000)
-                expect(mapAttributes['dpi']).to.equals(96)
+                expect(mapAttributes['dpi']).to.equals(254)
                 expect(mapAttributes['projection']).to.equals('EPSG:2056')
 
                 const layers = mapAttributes.layers
@@ -345,7 +345,7 @@ describe('Testing print', () => {
                 expect(layers[0]['style']).to.haveOwnProperty("[_mfp_style = '1']")
             })
         })
-        it('should send a print request correctly to mapfishprint with GPX layer', () => {
+        it.only('should send a print request correctly to mapfishprint with GPX layer', () => {
             interceptPrintRequest()
             interceptPrintStatus()
             interceptDownloadReport()
@@ -410,7 +410,7 @@ describe('Testing print', () => {
 
                 const mapAttributes = attributes.map
                 expect(mapAttributes['scale']).to.equals(10000)
-                expect(mapAttributes['dpi']).to.equals(96)
+                expect(mapAttributes['dpi']).to.equals(254)
                 expect(mapAttributes['projection']).to.equals('EPSG:2056')
 
                 const layers = mapAttributes.layers
@@ -431,6 +431,12 @@ describe('Testing print', () => {
                 expect(gpxLayer['geoJson']['features'][1]['properties']['_mfp_style']).to.equal('1')
                 expect(gpxLayer['style']).to.haveOwnProperty("[_mfp_style = '1']")
                 expect(gpxLayer['style']).to.haveOwnProperty("[_mfp_style = '2']")
+                expect(gpxLayer['style']["[_mfp_style = '2']"]['symbolizers'][0]['type']).to.equals(
+                    'line'
+                )
+                expect(
+                    gpxLayer['style']["[_mfp_style = '2']"]['symbolizers'][0]['strokeWidth']
+                ).to.lessThan(1.5) // thinner than the drawn in the OL map.
             })
         })
     })

--- a/tests/cypress/tests-e2e/print.cy.js
+++ b/tests/cypress/tests-e2e/print.cy.js
@@ -345,7 +345,7 @@ describe('Testing print', () => {
                 expect(layers[0]['style']).to.haveOwnProperty("[_mfp_style = '1']")
             })
         })
-        it.only('should send a print request correctly to mapfishprint with GPX layer', () => {
+        it('should send a print request correctly to mapfishprint with GPX layer', () => {
             interceptPrintRequest()
             interceptPrintStatus()
             interceptDownloadReport()


### PR DESCRIPTION

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-360-gpx-print-style/index.html)

### OL comparison:
**Old Geoadmin:**
![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/d4c3223b-b343-4aef-b0a8-7df64a8cd902)
**New Geoadmin:**
![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/9021374b-2263-4eaf-bbfb-47f23c78de3e)

### Print comparison
**Old Geoadmin:**
![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/718c32b4-2533-4bf6-ad7b-29f77ac2ce47)
**New Geoadmin:**
![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/b910afad-438a-4c35-a6bb-e202a24af87f)


[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-360-gpx-print-style/index.html)