### PR TITLE
PB-440: Allow prefixed KML

### DIFF
--- a/src/modules/menu/components/advancedTools/ImportFile/__tests__/utils.spec.js
+++ b/src/modules/menu/components/advancedTools/ImportFile/__tests__/utils.spec.js
@@ -1,0 +1,49 @@
+import { expect } from 'chai'
+import { describe, it } from 'vitest'
+
+import { isKml } from '@/modules/menu/components/advancedTools/ImportFile/utils'
+
+describe('Test ImportFile utils', () => {
+    it('Detect KML file syntax', () => {
+        expect(isKml('<kml>test</kml>')).to.be.true
+        expect(isKml('<kml:kml>test</kml:kml>')).to.be.true
+        expect(isKml(' <?xml version="1.0" encoding="UTF-8"?><kml:kml>test</kml:kml>')).to.be.true
+        expect(
+            isKml(`<?xml version="1.0" encoding="UTF-8"?>
+        <kml:kml>
+            test
+        </kml:kml>
+        `)
+        ).to.be.true
+        expect(
+            isKml(`
+<kml>
+    <Placemark>
+        <name>test</name>
+        <description>KML With Prefixed Namespace</description>
+        <Point>
+            <coordinates>7.438632503,46.951082887,598.947</coordinates>
+        </Point>
+    </Placemark>
+</kml>`)
+        ).to.be.true
+    })
+    it("Don't detect invalid KML file syntax", () => {
+        expect(isKml('<kmlz>test</kmlz>')).to.be.false
+        expect(isKml('<akml>test</akml>')).to.be.false
+        expect(isKml('<?xml version="1.0" encoding="UTF-8"?><div>test</div>')).to.be.false
+        expect(
+            isKml(`<div><![CDATA[
+<kml>
+    <Placemark>
+        <name>test</name>
+        <description>KML With Prefixed Namespace</description>
+        <Point>
+            <coordinates>7.438632503,46.951082887,598.947</coordinates>
+        </Point>
+    </Placemark>
+</kml>
+]]></div>`)
+        ).to.be.false
+    })
+})

--- a/src/modules/menu/components/advancedTools/ImportFile/utils.js
+++ b/src/modules/menu/components/advancedTools/ImportFile/utils.js
@@ -16,7 +16,9 @@ const dispatcher = { dispatcher: 'ImportFile/utils' }
  * @returns {boolean}
  */
 export function isKml(fileContent) {
-    return /<(kml:)?kml/.test(fileContent) && /<\/(kml:)?kml\s*>/.test(fileContent)
+    return /^\s*(<\?xml\b[^>]*\?>)?\s*<(kml:)?kml\b[^>]*>[\s\S.]*<\/(kml:)?kml\s*>/g.test(
+        fileContent
+    )
 }
 
 /**

--- a/src/modules/menu/components/advancedTools/ImportFile/utils.js
+++ b/src/modules/menu/components/advancedTools/ImportFile/utils.js
@@ -16,7 +16,7 @@ const dispatcher = { dispatcher: 'ImportFile/utils' }
  * @returns {boolean}
  */
 export function isKml(fileContent) {
-    return /<kml/.test(fileContent) && /<\/kml\s*>/.test(fileContent)
+    return /<(kml:)?kml/.test(fileContent) && /<\/(kml:)?kml\s*>/.test(fileContent)
 }
 
 /**


### PR DESCRIPTION
Based on the KML standard the kml tags can be with `kml:` prefixed. This
issue has been mentioned on the old viewer. see https://github.com/geoadmin/mf-geoadmin3/issues/5310

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-440-prefixed-kml/index.html)