### PR TITLE
PB-443: Set year on timeslider close

### DIFF
--- a/src/modules/map/components/toolbox/TimeSlider.vue
+++ b/src/modules/map/components/toolbox/TimeSlider.vue
@@ -229,7 +229,6 @@ function positionNodeLabel(year) {
 
 function grabCursor(event) {
     yearCursorIsGrabbed = true
-    isPristine.value = false
     if (event.type === 'touchstart') {
         // for touch events we have to select which touch we want to get the screen position
         // (there can be multiple fingers gestures)
@@ -277,6 +276,9 @@ function releaseCursor() {
     window.removeEventListener('touchmove', listenToMouseMove)
     window.removeEventListener('mouseup', releaseCursor)
     window.removeEventListener('touchend', releaseCursor)
+    if (isPristine.value && previewYear.value !== currentYear.value) {
+        isPristine.value = false
+    }
     store.dispatch('setPreviewYear', { year: currentYear.value, ...dispatcher })
 }
 

--- a/tests/cypress/tests-e2e/timeSlider.cy.js
+++ b/tests/cypress/tests-e2e/timeSlider.cy.js
@@ -64,30 +64,30 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             )
         }
         it('checks that the time slider is functional and behave correctly', () => {
-            // ---------------------- TEST 1 ------------------------------------------------------------------------------
-            cy.log('Test 1 : Invisible time layer given. time slider button should not appear')
+            // ----------------------------------------------------------------------------------------------------
+            cy.log(': Invisible time layer given. time slider button should not appear')
             cy.goToMapView({
                 layers: `${time_layer_std},f`,
             })
             cy.get('[data-cy="time-slider-button"]').should('not.exist')
 
-            // ---------------------- TEST 2 ------------------------------------------------------------------------------
-            cy.log('Test 2: visible non time enabled Layer, the button should not be visible')
+            // ----------------------------------------------------------------------------------------------------
+            cy.log('visible non time enabled Layer, the button should not be visible')
             cy.goToMapView({
                 layers: standard_layer,
             })
             cy.get('[data-cy="time-slider-button"]').should('not.exist')
 
-            // ---------------------- TEST 3 ------------------------------------------------------------------------------
-            cy.log('Test 3 to 7 uses the same goToMapView call')
-            cy.log('Test 3: With a visible time enabled Layer, the button should be visible')
+            // ----------------------------------------------------------------------------------------------------
+            cy.log('The following few tests use the same goToMapView call')
+            cy.log('With a visible time enabled Layer, the button should be visible')
             cy.goToMapView({
                 layers: `${time_layer_std}@year=${preSelectedYear}`,
             })
             cy.get('[data-cy="time-slider-button"]').should('be.visible')
-            // ---------------------- TEST 4 ------------------------------------------------------------------------------
+            // ----------------------------------------------------------------------------------------------------
             cy.log(
-                'Test 4: when clicking on the time slider button, the time slider should show up. at the correct year'
+                'when clicking on the time slider button, the time slider should show up. at the correct year'
             )
             cy.get('[data-cy="time-slider-button"]').click()
             cy.get('[data-cy="time-slider"]').should('be.visible')
@@ -96,17 +96,9 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
                 `${preSelectedYear}`
             )
 
-            // ---------------------- TEST 5 ------------------------------------------------------------------------------
+            // ------------------------------------------------------------------------------------------------
             cy.log(
-                'Test 5: when moving the time slider, we no longer have the same year as in the beginning'
-            )
-            const newYear = 2020
-            moveSlider(200)
-            cy.get('[data-cy="time-slider-bar-cursor-year"]').should('have.value', `${newYear}`)
-
-            // ---------------------- TEST 6 --------------------------------------------------------------------------
-            cy.log(
-                'Test 6: when removing the time slider, the time years in the time selector go back to their previous values'
+                'when removing the time slider, the time years in the time selector go back to their previous values'
             )
             cy.get('[data-cy="time-slider-button"]').click()
             cy.openMenuIfMobile()
@@ -117,9 +109,28 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             )
             cy.closeMenuIfMobile()
 
-            // ---------------------- TEST 7 --------------------------------------------------------------------------
+            // ----------------------------------------------------------------------------------------------------
             cy.log(
-                'Test 7: when bringing back a previously active time slider, the year has been preserved'
+                'when moving the time slider, we no longer have the same year as in the beginning'
+            )
+            cy.get('[data-cy="time-slider-button"]').click()
+
+            const newYear = 2020
+            moveSlider(200)
+            cy.get('[data-cy="time-slider-bar-cursor-year"]').should('have.value', `${newYear}`)
+            // ----------------------------------------------------------------------------------------------------
+            cy.log(
+                'When removing the time slider after altering it, the new year should be present in the layers'
+            )
+            cy.get('[data-cy="time-slider-button"]').click()
+            cy.openMenuIfMobile()
+
+            cy.get(`[data-cy="time-selector-${time_layer_std}-0"]`).should('contain', newYear)
+            cy.closeMenuIfMobile()
+
+            // ------------------------------------------------------------------------------------------------
+            cy.log(
+                'when bringing back a previously active time slider, the year has been preserved'
             )
             cy.get('[data-cy="time-slider-button"]').click()
             cy.openMenuIfMobile()
@@ -128,9 +139,9 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             cy.get(`[data-cy="time-selector-${time_layer_std}-0"]`).should('contain', newYear)
             cy.closeMenuIfMobile()
 
-            // ---------------------- TEST 8 ------------------------------------------------------------------------------
+            // ----------------------------------------------------------------------------------------------------
             cy.log(
-                'Test 8: With a visible time Layer and a TS parameter, the Time slider should appear at the correct year'
+                'With a visible time Layer and a TS parameter, the Time slider should appear at the correct year'
             )
 
             cy.goToMapView({
@@ -138,8 +149,8 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
                 timeSlider: 2013,
             })
             cy.get('[data-cy="time-slider-bar-cursor-year"]').should('have.value', '2013')
-            // ---------------------- TEST 9 ------------------------------------------------------------------------------
-            cy.log('Test 9: shows that the CSS is correct for all time enable layers')
+            // ----------------------------------------------------------------------------------------------------
+            cy.log('shows that the CSS is correct for all time enable layers')
             cy.log(' time selector years shown ')
             cy.openMenuIfMobile()
             cy.get(`[data-cy="time-selector-${time_layer_std}-0"]`).should('contain', 2019)
@@ -195,18 +206,18 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
                 })
             })
             cy.closeMenuIfMobile()
-            // ---------------------- TEST 10 -----------------------------------------------------------------------------
+            // ---------------------------------------------------------------------------------------------------
             cy.log(
-                'Test 10: When using the timeSlider with multiple layers, if there is data common to all layers, the time slider goes to the youngest year in common'
+                'When using the timeSlider with multiple layers, if there is data common to all layers, the time slider goes to the youngest year in common'
             )
             cy.get('[data-cy="menu-swiss-flag"').click()
             cy.goToMapView({ layers: `${time_layer_std};${time_layer_odd}` })
             cy.get('[data-cy="time-slider-button"]').click()
             cy.get('[data-cy="time-slider-bar-cursor-year"]').should('have.value', '2021')
             cy.url().should((url) => url.includes('timeSlider=2021'))
-            // ---------------------- TEST 11 -----------------------------------------------------------------------------
+            // ---------------------------------------------------------------------------------------------------
             cy.log(
-                'Test 11: invisible time layer and timeSlider as parameter : time slider button should not appear and the parameter should not be in URL'
+                'invisible time layer and timeSlider as parameter : time slider button should not appear and the parameter should not be in URL'
             )
 
             cy.get('[data-cy="menu-swiss-flag"').click()
@@ -217,10 +228,10 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             cy.get('[data-cy="time-slider-button"]').should('not.exist')
             cy.url().should((url) => !url.includes('timeSlider='))
 
-            // ---------------------- TEST 12 -----------------------------------------------------------------------------
+            // ---------------------------------------------------------------------------------------------------
 
             cy.log(
-                'Test 12: When using the timeSlider with multiple layers, if there are no data common to all layers, the time slider should be set to the youngest year with data'
+                'When using the timeSlider with multiple layers, if there are no data common to all layers, the time slider should be set to the youngest year with data'
             )
 
             cy.get('[data-cy="menu-swiss-flag"').click()
@@ -229,9 +240,9 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             cy.get('[data-cy="time-slider-bar-cursor-year"]').should('have.value', '2023')
             cy.url().should((url) => url.includes('timeSlider=2023'))
 
-            // ---------------------- TEST 13 -----------------------------------------------------------------------------
+            // ---------------------------------------------------------------------------------------------------
             cy.log(
-                'Test 13: When using a wrong Time Slider Parameter, the time slider should not appear and the url should not show the parameter'
+                'When using a wrong Time Slider Parameter, the time slider should not appear and the url should not show the parameter'
             )
 
             cy.get('[data-cy="menu-swiss-flag"').click()
@@ -249,9 +260,9 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             cy.get('[data-cy="time-slider-bar-cursor-year"]').should('not.exist')
             cy.url().should((url) => !url.includes('timeSlider='))
 
-            // ---------------------- TEST 14 -----------------------------------------------------------------------------
+            // ---------------------------------------------------------------------------------------------------
             cy.log(
-                'Test 14: When having a duplicate layer, when one is invisible, they both still behave as expected'
+                'When having a duplicate layer, when one is invisible, they both still behave as expected'
             )
             cy.goToMapView({ layers: `${time_layer_std}@year=2019`, timeSlider: 2017 })
             cy.openMenuIfMobile()
@@ -262,8 +273,8 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             cy.get(`[data-cy="time-selector-${time_layer_std}-1"]`).should('contain', 2017)
             cy.closeMenuIfMobile()
 
-            // ---------------------- TEST 15 -----------------------------------------------------------------------------
-            cy.log('Test 15 Check time slider year cursor text input')
+            // ---------------------------------------------------------------------------------------------------
+            cy.log('Check time slider year cursor text input')
 
             cy.get('[data-cy="time-slider-bar-cursor-arrow"]')
                 .invoke('attr', 'style')


### PR DESCRIPTION
When closing the timeslider, if it was modified in any way manually by the user, we save the year for all current layers. Also removed the numbers in the tests so that we don't have to re-enumerate each time we make a modification within the tests.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-443-set-year-on-timeslider-close/index.html)