### PR TITLE
PB-360: measurement label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@fortawesome/free-solid-svg-icons": "^6.5.2",
                 "@fortawesome/vue-fontawesome": "^3.0.6",
                 "@geoblocks/cesium-compass": "^0.5.0",
-                "@geoblocks/mapfishprint": "github:geoblocks/mapfishprint#34361f4a7f591e659756d89e8be321443c610441",
+                "@geoblocks/mapfishprint": "^0.2.13",
                 "@geoblocks/ol-maplibre-layer": "^0.1.3",
                 "@ivanv/vue-collapse-transition": "^1.0.2",
                 "@mapbox/togeojson": "^0.16.2",
@@ -806,9 +806,9 @@
             }
         },
         "node_modules/@geoblocks/mapfishprint": {
-            "version": "0.2.12",
-            "resolved": "git+ssh://git@github.com/geoblocks/mapfishprint.git#34361f4a7f591e659756d89e8be321443c610441",
-            "integrity": "sha512-gWKQOH6utfYFx64E0k+LiZu56cDeg0mpf5ej2zi36u4OFGyvocumdfAVgSQgyccekqSU97F4U9wjMxMjS3ic4w==",
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/@geoblocks/mapfishprint/-/mapfishprint-0.2.13.tgz",
+            "integrity": "sha512-y2WHuXoezDtfiVsNVb98YY/CYjOiIBGaCX7Jdx4FbVyT0yP3QKzoPupOfF+Evnu30o7u2lNNjPozF0/aQtfKbw==",
             "optionalDependencies": {
                 "@geoblocks/print": "0.7.8"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@fortawesome/free-solid-svg-icons": "^6.5.2",
                 "@fortawesome/vue-fontawesome": "^3.0.6",
                 "@geoblocks/cesium-compass": "^0.5.0",
-                "@geoblocks/mapfishprint": "^0.2.12",
+                "@geoblocks/mapfishprint": "github:geoblocks/mapfishprint#34361f4a7f591e659756d89e8be321443c610441",
                 "@geoblocks/ol-maplibre-layer": "^0.1.3",
                 "@ivanv/vue-collapse-transition": "^1.0.2",
                 "@mapbox/togeojson": "^0.16.2",
@@ -807,8 +807,8 @@
         },
         "node_modules/@geoblocks/mapfishprint": {
             "version": "0.2.12",
-            "resolved": "https://registry.npmjs.org/@geoblocks/mapfishprint/-/mapfishprint-0.2.12.tgz",
-            "integrity": "sha512-kg1iPhnvEp2flo3bsTpfiS9wMcMhWzdpeZewxgOnclg2pi+gnzcLpiIOQApOSGeiLo372Zv7qczxsziyBqZPxg==",
+            "resolved": "git+ssh://git@github.com/geoblocks/mapfishprint.git#34361f4a7f591e659756d89e8be321443c610441",
+            "integrity": "sha512-gWKQOH6utfYFx64E0k+LiZu56cDeg0mpf5ej2zi36u4OFGyvocumdfAVgSQgyccekqSU97F4U9wjMxMjS3ic4w==",
             "optionalDependencies": {
                 "@geoblocks/print": "0.7.8"
             },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@fortawesome/vue-fontawesome": "^3.0.6",
         "@geoblocks/cesium-compass": "^0.5.0",
-        "@geoblocks/mapfishprint": "^0.2.12",
+        "@geoblocks/mapfishprint": "github:geoblocks/mapfishprint#34361f4a7f591e659756d89e8be321443c610441",
         "@geoblocks/ol-maplibre-layer": "^0.1.3",
         "@ivanv/vue-collapse-transition": "^1.0.2",
         "@mapbox/togeojson": "^0.16.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@fortawesome/vue-fontawesome": "^3.0.6",
         "@geoblocks/cesium-compass": "^0.5.0",
-        "@geoblocks/mapfishprint": "github:geoblocks/mapfishprint#34361f4a7f591e659756d89e8be321443c610441",
+        "@geoblocks/mapfishprint": "^0.2.13",
         "@geoblocks/ol-maplibre-layer": "^0.1.3",
         "@ivanv/vue-collapse-transition": "^1.0.2",
         "@mapbox/togeojson": "^0.16.2",

--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -25,6 +25,7 @@ class GeoAdminCustomizer extends BaseCustomizer {
         this.printResolution = printResolution
         this.layerFilter = this.layerFilter.bind(this)
         this.line = this.line.bind(this)
+        this.text = this.text.bind(this)
     }
 
     /**
@@ -72,6 +73,13 @@ class GeoAdminCustomizer extends BaseCustomizer {
         if (symbolizer.strokeWidth) {
             symbolizer.strokeWidth = adjustWidth(symbolizer.strokeWidth, this.printResolution)
         }
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    text(layerState, symbolizer, text) {
+        symbolizer.pointRadius = adjustWidth(symbolizer.pointRadius, this.printResolution)
+        symbolizer.strokeWidth = adjustWidth(symbolizer.strokeWidth, this.printResolution)
+        symbolizer.haloRadius = adjustWidth(symbolizer.haloRadius, this.printResolution)
     }
 }
 

--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -77,9 +77,7 @@ class GeoAdminCustomizer extends BaseCustomizer {
     }
 
     /**
-     * Manipulate the symbolizer of a text style of a feature before printing it. In this case it
-     * manipulate the outline / halo for different text to match the old geadmin where there is no
-     * outline for marker and text
+     * Manipulate the symbolizer of a text style of a feature before printing it.
      *
      * @param {State} layerState
      * @param {MFPSymbolizerText} symbolizer Interface for the symbolizer of a text feature
@@ -87,16 +85,9 @@ class GeoAdminCustomizer extends BaseCustomizer {
      */
     // eslint-disable-next-line no-unused-vars
     text(layerState, symbolizer, text) {
-        // Remove the halo / outline if the font family is normal 16px Helvetica (as used in the point and marker text)
-        if (symbolizer.fontFamily === 'normal 16px Helvetica') {
-            symbolizer.pointRadius = 0
-            symbolizer.strokeWidth = 0
-            symbolizer.haloRadius = 0
-        } else {
-            symbolizer.pointRadius = adjustWidth(symbolizer.pointRadius, this.printResolution)
-            symbolizer.strokeWidth = adjustWidth(symbolizer.strokeWidth, this.printResolution)
-            symbolizer.haloRadius = adjustWidth(symbolizer.haloRadius, this.printResolution)
-        }
+        symbolizer.pointRadius = adjustWidth(symbolizer.pointRadius, this.printResolution)
+        symbolizer.strokeWidth = adjustWidth(symbolizer.strokeWidth, this.printResolution)
+        symbolizer.haloRadius = adjustWidth(symbolizer.haloRadius, this.printResolution)
     }
 
     /**

--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -26,6 +26,7 @@ class GeoAdminCustomizer extends BaseCustomizer {
         this.layerFilter = this.layerFilter.bind(this)
         this.line = this.line.bind(this)
         this.text = this.text.bind(this)
+        this.point = this.point.bind(this)
     }
 
     /**
@@ -75,11 +76,42 @@ class GeoAdminCustomizer extends BaseCustomizer {
         }
     }
 
+    /**
+     * Manipulate the symbolizer of a text style of a feature before printing it. In this case it
+     * manipulate the outline / halo for different text to match the old geadmin where there is no
+     * outline for marker and text
+     *
+     * @param {State} layerState
+     * @param {MFPSymbolizerText} symbolizer Interface for the symbolizer of a text feature
+     * @param {Text} text Text style of the feature
+     */
     // eslint-disable-next-line no-unused-vars
     text(layerState, symbolizer, text) {
-        symbolizer.pointRadius = adjustWidth(symbolizer.pointRadius, this.printResolution)
-        symbolizer.strokeWidth = adjustWidth(symbolizer.strokeWidth, this.printResolution)
-        symbolizer.haloRadius = adjustWidth(symbolizer.haloRadius, this.printResolution)
+        // Remove the halo / outline if the font family is normal 16px Helvetica (as used in the point and marker text)
+        if (symbolizer.fontFamily === 'normal 16px Helvetica') {
+            symbolizer.pointRadius = 0
+            symbolizer.strokeWidth = 0
+            symbolizer.haloRadius = 0
+        } else {
+            symbolizer.pointRadius = adjustWidth(symbolizer.pointRadius, this.printResolution)
+            symbolizer.strokeWidth = adjustWidth(symbolizer.strokeWidth, this.printResolution)
+            symbolizer.haloRadius = adjustWidth(symbolizer.haloRadius, this.printResolution)
+        }
+    }
+
+    /**
+     * Manipulate the symbolizer of a point style of a feature before printing it. In this case it
+     * manipulate the width and offset of the image to match the old geoadmin
+     *
+     * @param {State} layerState
+     * @param {MFPSymbolizerPoint} symbolizer Interface for the symbolizer of a text feature
+     * @param {Image} image Image style of the feature
+     */
+    // eslint-disable-next-line no-unused-vars
+    point(layerState, symbolizer, image) {
+        symbolizer.graphicWidth = adjustWidth(symbolizer.graphicWidth, this.printResolution)
+        symbolizer.graphicXOffset = adjustWidth(symbolizer.graphicXOffset, this.printResolution)
+        symbolizer.graphicYOffset = adjustWidth(symbolizer.graphicYOffset, this.printResolution)
     }
 }
 

--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -103,6 +103,11 @@ class GeoAdminCustomizer extends BaseCustomizer {
         symbolizer.graphicWidth = adjustWidth(symbolizer.graphicWidth, this.printResolution)
         symbolizer.graphicXOffset = adjustWidth(symbolizer.graphicXOffset, this.printResolution)
         symbolizer.graphicYOffset = adjustWidth(symbolizer.graphicYOffset, this.printResolution)
+        // Handling the case where we need to print a circle in the end of measurement lines
+        // It's not rendered in the OpenLayers (opacity == 0.0) but it's needed to be rendered in the print
+        if (symbolizer.fillOpacity === 0.0 && symbolizer.fillColor === '#ff0000') {
+            symbolizer.fillOpacity = 1
+        }
     }
 }
 

--- a/src/utils/__tests__/geodesicManager.spec.js
+++ b/src/utils/__tests__/geodesicManager.spec.js
@@ -114,8 +114,8 @@ describe('Unit tests for Geodesic geometries', () => {
                     [4500, 0],
                 ],
             ],
-            maxStyles: 6, // 4 measure points, azimuth circle, total length
-            minStyles: 2, // azimuth circle + total length
+            maxStyles: 7, // 4 measure points, azimuth circle, total length, transparent circle for printing
+            minStyles: 3, // azimuth circle + total length, transparent circle for printing
             segmentExtents: [[0, 0, 4500, 0]],
         })
 
@@ -180,8 +180,8 @@ describe('Unit tests for Geodesic geometries', () => {
                 ],
             ],
             geodesicPolygonGeom: null,
-            maxStyles: 5, // 3 measure points, azimuth circle, total length
-            minStyles: 2, // azimuth circle + total length
+            maxStyles: 6, // 3 measure points, azimuth circle, total length, transparent circle for printing
+            minStyles: 3, // azimuth circle + total length, transparent circle for printing
             segmentExtents: [[-HALFSIZE_WEBMERCATOR + 500, 0, HALFSIZE_WEBMERCATOR + 500, 0]],
         })
 
@@ -220,8 +220,8 @@ describe('Unit tests for Geodesic geometries', () => {
                 ],
             ],
             geodesicPolygonGeom: null,
-            maxStyles: 4, // 3 measure points, total length
-            minStyles: 1, // total length
+            maxStyles: 5, // 3 measure points, total length, transparent circle for printing
+            minStyles: 2, // total length, transparent circle for printing
             segmentExtents: [[-HALFSIZE_WEBMERCATOR + 500, 0, HALFSIZE_WEBMERCATOR + 500, 0]],
         })
 

--- a/src/utils/geodesicManager.js
+++ b/src/utils/geodesicManager.js
@@ -7,7 +7,7 @@ import {
 } from 'ol/extent'
 import { LineString, MultiLineString, MultiPolygon, Point, Polygon } from 'ol/geom'
 import RBush from 'ol/structs/RBush' /* Warning: private class of openlayers */
-import { Circle, Fill, Stroke, Style, Text } from 'ol/style'
+import { Circle, Fill, RegularShape, Stroke, Style, Text } from 'ol/style'
 import proj4 from 'proj4'
 
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
@@ -332,6 +332,7 @@ export class GeodesicGeometries {
         }
         styles.push(
             new Style({
+                image: tooltipArrow,
                 text: getTooltipTextBox(lengthText),
                 geometry: new Point(coordNormalize(this.coords[this.coords.length - 1])).transform(
                     WGS84.epsg,
@@ -346,6 +347,7 @@ export class GeodesicGeometries {
             const areaText = formatMeters(uArea, { dim: 2 })
             styles.push(
                 new Style({
+                    image: tooltipArrow,
                     text: getTooltipTextBox(areaText),
                     geometry: new Point(
                         this.geodesicPolygonGeom.getPolygon(0).getInteriorPoint().getCoordinates()
@@ -389,6 +391,15 @@ const circleStyle = new Circle({
     }),
 })
 
+const tooltipArrow = new RegularShape({
+    points: 4,
+    radius: 10,
+    fill: new Fill({
+        color: [255, 0, 0, 0.9],
+    }),
+    displacement: [0, 10],
+})
+
 const getTooltipTextBox = (text) =>
     new Text({
         text: text,
@@ -400,6 +411,20 @@ const getTooltipTextBox = (text) =>
             color: [255, 0, 0, 0.9],
             width: 3,
         }),
+        backgroundFill: new Fill({
+            color: [255, 0, 0, 0.9],
+        }),
+        // This background stroke is used to round the corners of the tooltip box
+        backgroundStroke: new Stroke({
+            color: [255, 0, 0, 0.9],
+            width: 7,
+            lineCap: 'round',
+            lineJoin: 'round',
+        }),
+        /* These padding values in the format [top, right, bottom, left] should approximately
+        center the text in the tooltip box */
+        padding: [2, 2.5, -1, 4],
+        scale: 1,
         offsetY: -18,
     })
 

--- a/src/utils/geodesicManager.js
+++ b/src/utils/geodesicManager.js
@@ -396,25 +396,11 @@ const getTooltipTextBox = (text) =>
         fill: new Fill({
             color: '#ffffff',
         }),
-        // backgroundFill: new Fill({
-        //     color: [255, 0, 0, 0.9],
-        // }),
-        // // This background stroke is used to round the corners of the tooltip box
-        // backgroundStroke: new Stroke({
-        //     color: [255, 0, 0, 0.9],
-        //     width: 7,
-        //     lineCap: 'round',
-        //     lineJoin: 'round',
-        // }),
         stroke: new Stroke({
             color: [255, 0, 0, 0.9],
             width: 3,
         }),
-        // /* These padding values in the format [top, right, bottom, left] should approximately
-        // center the text in the tooltip box */
-        // padding: [2, 2.5, -1, 4],
-        // scale: 1,
-        // offsetY: -18,
+        offsetY: -18,
     })
 
 /**

--- a/src/utils/geodesicManager.js
+++ b/src/utils/geodesicManager.js
@@ -7,7 +7,7 @@ import {
 } from 'ol/extent'
 import { LineString, MultiLineString, MultiPolygon, Point, Polygon } from 'ol/geom'
 import RBush from 'ol/structs/RBush' /* Warning: private class of openlayers */
-import { Circle, Fill, RegularShape, Stroke, Style, Text } from 'ol/style'
+import { Circle, Fill, Stroke, Style, Text } from 'ol/style'
 import proj4 from 'proj4'
 
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
@@ -332,7 +332,6 @@ export class GeodesicGeometries {
         }
         styles.push(
             new Style({
-                image: tooltipArrow,
                 text: getTooltipTextBox(lengthText),
                 geometry: new Point(coordNormalize(this.coords[this.coords.length - 1])).transform(
                     WGS84.epsg,
@@ -347,7 +346,6 @@ export class GeodesicGeometries {
             const areaText = formatMeters(uArea, { dim: 2 })
             styles.push(
                 new Style({
-                    image: tooltipArrow,
                     text: getTooltipTextBox(areaText),
                     geometry: new Point(
                         this.geodesicPolygonGeom.getPolygon(0).getInteriorPoint().getCoordinates()
@@ -391,15 +389,6 @@ const circleStyle = new Circle({
     }),
 })
 
-const tooltipArrow = new RegularShape({
-    points: 4,
-    radius: 10,
-    fill: new Fill({
-        color: [255, 0, 0, 0.9],
-    }),
-    displacement: [0, 10],
-})
-
 const getTooltipTextBox = (text) =>
     new Text({
         text: text,
@@ -407,21 +396,25 @@ const getTooltipTextBox = (text) =>
         fill: new Fill({
             color: '#ffffff',
         }),
-        backgroundFill: new Fill({
+        // backgroundFill: new Fill({
+        //     color: [255, 0, 0, 0.9],
+        // }),
+        // // This background stroke is used to round the corners of the tooltip box
+        // backgroundStroke: new Stroke({
+        //     color: [255, 0, 0, 0.9],
+        //     width: 7,
+        //     lineCap: 'round',
+        //     lineJoin: 'round',
+        // }),
+        stroke: new Stroke({
             color: [255, 0, 0, 0.9],
+            width: 3,
         }),
-        // This background stroke is used to round the corners of the tooltip box
-        backgroundStroke: new Stroke({
-            color: [255, 0, 0, 0.9],
-            width: 7,
-            lineCap: 'round',
-            lineJoin: 'round',
-        }),
-        /* These padding values in the format [top, right, bottom, left] should approximately
-        center the text in the tooltip box */
-        padding: [2, 2.5, -1, 4],
-        scale: 1,
-        offsetY: -18,
+        // /* These padding values in the format [top, right, bottom, left] should approximately
+        // center the text in the tooltip box */
+        // padding: [2, 2.5, -1, 4],
+        // scale: 1,
+        // offsetY: -18,
     })
 
 /**

--- a/src/utils/geodesicManager.js
+++ b/src/utils/geodesicManager.js
@@ -341,6 +341,24 @@ export class GeodesicGeometries {
                 zIndex: 40,
             })
         )
+        // This style will only be shown in the printing, that's why the alpha is 0.0
+        // THe alpha will be changed to 1 when passed to the service print
+        // See GeoAdminCustomizer in print module.
+        styles.push(
+            new Style({
+                image: new Circle({
+                    radius: 4,
+                    fill: new Fill({
+                        color: [255, 0, 0, 0.0],
+                    }),
+                }),
+                geometry: new Point(coordNormalize(this.coords[this.coords.length - 1])).transform(
+                    WGS84.epsg,
+                    this.projection.epsg
+                ),
+                zIndex: 23,
+            })
+        )
         //Total area tooltip
         if (this.isPolygon && this.geodesicPolygonGeom) {
             const uArea = Math.abs(this.totalArea)


### PR DESCRIPTION
[Test link](https://sys-map.dev.bgdi.ch/preview/fix-360-measurement-label/index.html)

## Measurement Lines

### Old GeoAdmin
Sample Link: https://s.geo.admin.ch/5xjzz9drm7gy

OL view: ![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/1f36b595-bc18-4fda-9c25-d1754d8982d3)
Print result: ![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/9b0792f6-e049-428c-bb04-fb2ba1a3ed77)


### Current PR
Sample link: https://sys-s.dev.bgdi.ch/uv66dijlpvys
OL view:
![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/1745c47c-033b-4ca6-86e7-88ca63941c83)


Print result:
![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/0286154e-eab9-4997-87d8-77f04e3456ec)


## Marker and Text
### Old GeoAdmin
Sample URL: https://s.geo.admin.ch/st54zbvdmieo
OL View:
![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/a51adad8-a05d-4302-ad8a-26c29ee25603)
Print result:
![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/b40831b8-2f81-429b-af79-4df477c2ae5b)


### Current PR
Sample link: https://sys-s.dev.bgdi.ch/k08kma0aqc7s
OL View: 
![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/bc7fbe1a-5b3a-4dfc-a769-c391775f88b0)


Print Result:
![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/b3d5caf8-c055-44d1-ae6a-f2028b9e1421)


## Remarks
- On the old geoadmin, the font size in the marker and text become bigger in the print. I am not sure why, I already checked the payload both are using font size = 16

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-360-measurement-label/index.html)



[Test link](https://sys-map.dev.bgdi.ch/preview/fix-360-measurement-label/index.html)