### PR TITLE
PB-448: Make sure print area layer always on top.

### DIFF
--- a/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
+++ b/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
@@ -39,6 +39,7 @@ function createWorldPolygon() {
         }),
         style: transparentStyle,
         id: PRINT_AREA_LAYER_ID,
+        zIndex: Infinity, // Make sure the print area is always on top
     })
     return vectorLayer
 }
@@ -70,8 +71,6 @@ export default function usePrintAreaRenderer(map) {
             worldPolygon = createWorldPolygon()
         }
         map.addLayer(worldPolygon)
-        // Make sure the print area is always on top
-        worldPolygon.setZIndex(9999)
         deregister = [
             worldPolygon.on('prerender', handlePreRender),
             worldPolygon.on('postrender', handlePostRender),

--- a/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
+++ b/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
@@ -70,6 +70,8 @@ export default function usePrintAreaRenderer(map) {
             worldPolygon = createWorldPolygon()
         }
         map.addLayer(worldPolygon)
+        // Make sure the print area is always on top
+        worldPolygon.setZIndex(9999)
         deregister = [
             worldPolygon.on('prerender', handlePreRender),
             worldPolygon.on('postrender', handlePostRender),


### PR DESCRIPTION
I use a simple approach here to set the zindex to something very high. I have checked the suggested approach in the ticket (using systemLayers), but it's not handling the addition to the map. Is it intended for this kind of use case?

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-448-missing-print-area-layer/index.html)