### PR TITLE
PB-437: Fix print scale

### DIFF
--- a/src/modules/menu/MenuModule.vue
+++ b/src/modules/menu/MenuModule.vue
@@ -1,8 +1,6 @@
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { computed, ref } from 'vue'
-import { onMounted } from 'vue'
-import { onBeforeUnmount } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 
@@ -24,28 +22,6 @@ const isDesktopMode = computed(() => store.getters.isDesktopMode)
 const isMenuShown = computed(() => store.getters.isMenuShown)
 const isMenuTrayShown = computed(() => store.getters.isMenuTrayShown)
 const hasDevSiteWarning = computed(() => store.getters.hasDevSiteWarning)
-
-const menuTray = ref(null)
-
-// Watch for changes on component mount
-onMounted(() => {
-    updateMenuTrayWidth()
-    window.addEventListener('resize', updateMenuTrayWidth)
-})
-
-// Cleanup on component unmount
-onBeforeUnmount(() => {
-    window.removeEventListener('resize', updateMenuTrayWidth)
-})
-
-const updateMenuTrayWidth = () => {
-    if (menuTray.value) {
-        store.dispatch('setMenuTrayWidth', {
-            width: menuTray.value.offsetWidth,
-            ...dispatcher,
-        })
-    }
-}
 
 function toggleMenu() {
     store.dispatch('toggleMenu', dispatcher)
@@ -72,7 +48,6 @@ function toggleMenu() {
             <transition name="slide-up">
                 <div
                     v-show="isMenuTrayShown"
-                    ref="menuTray"
                     class="menu-tray"
                     :class="{
                         'desktop-mode': isDesktopMode,

--- a/src/modules/menu/components/print/MenuPrintSection.vue
+++ b/src/modules/menu/components/print/MenuPrintSection.vue
@@ -30,7 +30,7 @@ const scales = computed(() => selectedLayout.value?.scales || [])
 
 const selectedLayoutName = computed({
     get() {
-        return store.state.print.selectedLayout?.name
+        return store.state.print.selectedLayout?.name ?? ''
     },
     set(value) {
         store.dispatch('setSelectedLayout', {

--- a/src/store/modules/print.store.js
+++ b/src/store/modules/print.store.js
@@ -5,18 +5,18 @@ export default {
     state: {
         layouts: [],
         selectedLayout: null,
-        selectedScale: 0,
+        selectedScale: null,
         printSectionShown: false,
     },
     getters: {
-        mapSize(state) {
-            const mapAttributes = state.selectedLayout.attributes.find(
+        printLayoutSize(state) {
+            const mapAttributes = state.selectedLayout?.attributes.find(
                 (attribute) => attribute.name === 'map'
             )
 
             return {
-                width: mapAttributes?.clientParams?.width?.default,
-                height: mapAttributes?.clientParams?.height?.default,
+                width: mapAttributes?.clientParams?.width?.default ?? 0,
+                height: mapAttributes?.clientParams?.height?.default ?? 0,
             }
         },
         selectedDPI(state) {
@@ -40,7 +40,6 @@ export default {
         },
         setSelectedLayout({ commit }, { layout, dispatcher }) {
             commit('setSelectedLayout', { layout, dispatcher })
-            commit('setSelectedScale', { scale: layout.scales[0], dispatcher })
         },
         setPrintSectionShown({ commit }, { show, dispatcher }) {
             commit('setPrintSectionShown', { show, dispatcher })

--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -124,13 +124,6 @@ export default {
         headerHeight: 100,
 
         /**
-         * Height of the menu tray (in px)
-         *
-         * @type Number
-         */
-        menuTrayWidth: 400,
-
-        /**
          * Float telling where across the screen is the compare slider. The compare Slider should
          * only be shown when the value is between 0 and 1
          *
@@ -311,9 +304,6 @@ export default {
         setHeaderHeight({ commit }, { height, dispatcher }) {
             commit('setHeaderHeight', { height: parseFloat(height), dispatcher })
         },
-        setMenuTrayWidth({ commit }, { width, dispatcher }) {
-            commit('setMenuTrayWidth', { width: parseFloat(width), dispatcher })
-        },
         setCompareRatio({ commit }, { compareRatio, dispatcher }) {
             /*
                 This check is here to make sure the compare ratio doesn't get out of hand
@@ -398,9 +388,6 @@ export default {
         },
         setHeaderHeight(state, { height }) {
             state.headerHeight = height
-        },
-        setMenuTrayWidth(state, { width }) {
-            state.menuTrayWidth = width
         },
         setCompareRatio(state, { compareRatio }) {
             state.compareRatio = compareRatio

--- a/tests/cypress/tests-e2e/print.cy.js
+++ b/tests/cypress/tests-e2e/print.cy.js
@@ -71,7 +71,7 @@ describe('Testing print', () => {
             cy.get('[data-cy="print-scale-selector"]').find('option').should('have.length', 15)
             cy.get('[data-cy="print-scale-selector"]')
                 .find('option:selected')
-                .should('have.text', `1:${formatThousand(1500000)}`)
+                .should('have.text', `1:${formatThousand(2500000)}`)
         })
     })
 
@@ -115,7 +115,7 @@ describe('Testing print', () => {
                 )
 
                 const mapAttributes = attributes.map
-                expect(mapAttributes['scale']).to.equals(1500000)
+                expect(mapAttributes['scale']).to.equals(2500000)
                 expect(mapAttributes['dpi']).to.equals(254)
                 expect(mapAttributes['projection']).to.equals('EPSG:2056')
 
@@ -240,7 +240,7 @@ describe('Testing print', () => {
                 )
 
                 const mapAttributes = attributes.map
-                expect(mapAttributes['scale']).to.equals(1500000)
+                expect(mapAttributes['scale']).to.equals(2500000)
                 expect(mapAttributes['dpi']).to.equals(254)
                 expect(mapAttributes['projection']).to.equals('EPSG:2056')
 


### PR DESCRIPTION
The print scale on mobile was empty. This was due to the fact that we took the menu width in the computation for the scale.

Now we don't take the menu width for the scale computation and we move the print center a bit down due to the header overlapping the map.

Also did some renaming to make the code clearer

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-437-print-scale/index.html)