### PR TITLE
PB-447: legacy parser not switching to map view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
                 "vue": "^3.4.21",
                 "vue-chartjs": "^5.3.0",
                 "vue-i18n": "^9.11.0",
-                "vue-router": "^4.3.0",
+                "vue-router": "^4.3.2",
                 "vue3-social-sharing": "^1.0.3",
                 "vuex": "^4.1.0"
             },
@@ -9645,9 +9645,9 @@
             }
         },
         "node_modules/vue-router": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.3.0.tgz",
-            "integrity": "sha512-dqUcs8tUeG+ssgWhcPbjHvazML16Oga5w34uCUmsk7i0BcnskoLGwjpa15fqMr2Fa5JgVBrdL2MEgqz6XZ/6IQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.3.2.tgz",
+            "integrity": "sha512-hKQJ1vDAZ5LVkKEnHhmm1f9pMiWIBNGF5AwU67PdH7TyXCj/a4hTccuUuYCAMgJK6rO/NVYtQIEN3yL8CECa7Q==",
             "dependencies": {
                 "@vue/devtools-api": "^6.5.1"
             },

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "vue": "^3.4.21",
         "vue-chartjs": "^5.3.0",
         "vue-i18n": "^9.11.0",
-        "vue-router": "^4.3.0",
+        "vue-router": "^4.3.2",
         "vue3-social-sharing": "^1.0.3",
         "vuex": "^4.1.0"
     },

--- a/src/router/appLoadingManagement.routerPlugin.js
+++ b/src/router/appLoadingManagement.routerPlugin.js
@@ -21,6 +21,7 @@ const dispatcher = { dispatcher: 'appLoadingManagement.routerPlugin' }
  * @param {Store} store
  */
 const appLoadingManagementRouterPlugin = (router, store) => {
+    log.debug('[APP LOADING MANAGEMENT ROUTER] entry in app loading management plugin')
     if (!store.state.app.isReady) {
         const isLegacyUrl = isLegacyParams(window?.location?.search)
 
@@ -47,7 +48,13 @@ const appLoadingManagementRouterPlugin = (router, store) => {
                     isLegacyUrl,
                     ...dispatcher,
                 })
+                log.error('0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0')
+                log.error(from)
+                log.error(to)
                 unRegisterRouterHook()
+                log.error('0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0')
+                log.error(from)
+                log.error(to)
             }
         })
         const unSubscribeStore = store.subscribe((mutation) => {
@@ -58,6 +65,8 @@ const appLoadingManagementRouterPlugin = (router, store) => {
             }
         })
     }
+    log.debug('[APP LOADING MANAGEMENT ROUTER] exiting app loading management plugin')
+    return true
 }
 
 export default appLoadingManagementRouterPlugin

--- a/src/router/appLoadingManagement.routerPlugin.js
+++ b/src/router/appLoadingManagement.routerPlugin.js
@@ -48,13 +48,7 @@ const appLoadingManagementRouterPlugin = (router, store) => {
                     isLegacyUrl,
                     ...dispatcher,
                 })
-                log.error('0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0')
-                log.error(from)
-                log.error(to)
                 unRegisterRouterHook()
-                log.error('0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0')
-                log.error(from)
-                log.error(to)
             }
         })
         const unSubscribeStore = store.subscribe((mutation) => {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -11,11 +11,11 @@ import {
     MAP_VIEW,
 } from '@/router/viewNames'
 import store from '@/store'
+import log from '@/utils/logging'
 import { parseQuery, stringifyQuery } from '@/utils/url-router'
 import EmbedView from '@/views/EmbedView.vue'
 import LegacyParamsView from '@/views/LegacyParamsView.vue'
 import MapView from '@/views/MapView.vue'
-import log from '@/utils/logging'
 
 const history = createWebHashHistory()
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -71,7 +71,7 @@ const router = createRouter({
 })
 
 router.onError((error) => {
-    log.error(error)
+    log.error('[Router error] :', error)
 })
 
 appLoadingManagementRouterPlugin(router, store)

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -15,6 +15,7 @@ import { parseQuery, stringifyQuery } from '@/utils/url-router'
 import EmbedView from '@/views/EmbedView.vue'
 import LegacyParamsView from '@/views/LegacyParamsView.vue'
 import MapView from '@/views/MapView.vue'
+import log from '@/utils/logging'
 
 const history = createWebHashHistory()
 
@@ -67,6 +68,10 @@ const router = createRouter({
     ],
     parseQuery: parseQuery,
     stringifyQuery: stringifyQuery,
+})
+
+router.onError((error) => {
+    log.error(error)
 })
 
 appLoadingManagementRouterPlugin(router, store)

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -23,8 +23,6 @@ import {
 } from '@/utils/legacyLayerParamUtils'
 import log from '@/utils/logging'
 
-const dispatcher = { dispatcher: 'legacyPermalinkManagement.routerPlugin' }
-
 const handleLegacyKmlAdminIdParam = async (legacyParams, newQuery) => {
     log.debug('Transforming legacy kml adminId, get KML ID from adminId...')
     const kmlLayer = await getKmlLayerFromLegacyAdminIdParam(legacyParams.get('adminId'))
@@ -271,10 +269,6 @@ const legacyPermalinkManagementRouterPlugin = (router, store) => {
         ? new URLSearchParams(window?.location?.search)
         : null
     if (legacyParams) {
-        store.dispatch('setNeedReloadBecauseOfLegacy', {
-            value: true,
-            ...dispatcher,
-        })
         // NOTE: the legacy embed view was at /embed.html. Unfortunately we cannot in this application
         // reroute to another path before the #, because the vue router using the createWebHashHistory
         // can only handle route after the hash. Therefore we have an external redirect service

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -288,6 +288,9 @@ const legacyPermalinkManagementRouterPlugin = (router, store) => {
         let unSubscribeStoreMutation = null
         const unsubscribeRouter = router.beforeEach(async (to, from) => {
             log.debug('[Legacy URL] entry into the legacy router')
+            log.debug('[Legacy URL] we came from the following route', from)
+            log.debug('[Legacy URL] We should reach the following route', to)
+
             if (MAP_VIEWS.includes(to.name) && from === START_LOCATION) {
                 // Redirect to the LegacyParamsView until the app is ready and that the legacy
                 // params have been parsed and converted. This is needed in order to postpone the
@@ -314,6 +317,9 @@ const legacyPermalinkManagementRouterPlugin = (router, store) => {
                         router.replace(newRoute)
                     }
                 })
+                log.debug(
+                    `[Legacy URL]: redirect between embed legacy view or standard legacy view`
+                )
                 return {
                     name: legacyEmbed ? LEGACY_EMBED_PARAM_VIEW : LEGACY_PARAM_VIEW,
                     replace: true,
@@ -326,8 +332,6 @@ const legacyPermalinkManagementRouterPlugin = (router, store) => {
                 unSubscribeStoreMutation()
             }
             log.debug('[Legacy URL] exiting the Legacy URL router.')
-            log.debug('[Legacy URL] we came from the following route', from)
-            log.debug('[Legacy URL] We should reach the following route', to)
             return true
         })
     }

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -281,9 +281,11 @@ const legacyPermalinkManagementRouterPlugin = (router, store) => {
         )
         let unSubscribeStoreMutation = null
         const unsubscribeRouter = router.beforeEach(async (to, from) => {
-            log.debug('[Legacy URL] entry into the legacy router')
-            log.debug('[Legacy URL] we came from the following route', from)
-            log.debug('[Legacy URL] We should reach the following route', to)
+            log.debug(
+                `[Legacy URL] entry into the legacy router with parameters 'form' and 'to': `,
+                from,
+                to
+            )
 
             if (MAP_VIEWS.includes(to.name) && from === START_LOCATION) {
                 // Redirect to the LegacyParamsView until the app is ready and that the legacy

--- a/src/store/modules/app.store.js
+++ b/src/store/modules/app.store.js
@@ -9,10 +9,17 @@ export default {
         isReady: false,
 
         /**
-         * Flag telling that the Map Module is ready. This is usefull for E2E testing which should
+         * Flag telling that the Map Module is ready. This is useful for E2E testing which should
          * not start before the Map Module is ready.
          */
         isMapReady: false,
+
+        /**
+         * Flag telling if we went through the legacy router. This is useful to force a router
+         * 'next' call in the case we went through the legacy parser and there is no default
+         * parameters.
+         */
+        needReloadBecauseOfLegacy: false,
     },
     getters: {},
     actions: {
@@ -22,9 +29,14 @@ export default {
         mapModuleReady: ({ commit }, { dispatcher }) => {
             commit('mapModuleReady', { dispatcher })
         },
+        setNeedReloadBecauseOfLegacy: ({ commit }, { value, dispatcher }) => {
+            commit('setNeedReloadBecauseOfLegacy', { value, dispatcher })
+        },
     },
     mutations: {
         setAppIsReady: (state) => (state.isReady = true),
         mapModuleReady: (state) => (state.isMapReady = true),
+        setNeedReloadBecauseOfLegacy: (state, { value }) =>
+            (state.needReloadBecauseOfLegacy = value),
     },
 }

--- a/src/store/modules/app.store.js
+++ b/src/store/modules/app.store.js
@@ -13,13 +13,6 @@ export default {
          * not start before the Map Module is ready.
          */
         isMapReady: false,
-
-        /**
-         * Flag telling if we went through the legacy router. This is useful to force a router
-         * 'next' call in the case we went through the legacy parser and there is no default
-         * parameters.
-         */
-        needReloadBecauseOfLegacy: false,
     },
     getters: {},
     actions: {
@@ -29,14 +22,9 @@ export default {
         mapModuleReady: ({ commit }, { dispatcher }) => {
             commit('mapModuleReady', { dispatcher })
         },
-        setNeedReloadBecauseOfLegacy: ({ commit }, { value, dispatcher }) => {
-            commit('setNeedReloadBecauseOfLegacy', { value, dispatcher })
-        },
     },
     mutations: {
         setAppIsReady: (state) => (state.isReady = true),
         mapModuleReady: (state) => (state.isMapReady = true),
-        setNeedReloadBecauseOfLegacy: (state, { value }) =>
-            (state.needReloadBecauseOfLegacy = value),
     },
 }


### PR DESCRIPTION
Issue : in some occasions, the router plugins would process the legacy query correctly, but not switch to the map view once it was done, staying stuck in the legacy view forever and not showing anything.

This happened when there was no change to make to the query due to default parameters not being in the URL, but still needing a redirect to the map view.

Fix : If we change the store and the view should change, we ask for a query change too

[Test link](https://sys-map.dev.bgdi.ch/preview/bugfix-pb-447-broken-legacy-parser/index.html)