### PR TITLE
PB-319: Bugfix on time slider click not keeping changes when closing the time slider.

### DIFF
--- a/src/modules/map/components/toolbox/TimeSlider.vue
+++ b/src/modules/map/components/toolbox/TimeSlider.vue
@@ -204,7 +204,10 @@ function setTooltipContent() {
     tippyInstance.setContent(tooltipContent)
 }
 
-function setCurrentYearAndDispatchToStore(year) {
+function setCurrentYearAndDispatchToStore(year, removePristineStatus = false) {
+    if (removePristineStatus) {
+        isPristine.value = false
+    }
     currentYear.value = year
     store.dispatch('setPreviewYear', { year: currentYear.value, ...dispatcher })
 }
@@ -386,6 +389,7 @@ function setYearToInputIfValid() {
                         :key="year"
                         :style="innerBarStepStyle"
                         class="time-slider-bar-inner-step"
+                        :data-cy="`time-slider-bar-${year}`"
                         :class="{
                             'has-no-data': !(
                                 yearsWithData.yearsJoint.includes(year) ||
@@ -396,7 +400,7 @@ function setYearToInputIfValid() {
                             'medium-tick': year % 25 === 0,
                             'small-tick': year % 5 === 0,
                         }"
-                        @click="setCurrentYearAndDispatchToStore(year)"
+                        @click="setCurrentYearAndDispatchToStore(year, true)"
                     />
                 </div>
                 <div

--- a/tests/cypress/tests-e2e/timeSlider.cy.js
+++ b/tests/cypress/tests-e2e/timeSlider.cy.js
@@ -139,6 +139,32 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             cy.get(`[data-cy="time-selector-${time_layer_std}-0"]`).should('contain', newYear)
             cy.closeMenuIfMobile()
 
+            // ------------------------------------------------------------------------------------------------
+            cy.log('When clicking on the time slider bar, we should go to that year')
+            cy.get(`[data-cy="time-slider-bar-${preSelectedYear}"]`).click()
+            cy.openMenuIfMobile()
+
+            cy.get('[data-cy="time-slider-bar-cursor-year"]').should(
+                'have.value',
+                `${preSelectedYear}`
+            )
+            cy.get(`[data-cy="time-selector-${time_layer_std}-0"]`).should(
+                'contain',
+                preSelectedYear
+            )
+            cy.closeMenuIfMobile()
+
+            // ------------------------------------------------------------------------------------------------
+            cy.log('Afterwards, the changes in the year should also be kept in the layers')
+            cy.log(
+                'When removing the time slider after altering it, the new year should be present in the layers'
+            )
+            cy.get('[data-cy="time-slider-button"]').click()
+            cy.openMenuIfMobile()
+
+            cy.get(`[data-cy="time-selector-${time_layer_std}-0"]`).should('contain', preSelectedYear)
+            cy.closeMenuIfMobile()
+
             // ----------------------------------------------------------------------------------------------------
             cy.log(
                 'With a visible time Layer and a TS parameter, the Time slider should appear at the correct year'

--- a/tests/cypress/tests-e2e/timeSlider.cy.js
+++ b/tests/cypress/tests-e2e/timeSlider.cy.js
@@ -141,7 +141,7 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
 
             // ------------------------------------------------------------------------------------------------
             cy.log('When clicking on the time slider bar, we should go to that year')
-            cy.get(`[data-cy="time-slider-bar-${preSelectedYear}"]`).click()
+            cy.get(`[data-cy="time-slider-bar-${preSelectedYear}"]`).click({ force: true })
             cy.openMenuIfMobile()
 
             cy.get('[data-cy="time-slider-bar-cursor-year"]').should(
@@ -162,7 +162,10 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             cy.get('[data-cy="time-slider-button"]').click()
             cy.openMenuIfMobile()
 
-            cy.get(`[data-cy="time-selector-${time_layer_std}-0"]`).should('contain', preSelectedYear)
+            cy.get(`[data-cy="time-selector-${time_layer_std}-0"]`).should(
+                'contain',
+                preSelectedYear
+            )
             cy.closeMenuIfMobile()
 
             // ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Issue : when clicking on the time slider bar, the years would not be saved in the layers when removing the time slider.

Fix : we do it now

[Test link](https://sys-map.dev.bgdi.ch/preview/bugfix-pb-319-years-not-saved-on-click/index.html)