### PR TITLE
PB-481: bugfix apply transparency instead of opacity

### DIFF
--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
@@ -93,7 +93,6 @@ function onToggleLayerVisibility() {
 }
 
 function onOpacityChange(e) {
-    
     store.dispatch('setLayerOpacity', {
         index: index.value,
         opacity: 1.0 - e.target.value,

--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
@@ -205,7 +205,7 @@ function duplicateLayer() {
                 max="1.0"
                 step="0.01"
                 :value="1.0 - layer.opacity"
-                :data-cy="`slider-opacity-layer-${id}-${index}`"
+                :data-cy="`slider-transparency-layer-${id}-${index}`"
                 @change="onTransparencyChange"
             />
             <button

--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
@@ -92,7 +92,7 @@ function onToggleLayerVisibility() {
     store.dispatch('toggleLayerVisibility', { index: index.value, ...dispatcher })
 }
 
-function onOpacityChange(e) {
+function onTransparencyChange(e) {
     store.dispatch('setLayerOpacity', {
         index: index.value,
         opacity: 1.0 - e.target.value,
@@ -199,14 +199,14 @@ function duplicateLayer() {
             </label>
             <input
                 :id="`transparency-${id}`"
-                class="menu-layer-transparency-slider"
+                class="menu-layer-transparency-slider ms-2 me-4"
                 type="range"
                 min="0.0"
                 max="1.0"
                 step="0.01"
                 :value="1.0 - layer.opacity"
                 :data-cy="`slider-opacity-layer-${id}-${index}`"
-                @change="onOpacityChange"
+                @change="onTransparencyChange"
             />
             <button
                 v-if="hasMultipleTimestamps"

--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
@@ -93,9 +93,10 @@ function onToggleLayerVisibility() {
 }
 
 function onOpacityChange(e) {
+    
     store.dispatch('setLayerOpacity', {
         index: index.value,
-        opacity: e.target.value,
+        opacity: 1.0 - e.target.value,
         ...dispatcher,
     })
 }
@@ -204,7 +205,7 @@ function duplicateLayer() {
                 min="0.0"
                 max="1.0"
                 step="0.01"
-                :value="layer.opacity"
+                :value="1.0 - layer.opacity"
                 :data-cy="`slider-opacity-layer-${id}-${index}`"
                 @change="onOpacityChange"
             />

--- a/tests/cypress/tests-e2e/layers.cy.js
+++ b/tests/cypress/tests-e2e/layers.cy.js
@@ -287,12 +287,12 @@ describe('Test of layer handling', () => {
                 cy.log('We ensure transparency works as expected for external layers too')
                 cy.openLayerSettings(fakeWmsLayerId1)
 
-                cy.get(`[data-cy^="slider-opacity-layer-${fakeWmsLayerId1}-"]`)
+                cy.get(`[data-cy^="slider-transparency-layer-${fakeWmsLayerId1}-"]`)
                     .should('be.visible')
                     .realClick({ position: 'right' })
                 cy.openLayerSettings(fakeWmsLayerId4)
 
-                cy.get(`[data-cy^="slider-opacity-layer-${fakeWmsLayerId4}-"]`)
+                cy.get(`[data-cy^="slider-transparency-layer-${fakeWmsLayerId4}-"]`)
                     .should('be.visible')
                     .realClick({ position: 'left' })
 
@@ -301,7 +301,7 @@ describe('Test of layer handling', () => {
                 // this way
                 cy.openLayerSettings(fakeWmsLayerId3)
 
-                cy.get(`[data-cy^="slider-opacity-layer-${fakeWmsLayerId3}-"]`)
+                cy.get(`[data-cy^="slider-transparency-layer-${fakeWmsLayerId3}-"]`)
                     .should('be.visible')
                     .realClick({ position: 'right' })
 
@@ -776,7 +776,7 @@ describe('Test of layer handling', () => {
                 const step = 5
                 const repetitions = 6
                 const command = '{rightarrow}'.repeat(repetitions)
-                cy.get(`[data-cy^="slider-opacity-layer-${layerId}-"]`)
+                cy.get(`[data-cy^="slider-transparency-layer-${layerId}-"]`)
                     .should('be.visible')
                     .type(command)
                 // checking that the opacity has changed accordingly
@@ -790,7 +790,7 @@ describe('Test of layer handling', () => {
                 )
                 visibleLayerIds.forEach((layerId, index) => {
                     cy.openLayerSettings(layerId)
-                    cy.get(`[data-cy="slider-opacity-layer-${layerId}-${index}"]`)
+                    cy.get(`[data-cy="slider-transparency-layer-${layerId}-${index}"]`)
                         .should('be.visible')
                         .realClick({ position: 'right' })
                     cy.readStoreValue('getters.visibleLayers').should((visibleLayers) => {
@@ -843,7 +843,7 @@ describe('Test of layer handling', () => {
             })
         })
         context('Timestamp management', () => {
-            it('layer with timestmap can be configured', () => {
+            it('layer with timestamp can be configured', () => {
                 goToMenuWithLayers()
                 cy.log('shows all possible timestamps in the timestamp popover')
                 const timedLayerId = 'test.timeenabled.wmts.layer'
@@ -885,9 +885,9 @@ describe('Test of layer handling', () => {
                     .should('be.visible')
                     .click()
                 // change the opacity to check later on that the new layer as the non default opacity
-                cy.get(`[data-cy="slider-opacity-layer-${timedLayerId}-2"]`)
+                cy.get(`[data-cy="slider-transparency-layer-${timedLayerId}-2"]`)
                     .should('be.visible')
-                    .realClick()
+                    .realClick({ position: 'right', force: true })
                 cy.get(`[data-cy="button-duplicate-layer-${timedLayerId}-2"]`)
                     .should('be.visible')
                     .realHover()
@@ -913,7 +913,7 @@ describe('Test of layer handling', () => {
                     expect(activeLayers[3]).not.to.be.undefined
                     expect(activeLayers[3].timeConfig.currentTimestamp).to.eq(timestamp)
                     expect(activeLayers[3].visible).to.be.true
-                    expect(activeLayers[3].opacity).to.eq(0.5)
+                    expect(activeLayers[3].opacity).to.eq(0)
                 })
 
                 //---------------------------------------------------------------------------------
@@ -934,9 +934,9 @@ describe('Test of layer handling', () => {
                 cy.get(`[data-cy="button-toggle-visibility-layer-${timedLayerId}-3"] svg`)
                     .should('be.visible')
                     .click()
-                cy.get(`[data-cy="slider-opacity-layer-${timedLayerId}-3"]`)
+                cy.get(`[data-cy="slider-transparency-layer-${timedLayerId}-3"]`)
                     .should('be.visible')
-                    .realClick({ position: 'right' })
+                    .realClick({ position: 'center' })
                 cy.get(`[data-cy="time-selector-${timedLayerId}-2"]`)
                     .should('be.visible')
                     .contains(timestamp.slice(0, 4))
@@ -956,12 +956,12 @@ describe('Test of layer handling', () => {
                     expect(activeLayers[3]).not.to.be.undefined
                     expect(activeLayers[3].timeConfig.currentTimestamp).to.eq(newTimestamp)
                     expect(activeLayers[3].visible).to.be.false
-                    expect(activeLayers[3].opacity).to.eq(0)
+                    expect(activeLayers[3].opacity).to.eq(0.5)
 
                     expect(activeLayers[2]).not.to.be.undefined
                     expect(activeLayers[2].timeConfig.currentTimestamp).to.eq(timestamp)
                     expect(activeLayers[2].visible).to.be.true
-                    expect(activeLayers[2].opacity).to.eq(0.5)
+                    expect(activeLayers[2].opacity).to.eq(0)
                 })
             })
         })
@@ -1051,7 +1051,7 @@ describe('Test of layer handling', () => {
                 cy.log('Moving the layers and change the opacity')
                 cy.log(`Moving ${middleLayerId} to the bottom and toggle it visibility`)
                 cy.get(`[data-cy^="button-lower-order-layer-${middleLayerId}-"]`).click()
-                cy.get(`[data-cy^="slider-opacity-layer-${middleLayerId}-"]`).realClick()
+                cy.get(`[data-cy^="slider-transparency-layer-${middleLayerId}-"]`).realClick()
                 cy.checkOlLayer([
                     'test.background.layer2',
                     { id: bottomLayerId, opacity: 0.75 },
@@ -1074,7 +1074,7 @@ describe('Test of layer handling', () => {
                 cy.get(`[data-cy="time-selector-${topLayerId}-2"]`)
                     .should('be.visible')
                     .contains(newTimestamp.slice(0, 4))
-                cy.get(`[data-cy="slider-opacity-layer-${topLayerId}-2"]`).realClick({
+                cy.get(`[data-cy="slider-transparency-layer-${topLayerId}-2"]`).realClick({
                     position: 'right',
                 })
                 cy.get(`[data-cy="menu-active-layer-${topLayerId}-3"]`).should('be.visible')

--- a/tests/cypress/tests-e2e/layers.cy.js
+++ b/tests/cypress/tests-e2e/layers.cy.js
@@ -887,7 +887,7 @@ describe('Test of layer handling', () => {
                 // change the opacity to check later on that the new layer as the non default opacity
                 cy.get(`[data-cy="slider-transparency-layer-${timedLayerId}-2"]`)
                     .should('be.visible')
-                    .realClick({ position: 'right', force: true })
+                    .realClick({ position: 'right' })
                 cy.get(`[data-cy="button-duplicate-layer-${timedLayerId}-2"]`)
                     .should('be.visible')
                     .realHover()

--- a/tests/cypress/tests-e2e/layers.cy.js
+++ b/tests/cypress/tests-e2e/layers.cy.js
@@ -289,12 +289,12 @@ describe('Test of layer handling', () => {
 
                 cy.get(`[data-cy^="slider-opacity-layer-${fakeWmsLayerId1}-"]`)
                     .should('be.visible')
-                    .realClick({ position: 'left' })
+                    .realClick({ position: 'right' })
                 cy.openLayerSettings(fakeWmsLayerId4)
 
                 cy.get(`[data-cy^="slider-opacity-layer-${fakeWmsLayerId4}-"]`)
                     .should('be.visible')
-                    .realClick({ position: 'right' })
+                    .realClick({ position: 'left' })
 
                 // we had some issues with wms transparency reverting back to default when reaching 0
                 // we test layer 1 and 3 for transparency 0, since that's both our wms fixtures tested
@@ -303,7 +303,7 @@ describe('Test of layer handling', () => {
 
                 cy.get(`[data-cy^="slider-opacity-layer-${fakeWmsLayerId3}-"]`)
                     .should('be.visible')
-                    .realClick({ position: 'left' })
+                    .realClick({ position: 'right' })
 
                 cy.checkOlLayer([
                     bgLayer,
@@ -775,14 +775,14 @@ describe('Test of layer handling', () => {
                 // using the keyboard to change slider's value
                 const step = 5
                 const repetitions = 6
-                const command = '{leftarrow}'.repeat(repetitions)
+                const command = '{rightarrow}'.repeat(repetitions)
                 cy.get(`[data-cy^="slider-opacity-layer-${layerId}-"]`)
                     .should('be.visible')
                     .type(command)
                 // checking that the opacity has changed accordingly
                 cy.readStoreValue('getters.visibleLayers', (visibleLayers) => {
                     const layer = visibleLayers.find((layer) => layer.id === layerId)
-                    expect(layer.opacity).to.eq(initialOpacity - step * repetitions)
+                    expect(layer.opacity).to.eq(initialOpacity + step * repetitions)
                 })
 
                 cy.log(
@@ -792,7 +792,7 @@ describe('Test of layer handling', () => {
                     cy.openLayerSettings(layerId)
                     cy.get(`[data-cy="slider-opacity-layer-${layerId}-${index}"]`)
                         .should('be.visible')
-                        .realClick({ position: 'left' })
+                        .realClick({ position: 'right' })
                     cy.readStoreValue('getters.visibleLayers').should((visibleLayers) => {
                         const layer = visibleLayers.find((layer) => layer.id === layerId)
                         expect(layer.opacity).to.eq(0.0)
@@ -936,7 +936,7 @@ describe('Test of layer handling', () => {
                     .click()
                 cy.get(`[data-cy="slider-opacity-layer-${timedLayerId}-3"]`)
                     .should('be.visible')
-                    .realClick({ position: 'left' })
+                    .realClick({ position: 'right' })
                 cy.get(`[data-cy="time-selector-${timedLayerId}-2"]`)
                     .should('be.visible')
                     .contains(timestamp.slice(0, 4))
@@ -1075,7 +1075,7 @@ describe('Test of layer handling', () => {
                     .should('be.visible')
                     .contains(newTimestamp.slice(0, 4))
                 cy.get(`[data-cy="slider-opacity-layer-${topLayerId}-2"]`).realClick({
-                    position: 'left',
+                    position: 'right',
                 })
                 cy.get(`[data-cy="menu-active-layer-${topLayerId}-3"]`).should('be.visible')
                 cy.get(`[data-cy="time-selector-${topLayerId}-3"]`)


### PR DESCRIPTION
Issue : On all labels for layers, we mention that we're modifying the transparency, when we are currently modifying the opacity.

fix : we reverse the value on the transparency slider, committing `1 - value` to the layer's opacity rather than the value.

[Test link](https://sys-map.dev.bgdi.ch/preview/bugfix-pb-481-reverse-transparency-slider/index.html)