### PR TITLE
PB-493: Fixed Time slider input cutoff on 3d Maps

### DIFF
--- a/src/modules/map/components/toolbox/TimeSlider.vue
+++ b/src/modules/map/components/toolbox/TimeSlider.vue
@@ -528,6 +528,9 @@ $time-slider-color-has-data: color.adjust($primary, $lightness: 30%);
         width: 32px;
         text-align: center;
     }
+    input {
+        margin: 0;
+    }
 }
 .time-slider-bar-cursor-year {
     &.form-control {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -21,7 +21,9 @@ li {
     @extend .clear-no-ios-long-press;
 }
 
-#main-component {
+// Add #cesium here to give this selector more specificity. Otherwise, the
+// cesium style will override the font as soon as the map is switched to 3d
+#main-component, #cesium {
     font-family: $frutiger;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
**RFC**
This could be one possible solution. It only addresses the font and the margin of the time slider though. There could potentially be other things that break with the cesium style. (1)

Another solution could be to re-order the css. For that, we'd have to prematurely load Cesium's `widgets.css` I guess, before our other rules are applied. The drawback would be that there's always cesium style around even if the 3d map isn't used. 

Open for other suggestions.


(1)
Although, when scanning through the `Cesium/Widgets/widgets.css`, the only other global style apart from `input` is `ul`. Everything else is a `.cesium-` prefixed class. So maybe it won't break too much.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-jira-pb-493-time-slider-cutoff/index.html)