### PR TITLE
PB-498: Fixed time selector css on mobile

### DIFF
--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItemTimeSelector.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItemTimeSelector.vue
@@ -121,9 +121,10 @@ function baseYear(timeEntry) {
     <button
         v-if="hasMultipleTimestamps"
         ref="timeSelectorButton"
-        class="btn btn-secondary me-2 w-13"
+        class="btn btn-secondary me-2"
         :class="{
             'btn-sm': compact,
+            'w-13': compact,
         }"
         :data-cy="`time-selector-${layerId}-${layerIndex}`"
     >


### PR DESCRIPTION
Issue : When using the mapviewer on mobile, the time selector button had its text cut out.

Fix : When on mobile view, we no longer enforce a width on the button, letting it fill the space to accommodate its content.

[Test link](https://sys-map.dev.bgdi.ch/preview/bugfix-pb-498-time-selector-cut-on-mobile/index.html)