### PR TITLE
PB-468 Fixed Time-Slider sliding under the menu on smaller screens

### DIFF
--- a/src/modules/map/components/toolbox/TimeSliderButton.vue
+++ b/src/modules/map/components/toolbox/TimeSliderButton.vue
@@ -80,6 +80,10 @@ $openCloseButtonHeight: 0rem;
 
 @include respond-above(sm) {
     .time-sliders {
+        // menu appears, we move the slider to the right and take the menu
+        // width into the width calculation
+        left: $menu-tray-width;
+        width: calc(100% - $map-button-diameter - $menu-tray-width - $spacer);
         top: calc($header-height + $openCloseButtonHeight);
         &.dev-disclaimer-present {
             top: calc($header-height + $openCloseButtonHeight + $dev-disclaimer-height);
@@ -89,9 +93,7 @@ $openCloseButtonHeight: 0rem;
 
 @include respond-above(lg) {
     .time-sliders {
-        left: $menu-tray-width;
         transform: none;
-        width: calc(100% - $map-button-diameter - $menu-tray-width - $spacer);
     }
     .time-sliders {
         top: 2 * $header-height;

--- a/src/modules/map/components/toolbox/TimeSliderButton.vue
+++ b/src/modules/map/components/toolbox/TimeSliderButton.vue
@@ -94,8 +94,6 @@ $openCloseButtonHeight: 0rem;
 @include respond-above(lg) {
     .time-sliders {
         transform: none;
-    }
-    .time-sliders {
         top: 2 * $header-height;
         &.dev-disclaimer-present {
             top: calc(2 * $header-height + $dev-disclaimer-height);


### PR DESCRIPTION
The styling, which moved the Time Slider to the right, was on the wrong screen selectors, making it slide underneath the Menu on the left.

Fixed this by moving the styling to a lower screen size selector.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-468-time-slider-underneath-menu/index.html)