### PR TITLE
PB-486: Fix print area when map is rotated

### DIFF
--- a/src/modules/map/components/openlayers/utils/printConstants.js
+++ b/src/modules/map/components/openlayers/utils/printConstants.js
@@ -1,6 +1,0 @@
-/**
- * The name of the OpenLayer layer that is used to render the print area.
- *
- * @type {String}
- */
-export const PRINT_AREA_LAYER_ID = 'printAreaLayer'

--- a/src/modules/map/components/openlayers/utils/usePrint.composable.js
+++ b/src/modules/map/components/openlayers/utils/usePrint.composable.js
@@ -6,8 +6,6 @@ import { getGenerateQRCodeUrl } from '@/api/qrcode.api.js'
 import { createShortLink } from '@/api/shortlink.api.js'
 import log from '@/utils/logging'
 
-import { PRINT_AREA_LAYER_ID } from './printConstants'
-
 const dispatcher = { dispatcher: 'usePrint.composable' }
 
 /** @enum */
@@ -81,7 +79,6 @@ export function usePrint(map) {
                 lang: store.state.i18n.lang,
                 printGrid: printGrid,
                 projection: store.state.position.projection,
-                excludedLayerIDs: [PRINT_AREA_LAYER_ID],
                 dpi: store.getters.selectedDPI,
             })
             currentJobReference.value = printJob.ref

--- a/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
+++ b/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
@@ -2,6 +2,7 @@ import { Feature } from 'ol'
 import { Polygon } from 'ol/geom'
 import * as olHas from 'ol/has'
 import VectorLayer from 'ol/layer/Vector'
+import { getRenderPixel } from 'ol/render'
 import VectorSource from 'ol/source/Vector'
 import { Fill, Style } from 'ol/style'
 import { computed, watch } from 'vue'
@@ -170,20 +171,19 @@ export default function usePrintAreaRenderer(map) {
         context.save()
 
         context.beginPath()
-        // Outside polygon, must be clockwise
-        context.moveTo(0, 0)
-        context.lineTo(width, 0)
-        context.lineTo(width, height)
-        context.lineTo(0, height)
-        context.lineTo(0, 0)
-        context.closePath()
 
-        // Inner polygon,must be counter-clockwise
-        context.moveTo(minx, miny)
-        context.lineTo(minx, maxy)
-        context.lineTo(maxx, maxy)
-        context.lineTo(maxx, miny)
-        context.lineTo(minx, miny)
+        // Outside polygon, must be clockwise
+        context.moveTo(...getRenderPixel(event, [0, 0]))
+        context.lineTo(...getRenderPixel(event, [width, 0]))
+        context.lineTo(...getRenderPixel(event, [width, height]))
+        context.lineTo(...getRenderPixel(event, [0, height]))
+
+        // Inner polygon, must be counter-clockwise
+        context.moveTo(...getRenderPixel(event, [minx, miny]))
+        context.lineTo(...getRenderPixel(event, [minx, maxy]))
+        context.lineTo(...getRenderPixel(event, [maxx, maxy]))
+        context.lineTo(...getRenderPixel(event, [maxx, miny]))
+
         context.closePath()
 
         context.fillStyle = 'rgba(0, 5, 25, 0.75)'

--- a/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
+++ b/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
@@ -23,7 +23,6 @@ export default function usePrintAreaRenderer(map) {
     const mapWidth = computed(() => store.state.ui.width)
     // Same here for simplicity we take the screen size minus the header size for the map size
     const mapHeight = computed(() => store.state.ui.height - store.state.ui.headerHeight)
-    const headerHeight = computed(() => store.state.ui.headerHeight)
 
     watch(isActive, (newValue) => {
         if (newValue) {
@@ -96,11 +95,9 @@ export default function usePrintAreaRenderer(map) {
         ]
 
         const minx = center[0] - w / 2
-        // here we move the center down due to the header that overlap the map
-        const miny = center[1] - h / 2 + headerHeight.value
+        const miny = center[1] - h / 2
         const maxx = center[0] + w / 2
-        // here we move the center down due to the header that overlap the map
-        const maxy = center[1] + h / 2 + headerHeight.value
+        const maxy = center[1] + h / 2
         return [minx, miny, maxx, maxy]
     }
 

--- a/src/modules/map/components/toolbox/Toggle3dButton.vue
+++ b/src/modules/map/components/toolbox/Toggle3dButton.vue
@@ -48,6 +48,8 @@ function checkWebGlSupport() {
 function toggle3d() {
     if (webGlIsSupported.value && !showDrawingOverlay.value) {
         store.dispatch('set3dActive', { active: !isActive.value, ...dispatcher })
+        // Hide print section when 3D is activated
+        store.dispatch('setPrintSectionShown', { show: false, ...dispatcher })
     }
 }
 </script>


### PR DESCRIPTION
The previous code from the old geoadmin was working by chance and when there is an internal change in the OpenLayers, it breaks. See the further discussion https://github.com/openlayers/openlayers/issues/15820

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-486-rotating-map-print-area/index.html)