### PR TITLE
PB-502: fix topic images absence

### DIFF
--- a/src/modules/menu/scss/topics-image.scss
+++ b/src/modules/menu/scss/topics-image.scss
@@ -39,7 +39,7 @@ $topics: (
     margin-right: auto;
     width: 107px;
     height: 57px;
-    background: url(../../assets/topics.png);
+    background: url('@/modules/menu/assets/topics.png');
     cursor: pointer;
 }
 


### PR DESCRIPTION
Issue : When opening the topic change popover, the images would not show anymore. This was due to the relative link in the css being incorrect.
Fix : We change the relative link to reach the correct location.

[Test link](https://sys-map.dev.bgdi.ch/preview/bugfix-pb-502-topic-images-not-showing/index.html)