### PR TITLE
PB-507: Fix logging in production build

### DIFF
--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -24,8 +24,8 @@ export const LogLevel = {
  * @param {...any} message
  */
 const log = (level, ...message) => {
-    // In production we don't log debug level
-    if (ENVIRONMENT === 'production' && [LogLevel.ERROR, LogLevel.WARNING].includes(level)) {
+    // In production we don't log debug level and info level
+    if (ENVIRONMENT === 'production' && ![LogLevel.ERROR, LogLevel.WARNING].includes(level)) {
         return
     }
 


### PR DESCRIPTION
In production build debug and info messages were printed when they shouldn't

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-507-log/index.html)