### PR TITLE
PB-501 Show dropdown for year selection in the time slider on tablet screens

### DIFF
--- a/src/modules/i18n/locales/en.json
+++ b/src/modules/i18n/locales/en.json
@@ -663,7 +663,7 @@
     "operation_successful": "Operation successful!",
     "operation_failed": "Oops! Something went wrong. Please try again.",
     "operation_aborted": "Operation aborted",
-    "outside_valid_year_range": "The entered year is outside ot the available range:",
+    "outside_valid_year_range": "The entered year is outside of the available range:",
     "linkedin_tooltip": "Share this map on LinkedIn",
     "share_map_title": "Link to the geoportal of the Swiss Confederation",
     "link_description": "Link description (optional)",

--- a/src/modules/map/components/toolbox/TimeSlider.vue
+++ b/src/modules/map/components/toolbox/TimeSlider.vue
@@ -344,7 +344,7 @@ function setYearToInputIfValid() {
         class="time-slider card"
         :class="{ grabbed: yearCursorIsGrabbed }"
     >
-        <div class="p-2 d-flex">
+        <div class="p-2 d-flex align-items-center justify-content-between">
             <div class="time-slider-bar px-5">
                 <div
                     ref="yearCursor"
@@ -418,6 +418,19 @@ function setYearToInputIfValid() {
                     </small>
                 </div>
             </div>
+
+            <div class="time-slider-dropdown">
+                <select
+                    class="form-select ml-2"
+                    :value="currentYear"
+                    @change="setCurrentYearAndDispatchToStore($event.target.value, true)"
+                >
+                    <option v-for="year in allYears" :key="year" :value="year">
+                        {{ year }}
+                    </option>
+                </select>
+            </div>
+
             <button
                 ref="playButton"
                 data-cy="time-slider-play-button"
@@ -450,6 +463,8 @@ function setYearToInputIfValid() {
 
 <style lang="scss">
 @use 'sass:color';
+
+@import '@/scss/media-query.mixin';
 @import '@/scss/webmapviewer-bootstrap-theme';
 
 $time-slider-color-background: color.adjust($white, $alpha: -0.1);
@@ -488,6 +503,47 @@ $time-slider-color-partial-data: color.adjust($primary, $lightness: 45%);
     border-color: $time-slider-color-has-data;
     background: $time-slider-color-has-data;
 }
+
+// Display the dropdown instead of the time slider on small screens (tablets),
+// but not on mobile
+.time-slider-dropdown {
+    display: none;
+}
+
+.time-slider {
+    width: 100%;
+}
+
+@include respond-above(sm) {
+    // dropdown mode
+    .time-slider-dropdown {
+        display: block;
+    }
+
+    .time-slider-bar {
+        display: none;
+    }
+
+    .time-slider {
+        width: auto;
+    }
+}
+
+@include respond-above(lg) {
+    // time slider mode
+    .time-slider-bar {
+        display: block;
+    }
+
+    .time-slider-dropdown {
+        display: none;
+    }
+
+    .time-slider {
+        width: 100%;
+    }
+}
+//
 
 .time-slider {
     background: $time-slider-color-background !important;

--- a/src/modules/map/components/toolbox/TimeSlider.vue
+++ b/src/modules/map/components/toolbox/TimeSlider.vue
@@ -29,7 +29,7 @@ const currentYear = ref(YOUNGEST_YEAR)
 const displayedYear = ref(YOUNGEST_YEAR)
 const isPristine = ref(true)
 let cursorX = 0
-let playYearsWithData = false
+const playYearsWithData = ref(false)
 let yearCursorIsGrabbed = false
 let playYearInterval = null
 
@@ -292,8 +292,8 @@ function releaseCursor() {
 }
 
 function togglePlayYearsWithData() {
-    playYearsWithData = !playYearsWithData
-    if (playYearsWithData) {
+    playYearsWithData.value = !playYearsWithData.value
+    if (playYearsWithData.value) {
         let yearsWithDataForPlayer = ALL_YEARS.filter(
             (year) =>
                 yearsWithData.value.yearsJoint.includes(year) ||

--- a/src/modules/map/components/toolbox/TimeSlider.vue
+++ b/src/modules/map/components/toolbox/TimeSlider.vue
@@ -373,7 +373,7 @@ function togglePlayYearsWithData() {
         :class="{ grabbed: yearCursorIsGrabbed }"
     >
         <div class="p-2 d-flex align-items-center justify-content-between">
-            <div class="time-slider-bar px-5">
+            <div class="time-slider-bar px-5" data-cy="time-slider-bar">
                 <div
                     ref="yearCursor"
                     data-cy="times-slider-cursor"
@@ -446,7 +446,7 @@ function togglePlayYearsWithData() {
                 </div>
             </div>
 
-            <div class="time-slider-dropdown">
+            <div class="time-slider-dropdown" data-cy="time-slider-dropdown">
                 <select v-model="currentYear" class="form-select ml-2">
                     <option v-for="year in allYears" :key="year" :value="year">
                         {{ year }}

--- a/src/modules/map/components/toolbox/TimeSlider.vue
+++ b/src/modules/map/components/toolbox/TimeSlider.vue
@@ -233,18 +233,30 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+    setPreviewYearToLayers()
+
+    tippyYearOutsideRange?.destroy()
+    tippyTimeSliderInfo?.destroy()
+})
+
+/** Set the current preview years to the layers if they have the year available in their data */
+function setPreviewYearToLayers() {
     activeLayers.value.forEach((layer, index) => {
-        if (layer.hasMultipleTimestamps) {
+        const year = previewYear.value
+        if (
+            layer.hasMultipleTimestamps &&
+            layer.timeConfig &&
+            layer.timeConfig.getTimeEntryForYear(year)
+        ) {
             store.dispatch('setTimedLayerCurrentYear', {
                 index,
-                year: previewYear.value,
+                year,
                 ...dispatcher,
             })
         }
     })
-    tippyYearOutsideRange?.destroy()
-    tippyTimeSliderInfo?.destroy()
-})
+}
+
 function dispatchPreviewYearToStore() {
     store.dispatch('setPreviewYear', { year: currentYear.value, ...dispatcher })
 }

--- a/src/modules/map/components/toolbox/TimeSlider.vue
+++ b/src/modules/map/components/toolbox/TimeSlider.vue
@@ -6,6 +6,7 @@ import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 
 import { OLDEST_YEAR, YOUNGEST_YEAR } from '@/config'
+import SearchableDropdown from '@/modules/map/components/toolbox/TimeSliderDropdown.vue'
 import { round } from '@/utils/numberUtils'
 
 const dispatcher = { dispatcher: 'TimeSlider.vue' }
@@ -459,21 +460,25 @@ function togglePlayYearsWithData() {
             </div>
 
             <div class="time-slider-dropdown" data-cy="time-slider-dropdown">
-                <select v-model="currentYear" class="form-select ml-2">
-                    <option v-for="year in allYears" :key="year" :value="year">
-                        {{ year }}
-                    </option>
-                </select>
+                <TimeSliderDropdown
+                    v-model.number="currentYear"
+                    :entries="allYears"
+                    :is-playing="playYearsWithData"
+                    @play="togglePlayYearsWithData"
+                >
+                </TimeSliderDropdown>
             </div>
 
-            <button
-                ref="playButton"
-                data-cy="time-slider-play-button"
-                class="btn btn-light btn-lg d-flex align-self-center p-3 m-1 border"
-                @click="togglePlayYearsWithData"
-            >
-                <FontAwesomeIcon :icon="playYearsWithData ? 'pause' : 'play'" />
-            </button>
+            <div class="time-slider-play-button">
+                <button
+                    ref="playButton"
+                    data-cy="time-slider-play-button"
+                    class="btn btn-light btn-lg d-flex align-self-center p-3 m-1 border"
+                    @click="togglePlayYearsWithData"
+                >
+                    <FontAwesomeIcon :icon="playYearsWithData ? 'pause' : 'play'" />
+                </button>
+            </div>
         </div>
         <!-- Time slider color tooltip content -->
         <div ref="timeSliderTooltipRef">
@@ -562,6 +567,10 @@ $time-slider-color-partial-data: color.adjust($primary, $lightness: 45%);
     .time-slider {
         width: auto;
     }
+
+    .time-slider-play-button {
+        display: none;
+    }
 }
 
 @include respond-above(lg) {
@@ -576,6 +585,10 @@ $time-slider-color-partial-data: color.adjust($primary, $lightness: 45%);
 
     .time-slider {
         width: 100%;
+    }
+
+    .time-slider-play-button {
+        display: block;
     }
 }
 //

--- a/src/modules/map/components/toolbox/TimeSliderButton.vue
+++ b/src/modules/map/components/toolbox/TimeSliderButton.vue
@@ -54,7 +54,9 @@ function toggleTimeSlider() {
                 'dev-disclaimer-present': hasDevSiteWarning,
             }"
         >
-            <TimeSlider v-if="isTimeSliderActive" />
+            <div class="d-flex justify-content-center">
+                <TimeSlider v-if="isTimeSliderActive" />
+            </div>
         </div>
     </div>
 </template>

--- a/src/modules/map/components/toolbox/TimeSliderDropdown.vue
+++ b/src/modules/map/components/toolbox/TimeSliderDropdown.vue
@@ -1,0 +1,155 @@
+<script setup>
+import { computed, ref } from 'vue'
+
+import TimeSliderDropdownList from '@/modules/map/components/toolbox/TimeSliderDropdownSearchList.vue'
+
+const emit = defineEmits(['update:modelValue', 'play'])
+
+const props = defineProps({
+    modelValue: {
+        type: [Number, String],
+        required: true,
+    },
+    entries: {
+        type: Array,
+        default: () => [],
+    },
+    isPlaying: {
+        type: Boolean,
+        default: false,
+    },
+})
+
+const isDropdownOpen = ref(false)
+const inputValue = ref('')
+// reference to the component
+const searchList = ref(null)
+
+// reference to the input
+const input = ref(null)
+
+const displayEntry = computed({
+    get() {
+        if (isDropdownOpen.value) {
+            return inputValue.value
+        } else {
+            return props.modelValue
+        }
+    },
+    set(value) {
+        inputValue.value = value
+    },
+})
+
+const dropdownEntries = computed(() => {
+    return props.entries
+        .filter((entry) => {
+            if (inputValue.value) {
+                return entry.toString().includes(inputValue.value)
+            } else {
+                // nothing searching, return all
+                return true
+            }
+        })
+        .map((entry) => ({
+            htmlDisplay: entry.toString(),
+            emphasize: inputValue.value?.toString() || '',
+            url: entry,
+        }))
+})
+
+function toggleList() {
+    if (isDropdownOpen.value) {
+        closeList()
+    } else {
+        openList()
+    }
+}
+
+function openList() {
+    isDropdownOpen.value = true
+}
+
+function closeList() {
+    isDropdownOpen.value = false
+    inputValue.value = null
+}
+
+function chooseEntry(value) {
+    emit('update:modelValue', value)
+    closeList()
+}
+
+function focusSearchlist() {
+    if (inputValue.value) {
+        searchList.value.goToFirst()
+    } else {
+        searchList.value.goToSpecific(props.modelValue)
+    }
+}
+
+function onEnter() {
+    if (inputValue.value.length == 4) {
+        emit('update:modelValue', inputValue.value)
+        input.value.blur()
+        closeList()
+    }
+}
+</script>
+
+<template>
+    <div v-click-outside="closeList">
+        <div class="d-flex">
+            <form
+                action=""
+                class="input-group input-group-append"
+                data-cy="searchable-dropdown"
+                @submit.prevent
+            >
+                <input
+                    ref="input"
+                    :value="displayEntry"
+                    class="form-control rounded-end-0"
+                    :class="{ 'rounded-bottom-0': isDropdownOpen }"
+                    @input="inputValue = $event.target.value"
+                    @focusin="openList"
+                    @keydown.esc.prevent="closeList"
+                    @keydown.down.prevent="focusSearchlist"
+                    @keydown.enter.prevent="onEnter"
+                />
+
+                <div class="input-group-append btn-group">
+                    <button
+                        class="btn border btn-outline-group d-flex align-items-center rounded-start-0 rounded-end-0"
+                        :class="{
+                            'url-input-dropdown-open': isDropdownOpen,
+                        }"
+                        type="button"
+                        data-cy="import-catalogue-providers-toggle"
+                        @click="toggleList"
+                    >
+                        <FontAwesomeIcon
+                            :icon="isDropdownOpen ? 'caret-up' : 'caret-down'"
+                            size="lg"
+                        />
+                    </button>
+                    <button
+                        ref="playButton"
+                        data-cy="time-slider-play-button"
+                        class="btn btn-outline-group d-flex align-items-center px-3 border rounded-start-0"
+                        :class="{ 'rounded-bottom-0': isDropdownOpen }"
+                        @click="emit('play')"
+                    >
+                        <FontAwesomeIcon :icon="isPlaying ? 'pause' : 'play'" size="sm" />
+                    </button>
+                </div>
+            </form>
+        </div>
+        <TimeSliderDropdownList
+            ref="searchList"
+            :entries="dropdownEntries"
+            :show-list="isDropdownOpen"
+            @choose-entry="chooseEntry"
+        />
+    </div>
+</template>

--- a/src/modules/map/components/toolbox/TimeSliderDropdownSearchList.vue
+++ b/src/modules/map/components/toolbox/TimeSliderDropdownSearchList.vue
@@ -1,0 +1,111 @@
+<script setup>
+import { nextTick, ref, toRefs } from 'vue'
+
+import TextSearchMarker from '@/utils/components/TextSearchMarker.vue'
+
+const props = defineProps({
+    showList: {
+        type: Boolean,
+        default: false,
+    },
+    entries: {
+        type: Array /* Array of Entries */,
+        default() {
+            return []
+        },
+    },
+})
+
+const emit = defineEmits(['chooseEntry'])
+
+const { showList, entries } = toRefs(props)
+const searchList = ref(null)
+
+function goToSpecific(value) {
+    const key = entries.value.findIndex((entry) => {
+        return entry.url == value
+    })
+    if (key >= 0) {
+        const elem = searchList.value.querySelector(`[tabindex="${key}"]`)
+        nextTick(() => {
+            elem.scrollIntoView()
+            elem.focus()
+        })
+    }
+}
+
+function goToPrevious(currentKey) {
+    if (currentKey === 0) {
+        return
+    }
+    const key = currentKey - 1
+    searchList.value.querySelector(`[tabindex="${key}"]`).focus()
+}
+
+function goToNext(currentKey) {
+    if (currentKey >= entries.value.length - 1) {
+        return
+    }
+    const key = currentKey + 1
+    searchList.value.querySelector(`[tabindex="${key}"]`).focus()
+}
+
+function goToFirst() {
+    searchList.value.querySelector('[tabindex="0"]').focus()
+}
+
+function goToLast() {
+    searchList.value.querySelector(`[tabindex="${entries.value.length - 1}"]`).focus()
+}
+
+defineExpose({ goToFirst, goToSpecific })
+</script>
+
+<template>
+    <div
+        v-show="showList"
+        class="entries-list-container shadow border rounded-bottom overflow-auto"
+    >
+        <div ref="searchList" class="entries-list">
+            <div
+                v-for="(entry, key) in entries"
+                :key="entry"
+                :tabindex="key"
+                class="entries-list-item px-2 py-1 text-nowrap"
+                @keydown.up.prevent="goToPrevious(key)"
+                @keydown.down.prevent="() => goToNext(key)"
+                @keydown.home.prevent="goToFirst"
+                @keydown.end.prevent="goToLast"
+                @keydown.esc.prevent="showList = false"
+                @keydown.enter.prevent="emit('chooseEntry', entry.url)"
+                @click="emit('chooseEntry', entry.url)"
+            >
+                <TextSearchMarker :text="entry.htmlDisplay" :search="entry.emphasize" />
+            </div>
+            <div v-show="entries.length === 0" class="entries-list-empty px-2 py-1">
+                <span>-</span>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+@import '@/scss/webmapviewer-bootstrap-theme';
+.entries-list-container {
+    max-height: 13rem;
+
+    .entries-list {
+        .entries-list-empty {
+            user-select: none;
+        }
+
+        .entries-list-item {
+            cursor: pointer;
+        }
+        .entries-list-item:focus,
+        .entries-list-item:hover {
+            background-color: $list-item-hover-bg-color;
+        }
+    }
+}
+</style>

--- a/src/modules/map/components/toolbox/useRangeTippy.js
+++ b/src/modules/map/components/toolbox/useRangeTippy.js
@@ -1,0 +1,35 @@
+import tippy from 'tippy.js'
+import { onMounted, onUnmounted, ref } from 'vue'
+
+/**
+ * Tippy instance to show a year input error
+ *
+ * @param {function} element Function that returns the element to mount the tippy on
+ * @param {string} tooltipContent The content of the tippy tooltip
+ * @returns The tippy instance and a function to update the content
+ */
+export function useRangeTippy(element, tooltipContent) {
+    let tippyInstance = ref(null)
+
+    onMounted(() => {
+        // we need lazy evaluation of the argument, as the reference
+        // is otherwise not yet set
+        tippyInstance.value = tippy(element(), {
+            content: tooltipContent,
+            arrow: true,
+            hideOnClick: false,
+            placement: 'bottom',
+            trigger: 'manual',
+            theme: 'danger',
+        })
+    })
+
+    onUnmounted(() => {
+        tippyInstance.value.destroy()
+    })
+
+    function updateTippyContent(newContent) {
+        tippyInstance.value.setContent(newContent)
+    }
+    return { tippyInstance, updateTippyContent }
+}

--- a/tests/cypress/tests-e2e/timeSlider.cy.js
+++ b/tests/cypress/tests-e2e/timeSlider.cy.js
@@ -348,5 +348,28 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
                         .should('lt', extractDecimal($barCursorPosition))
                 })
         })
+
+        it('checks that the timeslider dropdown is functional and behaves correctly', () => {
+            // ----------------------------------------------------------------------------------------------------
+            cy.log('Going to the map, the time slider appears')
+            cy.goToMapView({
+                layers: `${time_layer_std}@year=${preSelectedYear}`,
+                timeSlider: preSelectedYear,
+            })
+            cy.get('[data-cy="time-slider-bar"]').should('be.visible')
+
+            cy.log('When resizing the viewport to sm screens, the dropdown should appear')
+            cy.viewport(620, 568)
+            cy.get('[data-cy="time-slider-bar"]').should('not.be.visible')
+            cy.get('[data-cy="time-slider-dropdown"]').should('be.visible')
+
+            cy.get('[data-cy="time-slider-dropdown"] select').select('1999')
+
+            cy.log(
+                'When resizing back to mobile, the chosen year from the dropdown should be correct in the time slider'
+            )
+            cy.viewport(320, 568)
+            cy.get('[data-cy="time-slider-bar-cursor-year"]').should('have.value', 1999)
+        })
     })
 })

--- a/tests/cypress/tests-e2e/timeSlider.cy.js
+++ b/tests/cypress/tests-e2e/timeSlider.cy.js
@@ -122,6 +122,12 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             cy.log(
                 'When removing the time slider after altering it, the new year should be present in the layers'
             )
+
+            // proper way would be to use cy.tick, but I can't get it to work
+            // it somehow gets into a race condition and the rendering isn't updated
+            // after the debouncing is done
+            // eslint-disable-next-line cypress/no-unnecessary-waiting
+            cy.wait(1000)
             cy.get('[data-cy="time-slider-button"]').click()
             cy.openMenuIfMobile()
 
@@ -293,6 +299,9 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             cy.log(
                 'When having a duplicate layer, when one is invisible, they both still behave as expected'
             )
+        })
+
+        it('behaves correctly when years are being entered in the input', () => {
             cy.goToMapView({ layers: `${time_layer_std}@year=2019`, timeSlider: 2017 })
             cy.openMenuIfMobile()
             cy.get(`[data-cy="button-open-visible-layer-settings-${time_layer_std}-0"]`).click()
@@ -342,6 +351,13 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
                     cy.log('Time slider Bar moves when valid year entered')
                     cy.get('[data-cy="time-slider-bar-cursor-year"]').clear()
                     cy.get('[data-cy="time-slider-bar-cursor-year"]').type('2000')
+
+                    // proper way would be to use cy.tick, but I can't get it to work
+                    // it somehow gets into a race condition and the rendering isn't updated
+                    // after the debouncing is done
+                    // eslint-disable-next-line cypress/no-unnecessary-waiting
+                    cy.wait(750)
+
                     cy.get('[data-cy="time-slider-bar-cursor-arrow"]')
                         .invoke('attr', 'style')
                         .then(extractDecimal)

--- a/tests/cypress/tests-e2e/timeSlider.cy.js
+++ b/tests/cypress/tests-e2e/timeSlider.cy.js
@@ -363,7 +363,9 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             cy.get('[data-cy="time-slider-bar"]').should('not.be.visible')
             cy.get('[data-cy="time-slider-dropdown"]').should('be.visible')
 
-            cy.get('[data-cy="time-slider-dropdown"] select').select('1999')
+            cy.get('[data-cy="time-slider-dropdown"]')
+                .get('[data-cy="searchable-dropdown"] input')
+                .type('1999{downArrow}{enter}')
 
             cy.log(
                 'When resizing back to mobile, the chosen year from the dropdown should be correct in the time slider'


### PR DESCRIPTION
On small screens (but not mobile) show a Dropdown instead of the time slider.

- Add Dropdown on the time slider for small devices such as tablets
- Fix the play button icon
- Refactor the data flow in the time slider
- Prevent from updating layers with invalid year data
- Debounce the store updating

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-501-dropdown-timeslider-on-tablets/index.html)