### PR TITLE
PB-506 : embed sends information to parent about selected features

### DIFF
--- a/src/api/iframeFeatureEvent.api.js
+++ b/src/api/iframeFeatureEvent.api.js
@@ -1,0 +1,45 @@
+import log from '@/utils/logging.js'
+
+/**
+ * Sends information to the iFrame's parent about features, through the use of the postMessage
+ * HTML/Javascript API.
+ *
+ * @param {LayerFeature[]} features List of features for which we want to send information to the
+ *   iFrame's parent
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
+ */
+export function sendFeatureInformationToIFrameParent(features) {
+    const targetWindow = parent ?? window.parent ?? window.opener ?? window.top
+    if (!targetWindow) {
+        log.debug(
+            'Embed view loaded as root document of a browser tab, cannot communicate with opener/parent'
+        )
+        return
+    }
+    // if no features are given, nothing to do
+    if (features?.length === 0) {
+        return
+    }
+    log.debug('sending information about selected features to iframe parent')
+    // from what I can understand from the codepen, one event is fired per feature with a structured response
+    features.forEach((feature) => {
+        targetWindow.postMessage(
+            {
+                // see codepen above, for backward compatibility reasons we need to use the same type as mf-geoadmin3
+                type: 'gaFeatureSelection',
+                payload: {
+                    layerId: feature.layer.id,
+                    featureId: feature.id,
+                    // if we want to expose more stuff from our features (EGID, EWID, etc...), it should come here...
+                },
+            },
+            // meaning anyone, any host, can receive this event when adding our app as embedded on their website,
+            // so let's be cautious with what we add to the payload
+            '*'
+        )
+        // mf-geoadmin3 was also sending the same feature in a different unstructured/string format "layerId#featureId"
+        // but this comment here https://github.com/geoadmin/mf-geoadmin3/blob/6a7b99a2cc9980eec27b394ee709305a239549f1/src/components/tooltip/TooltipDirective.js#L661-L668
+        // suggest that this was already to accommodate some legacy support, and was supposed to be removed "soon"
+        // so let's not implement this format in the new viewer and see what happens.
+    })
+}

--- a/src/api/iframeFeatureEvent.api.js
+++ b/src/api/iframeFeatureEvent.api.js
@@ -17,7 +17,7 @@ export function sendFeatureInformationToIFrameParent(features) {
         return
     }
     // if no features are given, nothing to do
-    if (features?.length === 0) {
+    if (!Array.isArray(features) || features.length === 0) {
         return
     }
     log.debug('sending information about selected features to iframe parent')

--- a/src/store/plugins/click-on-map-management.plugin.js
+++ b/src/store/plugins/click-on-map-management.plugin.js
@@ -35,7 +35,11 @@ const clickOnMapManagementPlugin = (store) => {
                         ...dispatcher,
                     })
                     .then(() => {
+                        // while embedded, we do not change the way the feature tooltip is shown after
+                        // app initialization, this way the user that embed our app can choose to disable
+                        // tooltip entirely (and manage feature selection through the postMessage API)
                         if (
+                            !state.ui.embed &&
                             store.getters.noFeatureInfo &&
                             state.features.selectedFeaturesByLayerId.length > 0
                         ) {

--- a/src/views/EmbedView.vue
+++ b/src/views/EmbedView.vue
@@ -1,7 +1,8 @@
 <script setup>
-import { computed, onBeforeMount, onMounted } from 'vue'
+import { computed, onBeforeMount, onMounted, watch } from 'vue'
 import { useStore } from 'vuex'
 
+import { sendFeatureInformationToIFrameParent } from '@/api/iframeFeatureEvent.api'
 import I18nModule from '@/modules/i18n/I18nModule.vue'
 import InfoboxModule from '@/modules/infobox/InfoboxModule.vue'
 import MapFooter from '@/modules/map/components/footer/MapFooter.vue'
@@ -17,14 +18,22 @@ const dispatcher = { dispatcher: 'EmbedView.vue' }
 const store = useStore()
 
 const is3DActive = computed(() => store.state.cesium.active)
+const selectedLayerFeatures = computed(() => store.getters.selectedLayerFeatures)
 
 onBeforeMount(() => {
     store.dispatch('setEmbed', { embed: true, ...dispatcher })
 })
 
 onMounted(() => {
-    log.info(`Map view mounted`)
+    log.info(`Embedded map view mounted`)
 })
+
+// as described by this example on our documentation : https://codepen.io/geoadmin/pen/yOBzqM?editors=0010
+// our embed view should send a message (see https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage)
+// when a feature is selected while in embedded mode, so that the parent can get the selected feature(s) ID(s)
+watch(selectedLayerFeatures, () =>
+    sendFeatureInformationToIFrameParent(selectedLayerFeatures.value)
+)
 </script>
 
 <template>


### PR DESCRIPTION
using postMessage API to send the feature ID and layer ID of selected features to parent

Can be tested in the this codepen (by changing the URL from test.map.geo.admin.ch to this PR's testlink) [codepen here](https://codepen.io/geoadmin/pen/dyEXVKo)

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_pb-506_iframe_feature_selection_event/index.html)