### PR TITLE
PB-373: Fix missing label on GeoJSON layer

### DIFF
--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -316,7 +316,7 @@ async function transformOlMapToPrintParams(olMap, config) {
         const encodedMap = await encoder.encodeMap({
             map: olMap,
             scale,
-            printResolution: dpi,
+            printResolution: olMap.getView().getResolution(),
             dpi: dpi,
             customizer: customizer,
         })


### PR DESCRIPTION
[Test link](https://sys-map.dev.bgdi.ch/preview/fix-373-missing-label-on-json-layer/index.html)

- Sample: https://sys-s.dev.bgdi.ch/2et28t3xms6i
- OL Rendering: 
   ![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/29ce097f-a809-417e-8be0-6184d428b35e)
- Print result:
   ![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/958cdff6-e495-40a0-a844-674246bf8311)
- With PR #843 (correct offset, font)
  ![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/374f1fb4-a2e7-485f-b8f4-e7b13f5cb2b9)

**Remarks:**
The style of the label (rectangle with text inside) is not easily replicable in MapFish Print (same as the measurement label). So, I guess this is the best that we can do for now.

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-373-missing-label-on-json-layer/index.html)