### PR TITLE
PB-518: Fix timeslider flickering and WMS time enabled layer update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
                 "hammerjs": "^2.0.8",
                 "jquery": "^3.7.1",
                 "liang-barsky": "^1.0.5",
+                "lodash": "^4.17.21",
                 "maplibre-gl": "^4.1.2",
                 "ol": "^9.1.0",
                 "pako": "^2.1.0",
@@ -6201,8 +6202,7 @@
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "hammerjs": "^2.0.8",
         "jquery": "^3.7.1",
         "liang-barsky": "^1.0.5",
+        "lodash": "^4.17.21",
         "maplibre-gl": "^4.1.2",
         "ol": "^9.1.0",
         "pako": "^2.1.0",

--- a/src/modules/map/components/cesium/CesiumWMTSLayer.vue
+++ b/src/modules/map/components/cesium/CesiumWMTSLayer.vue
@@ -57,12 +57,11 @@ export default {
             return this.wmtsLayerConfig.opacity || 1.0
         },
         url() {
-            return getWmtsXyzUrl(
-                this.wmtsLayerConfig,
-                this.projection,
-                this.previewYear,
-                this.isTimeSliderActive
-            )
+            return getWmtsXyzUrl(this.wmtsLayerConfig, this.projection, {
+                addTimestamp: true,
+                previewYear: this.previewYear,
+                isTimeSliderActive: this.isTimeSliderActive,
+            })
         },
         tileMatrixSet() {
             const set =

--- a/src/utils/layerUtils.js
+++ b/src/utils/layerUtils.js
@@ -46,14 +46,22 @@ export function getTimestampFromConfig(config, previewYear, isTimeSliderActive) 
 /**
  * @param {GeoAdminWMTSLayer | ExternalWMTSLayer} wmtsLayerConfig
  * @param {CoordinateSystem} projection
- * @param {Number} previewYear
- * @param {Boolean} isTimeSliderActive
+ * @param {Boolean} [options.addTimestamp=false] Add the timestamp from the time config or the
+ *   timeslider to the ur. When false the timestamp is set to `{Time}` and need to processed later
+ *   on. Default is `false`
+ * @param {Number | null} [options.previewYear=null] Default is `null`
+ * @param {Boolean | null} [options.isTimeSliderActive=false] Default is `false`
  * @returns {String | null}
  */
-export function getWmtsXyzUrl(wmtsLayerConfig, projection, previewYear, isTimeSliderActive) {
+export function getWmtsXyzUrl(wmtsLayerConfig, projection, options = {}) {
+    const { addTimestamp = false, previewYear = null, isTimeSliderActive = false } = options ?? {}
     if (wmtsLayerConfig?.type === LayerTypes.WMTS && projection) {
-        const timestamp =
-            getTimestampFromConfig(wmtsLayerConfig, previewYear, isTimeSliderActive) ?? 'current'
+        let timestamp = '{Time}'
+        if (addTimestamp) {
+            timestamp =
+                getTimestampFromConfig(wmtsLayerConfig, previewYear, isTimeSliderActive) ??
+                'current'
+        }
 
         const layerId = wmtsLayerConfig.isExternal
             ? wmtsLayerConfig.id


### PR DESCRIPTION
Now when clicking on play on the time slider the layer is updated and not
removed/added which made a flickering effect.

Also solve the WMS time enabled layer which were not updated upon timestamp changes (via time config or time slider).

NOTE: The time slider flickering effect for 3D mode is not solved with this and cannot be easily solved as apparently Cesium doesn't support to update a layer, or at least I could not find a way.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-518-slider-smooth/index.html)