### PR TITLE
PB-451, PB-518: Fix WMS time enabled layer update

### DIFF
--- a/src/api/layers/LayerTimeConfigEntry.class.js
+++ b/src/api/layers/LayerTimeConfigEntry.class.js
@@ -11,6 +11,7 @@ import { isTimestampYYYYMMDD } from '@/utils/numberUtils'
  * @type {number}
  */
 export const YEAR_TO_DESCRIBE_ALL_OR_CURRENT_DATA = 9999
+
 /**
  * Timestamp to describe "all data" for time enabled WMS layer
  *

--- a/src/modules/map/components/cesium/CesiumWMSLayer.vue
+++ b/src/modules/map/components/cesium/CesiumWMSLayer.vue
@@ -10,6 +10,7 @@ import { mapState } from 'vuex'
 
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import GeoAdminWMSLayer from '@/api/layers/GeoAdminWMSLayer.class'
+import { ALL_YEARS_WMS_TIMESTAMP } from '@/api/layers/LayerTimeConfigEntry.class'
 import { DEFAULT_PROJECTION } from '@/config'
 import addImageryLayerMixins from '@/modules/map/components/cesium/utils/addImageryLayer-mixins'
 import CoordinateSystem from '@/utils/coordinates/CoordinateSystem.class'
@@ -89,10 +90,15 @@ export default {
                 LANG: this.currentLang,
                 VERSION: this.wmsVersion,
             }
-            if (this.timestamp) {
+            if (this.timestamp && this.timestamp !== ALL_YEARS_WMS_TIMESTAMP) {
                 params.TIME = this.timestamp
             }
             return params
+        },
+    },
+    watch: {
+        wmsUrlParams() {
+            this.updateLayer()
         },
     },
     methods: {

--- a/src/modules/map/components/cesium/CesiumWMTSLayer.vue
+++ b/src/modules/map/components/cesium/CesiumWMTSLayer.vue
@@ -80,7 +80,7 @@ export default {
         },
         dimensions() {
             const dimensions = {}
-            this.wmtsLayerConfig.dimensions.reduce((acc, dimension) => {
+            this.wmtsLayerConfig.dimensions?.reduce((acc, dimension) => {
                 if (dimension.current) {
                     acc[dimension.id] = 'current'
                 } else {
@@ -105,6 +105,11 @@ export default {
             }
 
             return dimensions
+        },
+    },
+    watch: {
+        dimensions() {
+            this.updateLayer()
         },
     },
     methods: {

--- a/src/modules/map/components/cesium/utils/addImageryLayer-mixins.js
+++ b/src/modules/map/components/cesium/utils/addImageryLayer-mixins.js
@@ -29,18 +29,21 @@ const addImageryLayerMixins = {
             this.getViewer().scene.imageryLayers.remove(layer)
             this.isPresentOnMap = false
         },
+        updateLayer() {
+            const viewer = this.getViewer()
+            const index = viewer.scene.imageryLayers.indexOf(this.layer)
+            viewer.scene.imageryLayers.remove(this.layer)
+            this.layer = this.createImagery(this.url)
+            viewer.scene.imageryLayers.add(this.layer, index)
+        },
     },
     watch: {
         opacity(newOpacity) {
             this.layer.alpha = newOpacity
             this.getViewer().scene.requestRender()
         },
-        url(newUrl) {
-            const viewer = this.getViewer()
-            const index = viewer.scene.imageryLayers.indexOf(this.layer)
-            viewer.scene.imageryLayers.remove(this.layer)
-            this.layer = this.createImagery(newUrl)
-            viewer.scene.imageryLayers.add(this.layer, index)
+        url() {
+            this.updateLayer()
         },
         zIndex(zIndex) {
             if (this.layer) {

--- a/src/utils/layerUtils.js
+++ b/src/utils/layerUtils.js
@@ -50,7 +50,7 @@ export function getTimestampFromConfig(config, previewYear, isTimeSliderActive) 
  *   timeslider to the ur. When false the timestamp is set to `{Time}` and need to processed later
  *   on. Default is `false`
  * @param {Number | null} [options.previewYear=null] Default is `null`
- * @param {Boolean | null} [options.isTimeSliderActive=false] Default is `false`
+ * @param {Boolean} [options.isTimeSliderActive=false] Default is `false`
  * @returns {String | null}
  */
 export function getWmtsXyzUrl(wmtsLayerConfig, projection, options = {}) {


### PR DESCRIPTION
WMS time enabled layer were not updated when changing their timestamp. This
was also an issue on 3D.

NOTE that for WMS all timestamps means that no TIME query param must be set.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-451-wms-time-enalbed/index.html)