### PR TITLE
PB-496: Added External WMS time config support

### DIFF
--- a/src/api/features/features.api.js
+++ b/src/api/features/features.api.js
@@ -340,6 +340,9 @@ async function identifyOnExternalWmsLayer(config) {
         // there might exist more implementation of WMS, but I stopped there looking for more
         // (please add more if you think one of our customer/external layer providers uses another flavor of WMS)
     }
+    if (layer.timeConfig?.currentYear) {
+        params.TIME = layer.timeConfig.currentYear
+    }
     // WMS 1.3.0 uses i,j to describe pixel coordinate where we want feature info
     if (params.VERSION === '1.3.0') {
         params.I = GET_FEATURE_INFO_FAKE_VIEWPORT_SIZE / 2

--- a/src/api/layers/ExternalWMSLayer.class.js
+++ b/src/api/layers/ExternalWMSLayer.class.js
@@ -3,6 +3,30 @@ import { InvalidLayerDataError } from '@/api/layers/InvalidLayerData.error'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
 
 /**
+ * A WMS Layer dimension
+ *
+ * See WMS OGC Spec
+ *
+ * @class
+ */
+export class WMSDimension {
+    /**
+     * @param {String} id Dimension identifier
+     * @param {String} dft Dimension default value
+     * @param {[String]} values All dimension values
+     * @param {Boolean} [optionals.current] Boolean flag if the dimension support current (see WMS
+     *   OGC spec)
+     */
+    constructor(id, dft, values, optionals = {}) {
+        const { current = false } = optionals
+        this.id = id
+        this.default = dft
+        this.values = values
+        this.current = current
+    }
+}
+
+/**
  * Metadata for an external WMS layer.
  *
  * @WARNING DON'T USE GETTER AND SETTER ! Instances of this class will be used a Vue 3 reactive
@@ -45,6 +69,12 @@ export default class ExternalWMSLayer extends ExternalLayer {
      * @param {ExternalLayerGetFeatureInfoCapability | null} [externalWmsData.getFeatureInfoCapability=null]
      *   Configuration describing how to request this layer's server to get feature information.
      *   Default is `null`
+     * @param {[WMSDimension]} [externalWmsData.dimensions=[]] WMS Dimensions. Default is `[]`
+     * @param {LayerTimeConfig | null} [externalWmsData.timeConfig=null] Time series config (if
+     *   available). Default is `null`
+     * @param {Number} [externalWmsData.currentYear=null] Current year of the time series config to
+     *   use. This parameter is needed as it is set in the URL while the timeConfig parameter is not
+     *   yet available and parse later on from the GetCapabilities. Default is `null`
      * @throws InvalidLayerDataError if no `externalWmsData` is given or if it is invalid
      */
     constructor(externalWmsData) {
@@ -67,6 +97,9 @@ export default class ExternalWMSLayer extends ExternalLayer {
             availableProjections = [],
             hasTooltip = false,
             getFeatureInfoCapability = null,
+            dimensions = [],
+            timeConfig = null,
+            currentYear = null,
         } = externalWmsData
         super({
             name,
@@ -83,8 +116,11 @@ export default class ExternalWMSLayer extends ExternalLayer {
             availableProjections,
             hasTooltip,
             getFeatureInfoCapability,
+            timeConfig,
+            currentYear,
         })
         this.wmsVersion = wmsVersion
         this.format = format
+        this.dimensions = dimensions
     }
 }

--- a/src/api/layers/ExternalWMTSLayer.class.js
+++ b/src/api/layers/ExternalWMTSLayer.class.js
@@ -97,7 +97,7 @@ export default class ExternalWMTSLayer extends ExternalLayer {
      *   identifiers. Default is `[]`
      * @param {[WMTSDimension]} [externalWmtsData.dimensions=[]] WMTS tile dimensions. Default is
      *   `[]`
-     * @param {LayerTimeConfig | null} [externalLayerData.timeConfig=null] Time series config (if
+     * @param {LayerTimeConfig | null} [externalWmtsData.timeConfig=null] Time series config (if
      *   available). Default is `null`
      * @param {Number} [externalWmtsData.currentYear=null] Current year of the time series config to
      *   use. This parameter is needed as it is set in the URL while the timeConfig parameter is not


### PR DESCRIPTION
[Test link with External WMS with time config](https://sys-s.dev.bgdi.ch/ay6qfhgvhdo3)
[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-496-wms-time-external/index.html)