### PR TITLE
PB-530: Added print date to the print API spec

### DIFF
--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -366,13 +366,14 @@ async function transformOlMapToPrintParams(olMap, config) {
                 },
             })
         }
-
+        const now = i18n.global.d(new Date(), 'datetime', i18n.global.locale)
         const spec = {
             attributes: {
                 map: encodedMap,
                 copyright: attributionsOneLine,
                 url: shortLink,
                 qrimage: qrCodeUrl,
+                printDate: now,
             },
             format: 'pdf',
             layout: layout.name,

--- a/src/modules/i18n/index.js
+++ b/src/modules/i18n/index.js
@@ -8,18 +8,43 @@ import rm from './locales/rm.json'
 
 export const languages = { de, fr, it, en, rm }
 
+const locales = Object.entries(languages).reduce((obj, entry) => {
+    const key = langToLocal(entry[0])
+    obj[key] = entry[1]
+    return obj
+}, {})
+
+export function langToLocal(lang) {
+    return ['de', 'fr', 'it', 'rm'].includes(lang) ? `${lang}-CH` : lang
+}
+
 // detecting navigator's locale as the default language
 // (if it is a language served by this app)
 let matchedLanguage = null
 if (navigator.languages) {
     // we keep the first match we found
-    matchedLanguage = navigator.languages.find((lang) => lang in languages)
+    matchedLanguage = navigator.languages.find((lang) => Object.keys(locales).includes(lang))
 }
+
+const datetimeFormats = Object.keys(locales).reduce((obj, key) => {
+    obj[key] = {
+        date: { year: 'numeric', month: 'numeric', day: 'numeric' },
+        datetime: {
+            year: 'numeric',
+            month: 'numeric',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: 'numeric',
+        },
+    }
+    return obj
+}, {})
 
 const i18n = createI18n({
     locale: matchedLanguage || 'en', // default locale
     messages: languages,
     legacy: false,
+    datetimeFormats,
 })
 
 export default i18n

--- a/src/store/modules/i18n.store.js
+++ b/src/store/modules/i18n.store.js
@@ -1,4 +1,4 @@
-import i18n from '@/modules/i18n'
+import i18n, { langToLocal } from '@/modules/i18n'
 
 /**
  * The name of the mutation for lang changes
@@ -29,7 +29,7 @@ const mutations = {}
 
 mutations[SET_LANG_MUTATION_KEY] = function (state, { lang }) {
     state.lang = lang
-    i18n.global.locale = lang
+    i18n.global.locale = langToLocal(lang)
 }
 
 export default {


### PR DESCRIPTION
Use the date formatting based on the locale (en => MM/DD/YYYY, H:MM PM/AM, fr-CH => DD.MM.YYYY, HH:MM

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-530-print-date/index.html)