### PR TITLE
PB-518: Removed time slider on 3D view

### DIFF
--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -53,7 +53,7 @@ onMounted(() => {
                 :toggle3d-button="!isDrawingMode"
                 compass-button
             >
-                <TimeSliderButton v-if="!isDrawingMode" />
+                <TimeSliderButton v-if="!isDrawingMode && !is3DActive" />
             </MapToolbox>
             <!-- we place the drawing module here so that it can receive the OpenLayers map instance through provide/inject -->
             <DrawingModule v-if="loadDrawingModule" />


### PR DESCRIPTION
Currently on Cesium changing the year is removing/adding the layer which
is not so nice when using the slider play feature as it result to a flickering
effect.

The way Cesium is configured don't allow us to do layer update. It seems that
we could do it with a state management system but would required a big rewrite
of 3D.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-518-remove-slider-3d/index.html)