### PR TITLE
PB-496: Fix external layer error and time slider issue

### DIFF
--- a/src/api/layers/ExternalLayer.class.js
+++ b/src/api/layers/ExternalLayer.class.js
@@ -1,7 +1,5 @@
 import AbstractLayer, { LayerAttribution } from '@/api/layers/AbstractLayer.class'
 import { InvalidLayerDataError } from '@/api/layers/InvalidLayerData.error'
-import { WGS84 } from '@/utils/coordinates/coordinateSystems'
-import log from '@/utils/logging'
 
 /**
  * Information required to create a GetFeatureInfo request to this external WM(T)S server. This
@@ -148,13 +146,6 @@ export default class ExternalLayer extends AbstractLayer {
         this.extent = extent
         this.legends = legends
         this.availableProjections = [...availableProjections]
-        if (this.availableProjections.length === 0) {
-            log.error(
-                'No supported projection found within external layer config, falling back to WGS84',
-                externalLayerData
-            )
-            this.availableProjections.push(WGS84)
-        }
         this.getFeatureInfoCapability = getFeatureInfoCapability
         this.currentYear = currentYear
         if (currentYear && this.timeConfig) {

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -169,9 +169,7 @@ const getters = {
      */
     visibleLayersWithTimeConfig: (state) =>
         // Here we cannot take the getter visibleLayers as it also contain the preview and system layers
-        state.activeLayers.filter(
-            (layer) => layer.visible && layer.timeConfig?.timeEntries?.length
-        ),
+        state.activeLayers.filter((layer) => layer.visible && layer.hasMultipleTimestamps),
 
     /**
      * Returns true if the layer comes from a third party (external layer or KML layer).


### PR DESCRIPTION
At startup we never know the projection of the external layers, the projection
is taken from the capabilities that needs to be loaded first. Therefore don't
test projection upon creation and don't do any fallback.

Also fixed an issue when a layer has only one timestamp, the time slider was
displayed but the user could not change the timestamp.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-496-external-layer-projection/index.html)