### PR TITLE
Script to generate reports on translation use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ scripts/check-layer-providers-results/*invalid_providers_wms.yaml
 scripts/check-layer-providers-results/*invalid_providers_wmts.yaml
 scripts/check-layer-providers-results/*invalid_providers_content.yaml
 scripts/check-layer-providers-results/*valid_providers.json
+
+# reports for translations
+translation_reports/*

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "build:int": "npm run build -- --mode integration",
         "build:prod": "npm run build -- --mode production",
         "update:translations": "node scripts/generate-i18n-files.js",
+	"check:translations": "node scripts/check-translations.js",
         "check:external": "npx vite-node scripts/check-external-layers-providers.js",
         "delete:reports": "rimraf tests/results/ || true",
         "delete:reports:unit": "rimraf tests/results/unit/ || true"

--- a/scripts/check-translations.js
+++ b/scripts/check-translations.js
@@ -1,0 +1,234 @@
+import fs from 'fs'
+import path from 'path'
+
+// regex constants
+const re_explicit = /[$.]t\([`'].+[`']\)/g
+const re_non_explicit = /[.$]t\((?!['`]).+\)/g
+
+// path constants
+const reportDir = 'translation_reports'
+const reportFile = 'report'
+const jsonFilePath = `${reportDir}/${reportFile}.json`
+const txtFilePath = `${reportDir}/${reportFile}.txt`
+const noExplicitUseTxtFilePath = `${reportDir}/translations_not_explicitly_used.txt`
+
+// language constants
+const langs = ['de', 'fr', 'it', 'en', 'rm']
+const translation_files_generic_path = 'src/modules/i18n/locales/lang.json'
+
+// dict used to store the current translation
+const translations = {}
+// dict used to store the usage data for the translation keys
+const translation_usage = {}
+
+// it's used to make the txt report a little bit more readable
+const translation_separator = '--------------------------------------------------------------\n'
+
+/** Read the I18n jsons used for translation and make a dictionary out of them to use in the code. */
+function init_translation_dictionary() {
+    langs.forEach((lang) => {
+        translations[lang] = JSON.parse(
+            fs.readFileSync(translation_files_generic_path.replace('lang', lang), {
+                encoding: 'utf-8',
+                flag: 'r',
+            })
+        )
+    })
+}
+
+/**
+ * If there is no entry in the `translation_usage` for the key, we create one. Then we increment the
+ * number of occurrences of the key appearing in the file If the key is not a variable, we add the
+ * translations to the dictionary
+ *
+ * @param {str} key The translation key we are checking
+ * @param {str} filePath In which file we found it
+ * @param {boolean} isNotAVariable Is it a variable called by the code
+ */
+function increaseTranslationCount(key, filePath, isNotAVariable = true) {
+    if (!translation_usage[key]) {
+        translation_usage[key] = {
+            occurrences_by_file: {},
+            skipTranslationInReport: !isNotAVariable,
+            en: isNotAVariable ? translations.en[key] : null,
+            rm: isNotAVariable ? translations.rm[key] : null,
+            fr: isNotAVariable ? translations.fr[key] : null,
+            it: isNotAVariable ? translations.it[key] : null,
+            de: isNotAVariable ? translations.de[key] : null,
+        }
+    }
+    if (!translation_usage[key].occurrences_by_file[filePath]) {
+        translation_usage[key].occurrences_by_file[filePath] = 0
+    }
+    translation_usage[key].occurrences_by_file[filePath] += 1
+}
+
+/**
+ * Recursive function which search for typescripts, vue and js files, and look for translations
+ * inside
+ *
+ * @param {str} directoryPath The root directory from which we start searching
+ */
+function searchDirectory(directoryPath) {
+    const files = fs.readdirSync(directoryPath)
+    files.forEach((file) => {
+        const filePath = `${directoryPath}/${file}`
+        if (
+            path.extname(file) === '.js' ||
+            path.extname(file) === '.vue' ||
+            path.extname(file) === '.ts'
+        ) {
+            const fileContent = fs.readFileSync(filePath, { encoding: 'utf-8', flag: 'r' })
+
+            // Check the file for use of explicit translations, either fully static or a mix
+            // of a variable and of a string (example : .t(`draw_${drawingType.value}`))
+            const explicit_array = fileContent.match(re_explicit) ?? []
+            const dynamic_element = /\$\{.+\}/
+            explicit_array.forEach((translation_key) => {
+                let key = translation_key
+                    .replace("'", '`')
+                    .replace("'", '`')
+                    .replace('$t(`', '')
+                    .replace('.t(`', '')
+                    .replace('`)', '')
+                if (key.match(dynamic_element)) {
+                    key = key.replace(key.match(dynamic_element)[0], '\\.+')
+                }
+                const re = RegExp(key)
+
+                for (const json_key of Object.keys(translations.en)) {
+                    if (json_key.match(re)) {
+                        increaseTranslationCount(json_key, filePath)
+                    }
+                }
+            })
+
+            // Check the file for use of non explicit translations, which are variables only
+            // and not realistically easy to find a translation key for. (example : .t(category.id))
+            const variable_array = (fileContent.match(re_non_explicit) ?? []).concat(
+                fileContent.match(re_non_explicit) ?? []
+            )
+
+            variable_array.forEach((key) => {
+                const strippedKey = key
+                    .replace('.t(', '')
+                    .replace('$t(', '')
+                    .replace(')', '')
+                    .replace(')', '')
+                    .replace(')', '')
+                increaseTranslationCount(strippedKey, filePath, false)
+            })
+        } else if (fs.statSync(`${directoryPath}/${file}`).isDirectory()) {
+            // if we are in a directory, we go further in
+            searchDirectory(`${directoryPath}/${file}`)
+        }
+    })
+}
+
+/**
+ * Some translations are not called explicitly by the code. We create a separate record so we can
+ * check manually if they are called or not.
+ */
+function createNonExplicitlyUsedTranslationsReport() {
+    for (const key of Object.keys(translation_usage)) {
+        langs.forEach((lang) => {
+            delete translations[lang][key]
+        })
+    }
+    fs.writeFileSync(noExplicitUseTxtFilePath, '')
+    for (const key of Object.keys(translations.en)) {
+        fs.appendFileSync(
+            noExplicitUseTxtFilePath,
+            '********************************************************\n'
+        )
+
+        fs.appendFileSync(
+            noExplicitUseTxtFilePath,
+            'The following key has no explicit translation usage in the mapviewer\n\n'
+        )
+        fs.appendFileSync(noExplicitUseTxtFilePath, key)
+        fs.appendFileSync(noExplicitUseTxtFilePath, '\n\n')
+        langs.forEach((lang) => {
+            fs.appendFileSync(noExplicitUseTxtFilePath, translation_separator)
+            fs.appendFileSync(
+                noExplicitUseTxtFilePath,
+                `The ${lang} Translation is: \n\n`
+                    .replace('it', 'Italian')
+                    .replace('en', 'English')
+                    .replace('rm', 'Rumantsch')
+                    .replace('de', 'German')
+                    .replace('fr', 'French')
+            )
+            fs.appendFileSync(noExplicitUseTxtFilePath, translations[lang][key] ?? '')
+            fs.appendFileSync(noExplicitUseTxtFilePath, '\n\n')
+        })
+        fs.appendFileSync(
+            noExplicitUseTxtFilePath,
+            '********************************************************\n'
+        )
+    }
+}
+
+/**
+ * Takes an entry in the 'translations' dictionary and format it for the txt report
+ *
+ * @param {string} key The translation key
+ * @param {Object} data The translations and occurrences of the key in the code
+ */
+function addEntryToTextReport(key, data) {
+    fs.appendFileSync(txtFilePath, '********************************************************\n')
+    fs.appendFileSync(txtFilePath, key)
+    fs.appendFileSync(txtFilePath, '\n\n')
+    fs.appendFileSync(txtFilePath, 'Number of occurences in files :\n')
+
+    for (const [fileName, count] of Object.entries(data.occurrences_by_file)) {
+        fs.appendFileSync(txtFilePath, `  ${fileName} : ${count}\n`)
+    }
+    if (data.skipTranslationInReport) {
+        fs.appendFileSync(
+            txtFilePath,
+            'This key is a variable found in the files. We cannot be sure of which translation key it refers to. \n\n'
+        )
+    } else {
+        langs.forEach((lang) => {
+            fs.appendFileSync(txtFilePath, translation_separator)
+            fs.appendFileSync(
+                txtFilePath,
+                `The ${lang} Translation is: \n\n`
+                    .replace('it', 'Italian')
+                    .replace('en', 'English')
+                    .replace('rm', 'Rumantsch')
+                    .replace('de', 'German')
+                    .replace('fr', 'French')
+            )
+            fs.appendFileSync(txtFilePath, data[lang] ?? '')
+            fs.appendFileSync(txtFilePath, '\n\n')
+        })
+    }
+    fs.appendFileSync(txtFilePath, '********************************************************\n')
+}
+
+init_translation_dictionary()
+searchDirectory('src')
+searchDirectory('tests')
+
+if (!fs.existsSync(reportDir)) {
+    fs.mkdirSync(reportDir)
+}
+
+// creating a simple json file which contains all translations keys used and their corresponding data
+
+fs.writeFileSync(jsonFilePath, JSON.stringify(translation_usage, null, '    '))
+
+// creating the txt report that shows all translations 'explicitly' called in code.
+// since some of theme are called by a mix between variables and static string
+// there is a chance some are not used.
+
+fs.writeFileSync(txtFilePath, '')
+for (const [key, value] of Object.entries(translation_usage)) {
+    addEntryToTextReport(key, value)
+}
+
+// creating the report that shows all translations that are not explicitly called in code
+// this might be because they're not used, or because they're called by a variable
+createNonExplicitlyUsedTranslationsReport()

--- a/scripts/check-translations.js
+++ b/scripts/check-translations.js
@@ -117,19 +117,24 @@ function searchDirectory(directoryPath) {
                 if (strippedKey.includes('||')) {
                     // left is a variable, right is a string
                     const splits = strippedKey.split('||')
-                    increaseTranslationCount(splits[0].replace(/\s/g, ''), filePath, false)
-                    increaseTranslationCount(
-                        splits[1].replace(/\s/g, '').replace(/'/g, ''),
-                        filePath,
-                        true
-                    )
+                    splits.forEach((split_key) => {
+                        increaseTranslationCount(
+                            split_key.replace(/\s/g, '').replace(/'/g, ''),
+                            filePath,
+                            Object.keys(translations.en).includes(
+                                split_key.replace(/\s/g, '').replace(/'/g, '')
+                            )
+                        )
+                    })
                 } else if (strippedKey.includes('?')) {
                     const splits = strippedKey.split('?')[1].split([':'])
-                    splits.forEach((ternary_operator_dependent_key) => {
+                    splits.forEach((split_key) => {
                         increaseTranslationCount(
-                            ternary_operator_dependent_key.replace(/\s/g, '').replace(/'/g, ''),
+                            split_key.replace(/\s/g, '').replace(/'/g, ''),
                             filePath,
-                            !ternary_operator_dependent_key.includes('.')
+                            Object.keys(translations.en).includes(
+                                split_key.replace(/\s/g, '').replace(/'/g, '')
+                            )
                         )
                     })
                 } else {


### PR DESCRIPTION
RFC 
The script is used to create three files.

report.json is a json file which contains all translation keys found, state their occurrences across the code, has their translation when there is one available and state if the key is a variable called in the code (in which case, it would be difficult to find all keys that could match this one)

report.txt is a human readable version of the same report

non_explicitly_used_keys.txt is a report which lists all translations for which there was no explicit translation found (i.e : all translations currently specified, but not in the previous reports). We cannot guarantee that they are not used.

We could still upgrade the script by checking for ternary operators which gives explicit values, but this will suffice for a first draft

usage : npm run check:translations

If this is sufficient, it's usable (even if we can't find every usage)
I'm still going to check for ternary operators (we have 2 keys which use those), or cases where there is a null / false check before assigning a value to translate, they are currently counted as "non explicit".

@hansmannj : once you've run it, feel free to tell me what you'd like to change to make files that are easier to read.

[Test link](https://sys-map.dev.bgdi.ch/preview/translation-checking-script/index.html)