### PR TITLE
PB-506 : send feature event regardless of embed mode

### DIFF
--- a/src/store/modules/features.store.js
+++ b/src/store/modules/features.store.js
@@ -3,6 +3,7 @@ import { containsCoordinate } from 'ol/extent'
 import EditableFeature, { EditableFeatureTypes } from '@/api/features/EditableFeature.class'
 import { identify, identifyOnGeomAdminLayer } from '@/api/features/features.api'
 import LayerFeature from '@/api/features/LayerFeature.class'
+import { sendFeatureInformationToIFrameParent } from '@/api/iframeFeatureEvent.api'
 import getProfile from '@/api/profile/profile.api'
 import {
     DEFAULT_FEATURE_COUNT_RECTANGLE_SELECTION,
@@ -222,6 +223,11 @@ export default {
                     layerFeatures.featureCountForMoreData =
                         layerFeatures.features.length % paginationSize === 0 ? paginationSize : 0
                 })
+
+                // as described by this example on our documentation : https://codepen.io/geoadmin/pen/yOBzqM?editors=0010
+                // our app should send a message (see https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage)
+                // when a feature is selected while embedded, so that the parent can get the selected feature(s) ID(s)
+                sendFeatureInformationToIFrameParent(layerFeatures)
             }
             commit('setSelectedFeatures', {
                 drawingFeatures,

--- a/src/views/EmbedView.vue
+++ b/src/views/EmbedView.vue
@@ -1,8 +1,7 @@
 <script setup>
-import { computed, onBeforeMount, onMounted, watch } from 'vue'
+import { computed, onBeforeMount, onMounted } from 'vue'
 import { useStore } from 'vuex'
 
-import { sendFeatureInformationToIFrameParent } from '@/api/iframeFeatureEvent.api'
 import I18nModule from '@/modules/i18n/I18nModule.vue'
 import InfoboxModule from '@/modules/infobox/InfoboxModule.vue'
 import MapFooter from '@/modules/map/components/footer/MapFooter.vue'
@@ -18,7 +17,6 @@ const dispatcher = { dispatcher: 'EmbedView.vue' }
 const store = useStore()
 
 const is3DActive = computed(() => store.state.cesium.active)
-const selectedLayerFeatures = computed(() => store.getters.selectedLayerFeatures)
 
 onBeforeMount(() => {
     store.dispatch('setEmbed', { embed: true, ...dispatcher })
@@ -27,13 +25,6 @@ onBeforeMount(() => {
 onMounted(() => {
     log.info(`Embedded map view mounted`)
 })
-
-// as described by this example on our documentation : https://codepen.io/geoadmin/pen/yOBzqM?editors=0010
-// our embed view should send a message (see https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage)
-// when a feature is selected while in embedded mode, so that the parent can get the selected feature(s) ID(s)
-watch(selectedLayerFeatures, () =>
-    sendFeatureInformationToIFrameParent(selectedLayerFeatures.value)
-)
 </script>
 
 <template>


### PR DESCRIPTION
the old viewer also sends feature events when the map is added to an iframe without pointing to its "embed.html" page, so we have to mimic the same behavior. Now sending this postMessage event whenever a layer feature is selected

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_pb-506_send_event_regardless_of_embed/index.html)