### PR TITLE
PB-521: fix geolocation tracking, zindex and accuracy and several geolocation improvements

### DIFF
--- a/src/modules/map/components/common/mouse-click.composable.js
+++ b/src/modules/map/components/common/mouse-click.composable.js
@@ -1,4 +1,3 @@
-import { computed } from 'vue'
 import { useStore } from 'vuex'
 
 import { ClickInfo, ClickType } from '@/store/modules/map.store'
@@ -14,9 +13,6 @@ export function useMouseOnMap() {
     let contextMenuTimeout = null
 
     const store = useStore()
-    const isCurrentlyTrackingGeoLocation = computed(
-        () => store.state.geolocation.active && store.state.geolocation.tracking
-    )
 
     /**
      * @param {[Number, Number]} screenPosition
@@ -72,13 +68,6 @@ export function useMouseOnMap() {
     function onMouseMove() {
         if (isPointerDown) {
             isStillOnStartingPosition = false
-        }
-        if (isCurrentlyTrackingGeoLocation.value) {
-            // stop tracking the user geolocation to the center of the view as soon as the map is dragged
-            store.dispatch('setGeolocationTracking', {
-                tracking: false,
-                ...dispatcher,
-            })
         }
     }
 

--- a/src/modules/map/components/common/z-index.composable.js
+++ b/src/modules/map/components/common/z-index.composable.js
@@ -14,12 +14,6 @@ export function useLayerZIndexCalculation() {
         }
         return [store.state.layers.currentBackgroundLayer]
     })
-    const selectedFeatures = computed(() => store.getters.selectedFeatures)
-    const pinnedLocation = computed(() => store.state.map.pinnedLocation)
-    const previewLocation = computed(() => store.state.map.previewedPinnedLocation)
-    const crossHair = computed(() => store.state.position.crossHair)
-    const showTileDebugInfo = computed(() => store.state.debug.showTileDebugInfo)
-    const showLayerExtents = computed(() => store.state.debug.showLayerExtents)
 
     const visibleLayers = computed(() => {
         const visibleLayersWithZIndex = [...backgroundLayers.value]
@@ -51,48 +45,13 @@ export function useLayerZIndexCalculation() {
         return visibleLayers.value.length + nbOfSubLayers
     })
     const zIndexHighlightedFeatures = computed(() => startingZIndexForThingsOnTopOfLayers.value)
-    const zIndexDroppedPin = computed(() => {
-        let zIndex = zIndexHighlightedFeatures.value
-        if (selectedFeatures.value.length > 0) {
-            zIndex++
-        }
-        return zIndex
-    })
-    const zIndexPreviewPosition = computed(() => {
-        let zIndex = zIndexDroppedPin.value
-        if (pinnedLocation.value) {
-            zIndex++
-        }
-        return zIndex
-    })
-    const zIndexCrossHair = computed(() => {
-        let zIndex = zIndexPreviewPosition.value
-        if (previewLocation.value) {
-            zIndex++
-        }
-        return zIndex
-    })
-    const zIndexTileInfo = computed(() => {
-        let zIndex = zIndexCrossHair.value
-        if (crossHair.value) {
-            zIndex++
-        }
-        return zIndex
-    })
-    const zIndexLayerExtents = computed(() => {
-        let zIndex = zIndexTileInfo.value
-        if (showTileDebugInfo.value) {
-            zIndex++
-        }
-        return zIndex
-    })
-    const nextAvailableZIndex = computed(() => {
-        let zIndex = zIndexLayerExtents.value
-        if (showLayerExtents.value) {
-            zIndex++
-        }
-        return zIndex
-    })
+    const zIndexDroppedPin = computed(() => zIndexHighlightedFeatures.value + 1)
+    const zIndexPreviewPosition = computed(() => zIndexDroppedPin.value + 1)
+    const zIndexCrossHair = computed(() => zIndexPreviewPosition.value + 1)
+    const zIndexGeolocation = computed(() => zIndexCrossHair.value + 1)
+    const zIndexTileInfo = computed(() => zIndexGeolocation.value + 1)
+    const zIndexLayerExtents = computed(() => zIndexTileInfo.value + 1)
+    const nextAvailableZIndex = computed(() => zIndexLayerExtents.value + 1)
 
     /**
      * Gives the z-index of a layer, taking into account if the map is shown in 3D or not. This
@@ -129,6 +88,7 @@ export function useLayerZIndexCalculation() {
         zIndexDroppedPin,
         zIndexPreviewPosition,
         zIndexCrossHair,
+        zIndexGeolocation,
         zIndexTileInfo,
         zIndexLayerExtents,
         nextAvailableZIndex,

--- a/src/modules/map/components/openlayers/OpenLayersAccuracyCircle.vue
+++ b/src/modules/map/components/openlayers/OpenLayersAccuracyCircle.vue
@@ -57,3 +57,7 @@ useAddLayerToMap(layer, olMap, zIndex)
 watch(position, (newPosition) => accuracyCircle.setCenter(newPosition))
 watch(accuracy, (newAccuracy) => accuracyCircle.setRadius(newAccuracy))
 </script>
+
+<template>
+    <div />
+</template>

--- a/src/modules/map/components/openlayers/OpenLayersAccuracyCircle.vue
+++ b/src/modules/map/components/openlayers/OpenLayersAccuracyCircle.vue
@@ -59,5 +59,5 @@ watch(accuracy, (newAccuracy) => accuracyCircle.setRadius(newAccuracy))
 </script>
 
 <template>
-    <div />
+    <slot />
 </template>

--- a/src/store/modules/geolocation.store.js
+++ b/src/store/modules/geolocation.store.js
@@ -1,4 +1,5 @@
 import log from '@/utils/logging'
+import { isNumber } from '@/utils/numberUtils'
 
 const state = {
     /**
@@ -62,7 +63,7 @@ const actions = {
         }
     },
     setGeolocationAccuracy: ({ commit }, { accuracy, dispatcher }) => {
-        if (Number.isFinite(accuracy)) {
+        if (isNumber(accuracy)) {
             commit('setGeolocationAccuracy', { accuracy: Number(accuracy), dispatcher })
         } else {
             log.error(`Invalid geolocation accuracy: ${accuracy}`)

--- a/src/store/modules/geolocation.store.js
+++ b/src/store/modules/geolocation.store.js
@@ -20,7 +20,7 @@ const state = {
      */
     tracking: false,
     /**
-     * Device position in EPSG:3857 (meters) [x, y]
+     * Device position in the current application projection [x, y]
      *
      * @type Array<Number>
      */
@@ -62,8 +62,10 @@ const actions = {
         }
     },
     setGeolocationAccuracy: ({ commit }, { accuracy, dispatcher }) => {
-        if (Number.isInteger(accuracy)) {
+        if (Number.isFinite(accuracy)) {
             commit('setGeolocationAccuracy', { accuracy: Number(accuracy), dispatcher })
+        } else {
+            log.error(`Invalid geolocation accuracy: ${accuracy}`)
         }
     },
 }


### PR DESCRIPTION
The geolocation tracking on non touch device was canceled as soon as the mouse
moved on the map, even if not action was undertaken ! Now we use the setCenter
to cancel the tracking, unless the setCenter is triggered by the geolocation.

Also did some improvement using the geolocation API by allowing cached location
and setting a timeout.

Also when re-activating the geolocation we first set the previous location
to make the app more reactive.

Also fixed the geolocation z-index, the geolocaiton marker would have been put behind new layers.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-521-goelocation/index.html)