### PR TITLE
PB-549: stopping searchbar focus on startup

### DIFF
--- a/src/modules/menu/components/search/SearchBar.vue
+++ b/src/modules/menu/components/search/SearchBar.vue
@@ -38,7 +38,6 @@ watch(searchQuery, (newQuery) => {
 
 onMounted(() => {
     searchValue.value = searchQuery.value
-    searchInput.value.focus()
 })
 
 let debounceSearch = null


### PR DESCRIPTION
Issue: users found that the search bar being focused (and expanded) on startup when they reloaded after searching for a layer or feature.

Fix: We no longer focus the search bar at startup, effectively stopping it from being opened

[Test link](https://sys-map.dev.bgdi.ch/preview/bugfix-pb-549-swisssearch-not-opening-on-startup/index.html)