### PR TITLE
PB-555 : fix too many resolutions being filtered out with WMTS layers

### DIFF
--- a/src/modules/map/components/openlayers/OpenLayersWMTSLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersWMTSLayer.vue
@@ -90,16 +90,19 @@ function getTransformedXYZUrl() {
         .replace('{y}', '{TileRow}')
 }
 
-/**
- * @param {Number} layerMaxResolution The maximum resolution for this layer.
- * @returns {WMTSTileGrid} The tile grid system for the wmts source
- */
+/** @returns {WMTSTileGrid} The tile grid system for the wmts source */
 function createTileGridForProjection() {
     const maxResolutionIndex = indexOfMaxResolution(projection.value, maxResolution.value)
+    let resolutions = projection.value.getResolutions()
+    let matrixIds = projection.value.getMatrixIds()
+    if (resolutions.length - 1 > maxResolutionIndex) {
+        resolutions = resolutions.slice(0, maxResolutionIndex)
+        matrixIds = matrixIds.slice(0, maxResolutionIndex)
+    }
     return new WMTSTileGrid({
-        resolutions: projection.value.getResolutions().slice(0, maxResolutionIndex),
+        resolutions,
         origin: projection.value.getTileOrigin(),
-        matrixIds: projection.value.getMatrixIds().slice(0, maxResolutionIndex),
+        matrixIds,
         extent: projection.value.bounds.flatten,
     })
 }

--- a/src/utils/layerUtils.js
+++ b/src/utils/layerUtils.js
@@ -80,7 +80,9 @@ export function getWmtsXyzUrl(wmtsLayerConfig, projection, options = {}) {
  * @returns {Number}
  */
 export function indexOfMaxResolution(projection, layerMaxResolution) {
-    return projection.getResolutions().indexOf(layerMaxResolution) === -1
-        ? projection.getResolutions().length
-        : projection.getResolutions().indexOf(layerMaxResolution)
+    const indexOfResolution = projection.getResolutions().indexOf(layerMaxResolution)
+    if (indexOfResolution === -1) {
+        return projection.getResolutions().length
+    }
+    return indexOfResolution
 }


### PR DESCRIPTION
Fix supports for 0.1 resolution

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_pb-555_load_resolution_0dot1/index.html)