### PR TITLE
PB-543 : fix Cesium CSS spillover

### DIFF
--- a/src/modules/map/components/cesium/CesiumGeoJSONLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGeoJSONLayer.vue
@@ -1,7 +1,5 @@
 <template>
-    <div>
-        <slot />
-    </div>
+    <slot />
 </template>
 
 <script>

--- a/src/modules/map/components/cesium/CesiumMap.vue
+++ b/src/modules/map/components/cesium/CesiumMap.vue
@@ -3,7 +3,7 @@
         v-if="isProjectionWebMercator"
         id="cesium"
         ref="viewer"
-        class="cesium-widget"
+        class="cesium-map"
         data-cy="cesium-map"
         @touchstart.passive="onTouchStart"
         @touchmove.passive="clearLongPressTimer"
@@ -78,7 +78,6 @@
     </div>
 </template>
 <script>
-import 'cesium/Build/Cesium/Widgets/widgets.css'
 import '@geoblocks/cesium-compass'
 
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
@@ -634,16 +633,47 @@ export default {
 <style lang="scss" scoped>
 @import '@/scss/webmapviewer-bootstrap-theme';
 @import '@/modules/map/scss/toolbox-buttons';
+@import '@/scss/media-query.mixin';
+
+.cesium-map,
+.cesium-widget,
+:global(.cesium-viewer),
+:global(.cesium-viewer-cesiumWidgetContainer),
+:global(.cesium-widget),
+:global(.cesium-widget canvas) {
+    overflow: hidden;
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
 
 // rule can't be scoped otherwise styles will be not applied
 :global(.cesium-viewer .cesium-widget-credits) {
     display: none !important;
 }
 :global(.cesium-performanceDisplay-defaultContainer) {
-    left: $screen-padding-for-ui-elements;
+    position: absolute;
+    right: $screen-padding-for-ui-elements;
     bottom: calc($footer-height + $screen-padding-for-ui-elements);
     top: unset;
-    right: unset;
+    left: unset;
+    border: $border-width solid $danger-border-subtle;
+    border-radius: $border-radius;
+    background-color: $danger-bg-subtle;
+    padding: 0.5rem;
+}
+
+@include respond-above(phone) {
+    :global(.cesium-performanceDisplay-defaultContainer) {
+        // Background wheel is on the opposite side of the screen past the phone threshold,
+        // so we move the debug box to the other side too (so that it is not covered/covering the
+        // BG wheel button)
+        left: $screen-padding-for-ui-elements;
+        right: unset;
+    }
 }
 
 .cesium-compass {

--- a/src/modules/map/components/cesium/CesiumWMSLayer.vue
+++ b/src/modules/map/components/cesium/CesiumWMSLayer.vue
@@ -1,7 +1,5 @@
 <template>
-    <div>
-        <slot />
-    </div>
+    <slot />
 </template>
 
 <script>

--- a/src/modules/map/components/cesium/CesiumWMTSLayer.vue
+++ b/src/modules/map/components/cesium/CesiumWMTSLayer.vue
@@ -1,7 +1,5 @@
 <template>
-    <div>
-        <slot />
-    </div>
+    <slot />
 </template>
 
 <script>

--- a/src/modules/map/components/toolbox/ZoomButtons.vue
+++ b/src/modules/map/components/toolbox/ZoomButtons.vue
@@ -13,7 +13,8 @@ const resolution = computed(() => store.getters.resolution)
 
 useTippyTooltip('#zoomButtons [data-tippy-content]', { placement: 'left' })
 
-const getViewer = inject('getViewer')
+// telling vue that getViewer is a factory method (avoid unnecessary computation or side effects)
+const getViewer = inject('getViewer', () => {}, true)
 
 // The `step` variable is used with the 3D viewer. The goal was to find an increase or
 // decrease in the zoom that emulated a zoom level in an agreeable way. `200` here is a

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -249,6 +249,7 @@ describe('Test on legacy param import', () => {
             )
             cy.readStoreValue('state.search.query').should('eq', '1530 Payerne')
             cy.url().should('include', 'swisssearch=1530+Payerne')
+            cy.get('[data-cy="searchbar"]').click()
             cy.get('[data-cy="search-results-locations"]').should('be.visible')
         })
         it('External WMS layer', () => {


### PR DESCRIPTION
Cesium CSS was altering how our buttons were shown, adding some padding or margins there and there. As we were importing the Cesium CSS file just to place the canvas (and its Cesium generated parent divs) correctly, I've switched to declare this CSS ourselves and remove the import of the Cesium CSS file.

Also removing a couple wrapping divs in the Cesium component that are not useful, as they clutter our "real" DOM with many empty divs

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_pb-543_fix_cesium_css_spillover/index.html)