### PR TITLE
PB-497: Add GPX on 3D map

### DIFF
--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -1,10 +1,4 @@
-<template>
-    <div>
-        <slot />
-    </div>
-</template>
-
-<script>
+<script setup>
 import {
     BillboardGraphics,
     Cartesian3,
@@ -14,143 +8,132 @@ import {
     GpxDataSource,
     HeightReference,
 } from 'cesium'
+import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { inject } from 'vue'
 
 import GPXLayer from '@/api/layers/GPXLayer.class'
 import log from '@/utils/logging'
 
-/** Adds a GPX layer to the Cesium viewer */
-export default {
-    inject: ['getViewer'],
-
-    props: {
-        gpxLayerConfig: {
-            type: GPXLayer,
-            required: true,
-        },
+const props = defineProps({
+    gpxLayerConfig: {
+        type: GPXLayer,
+        required: true,
     },
+})
 
-    data() {
-        return {
-            isPresentOnMap: false,
-            gpxDataSource: new GpxDataSource(),
-        }
-    },
+const isPresentOnMap = ref(false)
+const gpxDataSource = ref(new GpxDataSource())
 
-    computed: {
-        opacity() {
-            return this.gpxLayerConfig.opacity
-        },
-        gpxData() {
-            return this.gpxLayerConfig.gpxData
-        },
-    },
+// const opacity = ref(props.gpxLayerConfig.opacity)
+const gpxData = ref(props.gpxLayerConfig.gpxData)
 
-    watch: {
-        gpxData() {
-            this.addLayer()
-        },
-    },
+const getViewer = inject('getViewer')
+watch(gpxData, () => {
+    addLayer()
+})
 
-    mounted() {
-        log.debug('Mounted GPX layer')
-        this.addLayer()
-    },
+onMounted(() => {
+    log.debug('Mounted GPX layer')
+    addLayer()
+})
 
-    unmounted() {
-        log.debug('Unmounted GPX layer')
-        if (this.gpxDataSource && this.isPresentOnMap) {
-            this.removeLayer()
-        }
+onUnmounted(() => {
+    log.debug('Unmounted GPX layer')
+    if (gpxDataSource.value && isPresentOnMap.value) {
+        removeLayer()
+    }
 
-        delete this.gpxDataSource
-    },
+    gpxDataSource.value = null
+})
 
-    methods: {
-        addLayer() {
-            const gpxBlob = new Blob([this.gpxData], { type: 'application/gpx+xml' })
-            const gpxUrl = URL.createObjectURL(gpxBlob)
+function addLayer() {
+    const gpxBlob = new Blob([gpxData.value], { type: 'application/gpx+xml' })
+    const gpxUrl = URL.createObjectURL(gpxBlob)
 
-            this.gpxDataSource
-                .load(gpxUrl, {
-                    clampToGround: true,
+    gpxDataSource.value
+        .load(gpxUrl, {
+            clampToGround: true,
+        })
+        .then((dataSource) => {
+            getViewer().dataSources.add(dataSource)
+            isPresentOnMap.value = true
+        })
+        .then(updateStyle)
+}
+
+function removeLayer() {
+    log.debug('Remove GPX layer')
+    if (gpxDataSource.value) {
+        getViewer().dataSources.remove(gpxDataSource.value)
+        gpxDataSource.value = null
+        getViewer().scene.requestRender() // Request a render after removing the DataSource
+    }
+    isPresentOnMap.value = false
+}
+
+function updateStyle() {
+    // Function to create a red circle image using a canvas
+    function createRedCircleImage(radius) {
+        // Create a new canvas element
+        const canvas = document.createElement('canvas')
+        const context = canvas.getContext('2d')
+
+        // Set the canvas sizes
+        canvas.width = radius * 2
+        canvas.height = radius * 2
+
+        // Draw a red circle on the canvas
+        context.beginPath()
+        context.arc(radius, radius, radius, 0, 2 * Math.PI, false)
+        context.fillStyle = 'red'
+        context.fill()
+
+        // Return the data URL of the canvas drawing
+        return canvas.toDataURL()
+    }
+
+    // Create a red circle image with a radius of 8 pixels
+    const radius = 8
+    const billboardSize = radius * 2
+    const redCircleImage = createRedCircleImage(radius)
+    const entities = gpxDataSource.value._entityCollection.values
+
+    for (let i = 0; i < entities.length; i++) {
+        const entity = entities[i]
+        // Hide the billboard for billboard on the lines by checking if there is a description
+        // Imported GPX files from web-mapviewer have a description for the waypoints
+        // This might be not working for generic GPX files
+        if (cesiumDefined(entity.billboard)) {
+            if (!entity.description) {
+                entity.show = false
+            } else {
+                entity.show = true
+                entity.billboard = new BillboardGraphics({
+                    image: redCircleImage,
+                    width: billboardSize,
+                    height: billboardSize,
+                    eyeOffset: new Cartesian3(0, 0, -100), // Make sure the billboard is always seen
+                    heightReference: HeightReference.CLAMP_TO_TERRAIN, // Make the billboard always appear on top of the terrain
                 })
-                .then((dataSource) => {
-                    this.getViewer().dataSources.add(dataSource)
-                    this.isPresentOnMap = true
-                })
-                .then(() => this.updateStyle())
-        },
-        removeLayer() {
-            log.debug('Remove GPX layer')
-            if (this.gpxDataSource) {
-                this.getViewer().dataSources.remove(this.gpxDataSource)
-                this.gpxDataSource = null
-                this.getViewer().scene.requestRender() // Request a render after removing the DataSource
             }
-            this.isPresentOnMap = false
-        },
-        updateStyle() {
-            // Function to create a red circle image using a canvas
-            function createRedCircleImage(radius) {
-                // Create a new canvas element
-                const canvas = document.createElement('canvas')
-                const context = canvas.getContext('2d')
+        }
 
-                // Set the canvas sizes
-                canvas.width = radius * 2
-                canvas.height = radius * 2
+        if (cesiumDefined(entity.polyline)) {
+            entity.polyline.material = new ColorMaterialProperty(Color.RED)
+            entity.polyline.width = 1.5
+        }
 
-                // Draw a red circle on the canvas
-                context.beginPath()
-                context.arc(radius, radius, radius, 0, 2 * Math.PI, false)
-                context.fillStyle = 'red'
-                context.fill()
-
-                // Return the data URL of the canvas drawing
-                return canvas.toDataURL()
-            }
-
-            // Create a red circle image with a radius of 8 pixels
-            const radius = 8
-            const billboardSize = radius * 2
-            const redCircleImage = createRedCircleImage(radius)
-
-            const entities = this.gpxDataSource.entities.values
-            log.debug('Entities:', entities.length)
-            window.entities = entities
-            for (let i = 0; i < entities.length; i++) {
-                const entity = entities[i]
-                // Hide the billboard for billboard on the lines by checking if there is a description
-                // Imported GPX files from web-mapviewer have a description for the waypoints
-                // This might be not working for generic GPX files
-                if (cesiumDefined(entity.billboard)) {
-                    if (!entity.description) {
-                        entity.show = false
-                    } else {
-                        entity.show = true
-                        entity.billboard = new BillboardGraphics({
-                            image: redCircleImage,
-                            width: billboardSize,
-                            height: billboardSize,
-                            eyeOffset: new Cartesian3(0, 0, -100), // Make sure the billboard is always seen
-                            heightReference: HeightReference.CLAMP_TO_TERRAIN, // Make the billboard always appear on top of the terrain
-                        })
-                    }
-                }
-
-                if (cesiumDefined(entity.polyline)) {
-                    entity.polyline.material = new ColorMaterialProperty(Color.RED)
-                    entity.polyline.width = 1.5
-                }
-
-                if (cesiumDefined(entity.polygon)) {
-                    entity.polygon.material = new ColorMaterialProperty(Color.RED)
-                    entity.polygon.outline = true
-                    entity.polygon.outlineColor = Color.BLACK
-                }
-            }
-            this.getViewer().scene.requestRender()
-        },
-    },
+        if (cesiumDefined(entity.polygon)) {
+            entity.polygon.material = new ColorMaterialProperty(Color.RED)
+            entity.polygon.outline = true
+            entity.polygon.outlineColor = Color.BLACK
+        }
+    }
+    getViewer().scene.requestRender()
 }
 </script>
+<template>
+    <div>
+        <slot />
+    </div>
+</template>

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -5,27 +5,30 @@
 </template>
 
 <script>
-import VectorSource from 'ol/source/Vector'
-import { mapState } from 'vuex'
+import { GpxDataSource } from 'cesium'
 
 import GPXLayer from '@/api/layers/GPXLayer.class'
-import { parseGpx } from '@/utils/gpxUtils'
-
-import addPrimitiveFromOLLayerMixins from './utils/addPrimitiveFromOLLayer.mixins'
+import log from '@/utils/logging'
 
 /** Adds a GPX layer to the Cesium viewer */
 export default {
-    mixins: [addPrimitiveFromOLLayerMixins],
+    inject: ['getViewer'],
+
     props: {
         gpxLayerConfig: {
             type: GPXLayer,
             required: true,
         },
     },
+
+    data() {
+        return {
+            isPresentOnMap: false,
+            gpxDataSource: null,
+        }
+    },
+
     computed: {
-        ...mapState({
-            projection: (state) => state.position.projection,
-        }),
         opacity() {
             return this.gpxLayerConfig.opacity
         },
@@ -33,26 +36,54 @@ export default {
             return this.gpxLayerConfig.gpxData
         },
     },
+
     watch: {
         gpxData() {
-            this.loadDataInOLLayer().then(this.addPrimitive)
+            this.addLayer()
         },
     },
+
+    mounted() {
+        log.debug('Mounted GPX layer')
+        const gpxUrl =
+            'https://gist.githubusercontent.com/ismailsunni/e4345dd852c5deaff3434eadefdb467f/raw/0eac92b199e10c6498f4a1c305098a3e74ce1521/map.geo.admin.ch_GPX_20240529033356.gpx'
+        GpxDataSource.load(gpxUrl, {
+            clampToGround: true,
+        }).then((dataSource) => {
+            this.gpxDataSource = dataSource
+            if (!this.isPresentOnMap) {
+                this.addLayer()
+            }
+        })
+    },
+
+    unmounted() {
+        log.debug('Unmounted GPX layer')
+        if (this.gpxDataSource && this.isPresentOnMap) {
+            this.removeLayer()
+        }
+
+        delete this.gpxDataSource
+    },
+
     methods: {
-        loadDataInOLLayer() {
-            return new Promise((resolve, reject) => {
-                if (!this.gpxData) {
-                    reject(new Error('no GPX data loaded yet, could not create source'))
-                }
-                this.olLayer.setSource(
-                    new VectorSource({
-                        wrapX: true,
-                        projection: this.projection,
-                        features: parseGpx(this.gpxData, this.projection),
-                    })
-                )
-                resolve()
-            })
+        addLayer() {
+            log.debug('Adding GPX layer')
+            log.debug(this.gpxDataSource)
+            this.getViewer().dataSources.add(this.gpxDataSource)
+            this.isPresentOnMap = true
+            log.debug(this.getViewer().dataSources)
+        },
+        removeLayer() {
+            log.debug('Remove GPX layer')
+            log.debug(this.gpxDataSource)
+            if (this.gpxDataSource) {
+                this.getViewer().dataSources.remove(this.gpxDataSource)
+                this.gpxDataSource = null
+                this.getViewer().scene.requestRender() // Request a render after removing the DataSource
+            }
+            this.isPresentOnMap = false
+            log.debug(this.getViewer().dataSources)
         },
     },
 }

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -99,19 +99,21 @@ function createRedCircleImage(radius, opacity = 1) {
     return canvas.toDataURL()
 }
 
-function updateStyle() {
-    // Create a red circle image with a radius of 8 pixels
-    const radius = 8
+function createRedCircleBillboard(radius, opacity = 1) {
+    const redCircleImage = createRedCircleImage(radius, opacity)
     const billboardSize = radius * 2
-    const redCircleImage = createRedCircleImage(radius, opacity.value)
-
-    const redCircleBillboard = new BillboardGraphics({
+    return new BillboardGraphics({
         image: redCircleImage,
         width: billboardSize,
         height: billboardSize,
         eyeOffset: new Cartesian3(0, 0, -100), // Make sure the billboard is always seen
         heightReference: HeightReference.CLAMP_TO_TERRAIN, // Make the billboard always appear on top of the terrain
     })
+}
+
+function updateStyle() {
+    const radius = 8
+    const redCircleBillboard = createRedCircleBillboard(radius, opacity.value)
     const redColorMaterial = new ColorMaterialProperty(Color.RED.withAlpha(opacity.value))
 
     const entities = gpxDataSource.entities.values
@@ -146,7 +148,15 @@ function updateStyle() {
             entity.polygon.outlineColor = Color.BLACK
         }
     })
+    forceRender()
+}
+// Helper function to force render the scene after timeout to handle scene not rendered after we update the style
+// Note (IS): 1500 ms is a sweet number (from my experiment), not too fast (scene is not rendered properly) and not too long (user does not wait too long)
+function forceRender(timeout = 1500) {
     getViewer().scene.requestRender()
+    setTimeout(() => {
+        getViewer().scene.requestRender()
+    }, timeout)
 }
 </script>
 <template>

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -106,6 +106,15 @@ function updateStyle() {
     const radius = 8
     const billboardSize = radius * 2
     const redCircleImage = createRedCircleImage(radius)
+
+    const redCircleBillboard = new BillboardGraphics({
+        image: redCircleImage,
+        width: billboardSize,
+        height: billboardSize,
+        eyeOffset: new Cartesian3(0, 0, -100), // Make sure the billboard is always seen
+        heightReference: HeightReference.CLAMP_TO_TERRAIN, // Make the billboard always appear on top of the terrain
+    })
+
     const entities = gpxDataSource.value._entityCollection.values
 
     for (let i = 0; i < entities.length; i++) {
@@ -118,13 +127,7 @@ function updateStyle() {
                 entity.show = false
             } else {
                 entity.show = true
-                entity.billboard = new BillboardGraphics({
-                    image: redCircleImage,
-                    width: billboardSize,
-                    height: billboardSize,
-                    eyeOffset: new Cartesian3(0, 0, -100), // Make sure the billboard is always seen
-                    heightReference: HeightReference.CLAMP_TO_TERRAIN, // Make the billboard always appear on top of the terrain
-                })
+                entity.billboard = redCircleBillboard
             }
         }
 

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -29,16 +29,13 @@ const gpxData = ref(props.gpxLayerConfig.gpxData)
 
 const getViewer = inject('getViewer')
 watch(gpxData, () => {
+    removeLayer()
     addLayer()
 })
 
-watch(
-    () => props.gpxLayerConfig.opacity,
-    (newOpacity) => {
-        opacity.value = newOpacity
-        updateStyle()
-    }
-)
+watch(opacity, () => {
+    updateStyle()
+})
 
 onMounted(() => {
     log.debug('Mounted GPX layer')
@@ -153,7 +150,5 @@ function updateStyle() {
 }
 </script>
 <template>
-    <div>
-        <slot />
-    </div>
+    <slot />
 </template>

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -120,6 +120,10 @@ function updateStyle() {
 
     for (let i = 0; i < entities.length; i++) {
         const entity = entities[i]
+        if (opacity.value === 0) {
+            entity.show = false
+            continue
+        }
         // Hide the billboard for billboard on the lines by checking if there is a description
         // Imported GPX files from web-mapviewer have a description for the waypoints
         // This might be not working for generic GPX files
@@ -133,11 +137,13 @@ function updateStyle() {
         }
 
         if (cesiumDefined(entity.polyline)) {
+            entity.show = true
             entity.polyline.material = redColorMaterial
             entity.polyline.width = 1.5
         }
 
         if (cesiumDefined(entity.polygon)) {
+            entity.show = true
             entity.polygon.material = redColorMaterial
             entity.polygon.outline = true
             entity.polygon.outlineColor = Color.BLACK

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -114,6 +114,7 @@ function updateStyle() {
         eyeOffset: new Cartesian3(0, 0, -100), // Make sure the billboard is always seen
         heightReference: HeightReference.CLAMP_TO_TERRAIN, // Make the billboard always appear on top of the terrain
     })
+    const redColorMaterial = new ColorMaterialProperty(Color.RED.withAlpha(opacity.value))
 
     const entities = gpxDataSource.value._entityCollection.values
 
@@ -132,12 +133,12 @@ function updateStyle() {
         }
 
         if (cesiumDefined(entity.polyline)) {
-            entity.polyline.material = new ColorMaterialProperty(Color.RED.withAlpha(opacity.value))
+            entity.polyline.material = redColorMaterial
             entity.polyline.width = 1.5
         }
 
         if (cesiumDefined(entity.polygon)) {
-            entity.polygon.material = new ColorMaterialProperty(Color.RED.withAlpha(opacity.value))
+            entity.polygon.material = redColorMaterial
             entity.polygon.outline = true
             entity.polygon.outlineColor = Color.BLACK
         }

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -1,0 +1,59 @@
+<template>
+    <div>
+        <slot />
+    </div>
+</template>
+
+<script>
+import VectorSource from 'ol/source/Vector'
+import { mapState } from 'vuex'
+
+import GPXLayer from '@/api/layers/GPXLayer.class'
+import { parseGpx } from '@/utils/gpxUtils'
+
+import addPrimitiveFromOLLayerMixins from './utils/addPrimitiveFromOLLayer.mixins'
+
+/** Adds a GPX layer to the Cesium viewer */
+export default {
+    mixins: [addPrimitiveFromOLLayerMixins],
+    props: {
+        gpxLayerConfig: {
+            type: GPXLayer,
+            required: true,
+        },
+    },
+    computed: {
+        ...mapState({
+            projection: (state) => state.position.projection,
+        }),
+        opacity() {
+            return this.gpxLayerConfig.opacity
+        },
+        gpxData() {
+            return this.gpxLayerConfig.gpxData
+        },
+    },
+    watch: {
+        gpxData() {
+            this.loadDataInOLLayer().then(this.addPrimitive)
+        },
+    },
+    methods: {
+        loadDataInOLLayer() {
+            return new Promise((resolve, reject) => {
+                if (!this.gpxData) {
+                    reject(new Error('no GPX data loaded yet, could not create source'))
+                }
+                this.olLayer.setSource(
+                    new VectorSource({
+                        wrapX: true,
+                        projection: this.projection,
+                        features: parseGpx(this.gpxData, this.projection),
+                    })
+                )
+                resolve()
+            })
+        },
+    },
+}
+</script>

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -24,7 +24,7 @@ export default {
     data() {
         return {
             isPresentOnMap: false,
-            gpxDataSource: null,
+            gpxDataSource: new GpxDataSource(),
         }
     },
 
@@ -45,16 +45,7 @@ export default {
 
     mounted() {
         log.debug('Mounted GPX layer')
-        const gpxUrl =
-            'https://gist.githubusercontent.com/ismailsunni/e4345dd852c5deaff3434eadefdb467f/raw/0eac92b199e10c6498f4a1c305098a3e74ce1521/map.geo.admin.ch_GPX_20240529033356.gpx'
-        GpxDataSource.load(gpxUrl, {
-            clampToGround: true,
-        }).then((dataSource) => {
-            this.gpxDataSource = dataSource
-            if (!this.isPresentOnMap) {
-                this.addLayer()
-            }
-        })
+        this.addLayer()
     },
 
     unmounted() {
@@ -68,22 +59,24 @@ export default {
 
     methods: {
         addLayer() {
-            log.debug('Adding GPX layer')
-            log.debug(this.gpxDataSource)
+            const gpxBlob = new Blob([this.gpxData], { type: 'application/gpx+xml' })
+            const gpxUrl = URL.createObjectURL(gpxBlob)
+
+            this.gpxDataSource.load(gpxUrl, {
+                clampToGround: true,
+            })
+
             this.getViewer().dataSources.add(this.gpxDataSource)
             this.isPresentOnMap = true
-            log.debug(this.getViewer().dataSources)
         },
         removeLayer() {
             log.debug('Remove GPX layer')
-            log.debug(this.gpxDataSource)
             if (this.gpxDataSource) {
                 this.getViewer().dataSources.remove(this.gpxDataSource)
                 this.gpxDataSource = null
                 this.getViewer().scene.requestRender() // Request a render after removing the DataSource
             }
             this.isPresentOnMap = false
-            log.debug(this.getViewer().dataSources)
         },
     },
 }

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -55,10 +55,9 @@ onUnmounted(() => {
 
 function addLayer() {
     const gpxBlob = new Blob([gpxData.value], { type: 'application/gpx+xml' })
-    const gpxUrl = URL.createObjectURL(gpxBlob)
     gpxDataSource = new GpxDataSource()
     gpxDataSource
-        .load(gpxUrl, {
+        .load(gpxBlob, {
             clampToGround: true,
         })
         .then((dataSource) => {
@@ -117,7 +116,7 @@ function updateStyle() {
 
     const entities = gpxDataSource.entities.values
 
-    entities.array.forEach((entity) => {
+    entities.forEach((entity) => {
         if (opacity.value === 0) {
             entity.show = false
             return

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -24,13 +24,21 @@ const props = defineProps({
 const isPresentOnMap = ref(false)
 const gpxDataSource = ref(new GpxDataSource())
 
-// const opacity = ref(props.gpxLayerConfig.opacity)
+const opacity = ref(props.gpxLayerConfig.opacity)
 const gpxData = ref(props.gpxLayerConfig.gpxData)
 
 const getViewer = inject('getViewer')
 watch(gpxData, () => {
     addLayer()
 })
+
+watch(
+    () => props.gpxLayerConfig.opacity,
+    (newOpacity) => {
+        opacity.value = newOpacity
+        updateStyle()
+    }
+)
 
 onMounted(() => {
     log.debug('Mounted GPX layer')
@@ -85,7 +93,9 @@ function updateStyle() {
         // Draw a red circle on the canvas
         context.beginPath()
         context.arc(radius, radius, radius, 0, 2 * Math.PI, false)
-        context.fillStyle = 'red'
+
+        const color = `rgba(255, 0, 0, ${opacity.value})`
+        context.fillStyle = color
         context.fill()
 
         // Return the data URL of the canvas drawing
@@ -119,12 +129,12 @@ function updateStyle() {
         }
 
         if (cesiumDefined(entity.polyline)) {
-            entity.polyline.material = new ColorMaterialProperty(Color.RED)
+            entity.polyline.material = new ColorMaterialProperty(Color.RED.withAlpha(opacity.value))
             entity.polyline.width = 1.5
         }
 
         if (cesiumDefined(entity.polygon)) {
-            entity.polygon.material = new ColorMaterialProperty(Color.RED)
+            entity.polygon.material = new ColorMaterialProperty(Color.RED.withAlpha(opacity.value))
             entity.polygon.outline = true
             entity.polygon.outlineColor = Color.BLACK
         }

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -78,34 +78,33 @@ function removeLayer() {
     isPresentOnMap.value = false
 }
 
+// Function to create a red circle image using a canvas
+function createRedCircleImage(radius, opacity = 1) {
+    // Create a new canvas element
+    const canvas = document.createElement('canvas')
+    const context = canvas.getContext('2d')
+
+    // Set the canvas sizes
+    canvas.width = radius * 2
+    canvas.height = radius * 2
+
+    // Draw a red circle on the canvas
+    context.beginPath()
+    context.arc(radius, radius, radius, 0, 2 * Math.PI, false)
+
+    const color = `rgba(255, 0, 0, ${opacity})`
+    context.fillStyle = color
+    context.fill()
+
+    // Return the data URL of the canvas drawing
+    return canvas.toDataURL()
+}
+
 function updateStyle() {
-    log.debug('Update style', 'opacity', opacity.value)
-    // Function to create a red circle image using a canvas
-    function createRedCircleImage(radius) {
-        // Create a new canvas element
-        const canvas = document.createElement('canvas')
-        const context = canvas.getContext('2d')
-
-        // Set the canvas sizes
-        canvas.width = radius * 2
-        canvas.height = radius * 2
-
-        // Draw a red circle on the canvas
-        context.beginPath()
-        context.arc(radius, radius, radius, 0, 2 * Math.PI, false)
-
-        const color = `rgba(255, 0, 0, ${opacity.value})`
-        context.fillStyle = color
-        context.fill()
-
-        // Return the data URL of the canvas drawing
-        return canvas.toDataURL()
-    }
-
     // Create a red circle image with a radius of 8 pixels
     const radius = 8
     const billboardSize = radius * 2
-    const redCircleImage = createRedCircleImage(radius)
+    const redCircleImage = createRedCircleImage(radius, opacity.value)
 
     const redCircleBillboard = new BillboardGraphics({
         image: redCircleImage,
@@ -118,11 +117,10 @@ function updateStyle() {
 
     const entities = gpxDataSource.entities.values
 
-    for (let i = 0; i < entities.length; i++) {
-        const entity = entities[i]
+    entities.array.forEach((entity) => {
         if (opacity.value === 0) {
             entity.show = false
-            continue
+            return
         }
         // Hide the billboard for billboard on the lines by checking if there is a description
         // Imported GPX files from web-mapviewer have a description for the waypoints
@@ -148,7 +146,7 @@ function updateStyle() {
             entity.polygon.outline = true
             entity.polygon.outlineColor = Color.BLACK
         }
-    }
+    })
     getViewer().scene.requestRender()
 }
 </script>

--- a/src/modules/map/components/cesium/CesiumInternalLayer.vue
+++ b/src/modules/map/components/cesium/CesiumInternalLayer.vue
@@ -42,7 +42,6 @@
                 :z-index="zIndex"
             />
         </div>
-        <slot />
     </div>
     <CesiumGeoJSONLayer
         v-if="layerConfig.type === LayerTypes.GEOJSON"

--- a/src/modules/map/components/cesium/CesiumInternalLayer.vue
+++ b/src/modules/map/components/cesium/CesiumInternalLayer.vue
@@ -42,23 +42,6 @@
                 :z-index="zIndex"
             />
         </div>
-        <CesiumGeoJSONLayer
-            v-if="layerConfig.type === LayerTypes.GEOJSON"
-            :layer-id="layerConfig.id"
-            :opacity="layerConfig.opacity"
-            :geojson-url="layerConfig.geoJsonUrl"
-            :style-url="layerConfig.styleUrl"
-            :projection="projection"
-        />
-        <CesiumKMLLayer
-            v-if="layerConfig.type === LayerTypes.KML"
-            :kml-layer-config="layerConfig"
-        />
-        <CesiumGPXLayer
-            v-if="layerConfig.type === LayerTypes.GPX"
-            :gpx-layer-config="layerConfig"
-            :projection="projection"
-        />
         <slot />
     </div>
     <CesiumGeoJSONLayer
@@ -70,6 +53,7 @@
         :projection="projection"
     />
     <CesiumKMLLayer v-if="layerConfig.type === LayerTypes.KML" :kml-layer-config="layerConfig" />
+    <CesiumGPXLayer v-if="layerConfig.type === LayerTypes.GPX" :gpx-layer-config="layerConfig" />
     <slot />
 </template>
 

--- a/src/modules/map/components/cesium/CesiumInternalLayer.vue
+++ b/src/modules/map/components/cesium/CesiumInternalLayer.vue
@@ -42,6 +42,24 @@
                 :z-index="zIndex"
             />
         </div>
+        <CesiumGeoJSONLayer
+            v-if="layerConfig.type === LayerTypes.GEOJSON"
+            :layer-id="layerConfig.id"
+            :opacity="layerConfig.opacity"
+            :geojson-url="layerConfig.geoJsonUrl"
+            :style-url="layerConfig.styleUrl"
+            :projection="projection"
+        />
+        <CesiumKMLLayer
+            v-if="layerConfig.type === LayerTypes.KML"
+            :kml-layer-config="layerConfig"
+        />
+        <CesiumGPXLayer
+            v-if="layerConfig.type === LayerTypes.GPX"
+            :gpx-layer-config="layerConfig"
+            :projection="projection"
+        />
+        <slot />
     </div>
     <CesiumGeoJSONLayer
         v-if="layerConfig.type === LayerTypes.GEOJSON"
@@ -64,6 +82,7 @@ import CesiumVectorLayer from '@/modules/map/components/cesium/CesiumVectorLayer
 import CoordinateSystem from '@/utils/coordinates/CoordinateSystem.class'
 
 import CesiumGeoJSONLayer from './CesiumGeoJSONLayer.vue'
+import CesiumGPXLayer from './CesiumGPXLayer.vue'
 import CesiumKMLLayer from './CesiumKMLLayer.vue'
 import CesiumWMSLayer from './CesiumWMSLayer.vue'
 import CesiumWMTSLayer from './CesiumWMTSLayer.vue'
@@ -76,6 +95,7 @@ export default {
     name: 'CesiumInternalLayer',
     components: {
         CesiumVectorLayer,
+        CesiumGPXLayer,
         CesiumKMLLayer,
         CesiumGeoJSONLayer,
         CesiumWMTSLayer,

--- a/src/modules/map/components/cesium/CesiumMap.vue
+++ b/src/modules/map/components/cesium/CesiumMap.vue
@@ -109,6 +109,7 @@ import GeoAdminAggregateLayer from '@/api/layers/GeoAdminAggregateLayer.class.js
 import GeoAdminGeoJsonLayer from '@/api/layers/GeoAdminGeoJsonLayer.class'
 import GeoAdminWMSLayer from '@/api/layers/GeoAdminWMSLayer.class'
 import GeoAdminWMTSLayer from '@/api/layers/GeoAdminWMTSLayer.class'
+import GPXLayer from '@/api/layers/GPXLayer.class'
 import KMLLayer from '@/api/layers/KMLLayer.class'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
 import {
@@ -220,7 +221,10 @@ export default {
         },
         visiblePrimitiveLayers() {
             return this.visibleLayers.filter(
-                (l) => l instanceof GeoAdminGeoJsonLayer || l instanceof KMLLayer
+                (l) =>
+                    l instanceof GeoAdminGeoJsonLayer ||
+                    l instanceof KMLLayer ||
+                    l instanceof GPXLayer
             )
         },
         showFeaturesPopover() {


### PR DESCRIPTION
[Test link](https://sys-map.dev.bgdi.ch/preview/pb-497-gpx-on-3d/index.html) (can be tested with loading gpx file)

- Load GPX to Cesium with Cesium standard way
- Add style for point to match with the old geoadmin (red circle billboard)
- Handle transparency update

![image](https://github.com/geoadmin/web-mapviewer/assets/1421861/96a439ae-45ad-4013-ada2-b9fb7b3823fd)


[Test link](https://sys-map.dev.bgdi.ch/preview/pb-497-gpx-on-3d/index.html)