### PR TITLE
PB-228 : add aggregate layer support to 3D

### DIFF
--- a/src/modules/map/components/cesium/CesiumMap.vue
+++ b/src/modules/map/components/cesium/CesiumMap.vue
@@ -105,6 +105,7 @@ import { mapActions, mapGetters, mapState } from 'vuex'
 
 import { extractOlFeatureGeodesicCoordinates } from '@/api/features/features.api.js'
 import ExternalLayer from '@/api/layers/ExternalLayer.class'
+import GeoAdminAggregateLayer from '@/api/layers/GeoAdminAggregateLayer.class.js'
 import GeoAdminGeoJsonLayer from '@/api/layers/GeoAdminGeoJsonLayer.class'
 import GeoAdminWMSLayer from '@/api/layers/GeoAdminWMSLayer.class'
 import GeoAdminWMTSLayer from '@/api/layers/GeoAdminWMTSLayer.class'
@@ -198,6 +199,7 @@ export default {
                 (l) =>
                     l instanceof GeoAdminWMTSLayer ||
                     l instanceof GeoAdminWMSLayer ||
+                    l instanceof GeoAdminAggregateLayer ||
                     l instanceof ExternalLayer
             )
         },

--- a/src/modules/map/components/cesium/CesiumWMSLayer.vue
+++ b/src/modules/map/components/cesium/CesiumWMSLayer.vue
@@ -38,10 +38,13 @@ export default {
             type: Number,
             default: -1,
         },
-
         isTimeSliderActive: {
             type: Boolean,
             default: false,
+        },
+        parentLayerOpacity: {
+            type: Number,
+            default: null,
         },
     },
     computed: {
@@ -52,7 +55,7 @@ export default {
             return this.wmsLayerConfig.technicalName ?? this.wmsLayerConfig.id
         },
         opacity() {
-            return this.wmsLayerConfig.opacity ?? 1.0
+            return this.parentLayerOpacity ?? this.wmsLayerConfig.opacity ?? 1.0
         },
         wmsVersion() {
             return this.wmsLayerConfig.wmsVersion ?? '1.3.0'
@@ -107,15 +110,14 @@ export default {
                 new WebMapServiceImageryProvider({
                     url: url,
                     parameters: this.wmsUrlParams,
-                    subdomains: '0123',
-                    layers: this.wmsLayerConfig.id,
+                    layers: this.layerId,
                     maximumLevel: MAXIMUM_LEVEL_OF_DETAILS,
+                    enablePickFeatures: false,
                     rectangle: Rectangle.fromDegrees(
                         ...DEFAULT_PROJECTION.getBoundsAs(WGS84).flatten
                     ),
                 }),
                 {
-                    show: this.wmsLayerConfig.visible,
                     alpha: this.opacity,
                 }
             )

--- a/src/modules/map/components/cesium/CesiumWMTSLayer.vue
+++ b/src/modules/map/components/cesium/CesiumWMTSLayer.vue
@@ -54,13 +54,17 @@ export default {
             type: Boolean,
             default: false,
         },
+        parentLayerOpacity: {
+            type: Number,
+            default: null,
+        },
     },
     computed: {
         layerId() {
             return this.wmtsLayerConfig.id
         },
         opacity() {
-            return this.wmtsLayerConfig.opacity || 1.0
+            return this.parentLayerOpacity ?? this.wmtsLayerConfig.opacity ?? 1.0
         },
         url() {
             return getWmtsXyzUrl(this.wmtsLayerConfig, this.projection, {
@@ -139,7 +143,6 @@ export default {
         ...mapActions(['addLayerErrorKey', 'removeLayerErrorKey']),
         createImagery(url) {
             const options = {
-                show: this.wmtsLayerConfig.visible,
                 alpha: this.opacity,
             }
             if (this.wmtsLayerConfig instanceof ExternalWMTSLayer && this.tileMatrixSetId) {


### PR DESCRIPTION
removing the visible flag being used, we already remove the component altogether when the visibility flag is false, and it hinders aggregate from being displayed (sub-layers have their visibility flag set to false in the config for some reasons...) Also removing the subdomain for WMS, as we are fine landing always on the main URL endpoint (and can be problematic for external layer support)

Note : a good aggregate layer candidate is the RBD layer loaded by default in the displayed map (will be a WMTS for a while and switch to a WMS when closer to the ground)

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_pb-228_aggregate_in_3d/index.html)