### PR TITLE
PB-548 : fix camera position present in URL at startup issue

### DIFF
--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -165,7 +165,7 @@ const handleLegacyParams = async (legacyParams, store, originView) => {
     const { projection } = store.state.position
     let legacyCoordinates = []
     let latlongCoordinates = []
-    let cameraPosition = []
+    let cameraPosition = [null, null, null, null, null, null]
 
     legacyParams.forEach((param_value, param_key) => {
         handleLegacyParam(
@@ -179,9 +179,8 @@ const handleLegacyParams = async (legacyParams, store, originView) => {
             cameraPosition
         )
     })
-    if (cameraPosition.length >= 3) {
-        cameraPosition.push('')
-        newQuery['camera'] = cameraPosition.join(',')
+    if (cameraPosition.filter((value) => value !== null).length >= 3) {
+        newQuery['camera'] = cameraPosition.map((value) => value ?? '').join(',')
         newQuery['3d'] = true
         newQuery['sr'] = WEBMERCATOR.epsgNumber
 
@@ -206,8 +205,8 @@ const handleLegacyParams = async (legacyParams, store, originView) => {
     }
 
     // if a legacy coordinate (x/y, N/E or lon/lat) was used, we need to build the
-    // center param from them
-    if (legacyCoordinates.length === 2) {
+    // center param from them (only if the 3D camera isn't set too)
+    if (legacyCoordinates.length === 2 && !newQuery['camera']) {
         newQuery['center'] = legacyCoordinates.join(',')
     }
 
@@ -301,7 +300,7 @@ const legacyPermalinkManagementRouterPlugin = (router, store) => {
                     // legacy params some data are required (e.g. the layer config)
                     if (mutation.type === 'setAppIsReady') {
                         log.debug(
-                            '[Legacy URL] app is ready, handle legacy params=${legacyParams.toString()}',
+                            `[Legacy URL] app is ready, handle legacy params=${legacyParams.toString()}`,
                             legacyParams
                         )
                         const newRoute = await handleLegacyParams(

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -180,6 +180,10 @@ const handleLegacyParams = async (legacyParams, store, originView) => {
         )
     })
     if (cameraPosition.filter((value) => value !== null).length >= 3) {
+        // if no pitch is set, we look down to the ground instead of letting no value (0, looking at the horizon) go through
+        if (cameraPosition[3] === null) {
+            cameraPosition[3] = -90
+        }
         newQuery['camera'] = cameraPosition.map((value) => value ?? '').join(',')
         newQuery['3d'] = true
         newQuery['sr'] = WEBMERCATOR.epsgNumber

--- a/src/router/storeSync/PositionParamConfig.class.js
+++ b/src/router/storeSync/PositionParamConfig.class.js
@@ -24,7 +24,7 @@ function dispatchCenterFromUrlIntoStore(to, store, urlParamValue) {
 }
 
 function generateCenterUrlParamFromStoreValues(store) {
-    if (store.state.position.center) {
+    if (store.state.position.center && !store.state.cesium.active) {
         return store.state.position.center
             .map((val) => store.state.position.projection.roundCoordinateValue(val))
             .join(',')

--- a/src/router/storeSync/ZoomParamConfig.class.js
+++ b/src/router/storeSync/ZoomParamConfig.class.js
@@ -24,6 +24,9 @@ function dispatchZoomFromUrlIntoStore(to, store, urlParamValue) {
 }
 
 function generateZoomUrlParamFromStoreValues(store) {
+    if (store.state.cesium.active) {
+        return null
+    }
     return store.state.position.zoom
 }
 

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -154,7 +154,7 @@ const addFeatureIdentificationIntercepts = () => {
         featureDetailTemplate = featureDetail.feature
     })
 
-    cy.intercept('**identify**', (identifyRequest) => {
+    cy.intercept('**/MapServer/identify**', (identifyRequest) => {
         lastIdentifiedFeatures = []
 
         const {
@@ -310,7 +310,11 @@ Cypress.Commands.add(
         if (!('lang' in queryParams)) {
             queryParams.lang = 'en'
         }
-        if (!('center' in queryParams) && !('3d' in queryParams)) {
+        if (
+            !['lat', 'lon', 'x', 'y', 'center', '3d'].some((unwantedKey) =>
+                Object.keys(queryParams).includes(unwantedKey)
+            )
+        ) {
             // "old" MAP_CENTER constant re-projected in LV95
             queryParams.center = '2660013.5,1185172'
         } else if ('3d' in queryParams && !('sr' in queryParams)) {

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -393,7 +393,7 @@ describe('Test on legacy param import', () => {
             cy.readStoreValue('state.position.camera.y').should('eq', lat)
             cy.readStoreValue('state.position.camera.z').should('eq', 0)
             cy.readStoreValue('state.position.camera.heading').should('eq', heading)
-            cy.readStoreValue('state.position.camera.pitch').should('eq', 0)
+            cy.readStoreValue('state.position.camera.pitch').should('eq', -90)
             cy.readStoreValue('state.position.camera.roll').should('eq', 0)
 
             // EPSG is set to 3857


### PR DESCRIPTION
Removing 2D position URL params when 3D is active to diminish issues when we load the app directly in 3D. When zoom and/or position are present, the 3D viewer would react to changes in these values. This was creating some race condition issue at startup when a camera position was also described in the URL.

Camera initialization has also been separated from the logic to move the camera after init, so that we have a clearer logical decision (with logging)

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_pb-548_camera_after_reload/index.html)