### PR TITLE
PB-562 : do not force drawing module's style onto external KMLs

### DIFF
--- a/src/utils/__tests__/kmlUtils.spec.js
+++ b/src/utils/__tests__/kmlUtils.spec.js
@@ -6,6 +6,7 @@ import { beforeEach, describe, it } from 'vitest'
 
 import { DrawingIcon, DrawingIconSet } from '@/api/icon.api'
 import KMLLayer from '@/api/layers/KMLLayer.class'
+import { API_SERVICE_KML_BASE_URL } from '@/config.js'
 import { fakeIconSets } from '@/utils/__tests__/legacyKmlUtils.spec.js'
 import { WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
 import { BLUE } from '@/utils/featureStyleUtils'
@@ -126,7 +127,10 @@ describe('Test KML utils', () => {
 
         beforeEach(() => {
             const kml = readFileSync(resolve(__dirname, './webmapviewerOffsetTestKml.kml'), 'utf8')
-            const kmlLayer = new KMLLayer({ kmlFileUrl: '', kmlData: kml })
+            const kmlLayer = new KMLLayer({
+                kmlFileUrl: API_SERVICE_KML_BASE_URL, // so that it is not considered external
+                kmlData: kml,
+            })
             const olFeatures = parseKml(kmlLayer, WEBMERCATOR, fakeIconSets)
             features = olFeatures.map((f) => {
                 const ef = f.get('editableFeature')

--- a/src/utils/__tests__/legacyKmlUtils.spec.js
+++ b/src/utils/__tests__/legacyKmlUtils.spec.js
@@ -6,6 +6,7 @@ import { beforeEach, describe, it } from 'vitest'
 import { EditableFeatureTypes } from '@/api/features/EditableFeature.class'
 import { DrawingIcon, DrawingIconSet } from '@/api/icon.api'
 import KMLLayer from '@/api/layers/KMLLayer.class'
+import { API_SERVICE_KML_BASE_URL } from '@/config.js'
 import { WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
 import {
     BLACK,
@@ -111,7 +112,10 @@ describe('Validate deserialization of the mf-geoadmin3 viewer kml format', () =>
 
     beforeEach(() => {
         const kml = readFileSync(resolve(__dirname, './mfgeoadmin3TestKml.kml'), 'utf8')
-        const kmlLayer = new KMLLayer({ kmlFileUrl: '', kmlData: kml })
+        const kmlLayer = new KMLLayer({
+            kmlFileUrl: API_SERVICE_KML_BASE_URL, // so that it is not considered external
+            kmlData: kml,
+        })
         const olFeatures = parseKml(kmlLayer, WEBMERCATOR, fakeIconSets)
         features = olFeatures.map((f) => {
             const ef = f.get('editableFeature')

--- a/src/utils/kmlUtils.js
+++ b/src/utils/kmlUtils.js
@@ -463,24 +463,27 @@ export function parseKml(kmlLayer, projection, iconSets) {
         dataProjection: WGS84.epsg, // KML files should always be in WGS84
         featureProjection: projection.epsg,
     })
-    features.forEach((olFeature) => {
-        const editableFeature = getEditableFeatureFromKmlFeature(olFeature, kmlLayer, iconSets)
+    // we do not force our DrawingModule styling (especially colors) to external/non-drawing KMLs
+    if (!kmlLayer.isExternal) {
+        features.forEach((olFeature) => {
+            const editableFeature = getEditableFeatureFromKmlFeature(olFeature, kmlLayer, iconSets)
 
-        if (editableFeature) {
-            // Set the EditableFeature coordinates from the olFeature geometry
-            editableFeature.setCoordinatesFromFeature(olFeature)
-            olFeature.set('editableFeature', editableFeature)
-            olFeature.setStyle(featureStyleFunction)
+            if (editableFeature) {
+                // Set the EditableFeature coordinates from the olFeature geometry
+                editableFeature.setCoordinatesFromFeature(olFeature)
+                olFeature.set('editableFeature', editableFeature)
+                olFeature.setStyle(featureStyleFunction)
 
-            if (editableFeature.isLineOrMeasure()) {
-                /* The featureStyleFunction uses the geometries calculated in the geodesic object
-                if present. The lines connecting the vertices of the geometry will appear
-                geodesic (follow the shortest path) in this case instead of linear (be straight on
-                the screen)  */
-                olFeature.set('geodesic', new GeodesicGeometries(olFeature, projection))
+                if (editableFeature.isLineOrMeasure()) {
+                    /* The featureStyleFunction uses the geometries calculated in the geodesic object
+                    if present. The lines connecting the vertices of the geometry will appear
+                    geodesic (follow the shortest path) in this case instead of linear (be straight on
+                    the screen)  */
+                    olFeature.set('geodesic', new GeodesicGeometries(olFeature, projection))
+                }
             }
-        }
-    })
+        })
+    }
 
     return features
 }


### PR DESCRIPTION
forcing this resulted in KMLs being misrepresented, with colors not matching what was in the KML's data

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_pb-562_wrong_external_kml_style/index.html)