### PR TITLE
PB-590: Update selectable features to match preview

### DIFF
--- a/src/modules/map/components/toolbox/TimeSlider.vue
+++ b/src/modules/map/components/toolbox/TimeSlider.vue
@@ -197,6 +197,7 @@ const yearsWithData = computed(() => {
         yearsSeparate: yearsSeparate.sort((a, b) => b - a),
     }
 })
+const visibleLayersWithTimeConfig = computed(() => store.getters.visibleLayersWithTimeConfig)
 
 watch(screenWidth, (newValue) => {
     setSliderWidth(newValue)
@@ -212,6 +213,11 @@ watch(isInputYearValid, (newValue) => {
 
 watch(lang, () => {
     updateTippyContent(tippyYearOutsideRangeContent.value)
+})
+
+watch(visibleLayersWithTimeConfig, () => {
+    console.error('watch')
+    setPreviewYearToLayers()
 })
 
 onMounted(() => {

--- a/src/modules/map/components/toolbox/TimeSlider.vue
+++ b/src/modules/map/components/toolbox/TimeSlider.vue
@@ -26,6 +26,7 @@ const ALL_YEARS = (() => {
 const LABEL_WIDTH = 32
 const MARGIN_BETWEEN_LABELS = 50
 const PLAY_BUTTON_SIZE = 54
+const DEBOUNCE_INTERVAL = 500
 // dynamic internal data
 const sliderWidth = ref(0)
 const allYears = ref(ALL_YEARS)
@@ -84,8 +85,9 @@ const updateInputYear = debounce((value) => {
         isInputYearValid.value = true
         currentYear.value = parseInt(value)
         falseYear.value = null
+        setPreviewYearToLayers()
     }
-}, 500)
+}, DEBOUNCE_INTERVAL)
 
 /**
  * Used for the year in the input field Validate the input from the user. In case it's invalid, we
@@ -238,6 +240,7 @@ onMounted(() => {
         currentYear.value = previewYear.value
     }
 
+    setPreviewYearToLayers()
     tippyTimeSliderInfo = tippy(timeSliderBar.value, {
         content: timeSliderTooltipRef.value,
         hideOnClick: true,
@@ -281,7 +284,7 @@ function dispatchPreviewYearToStore() {
 
 const dispatchPreviewYearToStoreDebounced = debounce(() => {
     dispatchPreviewYearToStore()
-}, 500)
+}, DEBOUNCE_INTERVAL)
 
 function setSliderWidth() {
     // the padding of the slider container (4px each side) + the padding of the
@@ -348,6 +351,10 @@ function listenToMouseMove(event) {
 }
 
 function releaseCursor() {
+    //wait for debounce of preview year so that right features are selected
+    setTimeout(() => {
+        setPreviewYearToLayers()
+    }, DEBOUNCE_INTERVAL)
     yearCursorIsGrabbed = false
     window.removeEventListener('mousemove', listenToMouseMove)
     window.removeEventListener('touchmove', listenToMouseMove)

--- a/src/modules/map/components/toolbox/TimeSlider.vue
+++ b/src/modules/map/components/toolbox/TimeSlider.vue
@@ -216,7 +216,6 @@ watch(lang, () => {
 })
 
 watch(visibleLayersWithTimeConfig, () => {
-    console.error('watch')
     setPreviewYearToLayers()
 })
 

--- a/src/modules/map/components/toolbox/TimeSlider.vue
+++ b/src/modules/map/components/toolbox/TimeSlider.vue
@@ -267,7 +267,8 @@ function setPreviewYearToLayers() {
         if (
             layer.hasMultipleTimestamps &&
             layer.timeConfig &&
-            layer.timeConfig.getTimeEntryForYear(year)
+            layer.timeConfig.getTimeEntryForYear(year) &&
+            layer.visible
         ) {
             store.dispatch('setTimedLayerCurrentYear', {
                 index,
@@ -392,6 +393,7 @@ function togglePlayYearsWithData() {
             }
         }, 1000)
     } else {
+        setPreviewYearToLayers()
         clearInterval(playYearInterval)
         playYearInterval = null
     }

--- a/tests/cypress/tests-e2e/timeSlider.cy.js
+++ b/tests/cypress/tests-e2e/timeSlider.cy.js
@@ -302,12 +302,16 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             cy.get(`[data-cy="button-open-visible-layer-settings-${time_layer_std}-0"]`).click()
             cy.get(`[data-cy="button-duplicate-layer-${time_layer_std}-0"]`).click()
             cy.get(`[data-cy="button-toggle-visibility-layer-${time_layer_std}-0"]`).click()
-            cy.get(`[data-cy="time-selector-${time_layer_std}-0"]`).should('contain', 2019)
+            cy.get(`[data-cy="time-selector-${time_layer_std}-0"]`).should('contain', 2017)
             cy.get(`[data-cy="time-selector-${time_layer_std}-1"]`).should('contain', 2017)
 
-            // ---------------------------------------------------------------------------------------------------
-            cy.log('Check time slider year cursor text input')
+            cy.log('timeslider only updates selected layers')
+            cy.get('[data-cy="time-slider-bar-cursor-year"]').clear()
+            cy.get('[data-cy="time-slider-bar-cursor-year"]').type('2019')
+            cy.get(`[data-cy="time-selector-${time_layer_std}-0"]`).should('contain', 2017)
+            cy.get(`[data-cy="time-selector-${time_layer_std}-1"]`).should('contain', 2019)
 
+            cy.log('Check time slider year cursor text input')
             cy.get('[data-cy="time-slider-bar-cursor-arrow"]')
                 .invoke('attr', 'style')
                 .then(($barCursorPosition) => {

--- a/tests/cypress/tests-e2e/timeSlider.cy.js
+++ b/tests/cypress/tests-e2e/timeSlider.cy.js
@@ -202,26 +202,6 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             })
 
             // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-            cy.log(
-                `${time_layer_odd} : CSS of time selectors on a layer with data on the preview Year selected`
-            )
-            cy.get(`[data-cy="time-selector-${time_layer_odd}-1"]`).click()
-            timestamps[time_layer_odd].forEach((timestamp) => {
-                cy.get(`[data-cy="time-select-${timestamp}"]`).should('satisfy', (element) => {
-                    const classList = Array.from(element[0].classList)
-                    // in the odd layer, the year is set to 2009 and the time slider to 2013:
-                    // it should show 2013 as primary, 2009 as outline and everything else
-                    // should be a light button
-                    if (timestamp === '20130101') {
-                        return isPrimaryBtn(classList)
-                    } else {
-                        return timestamp === '20090101'
-                            ? isPrimaryOutlineBtn(classList)
-                            : isLightBtn(classList)
-                    }
-                })
-            })
-            // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
             cy.get(`[data-cy="time-selector-${time_layer_with_all}-2"]`).click()
             timestamps[time_layer_with_all].forEach((timestamp) => {
                 cy.get(`[data-cy="time-select-${timestamp}"]`).should('satisfy', (element) => {


### PR DESCRIPTION
[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-590-time-slider-feature-mismatch/index.html#/map?lang=de&center=2770091.86,1179697.67&z=5.612&bgLayer=ch.swisstopo.pixelkarte-grau&topic=luftbilder&layers=ch.swisstopo.lubis-luftbilder_schwarzweiss@year=1950;ch.swisstopo.lubis-luftbilder_farbe@year=9999;ch.swisstopo.lubis-luftbilder-dritte-kantone@year=9999;ch.swisstopo.lubis-luftbilder-dritte-firmen@year=1950;ch.swisstopo.lubis-luftbilder_infrarot@year=9999;ch.swisstopo.lubis-luftbilder_schraegaufnahmen@year=null;ch.swisstopo.lubis-terrestrische_aufnahmen@year=9999&featureInfo=default&catalogNodes=1180,1186,1179)
Update selectable features to match preview when opening time slider, releasing time slider cursor, input valid year in text field or add visible layer.  

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-590-time-slider-feature-mismatch/index.html)