### PR TITLE
Fix tooltip movable window pointer and icon issues

### DIFF
--- a/src/modules/map/components/MapPopover.vue
+++ b/src/modules/map/components/MapPopover.vue
@@ -158,6 +158,7 @@ function printContent() {
                     class="print-button btn btn-sm btn-light d-flex align-items-center"
                     data-tippy-content="print"
                     @click="printContent"
+                    @mousedown.stop=""
                 >
                     <FontAwesomeIcon icon="print" />
                 </button>
@@ -166,6 +167,7 @@ function printContent() {
                     class="btn btn-sm btn-light d-flex align-items-center"
                     data-cy="map-popover-close-button"
                     @click="showContent = !showContent"
+                    @mousedown.stop=""
                 >
                     <FontAwesomeIcon :icon="`caret-${showContent ? 'down' : 'right'}`" />
                 </button>
@@ -173,6 +175,7 @@ function printContent() {
                     class="btn btn-sm btn-light d-flex align-items-center"
                     data-cy="map-popover-close-button"
                     @click="onClose"
+                    @mousedown.stop=""
                 >
                     <FontAwesomeIcon icon="times" />
                 </button>

--- a/src/modules/map/components/cesium/CesiumMap.vue
+++ b/src/modules/map/components/cesium/CesiumMap.vue
@@ -60,6 +60,7 @@
                     class="btn btn-sm btn-light d-flex align-items-center"
                     data-cy="toggle-floating-off"
                     @click="setBottomPanelFeatureInfoPosition()"
+                    @mousedown.stop=""
                 >
                     <FontAwesomeIcon icon="caret-down" />
                 </button>

--- a/src/modules/map/components/openlayers/OpenLayersHighlightedFeatures.vue
+++ b/src/modules/map/components/openlayers/OpenLayersHighlightedFeatures.vue
@@ -124,6 +124,7 @@ function setBottomPanelFeatureInfoPosition() {
                 class="btn btn-sm btn-light d-flex align-items-center"
                 data-cy="toggle-floating-off"
                 @click="setBottomPanelFeatureInfoPosition"
+                @mousedown.stop=""
             >
                 <FontAwesomeIcon icon="angles-down" />
             </button>


### PR DESCRIPTION
The pointer was not set to `move` on the movable window header. Also clicking
on the window header buttons (close, print, ...) triggered also a move event
which is unwanted.

Made also the use movable composable usable if the component is not mounted
and fixed default params.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-movable-window/index.html)