### PR TITLE
PB-621: Fixed default lang with `-CH` suffix

### DIFF
--- a/src/modules/i18n/index.js
+++ b/src/modules/i18n/index.js
@@ -19,15 +19,13 @@ export function langToLocal(lang) {
 }
 
 export function localToLang(local) {
-    return local.replace('-CH', '')
+    return local.split('-')[0]
+}
 
 // detecting navigator's locale as the default language
 // (if it is a language served by this app)
-let matchedLanguage = null
-if (navigator.languages) {
-    // we keep the first match we found
-    matchedLanguage = navigator.languages.find((lang) => Object.keys(locales).includes(lang))
-}
+export const defaultLocal =
+    navigator.languages?.find((local) => Object.keys(locales).includes(local)) ?? 'en'
 
 const datetimeFormats = Object.keys(locales).reduce((obj, key) => {
     obj[key] = {
@@ -44,7 +42,7 @@ const datetimeFormats = Object.keys(locales).reduce((obj, key) => {
 }, {})
 
 const i18n = createI18n({
-    locale: matchedLanguage || 'en', // default locale
+    locale: defaultLocal,
     messages: languages,
     legacy: false,
     datetimeFormats,

--- a/src/modules/i18n/index.js
+++ b/src/modules/i18n/index.js
@@ -18,6 +18,9 @@ export function langToLocal(lang) {
     return ['de', 'fr', 'it', 'rm'].includes(lang) ? `${lang}-CH` : lang
 }
 
+export function localToLang(local) {
+    return local.replace('-CH', '')
+
 // detecting navigator's locale as the default language
 // (if it is a language served by this app)
 let matchedLanguage = null

--- a/src/store/modules/i18n.store.js
+++ b/src/store/modules/i18n.store.js
@@ -1,4 +1,4 @@
-import i18n, { langToLocal, localToLang } from '@/modules/i18n'
+import i18n, { defaultLocal, langToLocal, localToLang } from '@/modules/i18n'
 
 /**
  * The name of the mutation for lang changes
@@ -14,7 +14,7 @@ const state = {
      *
      * @type String
      */
-    lang: localToLang(i18n.global.locale),
+    lang: localToLang(defaultLocal),
 }
 
 const getters = {}

--- a/src/store/modules/i18n.store.js
+++ b/src/store/modules/i18n.store.js
@@ -1,4 +1,4 @@
-import i18n, { langToLocal } from '@/modules/i18n'
+import i18n, { langToLocal, localToLang } from '@/modules/i18n'
 
 /**
  * The name of the mutation for lang changes
@@ -14,7 +14,7 @@ const state = {
      *
      * @type String
      */
-    lang: i18n.global.locale,
+    lang: localToLang(i18n.global.locale),
 }
 
 const getters = {}


### PR DESCRIPTION
The `-CH` local suffix is not supported by our API backend. The default
language was set to the default browser language which could be de-CH or fr-CH.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-621-default-lang/index.html)