### PR TITLE
PB-622: Fix timed layer with only one timestamps

### DIFF
--- a/src/api/layers/layers.api.js
+++ b/src/api/layers/layers.api.js
@@ -54,7 +54,7 @@ const generateClassForLayerConfig = (layerConfig, id, allOtherLayers, lang) => {
             // this is not a well-formed URL, we do nothing with it
         }
         const timestamps = []
-        if (Array.isArray(layerConfig.timestamps) && layerConfig.timestamps.length > 1) {
+        if (Array.isArray(layerConfig.timestamps) && layerConfig.timestamps.length > 0) {
             timestamps.push(
                 ...layerConfig.timestamps.map((timestamp) => new LayerTimeConfigEntry(timestamp))
             )


### PR DESCRIPTION
Those layers were called using `current` as their timestamp were added to their
config.

For the layer `ch.swisstopo.swissimage-product_1946` this was an issue as it
only supported `1946` as timestamp and not `current`.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-622-wmts-unique-timestamp/index.html)