### PR TITLE
PB-570 : use service-proxy for failed KML/GPX URL import

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -10,3 +10,4 @@ VITE_API_SERVICE_KML_BASE_URL=https://sys-public.dev.bgdi.ch/
 VITE_APP_API_SERVICE_SHORTLINK_BASE_URL=https://sys-s.dev.bgdi.ch/
 VITE_APP_3D_TILES_BASE_URL=https://sys-3d.dev.bgdi.ch/
 VITE_APP_VECTORTILES_BASE_URL=https://sys-verctortiles.dev.bgdi.ch/
+VITE_APP_SERVICE_PROXY_BASE_URL=https://sys-proxy.dev.bgdi.ch/

--- a/.env.integration
+++ b/.env.integration
@@ -9,3 +9,4 @@ VITE_API_SERVICE_KML_BASE_URL=https://sys-public.int.bgdi.ch/
 VITE_APP_API_SERVICE_SHORTLINK_BASE_URL=https://sys-s.int.bgdi.ch/
 VITE_APP_3D_TILES_BASE_URL=https://sys-3d.int.bgdi.ch/
 VITE_APP_VECTORTILES_BASE_URL=https://sys-verctortiles.int.bgdi.ch/
+VITE_APP_SERVICE_PROXY_BASE_URL=https://sys-proxy.int.bgdi.ch/

--- a/.env.production
+++ b/.env.production
@@ -9,3 +9,4 @@ VITE_API_SERVICE_KML_BASE_URL=https://public.geo.admin.ch/
 VITE_APP_API_SERVICE_SHORTLINK_BASE_URL=https://s.geo.admin.ch/
 VITE_APP_3D_TILES_BASE_URL=https://3d.geo.admin.ch/
 VITE_APP_VECTORTILES_BASE_URL=https://vectortiles.geo.admin.ch/
+VITE_APP_SERVICE_PROXY_BASE_URL=https://proxy.geo.admin.ch/

--- a/src/api/__tests__/file-proxy.api.spec.js
+++ b/src/api/__tests__/file-proxy.api.spec.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai'
+import { describe, it } from 'vitest'
+
+import { transformFileUrl } from '@/api/file-proxy.api.js'
+
+describe('Serice-proxy tests', () => {
+    describe('transformFileUrl', () => {
+        it('returns null when the input is invalid', () => {
+            expect(transformFileUrl(null)).to.be.null
+            expect(transformFileUrl(undefined)).to.be.null
+            expect(transformFileUrl(123)).to.be.null
+            expect(transformFileUrl({})).to.be.null
+            expect(transformFileUrl([])).to.be.null
+        })
+        it('returns the URL transformed', () => {
+            expect(transformFileUrl('http://some-file.kml?one=1&foo=bar')).to.eq(
+                `http/some-file.kml${encodeURIComponent('?one=1&foo=bar')}`
+            )
+        })
+    })
+})

--- a/src/api/file-proxy.api.js
+++ b/src/api/file-proxy.api.js
@@ -1,0 +1,56 @@
+import axios from 'axios'
+import { isString } from 'lodash'
+
+import { API_SERVICE_PROXY_BASE_URL } from '@/config'
+import log from '@/utils/logging'
+
+/**
+ * Transform our file URL into a path, compatible with a call to service-proxy
+ *
+ * @param {String} fileUrl
+ * @see https://github.com/geoadmin/service-proxy?tab=readme-ov-file#using-the-proxy
+ */
+export function transformFileUrl(fileUrl) {
+    if (!isString(fileUrl)) {
+        return null
+    }
+    // copy from https://github.com/geoadmin/mf-geoadmin3/blob/master/src/components/UrlUtilsService.js#L59-L69
+    const parts = /^(http|https)(:\/\/)(.+)/.exec(fileUrl)
+    const protocol = parts[1]
+    const resource = parts[3]
+    return `${protocol}/${encodeURIComponent(resource)}`
+}
+
+/**
+ * Get a file through our service-proxy backend, taking care of CORS headers in the process.
+ *
+ * That means that a file for which there is no defined CORS header will still be accessible through
+ * this function (i.e. Dropbox/name your cloud share links)
+ *
+ * @param {String} fileUrl
+ * @param {Object} [options]
+ * @param {Number} [options.timeout] How long should the call wait before timing out
+ * @returns {Promise<AxiosResponse>} A promise which resolve to the proxy response
+ */
+export default function getFileThroughProxy(fileUrl, options = {}) {
+    const { timeout = null } = options
+    return new Promise((resolve, reject) => {
+        const fileAsPath = transformFileUrl(fileUrl)
+        if (!fileAsPath) {
+            reject(new Error(`Malformed file URL: ${fileUrl}`))
+            return
+        }
+        axios({
+            method: 'get',
+            url: `${API_SERVICE_PROXY_BASE_URL}${fileAsPath}`,
+            timeout,
+        })
+            .then((response) => {
+                resolve(response)
+            })
+            .catch((error) => {
+                log.error('Error while accessing file URL through service-proxy', fileUrl, error)
+                reject(error)
+            })
+    })
+}

--- a/src/config.js
+++ b/src/config.js
@@ -106,6 +106,18 @@ export const API_SERVICE_KML_BASE_URL = enforceEndingSlashInUrl(
 )
 
 /**
+ * Base part of the URL to be using service-proxy
+ *
+ * This URL always end with a slash, so there's no need at add another one after it to create REST
+ * endpoints
+ *
+ * @type {String}
+ */
+export const API_SERVICE_PROXY_BASE_URL = enforceEndingSlashInUrl(
+    import.meta.env.VITE_APP_SERVICE_PROXY_BASE_URL
+)
+
+/**
  * Base part of the URL to communicate with service-shortlink backend
  *
  * This URL always end with a slash, so there's no need at add another one after it to create REST


### PR DESCRIPTION
this should enable Dropbox/Google Drive/name your cloud provider users, for which the provider has explicitly not implemented CORS header, to still be able to import their file on our viewer.

This is a temporary solution to ease the go-live, but we need to think long-term how we want to deal with that (or if we want to stop supporting it)

Send me a PM on Slack to get a valid URL to my dropbox, I've uploaded a sample KML there

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_pb-570_service_proxy_for_kml_and_gpx/index.html)