### PR TITLE
PB-586 improve tooltip css

### DIFF
--- a/src/modules/infobox/components/FeatureDetail.vue
+++ b/src/modules/infobox/components/FeatureDetail.vue
@@ -134,4 +134,7 @@ function getIframeHosts(value) {
 :global(.htmlpopup-content) {
     padding: 7px;
 }
+:global(td) {
+    vertical-align: top;
+}
 </style>

--- a/src/modules/infobox/components/FeatureDetail.vue
+++ b/src/modules/infobox/components/FeatureDetail.vue
@@ -134,11 +134,11 @@ function getIframeHosts(value) {
 :global(.htmlpopup-content) {
     padding: 7px;
 }
-:global(td) {
+td {
     vertical-align: top;
 }
 
-:global(td.cell-left) {
+td.cell-left {
     padding-right: 10px;
 }
 </style>

--- a/src/modules/infobox/components/FeatureDetail.vue
+++ b/src/modules/infobox/components/FeatureDetail.vue
@@ -137,4 +137,8 @@ function getIframeHosts(value) {
 :global(td) {
     vertical-align: top;
 }
+
+:global(td.cell-left) {
+    padding-right: 10px;
+}
 </style>

--- a/src/modules/infobox/components/FeatureListCategory.vue
+++ b/src/modules/infobox/components/FeatureListCategory.vue
@@ -37,12 +37,12 @@ const { t } = useI18n()
 <template>
     <div class="feature-list-category border-start">
         <div
-            class="p-2 sticky-top bg-secondary-subtle border-bottom border-secondary-subtle d-flex cursor-pointer"
+            class="p-2 sticky-top bg-secondary-subtle border-bottom border-secondary-subtle d-flex align-items-center cursor-pointer"
             @click="showContent = !showContent"
         >
             <FontAwesomeIcon :icon="`caret-${showContent ? 'down' : 'right'}`" class="me-2" />
             <strong class="flex-grow-1">{{ name }}</strong>
-            <small class="text-muted align-self-center">
+            <small class="text-muted">
                 {{ children.length }}<span v-if="canLoadMore">+</span>
             </small>
         </div>

--- a/src/modules/infobox/components/FeatureListCategoryItem.vue
+++ b/src/modules/infobox/components/FeatureListCategoryItem.vue
@@ -40,7 +40,6 @@ const store = useStore()
 const isHighlightedFeature = computed(
     () => store.state.features.highlightedFeatureId === item.value.id
 )
-const showFeatureInfoInBottomPanel = computed(() => store.getters.showFeatureInfoInBottomPanel)
 function highlightFeature(feature) {
     store.dispatch('setHighlightedFeatureId', {
         highlightedFeatureId: feature?.id,
@@ -81,7 +80,7 @@ function showContentAndScrollIntoView(event) {
 <template>
     <div
         ref="featureTitle"
-        class="feature-list-category-item-name p-2 position-relative cursor-pointer"
+        class="feature-list-category-item-name p-1 d-flex align-items-center cursor-pointer"
         :class="{
             highlighted: isHighlightedFeature,
             'border-bottom': !showContent,
@@ -91,21 +90,14 @@ function showContentAndScrollIntoView(event) {
         @mouseenter.passive="highlightFeature(item)"
         @mouseleave.passive="clearHighlightedFeature"
     >
-        <FontAwesomeIcon :icon="`caret-${showContent ? 'down' : 'right'}`" class="mx-2 column" />
-        <TextTruncate
-            :text="name"
-            class="column-truncate"
-            :class="{
-                'infobox-active': showFeatureInfoInBottomPanel,
-            }"
-        >
+        <FontAwesomeIcon :icon="`caret-${showContent ? 'down' : 'right'}`" class="mx-2" />
+        <TextTruncate :text="name" class="flex-grow-1">
             <strong>{{ name }}</strong>
         </TextTruncate>
 
         <ZoomToExtentButton
             v-if="item.extent"
             :extent="item.extent"
-            class="float-end"
             @click="showContentAndScrollIntoView"
         />
     </div>
@@ -128,11 +120,7 @@ function showContentAndScrollIntoView(event) {
 @import '@/scss/variables-admin.module';
 @import '@/scss/webmapviewer-bootstrap-theme';
 
-$margin-top-to-align-with-glass: 3px;
-
 .feature-list-category-item-name {
-    display: table;
-    width: 100%;
     &.highlighted {
         background-color: rgba($mocassin-to-red-1, 0.8);
     }
@@ -140,22 +128,6 @@ $margin-top-to-align-with-glass: 3px;
 .feature-list-category-item-content {
     &.highlighted {
         box-shadow: inset 0 0 0 2px rgba($mocassin-to-red-1, 0.8);
-    }
-}
-.column {
-    float: left;
-    margin-top: $margin-top-to-align-with-glass + 2;
-}
-// floating tooltips have a fixed width, so we can truncate at the same 'spot'
-// every time.
-.column-truncate {
-    float: left;
-    width: 250px;
-    margin-top: $margin-top-to-align-with-glass;
-    &.infobox-active {
-        // infobox take the whole width of the screen. We truncate somewhere different
-        // depending on how wide the screen is.
-        width: 80vw;
     }
 }
 </style>

--- a/src/modules/infobox/components/FeatureListCategoryItem.vue
+++ b/src/modules/infobox/components/FeatureListCategoryItem.vue
@@ -81,7 +81,7 @@ function showContentAndScrollIntoView(event) {
 <template>
     <div
         ref="featureTitle"
-        class="feature-list-category-item-name p-2 align-middle position-relative cursor-pointer"
+        class="feature-list-category-item-name p-2 position-relative cursor-pointer"
         :class="{
             highlighted: isHighlightedFeature,
             'border-bottom': !showContent,
@@ -128,6 +128,8 @@ function showContentAndScrollIntoView(event) {
 @import '@/scss/variables-admin.module';
 @import '@/scss/webmapviewer-bootstrap-theme';
 
+$margin-top-to-align-with-glass: 3px;
+
 .feature-list-category-item-name {
     display: table;
     width: 100%;
@@ -142,12 +144,14 @@ function showContentAndScrollIntoView(event) {
 }
 .column {
     float: left;
+    margin-top: $margin-top-to-align-with-glass + 2;
 }
 // floating tooltips have a fixed width, so we can truncate at the same 'spot'
 // every time.
 .column-truncate {
     float: left;
     width: 250px;
+    margin-top: $margin-top-to-align-with-glass;
     &.infobox-active {
         // infobox take the whole width of the screen. We truncate somewhere different
         // depending on how wide the screen is.

--- a/src/modules/infobox/components/FeatureListCategoryItem.vue
+++ b/src/modules/infobox/components/FeatureListCategoryItem.vue
@@ -99,7 +99,7 @@ function showContentAndScrollIntoView(event) {
                 'infobox-active': showFeatureInfoInBottomPanel,
             }"
         >
-            <span class="font-weight-bold">{{ name }}</span>
+            <strong>{{ name }}</strong>
         </TextTruncate>
 
         <ZoomToExtentButton

--- a/src/modules/infobox/components/FeatureListCategoryItem.vue
+++ b/src/modules/infobox/components/FeatureListCategoryItem.vue
@@ -105,7 +105,7 @@ onUnmounted(() => {
 <template>
     <div
         ref="featureTitle"
-        class="feature-list-category-item-name p-2 align-middle position-relative cursor-pointer"
+        class="feature-list-category-item-name p-2 align-middle position-relative cursor-pointer text-truncate"
         :class="{ highlighted: isHighlightedFeature, 'border-bottom': !showContent }"
         data-cy="feature-item"
         @click="toggleShowContent"
@@ -143,9 +143,6 @@ onUnmounted(() => {
 @import '@/scss/variables-admin.module';
 
 .feature-list-category-item-name {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
     &.highlighted {
         background-color: rgba($mocassin-to-red-1, 0.8);
     }

--- a/src/modules/infobox/components/FeatureListCategoryItem.vue
+++ b/src/modules/infobox/components/FeatureListCategoryItem.vue
@@ -126,6 +126,7 @@ function showContentAndScrollIntoView(event) {
 
 <style lang="scss" scoped>
 @import '@/scss/variables-admin.module';
+@import '@/scss/webmapviewer-bootstrap-theme';
 
 .feature-list-category-item-name {
     display: table;
@@ -152,10 +153,5 @@ function showContentAndScrollIntoView(event) {
         // depending on how wide the screen is.
         width: 80vw;
     }
-}
-
-.font-weight-bold {
-    // this is a boostrap class, we need to use the bootstrap one
-    font-weight: bold;
 }
 </style>


### PR DESCRIPTION
Various issues with the tooltips CSS:

sometimes, features titles were too big
sometimes, the space between the attribute name and the attribute value was too small and hard to read.
sometimes, the alignment between an attribute's name and its value was a bit off, as they were centered on a cell (when the value or the name took more than one line to display)

Fix : We adapt the CSS for those elements, and add a tippy on top of the feature title when it's truncated.

[Test link](https://sys-map.dev.bgdi.ch/preview/bugfix-pb-586-improve-tooltip-css/index.html)