### PR TITLE
PB-588 : revert changes made to E and N in legacy parser

### DIFF
--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -68,11 +68,11 @@ const handleLegacyParam = (
         // storing coordinate parts for later conversion (LV03 or LV95)
         // legacy coordinates have to be saved in an array in order (y,x) for
         // convertion to be correct using proj4.
-        case 'E':
+        case 'N':
         case 'X':
             legacyCoordinates[1] = Number(legacyValue)
             break
-        case 'N':
+        case 'E':
         case 'Y':
             legacyCoordinates[0] = Number(legacyValue)
             break

--- a/tests/cypress/tests-e2e/drawing.cy.js
+++ b/tests/cypress/tests-e2e/drawing.cy.js
@@ -859,7 +859,7 @@ describe('Drawing module tests', () => {
             }).as('get-legacy-kml')
 
             // opening up the app and centering it directly on the single marker feature from the fixture
-            cy.goToMapView({ adminId: kmlFileAdminId, N: center[0], E: center[1] }, false)
+            cy.goToMapView({ adminId: kmlFileAdminId, E: center[0], N: center[1] }, false)
             cy.wait('@get-kml-metadata-by-admin-id')
             cy.wait('@get-legacy-kml')
             cy.waitUntilState((state) => state.drawing.iconSets.length > 0)

--- a/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -50,10 +50,8 @@ describe('Test on legacy param import', () => {
         })
 
         it('reproject LV95 coordinates param to EPSG:4326', () => {
-            // NOTE on the old viewer N := correspond to x in EPSG definition
-            // NOTE on the old viewer E := correspond to y in EPSG definition
-            const N = 2660000
-            const E = 1200000
+            const E = 2660000
+            const N = 1200000
             const lv95zoom = 8
             cy.goToMapView(
                 {


### PR DESCRIPTION
they were in the correct order, we broke the testlink generator (and subsequently all shortlinks) when we swap those

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_pb-588_revert_e_n_legacy_changes/index.html)