### PR TITLE
PB-542 : take into account "config3d" layers config property

### DIFF
--- a/src/api/layers/GeoAdminLayer.class.js
+++ b/src/api/layers/GeoAdminLayer.class.js
@@ -18,8 +18,10 @@ export default class GeoAdminLayer extends AbstractLayer {
     /**
      * @param {String} layerData.name Name of this layer in the current lang
      * @param {LayerTypes} layerData.type See {@link LayerTypes} geoAdminLayerData.
-     * @param {String} geoAdminLayerData.id The unique ID of this layer that will be used to
-     *   identify this layer
+     * @param {String} layerData.id The unique ID of this layer that will be used to identify this
+     *   layer
+     * @param {String | null} layerData.idIn3d The layer ID to be used as substitute for this layer
+     *   when we are showing the 3D map. Will be using the same layer if this is set to null.
      * @param {String} layerData.technicalName The ID/name to use when requesting the WMS/WMTS
      *   backend, this might be different than id, and many layers (with different id) can in fact
      *   request the same layer, through the same technical name, in the end)
@@ -69,6 +71,7 @@ export default class GeoAdminLayer extends AbstractLayer {
             name = null,
             type = null,
             id = null,
+            idIn3d = null,
             technicalName = null,
             opacity = 1.0,
             visible = true,
@@ -119,6 +122,7 @@ export default class GeoAdminLayer extends AbstractLayer {
         this.isBackground = isBackground
         this.isHighlightable = isHighlightable
         this.topics = topics
+        this.idIn3d = idIn3d
         this.isSpecificFor3D = id.toLowerCase().endsWith('_3d')
         this.searchable = searchable
     }

--- a/src/api/layers/GeoAdminWMSLayer.class.js
+++ b/src/api/layers/GeoAdminWMSLayer.class.js
@@ -19,6 +19,8 @@ export default class GeoAdminWMSLayer extends GeoAdminLayer {
     /**
      * @param {String} layerData.name The name of this layer (lang specific)
      * @param {String} layerData.id The unique ID of this layer
+     * @param {String | null} layerData.idIn3d The layer ID to be used as substitute for this layer
+     *   when we are showing the 3D map. Will be using the same layer if this is set to null.
      * @param {String} layerData.technicalName The ID/name to use when requesting the WMS backend,
      *   this might be different than id, and many layers (with different id) can in fact request
      *   the same layer, through the same technical name, in the end)
@@ -63,6 +65,7 @@ export default class GeoAdminWMSLayer extends GeoAdminLayer {
         const {
             name = null,
             id = null,
+            idIn3d = null,
             technicalName = null,
             opacity = 1.0,
             visible = true,
@@ -83,6 +86,7 @@ export default class GeoAdminWMSLayer extends GeoAdminLayer {
             name,
             type: LayerTypes.WMS,
             id,
+            idIn3d,
             technicalName,
             opacity,
             visible,

--- a/src/api/layers/GeoAdminWMTSLayer.class.js
+++ b/src/api/layers/GeoAdminWMTSLayer.class.js
@@ -19,6 +19,8 @@ export default class GeoAdminWMTSLayer extends GeoAdminLayer {
     /**
      * @param {String} layerData.name Layer name (internationalized)
      * @param {String} layerData.id Unique layer ID
+     * @param {String | null} layerData.idIn3d The layer ID to be used as substitute for this layer
+     *   when we are showing the 3D map. Will be using the same layer if this is set to null.
      * @param {String} layerData.technicalName ID to be used in our backend (can be different from
      *   the id)
      * @param {Number} [layerData.opacity=1.0] Opacity value between 0.0 (transparent) and 1.0
@@ -59,6 +61,7 @@ export default class GeoAdminWMTSLayer extends GeoAdminLayer {
         const {
             name = null,
             id = null,
+            idIn3d = null,
             technicalName = null,
             opacity = 1.0,
             visible = true,
@@ -84,6 +87,7 @@ export default class GeoAdminWMTSLayer extends GeoAdminLayer {
             name,
             type: LayerTypes.WMTS,
             id,
+            idIn3d,
             technicalName,
             opacity,
             visible,

--- a/src/api/layers/layers.api.js
+++ b/src/api/layers/layers.api.js
@@ -72,7 +72,8 @@ const generateClassForLayerConfig = (layerConfig, id, allOtherLayers, lang) => {
             case 'wmts':
                 layer = new GeoAdminWMTSLayer({
                     name,
-                    id: id,
+                    id,
+                    idIn3d: layerConfig.config3d ?? null,
                     technicalName: serverLayerName,
                     opacity,
                     visible: false,
@@ -95,7 +96,10 @@ const generateClassForLayerConfig = (layerConfig, id, allOtherLayers, lang) => {
                 layer = new GeoAdminWMSLayer({
                     name,
                     id: id,
-                    technicalName: serverLayerName,
+                    idIn3d: layerConfig.config3d ?? null,
+                    technicalName: Array.isArray(layerConfig.wmsLayers)
+                        ? layerConfig.wmsLayers.join(',')
+                        : layerConfig.wmsLayers ?? serverLayerName,
                     opacity,
                     visible: false,
                     attributions,

--- a/src/modules/map/components/cesium/CesiumMap.vue
+++ b/src/modules/map/components/cesium/CesiumMap.vue
@@ -179,6 +179,7 @@ export default {
             projection: (state) => state.position.projection,
             isFullScreenMode: (state) => state.ui.fullscreenMode,
             isTimeSliderActive: (state) => state.ui.isTimeSliderActive,
+            layersConfig: (state) => state.layers.config,
         }),
         ...mapGetters([
             'selectedFeatures',
@@ -196,13 +197,23 @@ export default {
             return this.uiMode === UIModes.DESKTOP
         },
         visibleImageryLayers() {
-            return this.visibleLayers.filter(
-                (l) =>
-                    l instanceof GeoAdminWMTSLayer ||
-                    l instanceof GeoAdminWMSLayer ||
-                    l instanceof GeoAdminAggregateLayer ||
-                    l instanceof ExternalLayer
-            )
+            return this.visibleLayers
+                .filter(
+                    (l) =>
+                        l instanceof GeoAdminWMTSLayer ||
+                        l instanceof GeoAdminWMSLayer ||
+                        l instanceof GeoAdminAggregateLayer ||
+                        l instanceof ExternalLayer
+                )
+                .map((visibleLayer) => {
+                    if (visibleLayer.idIn3d) {
+                        return (
+                            this.layersConfig.find((layer) => layer.id === visibleLayer.idIn3d) ??
+                            visibleLayer
+                        )
+                    }
+                    return visibleLayer
+                })
         },
         isFeatureInfoInTooltip() {
             return this.showFeatureInfoInTooltip

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -11,7 +11,6 @@ import {
     MAP_VIEWS,
 } from '@/router/viewNames'
 import { FeatureInfoPositions } from '@/store/modules/ui.store'
-import { backgroundMatriceBetween2dAnd3d as backgroundMatriceBetweenLegacyAndNew } from '@/store/plugins/2d-to-3d-management.plugin'
 import { LV03, LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 import CustomCoordinateSystem from '@/utils/coordinates/CustomCoordinateSystem.class'
 import SwissCoordinateSystem from '@/utils/coordinates/SwissCoordinateSystem.class'
@@ -193,14 +192,6 @@ const handleLegacyParams = async (legacyParams, store, originView) => {
         newQuery['camera'] = cameraPosition.map((value) => value ?? '').join(',')
         newQuery['3d'] = true
         newQuery['sr'] = WEBMERCATOR.epsgNumber
-
-        // Handle different background layer from legacy 3D parameter
-        if (newQuery['bgLayer']) {
-            const newBackgroundLayer = backgroundMatriceBetweenLegacyAndNew[newQuery['bgLayer']]
-            if (newBackgroundLayer) {
-                newQuery['bgLayer'] = newBackgroundLayer
-            }
-        }
     }
 
     // Convert legacies coordinates if needed (only if the 3D camera isn't set too)

--- a/src/store/modules/cesium.store.js
+++ b/src/store/modules/cesium.store.js
@@ -60,7 +60,13 @@ export default {
             const bgLayers = []
             const backgroundLayer = rootState.layers.currentBackgroundLayer
             if (backgroundLayer) {
-                bgLayers.push(backgroundLayer)
+                if (backgroundLayer.idIn3d) {
+                    bgLayers.push(
+                        rootState.layers.config.find((layer) => layer.id === backgroundLayer.idIn3d)
+                    )
+                } else {
+                    bgLayers.push(backgroundLayer)
+                }
             }
             if (state.showLabels) {
                 // labels are not up-to-date with the latest Cesium version, but we need then anyway ¯\_(ツ)_/¯

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -127,10 +127,8 @@ const getters = {
      *
      * @returns {[AbstractLayer]} List of background layers.
      */
-    backgroundLayers: (state, _, rootState) =>
-        state.config.filter(
-            (layer) => layer.isBackground && rootState.cesium.active === layer.isSpecificFor3D
-        ),
+    backgroundLayers: (state, _) =>
+        state.config.filter((layer) => layer.isBackground && layer.idIn3d),
 
     /**
      * Retrieves a layer config metadata defined by its unique ID
@@ -726,10 +724,6 @@ const actions = {
 const mutations = {
     setBackground(state, { bgLayer }) {
         state.currentBackgroundLayer = bgLayer
-        // forcing its visibility (if not void layer), as 3D layers have their visible flag set to false somehow
-        if (state.currentBackgroundLayer) {
-            state.currentBackgroundLayer.visible = true
-        }
     },
     setLayerConfig(state, { config }) {
         state.config = config

--- a/src/store/plugins/2d-to-3d-management.plugin.js
+++ b/src/store/plugins/2d-to-3d-management.plugin.js
@@ -1,12 +1,6 @@
 import { DEFAULT_PROJECTION } from '@/config'
 import { WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
 
-export const backgroundMatriceBetween2dAnd3d = {
-    'ch.swisstopo.pixelkarte-farbe': 'ch.swisstopo.swisstlm3d-karte-farbe_3d',
-    'ch.swisstopo.pixelkarte-grau': 'ch.swisstopo.swisstlm3d-karte-grau_3d',
-    'ch.swisstopo.swissimage': 'ch.swisstopo.swissimage_3d',
-}
-
 const dispatcher = { dispatcher: '2d-to-3d-management.plugin' }
 
 /**
@@ -17,34 +11,6 @@ const dispatcher = { dispatcher: '2d-to-3d-management.plugin' }
  */
 export default function from2Dto3Dplugin(store) {
     store.subscribeAction({
-        before: (action, state) => {
-            if (action.type === 'set3dActive') {
-                if (state.cesium.active) {
-                    // when going 2D, as we are before the action
-                    const matching2dBackgroundId = Object.entries(
-                        backgroundMatriceBetween2dAnd3d
-                    ).find(([_, layerId3d]) => {
-                        return layerId3d === state.layers.currentBackgroundLayer?.id
-                    })
-                    if (matching2dBackgroundId?.length > 0) {
-                        store.dispatch('setBackground', {
-                            bgLayer: matching2dBackgroundId[0],
-                            ...dispatcher,
-                        })
-                    }
-                } else if (state.layers.currentBackgroundLayer) {
-                    // when going 3D, as we are before the action
-                    const matching3dBackgroundId =
-                        backgroundMatriceBetween2dAnd3d[state.layers.currentBackgroundLayer.id]
-                    if (matching3dBackgroundId) {
-                        store.dispatch('setBackground', {
-                            bgLayer: matching3dBackgroundId,
-                            ...dispatcher,
-                        })
-                    }
-                }
-            }
-        },
         after: (action, state) => {
             if (action.type === 'set3dActive') {
                 if (DEFAULT_PROJECTION.epsg !== WEBMERCATOR.epsg) {

--- a/src/store/plugins/load-layersconfig-on-lang-change.js
+++ b/src/store/plugins/load-layersconfig-on-lang-change.js
@@ -1,4 +1,3 @@
-import GeoAdminWMTSLayer from '@/api/layers/GeoAdminWMTSLayer.class'
 import { loadLayersConfigFromBackend } from '@/api/layers/layers.api'
 import { loadTopics, parseTopics } from '@/api/topics.api'
 import { SET_LANG_MUTATION_KEY } from '@/store/modules/i18n.store'
@@ -43,23 +42,12 @@ const loadLayersAndTopicsConfigAndDispatchToStore = async (store, lang, topicId,
 
         // adding SWISSIMAGE as a possible background for 3D
         const swissimage = layersConfig.find((layer) => layer.id === 'ch.swisstopo.swissimage')
+        const swissimage3d = layersConfig.find(
+            (layer) => layer.id === 'ch.swisstopo.swissimage-product_3d'
+        )
         if (swissimage) {
-            layersConfig.push(
-                new GeoAdminWMTSLayer({
-                    name: swissimage.name,
-                    id: `${swissimage.id}_3d`,
-                    technicalName: swissimage.technicalName,
-                    visible: false,
-                    attributions: swissimage.attributions,
-                    format: swissimage.format,
-                    timeConfig: swissimage.timeConfig,
-                    isBackground: true,
-                    baseUrl: swissimage.baseUrl,
-                    hasTooltip: false,
-                    isHighlightable: false,
-                    topics: swissimage.topics,
-                })
-            )
+            swissimage3d.isBackground = true
+            swissimage.idIn3d = swissimage3d.id
         }
 
         store.dispatch('setLayerConfig', { config: layersConfig, dispatcher })

--- a/src/store/plugins/load-layersconfig-on-lang-change.js
+++ b/src/store/plugins/load-layersconfig-on-lang-change.js
@@ -45,7 +45,7 @@ const loadLayersAndTopicsConfigAndDispatchToStore = async (store, lang, topicId,
         const swissimage3d = layersConfig.find(
             (layer) => layer.id === 'ch.swisstopo.swissimage-product_3d'
         )
-        if (swissimage) {
+        if (swissimage && swissimage3d) {
             swissimage3d.isBackground = true
             swissimage.idIn3d = swissimage3d.id
         }

--- a/tests/cypress/fixtures/layers.fixture.json
+++ b/tests/cypress/fixtures/layers.fixture.json
@@ -196,6 +196,29 @@
     },
     "test.background.layer": {
         "attribution": "attribution_background",
+        "config3d": "test.background.layer_3d",
+        "background": true,
+        "searchable": false,
+        "format": "jpeg",
+        "hasLegend": false,
+        "topics": "ech",
+        "attributionUrl": "https://api3.geo.admin.ch/",
+        "tooltip": false,
+        "timeEnabled": false,
+        "highlightable": true,
+        "chargeable": true,
+        "timestamps": ["current"],
+        "resolutions": [
+            4000.0, 3750.0, 3500.0, 3250.0, 3000.0, 2750.0, 2500.0, 2250.0, 2000.0, 1750.0, 1500.0,
+            1250.0, 1000.0, 750.0, 650.0, 500.0, 250.0, 100.0, 50.0, 20.0, 10.0, 5.0, 2.5, 2.0, 1.5,
+            1.0, 0.5, 0.25
+        ],
+        "label": "Background test layer",
+        "type": "wmts",
+        "serverLayerName": "test.background.layer"
+    },
+    "test.background.layer_3d": {
+        "attribution": "attribution_background",
         "background": true,
         "searchable": false,
         "format": "jpeg",
@@ -218,6 +241,7 @@
     },
     "test.background.layer2": {
         "attribution": "attribution.test.wmts.layer",
+        "config3d": "test.background.layer2_3d",
         "searchable": false,
         "serverLayerName": "test.background.layer2",
         "format": "jpeg",
@@ -226,6 +250,28 @@
         "attributionUrl": "https://api3.geo.admin.ch/",
         "tooltip": false,
         "label": "Alternative background test layer",
+        "chargeable": true,
+        "highlightable": true,
+        "background": true,
+        "timestamps": ["current"],
+        "resolutions": [
+            4000.0, 3750.0, 3500.0, 3250.0, 3000.0, 2750.0, 2500.0, 2250.0, 2000.0, 1750.0, 1500.0,
+            1250.0, 1000.0, 750.0, 650.0, 500.0, 250.0, 100.0, 50.0, 20.0, 10.0, 5.0, 2.5, 2.0, 1.5,
+            1.0, 0.5, 0.25
+        ],
+        "type": "wmts",
+        "timeEnabled": false
+    },
+    "test.background.layer2_3d": {
+        "attribution": "attribution.test.wmts.layer",
+        "searchable": false,
+        "serverLayerName": "test.background.layer2_3d",
+        "format": "jpeg",
+        "hasLegend": false,
+        "topics": "ech",
+        "attributionUrl": "https://api3.geo.admin.ch/",
+        "tooltip": false,
+        "label": "Alternative background test layer in 3D",
         "chargeable": true,
         "highlightable": true,
         "background": true,

--- a/tests/cypress/tests-e2e/footer.cy.js
+++ b/tests/cypress/tests-e2e/footer.cy.js
@@ -36,7 +36,7 @@ describe('Testing the footer content / tools', () => {
             // checking that all layers flagged as backgrounds are represented in the wheel
             cy.fixture('layers.fixture').then((layers) => {
                 Object.values(layers)
-                    .filter((layer) => layer.background)
+                    .filter((layer) => layer.background && layer.idIn3d)
                     .forEach((bgLayer) => {
                         cy.get(`[data-cy="background-selector-${bgLayer.serverLayerName}"]`).click()
                         // checking that clicking on the wheel buttons changes the bgLayer of the app accordingly


### PR DESCRIPTION
and improve how we parse WMS layer config, taking into account possible "wmsLayers" property

This means that the BG layer set in the URL stays the same while going 3D, and CesiumMap component looks up for 3D equivalent for any WMS/WMTS (background included) if they are defined.

This should fix the issue we had with `ch.bazl.luftfahrthindernis` in 3D, where the "Last updated" label was on each tile (3D can't load a single tile WMS, so there's a specific 3D config for this one, among others)

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_pb-542_proper_3d_layer_selection/index.html)