### PR TITLE
PB-621 : fix issue where lang can't be changed anymore

### DIFF
--- a/src/modules/i18n/index.js
+++ b/src/modules/i18n/index.js
@@ -8,6 +8,9 @@ import rm from './locales/rm.json'
 
 export const languages = { de, fr, it, en, rm }
 
+const OFFICIAL_SWISS_LANG = ['de', 'fr', 'it', 'rm']
+const SUPPORTED_LANG = ['en', ...OFFICIAL_SWISS_LANG]
+
 const locales = Object.entries(languages).reduce((obj, entry) => {
     const key = langToLocal(entry[0])
     obj[key] = entry[1]
@@ -15,17 +18,14 @@ const locales = Object.entries(languages).reduce((obj, entry) => {
 }, {})
 
 export function langToLocal(lang) {
-    return ['de', 'fr', 'it', 'rm'].includes(lang) ? `${lang}-CH` : lang
-}
-
-export function localToLang(local) {
-    return local.split('-')[0]
+    return OFFICIAL_SWISS_LANG.includes(lang) ? `${lang}-CH` : lang
 }
 
 // detecting navigator's locale as the default language
 // (if it is a language served by this app)
-export const defaultLocal =
-    navigator.languages?.find((local) => Object.keys(locales).includes(local)) ?? 'en'
+const defaultLocal = SUPPORTED_LANG.find((lang) =>
+    navigator.languages?.find((navigatorLang) => navigatorLang.indexOf(lang) !== -1)
+)
 
 const datetimeFormats = Object.keys(locales).reduce((obj, key) => {
     obj[key] = {
@@ -42,7 +42,7 @@ const datetimeFormats = Object.keys(locales).reduce((obj, key) => {
 }, {})
 
 const i18n = createI18n({
-    locale: defaultLocal,
+    locale: defaultLocal ?? SUPPORTED_LANG[0],
     messages: languages,
     legacy: false,
     datetimeFormats,

--- a/src/store/modules/i18n.store.js
+++ b/src/store/modules/i18n.store.js
@@ -1,4 +1,4 @@
-import i18n, { defaultLocal, langToLocal, localToLang } from '@/modules/i18n'
+import i18n, { langToLocal } from '@/modules/i18n'
 
 /**
  * The name of the mutation for lang changes
@@ -14,7 +14,7 @@ const state = {
      *
      * @type String
      */
-    lang: localToLang(defaultLocal),
+    lang: i18n.global.locale,
 }
 
 const getters = {}


### PR DESCRIPTION
Instead of mapping locale to our i18n, which seems to break lang change after app startup, revert this part and improve the way we detect the default locale from the navigator available locales. This should alleviate the issue with only 'xx-CH' locales present in the browser's setting, while still enabling the lang change after startup

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_pb-621_lang_issue/index.html)