### PR TITLE
PB-497: Debug GPX loading on 3D

### DIFF
--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -1,10 +1,4 @@
-<template>
-    <div>
-        <slot />
-    </div>
-</template>
-
-<script>
+<script setup>
 import {
     BillboardGraphics,
     Cartesian3,
@@ -14,143 +8,132 @@ import {
     GpxDataSource,
     HeightReference,
 } from 'cesium'
+import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { inject } from 'vue'
 
 import GPXLayer from '@/api/layers/GPXLayer.class'
 import log from '@/utils/logging'
 
-/** Adds a GPX layer to the Cesium viewer */
-export default {
-    inject: ['getViewer'],
-
-    props: {
-        gpxLayerConfig: {
-            type: GPXLayer,
-            required: true,
-        },
+const props = defineProps({
+    gpxLayerConfig: {
+        type: GPXLayer,
+        required: true,
     },
+})
 
-    data() {
-        return {
-            isPresentOnMap: false,
-            gpxDataSource: new GpxDataSource(),
-        }
-    },
+const isPresentOnMap = ref(false)
+const gpxDataSource = ref(new GpxDataSource())
 
-    computed: {
-        opacity() {
-            return this.gpxLayerConfig.opacity
-        },
-        gpxData() {
-            return this.gpxLayerConfig.gpxData
-        },
-    },
+// const opacity = ref(props.gpxLayerConfig.opacity)
+const gpxData = ref(props.gpxLayerConfig.gpxData)
 
-    watch: {
-        gpxData() {
-            this.addLayer()
-        },
-    },
+const getViewer = inject('getViewer')
+watch(gpxData, () => {
+    addLayer()
+})
 
-    mounted() {
-        log.debug('Mounted GPX layer')
-        this.addLayer()
-    },
+onMounted(() => {
+    log.debug('Mounted GPX layer')
+    addLayer()
+})
 
-    unmounted() {
-        log.debug('Unmounted GPX layer')
-        if (this.gpxDataSource && this.isPresentOnMap) {
-            this.removeLayer()
-        }
+onUnmounted(() => {
+    log.debug('Unmounted GPX layer')
+    if (gpxDataSource.value && isPresentOnMap.value) {
+        removeLayer()
+    }
 
-        delete this.gpxDataSource
-    },
+    gpxDataSource.value = null
+})
 
-    methods: {
-        addLayer() {
-            const gpxBlob = new Blob([this.gpxData], { type: 'application/gpx+xml' })
-            const gpxUrl = URL.createObjectURL(gpxBlob)
+function addLayer() {
+    const gpxBlob = new Blob([gpxData.value], { type: 'application/gpx+xml' })
+    const gpxUrl = URL.createObjectURL(gpxBlob)
 
-            this.gpxDataSource
-                .load(gpxUrl, {
-                    clampToGround: true,
+    gpxDataSource.value
+        .load(gpxUrl, {
+            clampToGround: true,
+        })
+        .then((dataSource) => {
+            getViewer().dataSources.add(dataSource)
+            isPresentOnMap.value = true
+        })
+        .then(updateStyle)
+}
+
+function removeLayer() {
+    log.debug('Remove GPX layer')
+    if (gpxDataSource.value) {
+        getViewer().dataSources.remove(gpxDataSource.value)
+        gpxDataSource.value = null
+        getViewer().scene.requestRender() // Request a render after removing the DataSource
+    }
+    isPresentOnMap.value = false
+}
+
+function updateStyle() {
+    // Function to create a red circle image using a canvas
+    function createRedCircleImage(radius) {
+        // Create a new canvas element
+        const canvas = document.createElement('canvas')
+        const context = canvas.getContext('2d')
+
+        // Set the canvas sizes
+        canvas.width = radius * 2
+        canvas.height = radius * 2
+
+        // Draw a red circle on the canvas
+        context.beginPath()
+        context.arc(radius, radius, radius, 0, 2 * Math.PI, false)
+        context.fillStyle = 'red'
+        context.fill()
+
+        // Return the data URL of the canvas drawing
+        return canvas.toDataURL()
+    }
+
+    // Create a red circle image with a radius of 8 pixels
+    const radius = 8
+    const billboardSize = radius * 2
+    const redCircleImage = createRedCircleImage(radius)
+    const entities = gpxDataSource.value._entityCollection.values
+
+    for (let i = 0; i < entities.length; i++) {
+        const entity = entities[i]
+        // Hide the billboard for billboard on the lines by checking if there is a description
+        // Imported GPX files from web-mapviewer have a description for the waypoints
+        // This might be not working for generic GPX files
+        if (cesiumDefined(entity.billboard)) {
+            if (!entity.description) {
+                entity.show = false
+            } else {
+                entity.show = true
+                entity.billboard = new BillboardGraphics({
+                    image: redCircleImage,
+                    width: billboardSize,
+                    height: billboardSize,
+                    eyeOffset: new Cartesian3(0, 0, -100), // Make sure the billboard is always seen
+                    heightReference: HeightReference.CLAMP_TO_TERRAIN, // Make the billboard always appear on top of the terrain
                 })
-                .then((dataSource) => {
-                    this.getViewer().dataSources.add(dataSource)
-                    this.isPresentOnMap = true
-                })
-                .then(() => this.updateStyle())
-        },
-        removeLayer() {
-            log.debug('Remove GPX layer')
-            if (this.gpxDataSource) {
-                this.getViewer().dataSources.remove(this.gpxDataSource)
-                this.gpxDataSource = null
-                this.getViewer().scene.requestRender() // Request a render after removing the DataSource
             }
-            this.isPresentOnMap = false
-        },
-        updateStyle() {
-            // Function to create a red circle image using a canvas
-            function createRedCircleImage(radius) {
-                // Create a new canvas element
-                const canvas = document.createElement('canvas')
-                const context = canvas.getContext('2d')
+        }
 
-                // Set the canvas sizes
-                canvas.width = radius * 2
-                canvas.height = radius * 2
+        if (cesiumDefined(entity.polyline)) {
+            entity.polyline.material = new ColorMaterialProperty(Color.RED)
+            entity.polyline.width = 1.5
+        }
 
-                // Draw a red circle on the canvas
-                context.beginPath()
-                context.arc(radius, radius, radius, 0, 2 * Math.PI, false)
-                context.fillStyle = 'red'
-                context.fill()
-
-                // Return the data URL of the canvas drawing
-                return canvas.toDataURL()
-            }
-
-            // Create a red circle image with a radius of 8 pixels
-            const radius = 8
-            const billboardSize = radius * 2
-            const redCircleImage = createRedCircleImage(radius)
-
-            const entities = this.gpxDataSource.entities.values
-            log.debug('Entities:', entities.length)
-            window.entities = entities
-            for (let i = 0; i < entities.length; i++) {
-                const entity = entities[i]
-                // Hide the billboard for billboard on the lines by checking if there is a description
-                // Imported GPX files from web-mapviewer have a description for the waypoints
-                // This might be not working for generic GPX files
-                if (cesiumDefined(entity.billboard)) {
-                    if (!entity.description) {
-                        entity.show = false
-                    } else {
-                        entity.show = true
-                        entity.billboard = new BillboardGraphics({
-                            image: redCircleImage,
-                            width: billboardSize,
-                            height: billboardSize,
-                            eyeOffset: new Cartesian3(0, 0, -100), // Make sure the billboard is always seen
-                            heightReference: HeightReference.CLAMP_TO_TERRAIN, // Make the billboard always appear on top of the terrain
-                        })
-                    }
-                }
-
-                if (cesiumDefined(entity.polyline)) {
-                    entity.polyline.material = new ColorMaterialProperty(Color.RED)
-                    entity.polyline.width = 1.5
-                }
-
-                if (cesiumDefined(entity.polygon)) {
-                    entity.polygon.material = new ColorMaterialProperty(Color.RED)
-                    entity.polygon.outline = true
-                    entity.polygon.outlineColor = Color.BLACK
-                }
-            }
-            this.getViewer().scene.requestRender()
-        },
-    },
+        if (cesiumDefined(entity.polygon)) {
+            entity.polygon.material = new ColorMaterialProperty(Color.RED)
+            entity.polygon.outline = true
+            entity.polygon.outlineColor = Color.BLACK
+        }
+    }
+    getViewer().scene.requestRender()
 }
 </script>
+<template>
+    <div>
+        <slot />
+    </div>
+</template>

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -5,27 +5,30 @@
 </template>
 
 <script>
-import VectorSource from 'ol/source/Vector'
-import { mapState } from 'vuex'
+import { GpxDataSource } from 'cesium'
 
 import GPXLayer from '@/api/layers/GPXLayer.class'
-import { parseGpx } from '@/utils/gpxUtils'
-
-import addPrimitiveFromOLLayerMixins from './utils/addPrimitiveFromOLLayer.mixins'
+import log from '@/utils/logging'
 
 /** Adds a GPX layer to the Cesium viewer */
 export default {
-    mixins: [addPrimitiveFromOLLayerMixins],
+    inject: ['getViewer'],
+
     props: {
         gpxLayerConfig: {
             type: GPXLayer,
             required: true,
         },
     },
+
+    data() {
+        return {
+            isPresentOnMap: false,
+            gpxDataSource: null,
+        }
+    },
+
     computed: {
-        ...mapState({
-            projection: (state) => state.position.projection,
-        }),
         opacity() {
             return this.gpxLayerConfig.opacity
         },
@@ -33,26 +36,54 @@ export default {
             return this.gpxLayerConfig.gpxData
         },
     },
+
     watch: {
         gpxData() {
-            this.loadDataInOLLayer().then(this.addPrimitive)
+            this.addLayer()
         },
     },
+
+    mounted() {
+        log.debug('Mounted GPX layer')
+        const gpxUrl =
+            'https://gist.githubusercontent.com/ismailsunni/e4345dd852c5deaff3434eadefdb467f/raw/0eac92b199e10c6498f4a1c305098a3e74ce1521/map.geo.admin.ch_GPX_20240529033356.gpx'
+        GpxDataSource.load(gpxUrl, {
+            clampToGround: true,
+        }).then((dataSource) => {
+            this.gpxDataSource = dataSource
+            if (!this.isPresentOnMap) {
+                this.addLayer()
+            }
+        })
+    },
+
+    unmounted() {
+        log.debug('Unmounted GPX layer')
+        if (this.gpxDataSource && this.isPresentOnMap) {
+            this.removeLayer()
+        }
+
+        delete this.gpxDataSource
+    },
+
     methods: {
-        loadDataInOLLayer() {
-            return new Promise((resolve, reject) => {
-                if (!this.gpxData) {
-                    reject(new Error('no GPX data loaded yet, could not create source'))
-                }
-                this.olLayer.setSource(
-                    new VectorSource({
-                        wrapX: true,
-                        projection: this.projection,
-                        features: parseGpx(this.gpxData, this.projection),
-                    })
-                )
-                resolve()
-            })
+        addLayer() {
+            log.debug('Adding GPX layer')
+            log.debug(this.gpxDataSource)
+            this.getViewer().dataSources.add(this.gpxDataSource)
+            this.isPresentOnMap = true
+            log.debug(this.getViewer().dataSources)
+        },
+        removeLayer() {
+            log.debug('Remove GPX layer')
+            log.debug(this.gpxDataSource)
+            if (this.gpxDataSource) {
+                this.getViewer().dataSources.remove(this.gpxDataSource)
+                this.gpxDataSource = null
+                this.getViewer().scene.requestRender() // Request a render after removing the DataSource
+            }
+            this.isPresentOnMap = false
+            log.debug(this.getViewer().dataSources)
         },
     },
 }

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -99,19 +99,21 @@ function createRedCircleImage(radius, opacity = 1) {
     return canvas.toDataURL()
 }
 
-function updateStyle() {
-    // Create a red circle image with a radius of 8 pixels
-    const radius = 8
+function createRedCircleBillboard(radius, opacity = 1) {
+    const redCircleImage = createRedCircleImage(radius, opacity)
     const billboardSize = radius * 2
-    const redCircleImage = createRedCircleImage(radius, opacity.value)
-
-    const redCircleBillboard = new BillboardGraphics({
+    return new BillboardGraphics({
         image: redCircleImage,
         width: billboardSize,
         height: billboardSize,
         eyeOffset: new Cartesian3(0, 0, -100), // Make sure the billboard is always seen
         heightReference: HeightReference.CLAMP_TO_TERRAIN, // Make the billboard always appear on top of the terrain
     })
+}
+
+function updateStyle() {
+    const radius = 8
+    const redCircleBillboard = createRedCircleBillboard(radius, opacity.value)
     const redColorMaterial = new ColorMaterialProperty(Color.RED.withAlpha(opacity.value))
 
     const entities = gpxDataSource.entities.values
@@ -146,7 +148,15 @@ function updateStyle() {
             entity.polygon.outlineColor = Color.BLACK
         }
     })
+    forceRender()
+}
+// Helper function to force render the scene after timeout to handle scene not rendered after we update the style
+// Note (IS): 1500 ms is a sweet number (from my experiment), not too fast (scene is not rendered properly) and not too long (user does not wait too long)
+function forceRender(timeout = 1500) {
     getViewer().scene.requestRender()
+    setTimeout(() => {
+        getViewer().scene.requestRender()
+    }, timeout)
 }
 </script>
 <template>

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -106,6 +106,15 @@ function updateStyle() {
     const radius = 8
     const billboardSize = radius * 2
     const redCircleImage = createRedCircleImage(radius)
+
+    const redCircleBillboard = new BillboardGraphics({
+        image: redCircleImage,
+        width: billboardSize,
+        height: billboardSize,
+        eyeOffset: new Cartesian3(0, 0, -100), // Make sure the billboard is always seen
+        heightReference: HeightReference.CLAMP_TO_TERRAIN, // Make the billboard always appear on top of the terrain
+    })
+
     const entities = gpxDataSource.value._entityCollection.values
 
     for (let i = 0; i < entities.length; i++) {
@@ -118,13 +127,7 @@ function updateStyle() {
                 entity.show = false
             } else {
                 entity.show = true
-                entity.billboard = new BillboardGraphics({
-                    image: redCircleImage,
-                    width: billboardSize,
-                    height: billboardSize,
-                    eyeOffset: new Cartesian3(0, 0, -100), // Make sure the billboard is always seen
-                    heightReference: HeightReference.CLAMP_TO_TERRAIN, // Make the billboard always appear on top of the terrain
-                })
+                entity.billboard = redCircleBillboard
             }
         }
 

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -29,16 +29,13 @@ const gpxData = ref(props.gpxLayerConfig.gpxData)
 
 const getViewer = inject('getViewer')
 watch(gpxData, () => {
+    removeLayer()
     addLayer()
 })
 
-watch(
-    () => props.gpxLayerConfig.opacity,
-    (newOpacity) => {
-        opacity.value = newOpacity
-        updateStyle()
-    }
-)
+watch(opacity, () => {
+    updateStyle()
+})
 
 onMounted(() => {
     log.debug('Mounted GPX layer')
@@ -153,7 +150,5 @@ function updateStyle() {
 }
 </script>
 <template>
-    <div>
-        <slot />
-    </div>
+    <slot />
 </template>

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -120,6 +120,10 @@ function updateStyle() {
 
     for (let i = 0; i < entities.length; i++) {
         const entity = entities[i]
+        if (opacity.value === 0) {
+            entity.show = false
+            continue
+        }
         // Hide the billboard for billboard on the lines by checking if there is a description
         // Imported GPX files from web-mapviewer have a description for the waypoints
         // This might be not working for generic GPX files
@@ -133,11 +137,13 @@ function updateStyle() {
         }
 
         if (cesiumDefined(entity.polyline)) {
+            entity.show = true
             entity.polyline.material = redColorMaterial
             entity.polyline.width = 1.5
         }
 
         if (cesiumDefined(entity.polygon)) {
+            entity.show = true
             entity.polygon.material = redColorMaterial
             entity.polygon.outline = true
             entity.polygon.outlineColor = Color.BLACK

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -114,6 +114,7 @@ function updateStyle() {
         eyeOffset: new Cartesian3(0, 0, -100), // Make sure the billboard is always seen
         heightReference: HeightReference.CLAMP_TO_TERRAIN, // Make the billboard always appear on top of the terrain
     })
+    const redColorMaterial = new ColorMaterialProperty(Color.RED.withAlpha(opacity.value))
 
     const entities = gpxDataSource.value._entityCollection.values
 
@@ -132,12 +133,12 @@ function updateStyle() {
         }
 
         if (cesiumDefined(entity.polyline)) {
-            entity.polyline.material = new ColorMaterialProperty(Color.RED.withAlpha(opacity.value))
+            entity.polyline.material = redColorMaterial
             entity.polyline.width = 1.5
         }
 
         if (cesiumDefined(entity.polygon)) {
-            entity.polygon.material = new ColorMaterialProperty(Color.RED.withAlpha(opacity.value))
+            entity.polygon.material = redColorMaterial
             entity.polygon.outline = true
             entity.polygon.outlineColor = Color.BLACK
         }

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -1,0 +1,59 @@
+<template>
+    <div>
+        <slot />
+    </div>
+</template>
+
+<script>
+import VectorSource from 'ol/source/Vector'
+import { mapState } from 'vuex'
+
+import GPXLayer from '@/api/layers/GPXLayer.class'
+import { parseGpx } from '@/utils/gpxUtils'
+
+import addPrimitiveFromOLLayerMixins from './utils/addPrimitiveFromOLLayer.mixins'
+
+/** Adds a GPX layer to the Cesium viewer */
+export default {
+    mixins: [addPrimitiveFromOLLayerMixins],
+    props: {
+        gpxLayerConfig: {
+            type: GPXLayer,
+            required: true,
+        },
+    },
+    computed: {
+        ...mapState({
+            projection: (state) => state.position.projection,
+        }),
+        opacity() {
+            return this.gpxLayerConfig.opacity
+        },
+        gpxData() {
+            return this.gpxLayerConfig.gpxData
+        },
+    },
+    watch: {
+        gpxData() {
+            this.loadDataInOLLayer().then(this.addPrimitive)
+        },
+    },
+    methods: {
+        loadDataInOLLayer() {
+            return new Promise((resolve, reject) => {
+                if (!this.gpxData) {
+                    reject(new Error('no GPX data loaded yet, could not create source'))
+                }
+                this.olLayer.setSource(
+                    new VectorSource({
+                        wrapX: true,
+                        projection: this.projection,
+                        features: parseGpx(this.gpxData, this.projection),
+                    })
+                )
+                resolve()
+            })
+        },
+    },
+}
+</script>

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -24,7 +24,7 @@ export default {
     data() {
         return {
             isPresentOnMap: false,
-            gpxDataSource: null,
+            gpxDataSource: new GpxDataSource(),
         }
     },
 
@@ -45,16 +45,7 @@ export default {
 
     mounted() {
         log.debug('Mounted GPX layer')
-        const gpxUrl =
-            'https://gist.githubusercontent.com/ismailsunni/e4345dd852c5deaff3434eadefdb467f/raw/0eac92b199e10c6498f4a1c305098a3e74ce1521/map.geo.admin.ch_GPX_20240529033356.gpx'
-        GpxDataSource.load(gpxUrl, {
-            clampToGround: true,
-        }).then((dataSource) => {
-            this.gpxDataSource = dataSource
-            if (!this.isPresentOnMap) {
-                this.addLayer()
-            }
-        })
+        this.addLayer()
     },
 
     unmounted() {
@@ -68,22 +59,24 @@ export default {
 
     methods: {
         addLayer() {
-            log.debug('Adding GPX layer')
-            log.debug(this.gpxDataSource)
+            const gpxBlob = new Blob([this.gpxData], { type: 'application/gpx+xml' })
+            const gpxUrl = URL.createObjectURL(gpxBlob)
+
+            this.gpxDataSource.load(gpxUrl, {
+                clampToGround: true,
+            })
+
             this.getViewer().dataSources.add(this.gpxDataSource)
             this.isPresentOnMap = true
-            log.debug(this.getViewer().dataSources)
         },
         removeLayer() {
             log.debug('Remove GPX layer')
-            log.debug(this.gpxDataSource)
             if (this.gpxDataSource) {
                 this.getViewer().dataSources.remove(this.gpxDataSource)
                 this.gpxDataSource = null
                 this.getViewer().scene.requestRender() // Request a render after removing the DataSource
             }
             this.isPresentOnMap = false
-            log.debug(this.getViewer().dataSources)
         },
     },
 }

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -55,10 +55,9 @@ onUnmounted(() => {
 
 function addLayer() {
     const gpxBlob = new Blob([gpxData.value], { type: 'application/gpx+xml' })
-    const gpxUrl = URL.createObjectURL(gpxBlob)
     gpxDataSource = new GpxDataSource()
     gpxDataSource
-        .load(gpxUrl, {
+        .load(gpxBlob, {
             clampToGround: true,
         })
         .then((dataSource) => {
@@ -117,7 +116,7 @@ function updateStyle() {
 
     const entities = gpxDataSource.entities.values
 
-    entities.array.forEach((entity) => {
+    entities.forEach((entity) => {
         if (opacity.value === 0) {
             entity.show = false
             return

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -24,13 +24,21 @@ const props = defineProps({
 const isPresentOnMap = ref(false)
 const gpxDataSource = ref(new GpxDataSource())
 
-// const opacity = ref(props.gpxLayerConfig.opacity)
+const opacity = ref(props.gpxLayerConfig.opacity)
 const gpxData = ref(props.gpxLayerConfig.gpxData)
 
 const getViewer = inject('getViewer')
 watch(gpxData, () => {
     addLayer()
 })
+
+watch(
+    () => props.gpxLayerConfig.opacity,
+    (newOpacity) => {
+        opacity.value = newOpacity
+        updateStyle()
+    }
+)
 
 onMounted(() => {
     log.debug('Mounted GPX layer')
@@ -85,7 +93,9 @@ function updateStyle() {
         // Draw a red circle on the canvas
         context.beginPath()
         context.arc(radius, radius, radius, 0, 2 * Math.PI, false)
-        context.fillStyle = 'red'
+
+        const color = `rgba(255, 0, 0, ${opacity.value})`
+        context.fillStyle = color
         context.fill()
 
         // Return the data URL of the canvas drawing
@@ -119,12 +129,12 @@ function updateStyle() {
         }
 
         if (cesiumDefined(entity.polyline)) {
-            entity.polyline.material = new ColorMaterialProperty(Color.RED)
+            entity.polyline.material = new ColorMaterialProperty(Color.RED.withAlpha(opacity.value))
             entity.polyline.width = 1.5
         }
 
         if (cesiumDefined(entity.polygon)) {
-            entity.polygon.material = new ColorMaterialProperty(Color.RED)
+            entity.polygon.material = new ColorMaterialProperty(Color.RED.withAlpha(opacity.value))
             entity.polygon.outline = true
             entity.polygon.outlineColor = Color.BLACK
         }

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -78,34 +78,33 @@ function removeLayer() {
     isPresentOnMap.value = false
 }
 
+// Function to create a red circle image using a canvas
+function createRedCircleImage(radius, opacity = 1) {
+    // Create a new canvas element
+    const canvas = document.createElement('canvas')
+    const context = canvas.getContext('2d')
+
+    // Set the canvas sizes
+    canvas.width = radius * 2
+    canvas.height = radius * 2
+
+    // Draw a red circle on the canvas
+    context.beginPath()
+    context.arc(radius, radius, radius, 0, 2 * Math.PI, false)
+
+    const color = `rgba(255, 0, 0, ${opacity})`
+    context.fillStyle = color
+    context.fill()
+
+    // Return the data URL of the canvas drawing
+    return canvas.toDataURL()
+}
+
 function updateStyle() {
-    log.debug('Update style', 'opacity', opacity.value)
-    // Function to create a red circle image using a canvas
-    function createRedCircleImage(radius) {
-        // Create a new canvas element
-        const canvas = document.createElement('canvas')
-        const context = canvas.getContext('2d')
-
-        // Set the canvas sizes
-        canvas.width = radius * 2
-        canvas.height = radius * 2
-
-        // Draw a red circle on the canvas
-        context.beginPath()
-        context.arc(radius, radius, radius, 0, 2 * Math.PI, false)
-
-        const color = `rgba(255, 0, 0, ${opacity.value})`
-        context.fillStyle = color
-        context.fill()
-
-        // Return the data URL of the canvas drawing
-        return canvas.toDataURL()
-    }
-
     // Create a red circle image with a radius of 8 pixels
     const radius = 8
     const billboardSize = radius * 2
-    const redCircleImage = createRedCircleImage(radius)
+    const redCircleImage = createRedCircleImage(radius, opacity.value)
 
     const redCircleBillboard = new BillboardGraphics({
         image: redCircleImage,
@@ -118,11 +117,10 @@ function updateStyle() {
 
     const entities = gpxDataSource.entities.values
 
-    for (let i = 0; i < entities.length; i++) {
-        const entity = entities[i]
+    entities.array.forEach((entity) => {
         if (opacity.value === 0) {
             entity.show = false
-            continue
+            return
         }
         // Hide the billboard for billboard on the lines by checking if there is a description
         // Imported GPX files from web-mapviewer have a description for the waypoints
@@ -148,7 +146,7 @@ function updateStyle() {
             entity.polygon.outline = true
             entity.polygon.outlineColor = Color.BLACK
         }
-    }
+    })
     getViewer().scene.requestRender()
 }
 </script>

--- a/src/modules/map/components/cesium/CesiumGPXLayer.vue
+++ b/src/modules/map/components/cesium/CesiumGPXLayer.vue
@@ -40,17 +40,25 @@ watch(opacity, () => {
 onMounted(() => {
     log.debug('Mounted GPX layer')
     // TODO: Delete this debug
-    getViewer().scene.postRender.addEventListener(postRenderEventListener)
+    getViewer().scene.preRender.addEventListener(preRenderEventListener)
+    // getViewer().scene.postRender.addEventListener(postRenderEventListener)
     addLayer()
 })
 
 onUnmounted(() => {
     log.debug('Unmounted GPX layer')
     removeLayer()
-    getViewer().scene.postRender.removeEventListener(postRenderEventListener)
+    getViewer().scene.preRender.removeEventListener(preRenderEventListener)
+    // getViewer().scene.postRender.removeEventListener(postRenderEventListener)
 
     gpxDataSource = null
 })
+
+const preRenderEventListener = function () {
+    const firstEntityOpacity =
+        gpxDataSource?.entities?.values[0]?.polyline?.material?.color?.getValue()['alpha']
+    log.info(`Prerender, opacity should be ${opacity.value}, entity opacity: ${firstEntityOpacity}`)
+}
 
 const postRenderEventListener = function () {
     const firstEntityOpacity =

--- a/src/modules/map/components/cesium/CesiumInternalLayer.vue
+++ b/src/modules/map/components/cesium/CesiumInternalLayer.vue
@@ -42,7 +42,6 @@
                 :z-index="zIndex"
             />
         </div>
-        <slot />
     </div>
     <CesiumGeoJSONLayer
         v-if="layerConfig.type === LayerTypes.GEOJSON"

--- a/src/modules/map/components/cesium/CesiumInternalLayer.vue
+++ b/src/modules/map/components/cesium/CesiumInternalLayer.vue
@@ -42,23 +42,6 @@
                 :z-index="zIndex"
             />
         </div>
-        <CesiumGeoJSONLayer
-            v-if="layerConfig.type === LayerTypes.GEOJSON"
-            :layer-id="layerConfig.id"
-            :opacity="layerConfig.opacity"
-            :geojson-url="layerConfig.geoJsonUrl"
-            :style-url="layerConfig.styleUrl"
-            :projection="projection"
-        />
-        <CesiumKMLLayer
-            v-if="layerConfig.type === LayerTypes.KML"
-            :kml-layer-config="layerConfig"
-        />
-        <CesiumGPXLayer
-            v-if="layerConfig.type === LayerTypes.GPX"
-            :gpx-layer-config="layerConfig"
-            :projection="projection"
-        />
         <slot />
     </div>
     <CesiumGeoJSONLayer
@@ -70,6 +53,7 @@
         :projection="projection"
     />
     <CesiumKMLLayer v-if="layerConfig.type === LayerTypes.KML" :kml-layer-config="layerConfig" />
+    <CesiumGPXLayer v-if="layerConfig.type === LayerTypes.GPX" :gpx-layer-config="layerConfig" />
     <slot />
 </template>
 

--- a/src/modules/map/components/cesium/CesiumInternalLayer.vue
+++ b/src/modules/map/components/cesium/CesiumInternalLayer.vue
@@ -42,6 +42,24 @@
                 :z-index="zIndex"
             />
         </div>
+        <CesiumGeoJSONLayer
+            v-if="layerConfig.type === LayerTypes.GEOJSON"
+            :layer-id="layerConfig.id"
+            :opacity="layerConfig.opacity"
+            :geojson-url="layerConfig.geoJsonUrl"
+            :style-url="layerConfig.styleUrl"
+            :projection="projection"
+        />
+        <CesiumKMLLayer
+            v-if="layerConfig.type === LayerTypes.KML"
+            :kml-layer-config="layerConfig"
+        />
+        <CesiumGPXLayer
+            v-if="layerConfig.type === LayerTypes.GPX"
+            :gpx-layer-config="layerConfig"
+            :projection="projection"
+        />
+        <slot />
     </div>
     <CesiumGeoJSONLayer
         v-if="layerConfig.type === LayerTypes.GEOJSON"
@@ -64,6 +82,7 @@ import CesiumVectorLayer from '@/modules/map/components/cesium/CesiumVectorLayer
 import CoordinateSystem from '@/utils/coordinates/CoordinateSystem.class'
 
 import CesiumGeoJSONLayer from './CesiumGeoJSONLayer.vue'
+import CesiumGPXLayer from './CesiumGPXLayer.vue'
 import CesiumKMLLayer from './CesiumKMLLayer.vue'
 import CesiumWMSLayer from './CesiumWMSLayer.vue'
 import CesiumWMTSLayer from './CesiumWMTSLayer.vue'
@@ -76,6 +95,7 @@ export default {
     name: 'CesiumInternalLayer',
     components: {
         CesiumVectorLayer,
+        CesiumGPXLayer,
         CesiumKMLLayer,
         CesiumGeoJSONLayer,
         CesiumWMTSLayer,

--- a/src/modules/map/components/cesium/CesiumMap.vue
+++ b/src/modules/map/components/cesium/CesiumMap.vue
@@ -421,6 +421,7 @@ export default {
                 globe.maximumScreenSpaceError = 30
             }
             this.mapModuleReady(dispatcher)
+            window.cesiumViewer = this.viewer
         },
         highlightSelectedFeatures() {
             const [firstFeature] = this.selectedFeatures

--- a/src/modules/map/components/cesium/CesiumMap.vue
+++ b/src/modules/map/components/cesium/CesiumMap.vue
@@ -108,6 +108,7 @@ import GeoAdminAggregateLayer from '@/api/layers/GeoAdminAggregateLayer.class.js
 import GeoAdminGeoJsonLayer from '@/api/layers/GeoAdminGeoJsonLayer.class'
 import GeoAdminWMSLayer from '@/api/layers/GeoAdminWMSLayer.class'
 import GeoAdminWMTSLayer from '@/api/layers/GeoAdminWMTSLayer.class'
+import GPXLayer from '@/api/layers/GPXLayer.class'
 import KMLLayer from '@/api/layers/KMLLayer.class'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
 import {
@@ -208,7 +209,10 @@ export default {
         },
         visiblePrimitiveLayers() {
             return this.visibleLayers.filter(
-                (l) => l instanceof GeoAdminGeoJsonLayer || l instanceof KMLLayer
+                (l) =>
+                    l instanceof GeoAdminGeoJsonLayer ||
+                    l instanceof KMLLayer ||
+                    l instanceof GPXLayer
             )
         },
         showFeaturesPopover() {

--- a/src/modules/map/components/cesium/utils/olcs/FeatureConverter.ts
+++ b/src/modules/map/components/cesium/utils/olcs/FeatureConverter.ts
@@ -283,7 +283,10 @@ export default class FeatureConverter {
      * @param outline
      * @returns {CesiumColor | undefined}
      */
-    protected extractColorFromOlStyle(style: Style | Text, outline: boolean) : CesiumColor | undefined {
+    protected extractColorFromOlStyle(
+        style: Style | Text,
+        outline: boolean
+    ): CesiumColor | undefined {
         const fillColor: OLColorLike | OLColor | PatternDescriptor | null | undefined = style
             .getFill()
             ?.getColor()
@@ -296,7 +299,7 @@ export default class FeatureConverter {
             olColor = fillColor
         }
 
-        const cesiumColor: CesiumColor | ImageMaterialProperty =  convertColorToCesium(olColor)
+        const cesiumColor: CesiumColor | ImageMaterialProperty = convertColorToCesium(olColor)
         if (cesiumColor instanceof ImageMaterialProperty) {
             if (cesiumColor.color instanceof CesiumColor) {
                 return cesiumColor.color
@@ -330,8 +333,8 @@ export default class FeatureConverter {
         olStyle: Style,
         outlineGeometry?: CSGeometry | CircleOutlineGeometry
     ): PrimitiveCollection {
-        const fillColor : CesiumColor | undefined = this.extractColorFromOlStyle(olStyle, false)
-        const outlineColor : CesiumColor | undefined = this.extractColorFromOlStyle(olStyle, true)
+        const fillColor: CesiumColor | undefined = this.extractColorFromOlStyle(olStyle, false)
+        const outlineColor: CesiumColor | undefined = this.extractColorFromOlStyle(olStyle, true)
 
         const primitives = new PrimitiveCollection()
         if (olStyle.getFill()) {
@@ -774,7 +777,8 @@ export default class FeatureConverter {
             imageStyle.load()
         }
 
-        const image : HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | ImageBitmap | null = imageStyle.getImage(1) // get normal density
+        const image: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | ImageBitmap | null =
+            imageStyle.getImage(1) // get normal density
         const isImageLoaded = function (image: HTMLImageElement) {
             return (
                 image.src != '' &&
@@ -788,12 +792,7 @@ export default class FeatureConverter {
             if (!image) {
                 return
             }
-            if (
-                !(
-                    typeof image === 'string' ||
-                    image instanceof HTMLCanvasElement
-                )
-            ) {
+            if (!(typeof image === 'string' || image instanceof HTMLCanvasElement)) {
                 return
             }
             const center = olGeometry.getCoordinates()
@@ -804,7 +803,7 @@ export default class FeatureConverter {
                 color = new CesiumColor(1.0, 1.0, 1.0, opacity)
             }
 
-            const scale : number | Size = imageStyle.getScale()
+            const scale: number | Size = imageStyle.getScale()
             if (Array.isArray(scale)) {
                 return
             }
@@ -1068,7 +1067,7 @@ export default class FeatureConverter {
         geometry: OLGeometry,
         style: Text
     ): LabelCollection | null {
-        const text : string | string[] | undefined = style.getText()
+        const text: string | string[] | undefined = style.getText()
         if (!text || Array.isArray(text)) {
             return null
         }
@@ -1084,7 +1083,7 @@ export default class FeatureConverter {
         const options: Parameters<LabelCollection['add']>[0] = {
             position: ol4326CoordinateToCesiumCartesian(extentCenter),
             text,
-            heightReference: this.getHeightReference(layer, feature, geometry)
+            heightReference: this.getHeightReference(layer, feature, geometry),
         }
 
         const offsetX = style.getOffsetX()


### PR DESCRIPTION
[Test link](https://sys-map.dev.bgdi.ch/preview/pb-497-gpx-on-3d-debug/index.html)
Test data: [here](https://680065d6-ee88-4581-88f2-50d322effb5f.filesusr.com/ugd/02a5b7_589532ce238447f8b10923e3c622ab90.gpx?dn=crossingswitzerland2024_(01-02-2024).gpx) (you can load it from url or file by downloading it first) (smaller GPX might work well, so I use this one to test)

By default it's not using a dirty hack (request render after 1500ms). When you load a GPX layer, it won't be rendered directly. You can request render it manually from the dev tool console by running `window.cesiumViewer.scene.requestRender()`

1. When you changed the opacity, if you check the log, it will show you that the opacity on the entity **is already updated** before the rendering happened. You can see the `prerender` log and the current opacity of the layer and the entity
2. It will be rendered again if you manually triggered it using the code above
3. To enable the dirty hack, you can run `window.useDirtyHack = true` in the console. By doing this, you can see the layer is rendered directly whenever we update the opacity.

To comparison, below is the sample code in sandcastle to load GPX and update opacity: [here](https://sandcastle.cesium.com/#c=jVeNbts2EH4VwihQGYgpRYlT1026FVnbbUjXommLYfPQUOLZIkqTGknFcQu/+46UZMmxE8xAAIn33em7fybXyjpyK2AFhlwQBStyCVZUS/olnEWzQR7eL7VyTCgws8ER+TFTBH8G/q3Auo+gOJh3mgOZEmcqOJqpzfDFTNVmqc1BAeWQVYvrQq/eGLYE+wHMNeRacfyq10F4HJNrpnjOrJNAMmZFTiy4qpypILzSjJO3H/4knDmG1pkhi/Lus5FoYjYonCvtNI7PJklyNuZnI4DJZHQ6nhyPJpN5Ohon/CRNYT7PxnM6FxJsZQ3N9TKuFjxOUjbOnn0dT56PT9Ic0pPJ6emz+SQ7Tp6nJ3CSn6Upy54nFD/4E1cXudHWCrWwK+G+g5FIO03S069RcjxK0pF/HnrsbPCCIPOPUEqWA0F0QVwBhOWuYpJ8/nhFnCZrXZngmKflnW1c+wX9vEYZau6k5m1fRCWGJaoDgZnJJVuWn/RboyvF63RshhS/qaJ5pXIntCKRTx/fWpipYZ3RJl+dxFLGedS9+6R6ILr0l9ZLz91746lLtsba6Ix8R/knfVj30gBzGARMPtoPJpzWMkOv59oQXbJcuDXB6nBGy2AURS3kgnCdV0tQjubB0GsJ/g1LlYvb2cB/iLRoivGw9g+suFAkdS2PGiFmJ0SiNZdpvqasLLGeLwshedTg9ql7yi1NyTLYkmwOr/zZY0xrpYZrX4k6uHO+2RAXKL+vhdOGbOtXn2Zf/3GuQpWVu8f1N3/2GNdaaZdrUKJuXdZxNUwtoGG4g1gKhYDkgIDdoeB4X2AdlF6FJgeEt0xWsNV7JBYB3ovFNThSlfuxIHDrAy0FflbVBbzzQazP1x5x1QC6cByRrp+G7UTshRVZlsxYeIP96aJ9L1pygd7nkt9PlZ4TJiXBbwsnwCLdba/5piK26V1voesy2uLrj1iKDfWa5UWv+QNivaVMiJiTqJksHOY443mDoaWWa4kHwx6a+L7EnZFXxiDsUkvte/KeBubXgRFM4oRFAF2A++IJRZ0Z0o6z3yspmMKJBlTpVTTsIHXJ1T9f0LpchyAEm2F+5IWvPCKcbQN3nyfOzZZjb4SGox0yfX+oAX70oHBhANTD4kyGDdhJ94gNd5bCU6TVNPnTekOEfcCRKNLY1kPIZ1syTUB8Vft4eMfqmGQs/9aO5TolTy1pc9HpPpStA0F614g+GF2CceuoDWiXnE1HK44frqZMSJlpZnhdTp0KuQ+oi6arqnsC6qP0SpYFa/uq4xLHWzab9tQXgpZ+Uy6im+bSgpcXf2upA95YmZInP5rHzc3/UV76O8+THzv3nL1LUWfqYVxUQza9ifWqLKUfUtjNmJdeDe2MEi5syVxehCHlU0Pqp25q15abG5mvGedTvgibtrd560tHbu1jm8CiLtSbAJHd+Pc7K8aTsAG8RCiclb9+eneF4pvaebq7e/sDpdRW+Nk0JSzDWFcOen3vdDklx0l51zuTMHd7hyXOanRs79y3xKK5DplFxqLT9Ii0fwmd9IdMpg1mY2QYF5WdkvGOoVB7U7IqxJbg5rBvYbv3PVwysxBqZMSicH2zD+iH3P3tw3ux3a3/9O2tBHeF9zTpm7rBx23uCmB8ZzNiXryrg6PBecjjy9bcz2JZaoP70ciI0tjBEgeTAxtnVf4NsApqRQ89j/uq53jfIoJfHPgfgYR7F0rmlZTX4js68PI8Rvyeqr++Ytre3/pr9NrDiuOXV/UhpfQ8xtfDmttb3I78Pw)


Notes:
- Obviously, setting the `requestRenderMode : false` will fix the problem, but it's not what we want
- after reading the documentation, cesium with `requestRenderMode : true` will re-render if there is something dirty, or we can do it manually using `requestRender`. But for some reason, it's not working properly in mapviewer but it's working fine in the sandcastle.
- I have tried different way to style, but even using the default style, the GPX is not rendered directly.

[Test link](https://sys-map.dev.bgdi.ch/preview/pb-497-gpx-on-3d-debug/index.html)