### PR TITLE
PB-639 : prevent parsing of non legacy layers URL param

### DIFF
--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -86,6 +86,16 @@ const handleLegacyParam = (
             break
 
         case 'layers':
+            // if the "legacy" value already contains our new separators, it means the app was accessed
+            // without using the hash slash approach, but we still shouldn't be parsing as legacy
+            if (
+                ['@feature', '@year', ';'].some(
+                    (newSeparator) => legacyValue.indexOf(newSeparator) !== -1
+                )
+            ) {
+                newValue = legacyValue
+                break
+            }
             // for legacy layers param, we need to give the layers visibility, opacity and timestamps,
             // as they are combined into one value with the layer in the current 'layers' parameter
             // implementation


### PR DESCRIPTION
enable users to use URLs withouth `#/map` notation (easy boarding)

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_pb-639_prevent_parsing_non_legacy_layers/index.html)