### PR TITLE
PB-570 : also proxy KML loaded at startup

### DIFF
--- a/src/api/files.api.js
+++ b/src/api/files.api.js
@@ -1,7 +1,8 @@
-import axios from 'axios'
+import axios, { AxiosError } from 'axios'
 import FormData from 'form-data'
 import pako from 'pako'
 
+import getFileThroughProxy from '@/api/file-proxy.api.js'
 import { API_SERVICE_KML_BASE_URL } from '@/config'
 import log from '@/utils/logging'
 
@@ -323,9 +324,19 @@ export function loadKmlData(kmlLayer) {
                 }
             })
             .catch((error) => {
-                const msg = `Failed to load KML data: ${error}`
-                log.error(msg)
-                reject(new Error(msg))
+                if (error instanceof AxiosError) {
+                    getFileThroughProxy(kmlLayer.kmlFileUrl)
+                        .then((response) => {
+                            resolve(response.data)
+                        })
+                        .catch((error) => {
+                            reject(error)
+                        })
+                } else {
+                    const msg = `Failed to load KML data: ${error}`
+                    log.error(msg)
+                    reject(new Error(msg))
+                }
             })
     })
 }


### PR DESCRIPTION
KML defined in the layers URL param weren't treated the same way as when we import them through the import file tool.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug_pb-570_also_proxy_kml_on_load/index.html)