### PR TITLE
Revert "PB-546: Put print overlay always on top"

### DIFF
--- a/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
+++ b/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
@@ -33,13 +33,9 @@ export default function usePrintAreaRenderer(map) {
     })
 
     function activatePrintArea() {
-        // layers in openlayers array are not sorted by zIndex by default !
-        const sortedMapsByZIndex = map
-            .getAllLayers()
-            .toSorted((a, b) => b.get('zIndex') - a.get('zIndex'))
         deregister = [
-            sortedMapsByZIndex[0].on('prerender', handlePreRender),
-            sortedMapsByZIndex[0].on('postrender', handlePostRender),
+            map.getAllLayers()[0].on('prerender', handlePreRender),
+            map.getAllLayers()[0].on('postrender', handlePostRender),
             watch(printLayoutSize, async () => {
                 await store.dispatch('setSelectedScale', {
                     scale: getOptimalScale(),

--- a/src/modules/menu/components/settings/HelpLink.vue
+++ b/src/modules/menu/components/settings/HelpLink.vue
@@ -10,22 +10,9 @@ const i18n = useI18n()
 
 const isDesktopMode = computed(() => store.getters.isDesktopMode)
 const lang = computed(() => store.state.i18n.lang)
-const helpPage = computed(() => {
-    if (lang.value === 'de') {
-        return `de/kartenviewer-hilfe`
-    }
-    if (lang.value === 'fr') {
-        return 'fr/visualiseur-de-cartes-aide'
-    }
-    if (lang.value === 'it') {
-        return 'it/visualizzatore-di-mappe-aiuto'
-    }
-    // Fallback to english for the rest (en and rm)
-    return 'en/map-viewer-help'
-})
 
 function openCmsLink() {
-    window.open(`https://www.geo.admin.ch/${helpPage.value}`, '_blank', 'noreferrer')
+    window.open(`https://help.geo.admin.ch?lang=${lang.value}`, '_blank', 'noreferrer')
 }
 </script>
 


### PR DESCRIPTION
Reverts geoadmin/web-mapviewer#911 

It contained also the PR #910 

[Test link](https://sys-map.dev.bgdi.ch/preview/revert-911-bug-pb-546-print-overlay/index.html)