### PR TITLE
PB-546: Print overlay not centered on high resolution device (e.g. Retina or HiDPI device)

### DIFF
--- a/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
+++ b/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
@@ -14,7 +14,6 @@ export default function usePrintAreaRenderer(map) {
     const POINTS_PER_INCH = 72 // PostScript points 1/72"
     const MM_PER_INCHES = 25.4
     const UNITS_RATIO = 39.37 // inches per meter
-    let printRectangle = []
 
     const isActive = computed(() => store.state.print.printSectionShown)
     const printLayoutSize = computed(() => store.getters.printLayoutSize)
@@ -45,21 +44,20 @@ export default function usePrintAreaRenderer(map) {
                     scale: getOptimalScale(),
                     ...dispatcher,
                 })
-                updatePrintRectanglePixels(selectedScale.value, printLayoutSize.value)
             }),
             watch(selectedScale, () => {
-                updatePrintRectanglePixels(selectedScale.value, printLayoutSize.value)
+                updatePrintOverlay()
             }),
             map.on('change:size', () => {
-                updatePrintRectanglePixels(selectedScale.value, printLayoutSize.value)
+                updatePrintOverlay()
             }),
             map.getView().on('propertychange', () => {
-                updatePrintRectanglePixels(selectedScale.value, printLayoutSize.value)
+                updatePrintOverlay()
             }),
         ]
         const scale = getOptimalScale()
         store.dispatch('setSelectedScale', { scale, ...dispatcher })
-        updatePrintRectanglePixels(scale, printLayoutSize.value)
+        updatePrintOverlay()
     }
 
     function deactivatePrintArea() {
@@ -74,34 +72,32 @@ export default function usePrintAreaRenderer(map) {
         map.render()
     }
 
-    function updatePrintRectanglePixels(scale, size) {
+    function updatePrintOverlay() {
         if (isActive.value) {
-            printRectangle = calculatePageBoundsPixels(scale, size)
             map.render()
         }
     }
 
     function calculatePageBoundsPixels(scale, size) {
-        log.debug(`Calculate page bounds pixels for scale ${scale}`)
+        log.debug(`Calculate page bounds pixels for scale ${scale} size=${JSON.stringify(size)}`)
         const s = parseFloat(scale)
         const view = map.getView()
         const resolution = view.getResolution()
-        const w =
-            (((((size.width / POINTS_PER_INCH) * MM_PER_INCHES) / 1000.0) * s) / resolution) *
-            olHas.DEVICE_PIXEL_RATIO
-        const h =
-            (((((size.height / POINTS_PER_INCH) * MM_PER_INCHES) / 1000.0) * s) / resolution) *
-            olHas.DEVICE_PIXEL_RATIO
+        const w = ((((size.width / POINTS_PER_INCH) * MM_PER_INCHES) / 1000.0) * s) / resolution
+        const h = ((((size.height / POINTS_PER_INCH) * MM_PER_INCHES) / 1000.0) * s) / resolution
         const mapSize = map.getSize()
-        const center = [
-            (mapSize[0] * olHas.DEVICE_PIXEL_RATIO) / 2,
-            (mapSize[1] * olHas.DEVICE_PIXEL_RATIO) / 2,
-        ]
+        const center = [mapSize[0] / 2, mapSize[1] / 2]
 
         const minx = center[0] - w / 2
         const miny = center[1] - h / 2
         const maxx = center[0] + w / 2
         const maxy = center[1] + h / 2
+
+        log.debug(`resolution=${resolution} ratio=${olHas.DEVICE_PIXEL_RATIO} w=${w} h=${h} `)
+        log.debug(`mapSize=${JSON.stringify(mapSize)} center=${JSON.stringify(center)}`)
+        log.debug(
+            `Calculated page bounds pixels for scale ${scale}: [${minx}, ${miny}, ${maxx}, ${maxy}]`
+        )
         return [minx, miny, maxx, maxy]
     }
 
@@ -115,8 +111,10 @@ export default function usePrintAreaRenderer(map) {
         const context = event.context
         const size = map.getSize()
 
-        const height = size[1] * olHas.DEVICE_PIXEL_RATIO
-        const width = size[0] * olHas.DEVICE_PIXEL_RATIO
+        const height = size[1]
+        const width = size[0]
+
+        const printRectangle = calculatePageBoundsPixels(selectedScale.value, printLayoutSize.value)
 
         const minx = printRectangle[0]
         const miny = printRectangle[1]


### PR DESCRIPTION
Somehow, probably due to an openlayer update, the print overlay was not anymore
centered on the map on HiDPI and Retina devices (e.g. Iphone, Dell XPS 15, HP ZBook G9).

After some test it turns out that the issue arised only when the DEVICE_PIXEL_RATIO
was not 1. Removing this ratio from the computed print area solved the issue.
This ratio in the print area has been introduced in 2014 in the old mf-geoadmin3
project (see https://github.com/geoadmin/mf-geoadmin3/pull/1359)
in order to solve the same issue observed here on HiDPI and Retina
device. This issue has been probably solved internally in openlayers now.

To test use Iphone and/or our HP zbook G9 without external display.
[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-546-print-overlay-center/index.html)