### PR TITLE
PB-546: Improved default print scale computed from map size

### DIFF
--- a/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
+++ b/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
@@ -20,8 +20,10 @@ export default function usePrintAreaRenderer(map) {
     const selectedScale = computed(() => store.state.print.selectedScale)
     // For simplicity we use the screen size for the map size
     const mapWidth = computed(() => store.state.ui.width)
-    // Same here for simplicity we take the screen size minus the header size for the map size
-    const mapHeight = computed(() => store.state.ui.height - store.state.ui.headerHeight)
+    // Same here for simplicity we take the screen size minus the header size for the map size (map
+    // is under the header). We take the header size twice as the overlay is then centered on the
+    // whole map (not only the part below the header)
+    const mapHeight = computed(() => store.state.ui.height - store.state.ui.headerHeight * 2)
 
     watch(isActive, (newValue) => {
         if (newValue) {
@@ -168,6 +170,6 @@ export default function usePrintAreaRenderer(map) {
             selectedLayoutScales
         )
         // Find the first scale that is smaller than the testScale in descending order
-        return selectedLayoutScales.find((scale) => scale < testScale) ?? selectedLayoutScales[0]
+        return selectedLayoutScales.find((scale) => scale <= testScale) ?? selectedLayoutScales[0]
     }
 }

--- a/tests/cypress/tests-e2e/print.cy.js
+++ b/tests/cypress/tests-e2e/print.cy.js
@@ -76,7 +76,7 @@ describe('Testing print', () => {
             cy.get('[data-cy="print-scale-selector"]').find('option').should('have.length', 15)
             cy.get('[data-cy="print-scale-selector"]')
                 .find('option:selected')
-                .should('have.text', `1:${formatThousand(2500000)}`)
+                .should('have.text', `1:${formatThousand(1500000)}`)
         })
     })
 
@@ -120,7 +120,7 @@ describe('Testing print', () => {
                 )
 
                 const mapAttributes = attributes.map
-                expect(mapAttributes['scale']).to.equals(2500000)
+                expect(mapAttributes['scale']).to.equals(1500000)
                 expect(mapAttributes['dpi']).to.equals(254)
                 expect(mapAttributes['projection']).to.equals('EPSG:2056')
 
@@ -271,7 +271,7 @@ describe('Testing print', () => {
                 )
 
                 const mapAttributes = attributes.map
-                expect(mapAttributes['scale']).to.equals(2500000)
+                expect(mapAttributes['scale']).to.equals(1500000)
                 expect(mapAttributes['dpi']).to.equals(254)
                 expect(mapAttributes['projection']).to.equals('EPSG:2056')
 
@@ -312,7 +312,7 @@ describe('Testing print', () => {
                 )
 
                 const mapAttributes = attributes.map
-                expect(mapAttributes['scale']).to.equals(10000)
+                expect(mapAttributes['scale']).to.equals(5000)
                 expect(mapAttributes['dpi']).to.equals(254)
                 expect(mapAttributes['projection']).to.equals('EPSG:2056')
 
@@ -444,7 +444,7 @@ describe('Testing print', () => {
                 )
 
                 const mapAttributes = attributes.map
-                expect(mapAttributes['scale']).to.equals(10000)
+                expect(mapAttributes['scale']).to.equals(5000)
                 expect(mapAttributes['dpi']).to.equals(254)
                 expect(mapAttributes['projection']).to.equals('EPSG:2056')
 
@@ -515,7 +515,7 @@ describe('Testing print', () => {
                 )
 
                 const mapAttributes = attributes.map
-                expect(mapAttributes['scale']).to.equals(10000)
+                expect(mapAttributes['scale']).to.equals(5000)
                 expect(mapAttributes['dpi']).to.equals(254)
                 expect(mapAttributes['projection']).to.equals('EPSG:2056')
 


### PR DESCRIPTION
Sometimes the initial default print scale was under the header which is not so
nice. This was due to the fact that the map is under the header and that during
the scale computation we took only one header height in consideration but the
print overlay is then center on the whole map, not only on the visible map.
To avoid this issue we take twice the header size now.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-546-print-scale/index.html)