### PR TITLE
Fix uncaught exception when using drag selection

### DIFF
--- a/src/modules/map/components/openlayers/OpenLayersRectangleSelectionFeedback.vue
+++ b/src/modules/map/components/openlayers/OpenLayersRectangleSelectionFeedback.vue
@@ -38,12 +38,11 @@ const vectorLayer = new VectorLayer({
 watch(selectionPolygon, () => updateLayer())
 
 function updateLayer() {
+    map.removeLayer(vectorLayer)
     vectorLayer.getSource().clear()
     if (selectionPolygon.value) {
         vectorLayer.getSource().addFeature(selectionPolygon.value)
         map.addLayer(vectorLayer)
-    } else {
-        map.removeLayer(vectorLayer)
     }
 }
 </script>


### PR DESCRIPTION
When using CRTL + selection when we already had a drag selection, an uncaught
exception occurred. Although everything seems to work fine, having uncaught exception
is not so good.

So now in order to avoid this exception we first need to remove the selection
layer in every case before re-adding it if needed.

See 
![image](https://github.com/geoadmin/web-mapviewer/assets/67745584/eed3d7d0-e0cf-4278-b415-511a289f4afe)


[Test link](https://sys-map.dev.bgdi.ch/preview/bug-multi-selection/index.html)