### PR TITLE
PB-637: Keep time layer selected year when changing the language

### DIFF
--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -242,7 +242,9 @@ const actions = {
                 clone.visible = layer.visible
                 clone.opacity = layer.opacity
                 if (layer.timeConfig) {
-                    clone.timeConfig.currentYear = layer.timeConfig.currentYear
+                    clone.timeConfig.updateCurrentTimeEntry(
+                        clone.timeConfig.getTimeEntryForYear(layer.timeConfig.currentYear)
+                    )
                 }
                 return clone
             } else {

--- a/tests/cypress/tests-e2e/layers.cy.js
+++ b/tests/cypress/tests-e2e/layers.cy.js
@@ -880,6 +880,18 @@ describe('Test of layer handling', () => {
                 })
 
                 //---------------------------------------------------------------------------------
+                cy.log('keep timestamp configuration when the language changes')
+                cy.get('[data-cy="menu-settings-section"]').should('be.visible').click()
+                cy.get('[data-cy="menu-lang-en"]').should('have.class', 'btn-primary')
+                cy.get('[data-cy="menu-lang-fr"]').should('be.visible').click()
+                cy.get('[data-cy="menu-lang-fr"]').should('have.class', 'btn-primary')
+                cy.get('[data-cy="menu-active-layers"]').should('be.visible').click()
+                cy.get('[data-cy="time-selector-test.timeenabled.wmts.layer-2"]').contains('2016')
+                cy.get('[data-cy="menu-settings-section"]').should('be.visible').click()
+                cy.get('[data-cy="menu-lang-en"]').should('be.visible').click()
+                cy.get('[data-cy="menu-active-layers"]').should('be.visible').click()
+
+                //---------------------------------------------------------------------------------
                 cy.log(`duplicate time layer`)
                 cy.get(`[data-cy^="button-open-visible-layer-settings-${timedLayerId}-2"]`)
                     .should('be.visible')


### PR DESCRIPTION
When changing the language the timed layer where reset to their default time
parameter.

The issue is that only their current year where updated but not their current
timestamp.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-637-time-layer-config-lang/index.html)