### PR TITLE
PB-647: Fix CSS non link attribution

### DIFF
--- a/src/modules/map/components/footer/MapFooterAttributionItem.vue
+++ b/src/modules/map/components/footer/MapFooterAttributionItem.vue
@@ -4,8 +4,8 @@
         :id="`source-${sourceId}`"
         :href="sourceUrl"
         :target="sourceUrl ? '_blank' : null"
-        class="map-footer-attribution-source"
-        :class="{ 'text-primary': hasDataDisclaimer }"
+        class="map-footer-attribution-source clear-no-ios-long-press"
+        :class="{ 'text-primary': hasDataDisclaimer, 'is-link': sourceUrl || hasDataDisclaimer }"
         :data-cy="`layer-copyright-${sourceName}`"
     >
         {{ `${sourceName}${isLast ? '' : ','}` }}
@@ -45,11 +45,13 @@ export default {
 .map-footer-attribution-source {
     margin-left: 2px;
     color: $black;
-    text-decoration: none;
 
-    &:hover {
-        text-decoration: underline;
-        cursor: pointer;
+    &.is-link {
+        text-decoration: none;
+        &:hover {
+            text-decoration: underline;
+            cursor: pointer;
+        }
     }
 }
 </style>


### PR DESCRIPTION
Some attribution are not link and cannot be clicked. In this case they should
be selectable. Previously all attributions were not selectable and they all
had the pointer cursor.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-647-attributions/index.html/#/map?lang=en&center=2660000,1190000&z=1&bgLayer=ch.swisstopo.pixelkarte-farbe&topic=ech&layers=ch.meteoschweiz.messwerte-lufttemperatur-10min)

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-647-attributions/index.html)