### PR TITLE
PB-634: Fix feature selection of layer "Moorlandschaften AuLaV"

### DIFF
--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -132,7 +132,7 @@ function dispatchLayersFromUrlIntoStore(to, store, urlParamValue) {
                                 store.getters.getLayerConfigById(parsedLayer.id),
                                 featureId,
                                 store.state.position.projection,
-                                store.state.i18n.lang
+                                { lang: store.state.i18n.lang }
                             )
                         )
                     })

--- a/tests/cypress/tests-e2e/featureSelection.cy.js
+++ b/tests/cypress/tests-e2e/featureSelection.cy.js
@@ -339,16 +339,13 @@ describe('Testing the feature selection', () => {
             cy.intercept('**identify**', {
                 fixture: 'features/features.fixture',
             }).as('identifySingleFeature')
-            cy.intercept('**/MapServer/**/**?sr=**&geometryFormat=geojson', {
-                fixture: 'features/featureDetail.fixture',
-            }).as('detailSingleFeature')
 
             drawRectangleOnMap({
                 x: 30,
                 y: -80,
             })
             cy.wait('@identifySingleFeature')
-            cy.wait('@detailSingleFeature')
+            cy.wait('@featureDetail')
 
             cy.get('@highlightedFeatures').should('be.visible')
             cy.get('@highlightedFeatures').find('[data-cy="feature-item"]').should('have.length', 1)


### PR DESCRIPTION
This layer requires to give the coordinate and other params in order to get
the correct feature.

So in the htmlpopup and in the get feature request we pass the coord, imageDisplay
and mapExtent parameter like in the identify request. This was done like this
in the old viewer. No idea why we need those parameters though.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-634-feature-selection/index.html)

[Test Link with legacy feature pre-selection](https://sys-map.dev.bgdi.ch/preview/bug-pb-634-feature-selection/index.html?ch.babs.kulturgueter=9767,9227,9228)

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-634-feature-selection/index.html)