### PR TITLE
PB-590: Quick fix for timeslider preview year for layer without current year entry

### DIFF
--- a/src/modules/map/components/toolbox/TimeSlider.vue
+++ b/src/modules/map/components/toolbox/TimeSlider.vue
@@ -248,6 +248,7 @@ function setPreviewYearToLayers() {
     activeLayers.value.forEach((layer, index) => {
         const year = previewYear.value
         if (
+            layer.visible &&
             layer.hasMultipleTimestamps &&
             layer.timeConfig &&
             layer.timeConfig.getTimeEntryForYear(year)

--- a/src/modules/map/components/toolbox/TimeSlider.vue
+++ b/src/modules/map/components/toolbox/TimeSlider.vue
@@ -50,9 +50,7 @@ const yearCursorInput = ref(null)
 const store = useStore()
 const screenWidth = computed(() => store.state.ui.width)
 const lang = computed(() => store.state.i18n.lang)
-const layersWithTimestamps = computed(() =>
-    store.getters.visibleLayers.filter((layer) => layer.hasMultipleTimestamps)
-)
+const layersWithTimestamps = computed(() => store.getters.visibleLayersWithTimeConfig)
 const activeLayers = computed(() => store.state.layers.activeLayers)
 const previewYear = computed(() => store.state.layers.previewYear)
 
@@ -241,7 +239,6 @@ onMounted(() => {
 
 onUnmounted(() => {
     window.removeEventListener('keydown', handleKeyDownEvent)
-    setPreviewYearToLayers()
 
     tippyTimeSliderInfo?.destroy()
 })
@@ -266,6 +263,7 @@ function setPreviewYearToLayers() {
 
 function dispatchPreviewYearToStore() {
     store.dispatch('setPreviewYear', { year: currentYear.value, ...dispatcher })
+    setPreviewYearToLayers()
 }
 
 const dispatchPreviewYearToStoreDebounced = debounce(() => {

--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItemTimeSelector.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItemTimeSelector.vue
@@ -110,20 +110,8 @@ function hidePopover() {
     popover?.hide()
 }
 
-// for CSS : isSelected refers to either the current year, or the preview year if the time slider is active and the layer is visible
 function isSelected(timeEntry) {
-    return isTimeSliderActive.value && isLayerVisible.value
-        ? previewYear.value === timeEntry?.year
-        : timeConfig.value.currentTimestamp === timeEntry?.timestamp
-}
-// for CSS : baseYear refer to the year to which the timestamp will return to when the time slider is unmounted.
-function baseYear(timeEntry) {
-    return (
-        isTimeSliderActive.value &&
-        isLayerVisible.value &&
-        timeConfig.value.currentTimestamp === timeEntry?.timestamp &&
-        timeEntry?.year !== previewYear.value
-    )
+    return timeConfig.value.currentTimestamp === timeEntry?.timestamp
 }
 </script>
 
@@ -159,8 +147,7 @@ function baseYear(timeEntry) {
                 class="btn mb-1 me-1 btn-timestamp"
                 :class="{
                     'btn-primary': isSelected(timeEntry),
-                    'btn-outline-primary': baseYear(timeEntry),
-                    'btn-light': !isSelected(timeEntry) && !baseYear(timeEntry),
+                    'btn-light': !isSelected(timeEntry),
                 }"
                 :data-cy="`time-select-${timeEntry.timestamp}`"
                 @click="handleClickOnTimestamp(timeEntry.year)"

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -82,14 +82,26 @@ const state = {
 
 const getters = {
     /**
-     * Filter all the active layers and gives only those who have the flag `visible` to `true`
+     * Filter all the active layers and gives only those who are visible on the map.
+     *
+     * This includes system layers and the preview layer. When the time slider is enabled, the time
+     * enabled layer with non matching preview year are filtered out.
      *
      * Layers are ordered from bottom to top (last layer is shown on top of all the others)
      *
      * @returns {AbstractLayer[]} All layers that are currently visible on the map
      */
-    visibleLayers: (state) => {
-        const visibleLayers = state.activeLayers.filter((layer) => layer.visible)
+    visibleLayers: (state, getters, rootState) => {
+        const visibleLayers = state.activeLayers.filter((layer) => {
+            if (
+                rootState.ui.isTimeSliderActive &&
+                layer.timeConfig &&
+                layer.timeConfig.getTimeEntryForYear(state.previewYear) === null
+            ) {
+                return false
+            }
+            return layer.visible
+        })
         if (state.previewLayer !== null) {
             visibleLayers.push(state.previewLayer)
         }
@@ -177,12 +189,13 @@ const getters = {
     },
 
     /**
-     * Get visiblelayers with time config. (Preview and system layer are filtered)
+     * Get visiblelayers with time config. (Preview layers and system layers are filtered)
      *
      * @returns {GeoAdminLayer[]} List of layers with time config
      */
     visibleLayersWithTimeConfig: (state) =>
-        // Here we cannot take the getter visibleLayers as it also contain the preview and system layers
+        // Here we cannot take the getter visibleLayers as it also contain the preview and system
+        // layers as well as the layer without matching previewYear are filtered out
         state.activeLayers.filter((layer) => layer.visible && layer.hasMultipleTimestamps),
 
     /**

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -93,9 +93,12 @@ const getters = {
      */
     visibleLayers: (state, getters, rootState) => {
         const visibleLayers = state.activeLayers.filter((layer) => {
+            // timeslider is not used on layer having only one timestamp as it doesn't make sense
+            // there.
             if (
                 rootState.ui.isTimeSliderActive &&
                 layer.timeConfig &&
+                layer.hasMultipleTimestamps &&
                 layer.timeConfig.getTimeEntryForYear(state.previewYear) === null
             ) {
                 return false

--- a/tests/cypress/tests-e2e/timeSlider.cy.js
+++ b/tests/cypress/tests-e2e/timeSlider.cy.js
@@ -49,13 +49,6 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
                 !classList.includes('btn-outline-primary')
             )
         }
-        function isPrimaryOutlineBtn(classList) {
-            return (
-                classList.includes('btn-outline-primary') &&
-                !classList.includes('btn-light') &&
-                !classList.includes('btn-primary')
-            )
-        }
         function isLightBtn(classList) {
             return (
                 classList.includes('btn-light') &&
@@ -215,9 +208,7 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
                     if (timestamp === '20130101') {
                         return isPrimaryBtn(classList)
                     } else {
-                        return timestamp === '20090101'
-                            ? isPrimaryOutlineBtn(classList)
-                            : isLightBtn(classList)
+                        return isLightBtn(classList)
                     }
                 })
             })
@@ -232,7 +223,7 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
                     // a light button
 
                     return timestamp === '20090101'
-                        ? isPrimaryOutlineBtn(classList)
+                        ? isPrimaryBtn(classList)
                         : isLightBtn(classList)
                 })
             })
@@ -302,7 +293,7 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             cy.get(`[data-cy="button-open-visible-layer-settings-${time_layer_std}-0"]`).click()
             cy.get(`[data-cy="button-duplicate-layer-${time_layer_std}-0"]`).click()
             cy.get(`[data-cy="button-toggle-visibility-layer-${time_layer_std}-0"]`).click()
-            cy.get(`[data-cy="time-selector-${time_layer_std}-0"]`).should('contain', 2019)
+            cy.get(`[data-cy="time-selector-${time_layer_std}-0"]`).should('contain', 2017)
             cy.get(`[data-cy="time-selector-${time_layer_std}-1"]`).should('contain', 2017)
 
             // ---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
In the timeslider when a layer did not have any matching timestamp from the preview
year, the layer was still displayed. Also the feature selection only work on
the previously configured timestamp (before entering the timeslider).

The first issue has been resolved by filtering visible layers that don't
match the preview year.

The second issue has been solved by directly setting the preview year in the
layer config and not only when unmounting.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-590-time-slider-no-data-quick/index.html)