### PR TITLE
PB-675: Clean up TimeSlider code

### DIFF
--- a/src/api/features/features.api.js
+++ b/src/api/features/features.api.js
@@ -7,7 +7,10 @@ import ExternalGroupOfLayers from '@/api/layers/ExternalGroupOfLayers.class'
 import ExternalLayer from '@/api/layers/ExternalLayer.class'
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import GeoAdminLayer from '@/api/layers/GeoAdminLayer.class'
-import { YEAR_TO_DESCRIBE_ALL_OR_CURRENT_DATA } from '@/api/layers/LayerTimeConfigEntry.class'
+import {
+    ALL_YEARS_TIMESTAMP,
+    CURRENT_YEAR_TIMESTAMP,
+} from '@/api/layers/LayerTimeConfigEntry.class'
 import { API_BASE_URL, DEFAULT_FEATURE_COUNT_SINGLE_POINT } from '@/config'
 import allCoordinateSystems, { LV95 } from '@/utils/coordinates/coordinateSystems'
 import { projExtent } from '@/utils/coordinates/coordinateUtils'
@@ -33,7 +36,7 @@ function getApi3TimeInstantParam(layer) {
     // timestamp therefore we need to set it to null in this case.
     if (
         layer.timeConfig?.currentYear &&
-        layer.timeConfig.currentYear !== YEAR_TO_DESCRIBE_ALL_OR_CURRENT_DATA
+        ![ALL_YEARS_TIMESTAMP, CURRENT_YEAR_TIMESTAMP].includes(layer.timeConfig.currentYear)
     ) {
         return layer.timeConfig.currentYear
     }
@@ -384,7 +387,8 @@ async function identifyOnExternalWmsLayer(config) {
         // there might exist more implementation of WMS, but I stopped there looking for more
         // (please add more if you think one of our customer/external layer providers uses another flavor of WMS)
     }
-    if (layer.timeConfig?.currentYear) {
+    // In WMS "all" years mean no TIME parameter
+    if (layer.timeConfig?.currentYear && layer.timeConfig.currentYear !== ALL_YEARS_TIMESTAMP) {
         params.TIME = layer.timeConfig.currentYear
     }
     // WMS 1.3.0 uses i,j to describe pixel coordinate where we want feature info

--- a/src/api/layers/LayerTimeConfig.class.js
+++ b/src/api/layers/LayerTimeConfig.class.js
@@ -1,7 +1,4 @@
-import LayerTimeConfigEntry, {
-    ALL_YEARS_WMS_TIMESTAMP,
-    YEAR_TO_DESCRIBE_ALL_OR_CURRENT_DATA,
-} from '@/api/layers/LayerTimeConfigEntry.class'
+import LayerTimeConfigEntry, { ALL_YEARS_TIMESTAMP } from '@/api/layers/LayerTimeConfigEntry.class'
 
 /**
  * @class
@@ -25,8 +22,8 @@ export default class LayerTimeConfig {
         this.behaviour = behaviour
         /** @type {LayerTimeConfigEntry[]} */
         this.timeEntries = [...timeEntries]
-        if (this.behaviour === ALL_YEARS_WMS_TIMESTAMP) {
-            this.timeEntries.splice(0, 0, new LayerTimeConfigEntry(ALL_YEARS_WMS_TIMESTAMP))
+        if (this.behaviour === ALL_YEARS_TIMESTAMP) {
+            this.timeEntries.splice(0, 0, new LayerTimeConfigEntry(ALL_YEARS_TIMESTAMP))
         }
         /*
          * Here we will define what is the first "currentTimeEntry" for this configuration.
@@ -57,9 +54,7 @@ export default class LayerTimeConfig {
             this.updateCurrentTimeEntry(behaviour)
         }
 
-        this.years = this.timeEntries
-            .map((entry) => entry.year)
-            .filter((year) => year !== YEAR_TO_DESCRIBE_ALL_OR_CURRENT_DATA)
+        this.years = this.timeEntries.map((entry) => entry.year)
     }
 
     /**

--- a/src/api/layers/LayerTimeConfigEntry.class.js
+++ b/src/api/layers/LayerTimeConfigEntry.class.js
@@ -17,7 +17,7 @@ export const YEAR_TO_DESCRIBE_ALL_OR_CURRENT_DATA = 9999
  *
  * @type {string}
  */
-export const ALL_YEARS_WMS_TIMESTAMP = 'all'
+export const ALL_YEARS_TIMESTAMP = 'all'
 /**
  * Timestamp to describe "current" or latest available data for a time enabled WMTS layer (and also
  * is the default value to give any WMTS layer that is not time enabled, as this timestamp is
@@ -25,7 +25,7 @@ export const ALL_YEARS_WMS_TIMESTAMP = 'all'
  *
  * @type {string}
  */
-export const CURRENT_YEAR_WMTS_TIMESTAMP = 'current'
+export const CURRENT_YEAR_TIMESTAMP = 'current'
 
 /**
  * @WARNING DON'T USE GETTER AND SETTER ! Instances of this class will be used a Vue 3 reactive
@@ -40,11 +40,18 @@ export default class LayerTimeConfigEntry {
     /** @param {String} timestamp A full timestamp as YYYYYMMDD or ISO 8601 format */
     constructor(timestamp) {
         this.timestamp = timestamp
-        if (
-            this.timestamp === ALL_YEARS_WMS_TIMESTAMP ||
-            this.timestamp === CURRENT_YEAR_WMTS_TIMESTAMP
-        ) {
-            this.year = YEAR_TO_DESCRIBE_ALL_OR_CURRENT_DATA
+        if (this.timestamp === ALL_YEARS_TIMESTAMP || this.timestamp === CURRENT_YEAR_TIMESTAMP) {
+            // for "all" and "current" timestamps we use it as well as year to be added in the UI selection
+            // as well as in the URL year attribute of layers param.
+            this.year = this.timestamp
+        } else if (this.timestamp.startsWith('9999')) {
+            // TODO PB-680 clean up "all" hack
+            // Currently the backends (mf-chsdi3 for layerConfig and WMTS) are using a hack to describe "all"
+            // by using a timestamp with the year 9999 (we have in my knowledge three type of "all" WMTS timestmaps
+            //  1. 9999      (e.g. ch.swisstopo.lubis-terrestrische_aufnahmen)
+            //  2. 99990101  (e.g. ch.astra.unfaelle-personenschaeden_alle)
+            //  3. 99991231  (e.g. ch.swisstopo.lubis-luftbilder-dritte-firmen)
+            this.year = ALL_YEARS_TIMESTAMP
         } else {
             if (isTimestampYYYYMMDD(timestamp)) {
                 this.year = parseInt(timestamp.substring(0, 4))

--- a/src/api/layers/WMSCapabilitiesParser.class.js
+++ b/src/api/layers/WMSCapabilitiesParser.class.js
@@ -115,7 +115,7 @@ export default class WMSCapabilitiesParser {
      *   is `null`
      * @param {boolean} [ignoreError=true] Don't throw exception in case of error, but return a
      *   default value or null. Default is `true`
-     * @returns {ExternalWMSLayer | null} ExternalWMSLayer object or nul in case of error
+     * @returns {ExternalWMSLayer | null} ExternalWMSLayer object or null in case of error
      */
     getExternalLayerObject(
         layerId,

--- a/src/api/layers/layers.api.js
+++ b/src/api/layers/layers.api.js
@@ -13,7 +13,6 @@ import { API_BASE_URL, DEFAULT_GEOADMIN_MAX_WMTS_RESOLUTION, WMTS_BASE_URL } fro
 import log from '@/utils/logging'
 
 // API file that covers the backend endpoint http://api3.geo.admin.ch/rest/services/all/MapServer/layersConfig
-// TODO : implement loading of a cached CloudFront version for MVP
 
 /**
  * Transform the backend metadata JSON object into instances of {@link GeoAdminLayer}, instantiating
@@ -53,10 +52,10 @@ const generateClassForLayerConfig = (layerConfig, id, allOtherLayers, lang) => {
         } catch (_) {
             // this is not a well-formed URL, we do nothing with it
         }
-        const timestamps = []
+        let timestamps = []
         if (Array.isArray(layerConfig.timestamps) && layerConfig.timestamps.length > 0) {
-            timestamps.push(
-                ...layerConfig.timestamps.map((timestamp) => new LayerTimeConfigEntry(timestamp))
+            timestamps = layerConfig.timestamps.map(
+                (timestamp) => new LayerTimeConfigEntry(timestamp)
             )
         }
         const timeConfig = new LayerTimeConfig(layerConfig.timeBehaviour, timestamps)

--- a/src/api/layers/layers.api.js
+++ b/src/api/layers/layers.api.js
@@ -58,7 +58,10 @@ const generateClassForLayerConfig = (layerConfig, id, allOtherLayers, lang) => {
                 (timestamp) => new LayerTimeConfigEntry(timestamp)
             )
         }
-        const timeConfig = new LayerTimeConfig(layerConfig.timeBehaviour, timestamps)
+        const timeConfig =
+            timestamps.length > 0
+                ? new LayerTimeConfig(layerConfig.timeBehaviour, timestamps)
+                : null
         const topics = layerConfig.topics ? layerConfig.topics.split(',') : []
         const attributions = []
         if (attributionName) {

--- a/src/modules/map/components/cesium/CesiumInternalLayer.vue
+++ b/src/modules/map/components/cesium/CesiumInternalLayer.vue
@@ -3,7 +3,6 @@
     <CesiumWMTSLayer
         v-if="layerConfig.type === LayerTypes.WMTS"
         :wmts-layer-config="layerConfig"
-        :preview-year="previewYear"
         :projection="projection"
         :parent-layer-opacity="parentLayerOpacity"
         :z-index="zIndex"
@@ -12,7 +11,6 @@
     <CesiumWMSLayer
         v-if="layerConfig.type === LayerTypes.WMS"
         :wms-layer-config="layerConfig"
-        :preview-year="previewYear"
         :projection="projection"
         :z-index="zIndex"
         :is-time-slider-active="isTimeSliderActive"
@@ -22,7 +20,6 @@
             v-for="(layer, index) in layerConfig.layers"
             :key="`${layer.id}-${index}`"
             :wms-layer-config="layer"
-            :preview-year="previewYear"
             :projection="projection"
             :parent-layer-opacity="parentLayerOpacity"
             :z-index="zIndex + index"
@@ -36,7 +33,6 @@
                 v-if="shouldAggregateSubLayerBeVisible(aggregateSubLayer)"
                 :layer-config="aggregateSubLayer.layer"
                 :parent-layer-opacity="layerConfig.opacity"
-                :preview-year="previewYear"
                 :projection="projection"
                 :is-time-slider-active="isTimeSliderActive"
                 :z-index="zIndex"
@@ -92,10 +88,6 @@ export default {
         zIndex: {
             type: Number,
             default: -1,
-        },
-        previewYear: {
-            type: Number,
-            default: null,
         },
         projection: {
             type: CoordinateSystem,

--- a/src/modules/map/components/cesium/CesiumMap.vue
+++ b/src/modules/map/components/cesium/CesiumMap.vue
@@ -34,7 +34,6 @@
                 v-for="(layer, index) in visibleImageryLayers"
                 :key="layer.id"
                 :layer-config="layer"
-                :preview-year="previewYear"
                 :projection="projection"
                 :z-index="index + startingZIndexForImageryLayers"
                 :is-time-slider-active="isTimeSliderActive"
@@ -43,7 +42,6 @@
                 v-for="layer in visiblePrimitiveLayers"
                 :key="layer.id"
                 :layer-config="layer"
-                :preview-year="previewYear"
                 :projection="projection"
             />
         </div>
@@ -176,7 +174,6 @@ export default {
             rotation: (state) => state.position.rotation,
             cameraPosition: (state) => state.position.camera,
             uiMode: (state) => state.ui.mode,
-            previewYear: (state) => state.layers.previewYear,
             projection: (state) => state.position.projection,
             isFullScreenMode: (state) => state.ui.fullscreenMode,
             isTimeSliderActive: (state) => state.ui.isTimeSliderActive,

--- a/src/modules/map/components/cesium/CesiumWMSLayer.vue
+++ b/src/modules/map/components/cesium/CesiumWMSLayer.vue
@@ -8,7 +8,7 @@ import { mapState } from 'vuex'
 
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import GeoAdminWMSLayer from '@/api/layers/GeoAdminWMSLayer.class'
-import { ALL_YEARS_WMS_TIMESTAMP } from '@/api/layers/LayerTimeConfigEntry.class'
+import { ALL_YEARS_TIMESTAMP } from '@/api/layers/LayerTimeConfigEntry.class'
 import { DEFAULT_PROJECTION } from '@/config'
 import addImageryLayerMixins from '@/modules/map/components/cesium/utils/addImageryLayer-mixins'
 import CoordinateSystem from '@/utils/coordinates/CoordinateSystem.class'
@@ -91,7 +91,7 @@ export default {
                 LANG: this.currentLang,
                 VERSION: this.wmsVersion,
             }
-            if (this.timestamp && this.timestamp !== ALL_YEARS_WMS_TIMESTAMP) {
+            if (this.timestamp && this.timestamp !== ALL_YEARS_TIMESTAMP) {
                 params.TIME = this.timestamp
             }
             return params

--- a/src/modules/map/components/cesium/CesiumWMSLayer.vue
+++ b/src/modules/map/components/cesium/CesiumWMSLayer.vue
@@ -24,10 +24,6 @@ export default {
             type: [GeoAdminWMSLayer, ExternalWMSLayer],
             required: true,
         },
-        previewYear: {
-            type: Number,
-            default: null,
-        },
         projection: {
             type: CoordinateSystem,
             required: true,
@@ -65,11 +61,7 @@ export default {
             return this.wmsLayerConfig.baseUrl
         },
         timestamp() {
-            return getTimestampFromConfig(
-                this.wmsLayerConfig,
-                this.previewYear,
-                this.isTimeSliderActive
-            )
+            return getTimestampFromConfig(this.wmsLayerConfig)
         },
         /**
          * Definition of all relevant URL param for our WMS backends. Passes as parameters to

--- a/src/modules/map/components/cesium/CesiumWMTSLayer.vue
+++ b/src/modules/map/components/cesium/CesiumWMTSLayer.vue
@@ -36,10 +36,6 @@ export default {
             type: [GeoAdminWMTSLayer, ExternalWMTSLayer],
             required: true,
         },
-        previewYear: {
-            type: Number,
-            default: null,
-        },
         projection: {
             type: CoordinateSystem,
             required: true,
@@ -67,8 +63,6 @@ export default {
         url() {
             return getWmtsXyzUrl(this.wmtsLayerConfig, this.projection, {
                 addTimestamp: true,
-                previewYear: this.previewYear,
-                isTimeSliderActive: this.isTimeSliderActive,
             })
         },
         tileMatrixSet() {
@@ -102,12 +96,7 @@ export default {
             }, dimensions)
             if (this.wmtsLayerConfig.hasMultipleTimestamps) {
                 // if we have a time config use it as dimension
-                const timestamp =
-                    getTimestampFromConfig(
-                        this.wmtsLayerConfig,
-                        this.previewYear,
-                        this.isTimeSliderActive
-                    ) ?? 'current'
+                const timestamp = getTimestampFromConfig(this.wmtsLayerConfig)
                 // overwrite any Time, TIME or time dimension
                 const timeDimension = Object.entries(dimensions).find(
                     (e) => e[0].toLowerCase() === 'time'

--- a/src/modules/map/components/openlayers/OpenLayersExternalWMTSLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersExternalWMTSLayer.vue
@@ -31,8 +31,6 @@ const { externalWmtsLayerConfig, parentLayerOpacity, zIndex } = toRefs(props)
 // mapping relevant store values
 const store = useStore()
 const projection = computed(() => store.state.position.projection)
-const previewYear = computed(() => store.state.layers.previewYear)
-const isTimeSliderActive = computed(() => store.state.ui.isTimeSliderActive)
 
 // extracting useful info from what we've linked so far
 const layerId = computed(() => externalWmtsLayerConfig.value.id)
@@ -48,14 +46,7 @@ const options = computed(() => {
     return _options
 })
 // Use "current" as the default timestamp if not defined in the layer config (or no preview year)
-const timestamp = computed(
-    () =>
-        getTimestampFromConfig(
-            externalWmtsLayerConfig.value,
-            previewYear.value,
-            isTimeSliderActive.value
-        ) ?? 'current'
-)
+const timestamp = computed(() => getTimestampFromConfig(externalWmtsLayerConfig.value))
 const dimensions = computed(() => {
     if (!options.value) {
         return null

--- a/src/modules/map/components/openlayers/OpenLayersWMSLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersWMSLayer.vue
@@ -9,7 +9,7 @@ import { useStore } from 'vuex'
 
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import GeoAdminWMSLayer from '@/api/layers/GeoAdminWMSLayer.class'
-import { ALL_YEARS_WMS_TIMESTAMP } from '@/api/layers/LayerTimeConfigEntry.class'
+import { ALL_YEARS_TIMESTAMP } from '@/api/layers/LayerTimeConfigEntry.class'
 import { WMS_TILE_SIZE } from '@/config'
 import useAddLayerToMap from '@/modules/map/components/openlayers/utils/useAddLayerToMap.composable'
 import { LV95 } from '@/utils/coordinates/coordinateSystems.js'
@@ -72,7 +72,7 @@ const wmsUrlParams = computed(() => {
         CRS: projection.value.epsg,
         TIME: timestamp.value,
     }
-    if (timestamp.value === ALL_YEARS_WMS_TIMESTAMP) {
+    if (timestamp.value === ALL_YEARS_TIMESTAMP) {
         // To request all timestamp we need to set the TIME to null which will force openlayer
         // to send a request without TIME param, otherwise openlayer takes the previous TIME param.
         params.TIME = null

--- a/src/modules/map/components/openlayers/OpenLayersWMSLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersWMSLayer.vue
@@ -35,7 +35,6 @@ const { wmsLayerConfig, parentLayerOpacity, zIndex } = toRefs(props)
 
 // mapping relevant store values
 const store = useStore()
-const previewYear = computed(() => store.state.layers.previewYear)
 const projection = computed(() => store.state.position.projection)
 const currentLang = computed(() => store.state.i18n.lang)
 
@@ -46,10 +45,7 @@ const format = computed(() => wmsLayerConfig.value.format || 'png')
 const gutter = computed(() => wmsLayerConfig.value.gutter || -1)
 const opacity = computed(() => parentLayerOpacity.value ?? wmsLayerConfig.value.opacity)
 const url = computed(() => wmsLayerConfig.value.baseUrl)
-const isTimeSliderActive = computed(() => store.state.ui.isTimeSliderActive)
-const timestamp = computed(() =>
-    getTimestampFromConfig(wmsLayerConfig.value, previewYear.value, isTimeSliderActive.value)
-)
+const timestamp = computed(() => getTimestampFromConfig(wmsLayerConfig.value))
 
 /**
  * Definition of all relevant URL param for our WMS backends. This is because both

--- a/src/modules/map/components/openlayers/OpenLayersWMTSLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersWMTSLayer.vue
@@ -28,22 +28,13 @@ const { wmtsLayerConfig, parentLayerOpacity, zIndex } = toRefs(props)
 
 // mapping relevant store values
 const store = useStore()
-const previewYear = computed(() => store.state.layers.previewYear)
 const projection = computed(() => store.state.position.projection)
-const isTimeSliderActive = computed(() => store.state.ui.isTimeSliderActive)
 // extracting useful info from what we've linked so far
 const layerId = computed(() => wmtsLayerConfig.value.technicalName)
 const maxResolution = computed(() => wmtsLayerConfig.value.maxResolution)
 const opacity = computed(() => parentLayerOpacity.value ?? wmtsLayerConfig.value.opacity)
 // Use "current" as the default timestamp if not defined in the layer config (or no preview year)
-const timestamp = computed(
-    () =>
-        getTimestampFromConfig(
-            wmtsLayerConfig.value,
-            previewYear.value,
-            isTimeSliderActive.value
-        ) ?? 'current'
-)
+const timestamp = computed(() => getTimestampFromConfig(wmtsLayerConfig.value))
 const wmtsSourceConfig = computed(() => {
     return {
         // No local cache, so that our CloudFront cache is always used. Was creating an issue on mf-geoadmin3, see :

--- a/src/modules/map/components/toolbox/TimeSlider.vue
+++ b/src/modules/map/components/toolbox/TimeSlider.vue
@@ -177,7 +177,7 @@ watch(lang, () => {
 })
 
 onMounted(() => {
-    log.debug(`Activing time slider, previewYear=${previewYear.value}`)
+    log.debug(`Activating time slider, previewYear=${previewYear.value}`)
     setSliderWidth()
 
     /*

--- a/src/modules/map/components/toolbox/TimeSlider.vue
+++ b/src/modules/map/components/toolbox/TimeSlider.vue
@@ -232,6 +232,10 @@ onMounted(() => {
 
         dispatchPreviewYearToStoreDebounced()
     })
+
+    watch(layersWithTimestamps, () => {
+        dispatchPreviewYearToStoreDebounced()
+    })
 })
 
 onUnmounted(() => {
@@ -244,7 +248,12 @@ onUnmounted(() => {
 function setPreviewYearToLayers() {
     activeLayers.value.forEach((layer, index) => {
         const year = previewYear.value
-        if (layer.visible && layer.hasMultipleTimestamps && layer.timeConfig) {
+        if (
+            layer.visible &&
+            layer.hasMultipleTimestamps &&
+            layer.timeConfig &&
+            layer.timeConfig.currentYear !== year
+        ) {
             // if there is not timeEntry for the given year we need to set the year to
             // null which will result to setting the currentTimeEntry to null as well
             store.dispatch('setTimedLayerCurrentYear', {

--- a/src/modules/map/components/toolbox/TimeSlider.vue
+++ b/src/modules/map/components/toolbox/TimeSlider.vue
@@ -8,7 +8,8 @@ import { useStore } from 'vuex'
 import { OLDEST_YEAR, YOUNGEST_YEAR } from '@/config'
 import TimeSliderDropdown from '@/modules/map/components/toolbox/TimeSliderDropdown.vue'
 import debounce from '@/utils/debounce'
-import { round } from '@/utils/numberUtils'
+import log from '@/utils/logging'
+import { isNumber, round } from '@/utils/numberUtils'
 
 import { useRangeTippy } from './useRangeTippy'
 
@@ -29,7 +30,7 @@ const PLAY_BUTTON_SIZE = 54
 // dynamic internal data
 const sliderWidth = ref(0)
 const allYears = ref(ALL_YEARS)
-const _currentYear = ref(YOUNGEST_YEAR)
+const currentYear = ref(YOUNGEST_YEAR)
 // used to hold the value in case the entered year is invalid
 const falseYear = ref(null)
 let cursorX = 0
@@ -94,28 +95,6 @@ const inputYear = computed({
 })
 
 /**
- * The currently selected year
- *
- * We can't use the store value directly, as sometimes we want to update the current year displayed
- * without updating the store too much
- */
-const currentYear = computed({
-    get() {
-        return _currentYear.value
-    },
-    set(value) {
-        _currentYear.value = value
-
-        // we need to reset those here, otherwise, when the error is shown and the users drags
-        // the cursor to a correct year, the error won't go away
-        falseYear.value = null
-        isInputYearValid.value = true
-
-        dispatchPreviewYearToStoreDebounced()
-    },
-})
-
-/**
  * Filtering of all years to only give ones that will need to be shown in the label section of the
  * time selector. Depending on the selector's width, we will show all 10s or 25s or 50s years.
  */
@@ -174,9 +153,10 @@ const yearsWithData = computed(() => {
         })
     }
     yearsSeparate = yearsSeparate.filter((year) => !yearsJoint.includes(year))
+    // Here below we need to filter out non valid number years (e.g. 'current' and/or 'all')
     return {
-        yearsJoint: yearsJoint.sort((a, b) => b - a),
-        yearsSeparate: yearsSeparate.sort((a, b) => b - a),
+        yearsJoint: yearsJoint.sort((a, b) => b - a).filter((year) => isNumber(year)),
+        yearsSeparate: yearsSeparate.sort((a, b) => b - a).filter((year) => isNumber(year)),
     }
 })
 
@@ -197,6 +177,7 @@ watch(lang, () => {
 })
 
 onMounted(() => {
+    log.debug(`Activing time slider, previewYear=${previewYear.value}`)
     setSliderWidth()
 
     /*
@@ -206,7 +187,7 @@ onMounted(() => {
         - if there is joint data (when there is only one layer, all data is joint data), we go to the most recent joint data
         - else, we set it to the most recent year with data
     */
-    if (!previewYear.value) {
+    if (previewYear.value === null) {
         // initialize the current year from the timeConfig layers
         if (
             layersWithTimestamps.value.length === 1 &&
@@ -218,9 +199,16 @@ onMounted(() => {
         } else {
             currentYear.value = yearsWithData.value.yearsSeparate[0]
         }
+
+        // dispatch current year to the preview year
+        dispatchPreviewYearToStore()
     } else {
         currentYear.value = previewYear.value
+        // make sure that all layers uses the preview year
+        setPreviewYearToLayers()
     }
+
+    log.debug(`Time slider activated, currentYear=${currentYear.value}`)
 
     tippyTimeSliderInfo = tippy(timeSliderBar.value, {
         content: timeSliderTooltipRef.value,
@@ -235,6 +223,15 @@ onMounted(() => {
     })
 
     window.addEventListener('keydown', handleKeyDownEvent)
+
+    watch(currentYear, () => {
+        // we need to reset those here, otherwise, when the error is shown and the users drags
+        // the cursor to a correct year, the error won't go away
+        falseYear.value = null
+        isInputYearValid.value = true
+
+        dispatchPreviewYearToStoreDebounced()
+    })
 })
 
 onUnmounted(() => {
@@ -247,15 +244,12 @@ onUnmounted(() => {
 function setPreviewYearToLayers() {
     activeLayers.value.forEach((layer, index) => {
         const year = previewYear.value
-        if (
-            layer.visible &&
-            layer.hasMultipleTimestamps &&
-            layer.timeConfig &&
-            layer.timeConfig.getTimeEntryForYear(year)
-        ) {
+        if (layer.visible && layer.hasMultipleTimestamps && layer.timeConfig) {
+            // if there is not timeEntry for the given year we need to set the year to
+            // null which will result to setting the currentTimeEntry to null as well
             store.dispatch('setTimedLayerCurrentYear', {
                 index,
-                year,
+                year: year,
                 ...dispatcher,
             })
         }

--- a/src/modules/map/components/toolbox/TimeSliderButton.vue
+++ b/src/modules/map/components/toolbox/TimeSliderButton.vue
@@ -30,6 +30,12 @@ watch(visibleLayersWithTimeConfig, () =>
 )
 
 function toggleTimeSlider() {
+    if (isTimeSliderActive.value) {
+        // when closing the timeslider we reset the preview year to nul so that next time
+        // we reopen it we use the correct year from the layer current configurations and not reuse
+        // the last preview.
+        store.dispatch('setPreviewYear', { year: null, ...dispatcher })
+    }
     store.dispatch('setTimeSliderActive', {
         timeSliderActive: !isTimeSliderActive.value,
         ...dispatcher,

--- a/src/modules/map/components/toolbox/TimeSliderButton.vue
+++ b/src/modules/map/components/toolbox/TimeSliderButton.vue
@@ -31,7 +31,7 @@ watch(visibleLayersWithTimeConfig, () =>
 
 function toggleTimeSlider() {
     if (isTimeSliderActive.value) {
-        // when closing the timeslider we reset the preview year to nul so that next time
+        // when closing the timeslider we reset the preview year to null so that next time
         // we reopen it we use the correct year from the layer current configurations and not reuse
         // the last preview.
         store.dispatch('setPreviewYear', { year: null, ...dispatcher })

--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItemTimeSelector.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItemTimeSelector.vue
@@ -6,8 +6,8 @@ import { useStore } from 'vuex'
 
 import LayerTimeConfig from '@/api/layers/LayerTimeConfig.class'
 import {
-    CURRENT_YEAR_WMTS_TIMESTAMP,
-    YEAR_TO_DESCRIBE_ALL_OR_CURRENT_DATA,
+    ALL_YEARS_TIMESTAMP,
+    CURRENT_YEAR_TIMESTAMP,
 } from '@/api/layers/LayerTimeConfigEntry.class'
 import TextTruncate from '@/utils/components/TextTruncate.vue'
 
@@ -39,22 +39,12 @@ const i18n = useI18n()
 const timeSelectorButton = ref(null)
 const timeSelectorModal = ref(null)
 
-const previewYear = computed(() => store.state.layers.previewYear)
-const hasMultipleTimestamps = computed(
-    () => timeConfig.value.timeEntries.length > 1 && hasValidTimestamp.value
-)
+const hasMultipleTimestamps = computed(() => timeConfig.value.timeEntries.length > 1)
 const isTimeSliderActive = computed(() => store.state.ui.isTimeSliderActive)
 
-const isLayerVisible = computed(() => store.state.layers.activeLayers[layerIndex.value].visible)
 const humanReadableCurrentTimestamp = computed(() => {
-    if (isLayerVisible.value && isTimeSliderActive.value) {
-        return timeConfig.value.years.includes(previewYear.value) ? previewYear.value : '-'
-    }
     return renderHumanReadableTimestamp(timeConfig.value.currentTimeEntry)
 })
-// Some external layers might have a time dimension with invalid timestamps, in this case we
-// use the default timestamp as dimension and don't display the time selector.
-const hasValidTimestamp = computed(() => !!timeConfig.value?.currentTimeEntry?.year)
 
 let popover = null
 
@@ -86,10 +76,10 @@ function renderHumanReadableTimestamp(timeEntry) {
     if (!timeEntry) {
         return '-'
     }
-    if (timeEntry.timestamp === CURRENT_YEAR_WMTS_TIMESTAMP) {
+    if (timeEntry.year === CURRENT_YEAR_TIMESTAMP) {
         return i18n.t(`time_current`)
     }
-    if (timeEntry.year === YEAR_TO_DESCRIBE_ALL_OR_CURRENT_DATA) {
+    if (timeEntry.year === ALL_YEARS_TIMESTAMP) {
         return i18n.t('time_all')
     }
     if (timeEntry.year === null) {

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -30,6 +30,7 @@ import log from '@/utils/logging'
  *   will return the untouched ActiveLayerConfig for other layer types
  */
 export function createLayerObject(parsedLayer, currentLayer, store, featuresRequests) {
+    const { year, updateDelay, features } = parsedLayer.customAttributes ?? {}
     const defaultOpacity = 1.0
     let layer = null
     if (currentLayer && (currentLayer.isExternal || currentLayer instanceof KMLLayer)) {
@@ -71,7 +72,6 @@ export function createLayerObject(parsedLayer, currentLayer, store, featuresRequ
     }
     // format is WMTS|GET_CAPABILITIES_URL|LAYER_ID
     else if (parsedLayer.type === LayerTypes.WMTS) {
-        const { year = null } = parsedLayer.customAttributes ?? {}
         layer = new ExternalWMTSLayer({
             id: parsedLayer.id,
             name: parsedLayer.id,
@@ -83,7 +83,6 @@ export function createLayerObject(parsedLayer, currentLayer, store, featuresRequ
     }
     // format is : WMS|BASE_URL|LAYER_ID
     else if (parsedLayer.type === LayerTypes.WMS) {
-        const { year = null } = parsedLayer.customAttributes ?? {}
         // here we assume that is a regular WMS layer, upon parsing of the WMS get capabilities
         // the layer might be updated to an external group of layers if needed.
         layer = new ExternalWMSLayer({
@@ -95,7 +94,6 @@ export function createLayerObject(parsedLayer, currentLayer, store, featuresRequ
             currentYear: year,
         })
     } else {
-        const { year } = parsedLayer.customAttributes
         // Finally check if this is a Geoadmin layer
         layer = store.getters.getLayerConfigById(parsedLayer.id)?.clone()
         if (layer) {
@@ -109,10 +107,8 @@ export function createLayerObject(parsedLayer, currentLayer, store, featuresRequ
         }
     }
 
-    // If we have a layer parse extra parameters
+    // If we have a layer parse extra parameters that could be used by any type of layer
     if (layer) {
-        const { updateDelay, features } = parsedLayer.customAttributes
-
         if (updateDelay !== undefined) {
             layer.updateDelay = updateDelay
         }

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -95,51 +95,52 @@ export function createLayerObject(parsedLayer, currentLayer, store, featuresRequ
             currentYear: year,
         })
     } else {
+        const { year } = parsedLayer.customAttributes
         // Finally check if this is a Geoadmin layer
         layer = store.getters.getLayerConfigById(parsedLayer.id)?.clone()
-
         if (layer) {
-            const { year, updateDelay, features } = parsedLayer.customAttributes
-
             layer.visible = parsedLayer.visible
-
             if (parsedLayer.opacity !== undefined) {
                 layer.opacity = parsedLayer.opacity
             }
-
             if (year !== undefined && layer.timeConfig) {
                 layer.timeConfig.updateCurrentTimeEntry(layer.timeConfig.getTimeEntryForYear(year))
             }
-
-            if (updateDelay !== undefined) {
-                layer.updateDelay = updateDelay
-            }
-
-            if (features !== undefined) {
-                features
-                    .toString()
-                    .split(':')
-                    .forEach((featureId) => {
-                        featuresRequests.push(
-                            getFeature(
-                                store.getters.getLayerConfigById(parsedLayer.id),
-                                featureId,
-                                store.state.position.projection,
-                                {
-                                    lang: store.state.i18n.lang,
-                                    screenWidth: store.state.ui.width,
-                                    screenHeight: store.state.ui.height,
-                                    mapExtent: flattenExtent(store.getters.extent),
-                                }
-                            )
-                        )
-                    })
-            }
-        } else {
-            log.error(
-                `Invalid layer ${parsedLayer.id} parsed from the URL, layer is not found in layer config and is not external`
-            )
         }
+    }
+
+    // If we have a layer parse extra parameters
+    if (layer) {
+        const { updateDelay, features } = parsedLayer.customAttributes
+
+        if (updateDelay !== undefined) {
+            layer.updateDelay = updateDelay
+        }
+
+        if (features !== undefined) {
+            features
+                .toString()
+                .split(':')
+                .forEach((featureId) => {
+                    featuresRequests.push(
+                        getFeature(
+                            store.getters.getLayerConfigById(parsedLayer.id),
+                            featureId,
+                            store.state.position.projection,
+                            {
+                                lang: store.state.i18n.lang,
+                                screenWidth: store.state.ui.width,
+                                screenHeight: store.state.ui.height,
+                                mapExtent: flattenExtent(store.getters.extent),
+                            }
+                        )
+                    )
+                })
+        }
+    } else {
+        log.error(
+            `Invalid layer ${parsedLayer.id} parsed from the URL, layer is not found in layer config and is not external`
+        )
     }
 
     return layer

--- a/src/router/storeSync/__tests__/layersParamParser.spec.js
+++ b/src/router/storeSync/__tests__/layersParamParser.spec.js
@@ -386,6 +386,7 @@ describe('Testing layersParamParser', () => {
                             new LayerTimeConfigEntry('20000101'),
                             new LayerTimeConfigEntry('19500101'),
                         ])
+                        layer.hasMultipleTimestamps = true
                         layer.timeConfig.currentTimeEntry = wantedTimeEntry
                         expect(transformLayerIntoUrlString(layer, pristineLayer)).to.eq(
                             `${expectedLayerUrlId}@year=2050`

--- a/src/router/storeSync/layersParamParser.js
+++ b/src/router/storeSync/layersParamParser.js
@@ -153,7 +153,7 @@ export function transformLayerIntoUrlString(layer, defaultLayerConfig, featuresI
             // Always add the `@year` if we have a valid currentYear
             layerUrlString += `@year=${layer.timeConfig.currentYear}`
         } else if (layer.timeConfig.currentTimeEntry === null) {
-            // Rhe currentTimeEntry is null, this means that a user entered via the timeSlider
+            // The currentTimeEntry is null, this means that a user entered via the timeSlider
             // a non matching year for this layer (year set by timeSlider don't match any available
             // timestamps for this layer). In this case we set the `@year=none` and the layer won't
             // be visible.

--- a/src/router/storeSync/layersParamParser.js
+++ b/src/router/storeSync/layersParamParser.js
@@ -147,9 +147,11 @@ export function parseLayersParam(queryValue) {
 export function transformLayerIntoUrlString(layer, defaultLayerConfig, featuresIds) {
     // NOTE we need to encode ,;@ characters from the layer to avoid parsing issue.
     let layerUrlString = encodeLayerParam(encodeLayerId(layer))
-    if (layer.timeConfig && layer.timeConfig.currentTimeEntry !== null) {
-        // here some external layer might not have a proper year so we need to use the timestamp instead
-        layerUrlString += `@year=${layer.timeConfig.currentYear ?? layer.timeConfig.currentTimestamp}`
+    // Here we set the @year only if we have a valid year.
+    // NOTE: external layers might have invalid timestamps, in this case they won't have the time
+    // selector buttons and the application will use the default timestamp and we don't add any @year param
+    if (layer.timeConfig && layer.timeConfig.currentYear !== null) {
+        layerUrlString += `@year=${layer.timeConfig.currentYear}`
     } else if (layer.timeConfig && layer.timeConfig.currentTimeEntry === null) {
         // The layer is a time enabled layer, but the user asked for a timestamp that don't exists for
         // this layer (e.g. using TimeSlider), in this case we don't have a current time entry which

--- a/src/utils/kmlUtils.js
+++ b/src/utils/kmlUtils.js
@@ -190,7 +190,7 @@ class IconArgs {
  * - /api/icons/sets/{set_name}/icons/{icon_name}@{icon_scale}-{red},{green},{blue}.png
  *
  * @param {string} url URL string
- * @returns {IconArgs | null} Returns the parsed URL or nul in case of invalid non recognize url
+ * @returns {IconArgs | null} Returns the parsed URL or null in case of invalid non recognize url
  */
 export function parseIconUrl(url) {
     // legacy icon urls pattern
@@ -275,7 +275,7 @@ function generateIconFromStyle(iconStyle, iconArgs) {
  * @param {IconArgs} iconArgs Geoadmin icon arguments
  * @param {IconStyle | null} iconStyle Ol icon style
  * @param {DrawingIconSet[] | null} availableIconSets
- * @returns {DrawingIcon | null} Return the drawing icon or nul in case of non geoadmin icon
+ * @returns {DrawingIcon | null} Return the drawing icon or null in case of non geoadmin icon
  */
 export function getIcon(iconArgs, iconStyle, availableIconSets) {
     if (!iconArgs) {

--- a/src/utils/layerUtils.js
+++ b/src/utils/layerUtils.js
@@ -15,6 +15,26 @@ import LayerTypes from '@/api/layers/LayerTypes.enum.js'
  *   default opacity for the layer.
  * @property {String} [baseUrl] The base URL of this layer, if applicable (only for external layers)
  * @property {Object} [customAttributes] Other attributes relevant for this layer, such as time
+ * @property {String | Number | null | undefined} [customAttributes.year=undefined] Selected year of
+ *   the time enabled layer. Can be one of the following values:
+ *
+ *   - Undefined := either the layer has no timeConfig or we use the default year defined in
+ *       layerConfig.timeBehaviour
+ *   - 'none' := no year is selected, which means that the layer won't be visible. This happens when
+ *       using the TimeSlider where a user can select a year that has no data for this layer.
+ *   - 'all' := load all years for this layer (for WMS this means that no TIME param is added and for
+ *       WMTS we use the geoadmin definition YEAR_TO_DESCRIBE_ALL_OR_CURRENT_DATA as timestamp)
+ *   - 'current' := load current year, only valid for WMTS layer where 'current' is a valid timestamp.
+ *   - YYYY := any valid year entry for this layer, this will load the data only for this year.
+ *
+ *   This attribute has only effect on timeEnabled layer and External WMS/WMTS layer with timestamp.
+ *   Default is `undefined`
+ * @property {Number | undefined} [customAttributes.updateDelay=undefined] Automatic refresh time in
+ *   millisecondes of the layer. Has only effect on GeoAdminGeoJsonLayer. Default is `undefined`
+ * @property {String | undefined} [customAttributes.features=undefined] Colon separated list of
+ *   feature IDs to select. Default is `undefined`
+ * @property {String | undefined} [customAttributes.adminId=undefined] KML admin ID required to edit
+ *   a KML drawing. Default is `undefined`
  */
 
 /**

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -143,7 +143,7 @@ export function getLayersFromLegacyUrlParams(
                 layer.opacity = layerOpacities[index]
             }
             // checking if a timestamp is defined for this layer
-            if (layerTimestamps.length > index && layerTimestamps[index]) {
+            if (layerTimestamps.length > index && layerTimestamps[index] !== '') {
                 layer.timeConfig.updateCurrentTimeEntry(layerTimestamps[index])
             }
             layersToBeActivated.push(layer)

--- a/tests/cypress/tests-e2e/featureSelection.cy.js
+++ b/tests/cypress/tests-e2e/featureSelection.cy.js
@@ -142,11 +142,12 @@ describe('Testing the feature selection', () => {
                     .get('layers')
                     .split(';')
                     .forEach((layerParam) => {
-                        const layerAndFeatures = layerParam.split('@features=')
-                        if (layerAndFeatures[0] === standardLayer) {
-                            expect(layerAndFeatures[1]).to.eq(`${expectedFeatureIds[0]}`)
-                        } else {
-                            expect(layerAndFeatures.length).to.eq(1)
+                        const layerAndAttributes = layerParam.split('@')
+                        if (layerAndAttributes[0] === standardLayer) {
+                            const featureAttribute = layerAndAttributes
+                                .find((attribute) => attribute.startsWith('features'))
+                                ?.split('=')
+                            expect(featureAttribute[1]).to.eq(`${expectedFeatureIds[0]}`)
                         }
                     })
             })

--- a/tests/cypress/tests-e2e/timeSlider.cy.js
+++ b/tests/cypress/tests-e2e/timeSlider.cy.js
@@ -56,9 +56,9 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
                 !classList.includes('btn-outline-primary')
             )
         }
-        it('checks that the time slider is functional and behave correctly', () => {
+        it('checks that the time slider is functional and behave correctly part 1', () => {
             cy.viewport(1920, 1080)
-            // ----------------------------------------------------------------------------------------------------
+            //----------------------------------------------------------------------------------------------------
             cy.log(': Invisible time layer given. time slider button should not appear')
             cy.goToMapView({
                 layers: `${time_layer_std},f`,
@@ -162,7 +162,8 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
                 'contain',
                 preSelectedYear
             )
-
+        })
+        it('checks that the time slider is functional and behave correctly with the timeSlider param at startup', () => {
             // ----------------------------------------------------------------------------------------------------
             cy.log(
                 'With a visible time Layer and a TS parameter, the Time slider should appear at the correct year'
@@ -177,10 +178,8 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             cy.log('shows that the CSS is correct for all time enable layers')
             cy.log(' time selector years shown ')
             cy.openMenuIfMobile()
-            cy.get(`[data-cy="time-selector-${time_layer_std}-0"]`).should('contain', 2019)
-            cy.get(`[data-cy="time-selector-${time_layer_odd}-1"]`).should('contain', 2013)
-            cy.get(`[data-cy="time-selector-${time_layer_with_all}-2"]`).should('contain', '-')
             // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+            cy.get(`[data-cy="time-selector-${time_layer_std}-0"]`).should('contain', 2019)
             cy.log(`${time_layer_std} : CSS of time selectors on an invisible layer`)
             cy.get(`[data-cy="time-selector-${time_layer_std}-0"]`).click()
             timestamps[time_layer_std].forEach((timestamp) => {
@@ -198,6 +197,7 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             cy.log(
                 `${time_layer_odd} : CSS of time selectors on a layer with data on the preview Year selected`
             )
+            cy.get(`[data-cy="time-selector-${time_layer_odd}-1"]`).should('contain', 2013)
             cy.get(`[data-cy="time-selector-${time_layer_odd}-1"]`).click()
             timestamps[time_layer_odd].forEach((timestamp) => {
                 cy.get(`[data-cy="time-select-${timestamp}"]`).should('satisfy', (element) => {
@@ -213,18 +213,12 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
                 })
             })
             // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+            cy.get(`[data-cy="time-selector-${time_layer_with_all}-2"]`).should('contain', '-')
             cy.get(`[data-cy="time-selector-${time_layer_with_all}-2"]`).click()
             timestamps[time_layer_with_all].forEach((timestamp) => {
                 cy.get(`[data-cy="time-select-${timestamp}"]`).should('satisfy', (element) => {
                     const classList = Array.from(element[0].classList)
-                    // in the 'all' layer, the time slider is over a non existing value,
-                    // which means there is no primary button, and that the base value of
-                    // the layer (2009) should be an outline. Everything else should be
-                    // a light button
-
-                    return timestamp === '20090101'
-                        ? isPrimaryBtn(classList)
-                        : isLightBtn(classList)
+                    return isLightBtn(classList)
                 })
             })
             // ---------------------------------------------------------------------------------------------------
@@ -256,7 +250,9 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             )
 
             cy.get('[data-cy="menu-swiss-flag"').click()
-            cy.goToMapView({ layers: `${time_layer_std};${time_layer_odd};${time_layer_with_all}` })
+            cy.goToMapView({
+                layers: `${time_layer_std};${time_layer_odd};${time_layer_with_all}`,
+            })
             cy.get('[data-cy="time-slider-button"]').click()
             cy.get('[data-cy="time-slider-bar-cursor-year"]').should('have.value', '2023')
             cy.url().should((url) => url.includes('timeSlider=2023'))


### PR DESCRIPTION
Try to make the code cleaner, more robust and easier to understand (not sure
I achieved this though).

One major changes is that for the `"all"` hack, now in the url we don't use anymore
`@year=9999` but `@year=all` (legacy timestamp with `9999` are still working and are
translated to `@year=all`)

Also added support for `@year=none` when a layer as no data for timeslider
preview year.

I also tried to document the layer attributes and all special cases

I aslo created a ticket PB-680 to do more clean up concerning the `"all"` hack
in future.

[Test link with all different time enable layers using legacy link - map.geo.admin.ch](https://map.geo.admin.ch/?lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-grau&layers=ch.swisstopo.lubis-luftbilder-dritte-kantone,ch.swisstopo.swissimage-product_1946,ch.swisstopo.swissimage-product.metadata,ch.swisstopo.swissimage-product_3d,ch.swisstopo.pixelkarte-farbe-pk25.noscale,ch.swisstopo.lubis-luftbilder-dritte-firmen,ch.astra.unfaelle-personenschaeden_fahrraeder,ch.swisstopo.lubis-terrestrische_aufnahmen&layers_timestamp=99991231,1946,2022,,current,99991231,99990101,9999&layers_opacity=1,1,0.7,1,1,1,1,1)

[Test link with all different time enable layers using legacy link](https://sys-map.dev.bgdi.ch/preview/bug-pb-590-time-slider-no-data/index.html?lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-grau&layers=ch.swisstopo.lubis-luftbilder-dritte-kantone,ch.swisstopo.swissimage-product_1946,ch.swisstopo.swissimage-product.metadata,ch.swisstopo.swissimage-product_3d,ch.swisstopo.pixelkarte-farbe-pk25.noscale,ch.swisstopo.lubis-luftbilder-dritte-firmen,ch.astra.unfaelle-personenschaeden_fahrraeder,ch.swisstopo.lubis-terrestrische_aufnahmen&layers_timestamp=99991231,1946,2022,,current,99991231,99990101,9999&layers_opacity=1,1,0.7,1,1,1,1,1)

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-590-time-slider-no-data/index.html)