### PR TITLE
Fix time selector button CSS

### DIFF
--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItemTimeSelector.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItemTimeSelector.vue
@@ -9,6 +9,7 @@ import {
     CURRENT_YEAR_WMTS_TIMESTAMP,
     YEAR_TO_DESCRIBE_ALL_OR_CURRENT_DATA,
 } from '@/api/layers/LayerTimeConfigEntry.class'
+import TextTruncate from '@/utils/components/TextTruncate.vue'
 
 const dispatcher = { dispatcher: 'MenuActiveLayersListItemTimeSelector.vue' }
 
@@ -119,14 +120,14 @@ function isSelected(timeEntry) {
     <button
         v-if="hasMultipleTimestamps"
         ref="timeSelectorButton"
-        class="btn btn-secondary me-2 btn-timestamp"
+        class="btn btn-secondary me-1 btn-timestamp btn-timestamp-selector"
         :class="{
             'btn-sm': compact,
-            'w-13': compact,
+            'btn-timestamp-selector-compact': compact,
         }"
         :data-cy="`time-selector-${layerId}-${layerIndex}`"
     >
-        {{ humanReadableCurrentTimestamp }}
+        <TextTruncate>{{ humanReadableCurrentTimestamp }}</TextTruncate>
     </button>
     <div
         v-if="hasMultipleTimestamps"
@@ -144,7 +145,7 @@ function isSelected(timeEntry) {
             <button
                 v-for="timeEntry in timeConfig.timeEntries"
                 :key="timeEntry.timestamp"
-                class="btn mb-1 me-1 btn-timestamp"
+                class="btn mb-1 me-1 btn-timestamp-selection-popup"
                 :class="{
                     'btn-primary': isSelected(timeEntry),
                     'btn-light': !isSelected(timeEntry),
@@ -152,7 +153,7 @@ function isSelected(timeEntry) {
                 :data-cy="`time-select-${timeEntry.timestamp}`"
                 @click="handleClickOnTimestamp(timeEntry.year)"
             >
-                {{ renderHumanReadableTimestamp(timeEntry) }}
+                <TextTruncate>{{ renderHumanReadableTimestamp(timeEntry) }}</TextTruncate>
             </button>
         </div>
     </div>
@@ -166,7 +167,22 @@ function isSelected(timeEntry) {
     background: white;
     grid-template-columns: 1fr 1fr 1fr;
 }
-.btn-timestamp {
-    white-space: nowrap;
+.btn-timestamp-selection-popup {
+    max-width: 100px;
+}
+.btn-timestamp-selector {
+    font-size: small;
+    $btn-width: 68px; // 68px allow the word "Actual" in all languages without being truncated
+    // Here we need to use min/max-width otherwise the size is not always identical over all layers
+    min-width: $btn-width;
+    max-width: $btn-width;
+
+    &-compact {
+        $btn-width: 60px; // 60px allow the word "Actual" in all languages without being truncated
+        min-width: $btn-width;
+        max-width: $btn-width;
+        padding-top: 2px;
+        padding-bottom: 2px;
+    }
 }
 </style>

--- a/src/modules/menu/components/common/MenuItemCheckBox.vue
+++ b/src/modules/menu/components/common/MenuItemCheckBox.vue
@@ -3,6 +3,8 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { toRefs } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import TextTruncate from '@/utils/components/TextTruncate.vue'
+
 const model = defineModel({ type: Boolean })
 const emits = defineEmits(['click'])
 const i18n = useI18n()
@@ -39,7 +41,9 @@ function onClick(ev) {
             >
                 <FontAwesomeIcon :icon="`far fa-${model ? 'check-' : ''}square`" />
             </button>
-            <label v-if="label" class="ms-2 menu-check-box-item-name">{{ i18n.t(label) }}</label>
+            <label v-if="label" class="ms-2 menu-check-box-item-name"
+                ><TextTruncate>{{ i18n.t(label) }}</TextTruncate></label
+            >
         </div>
     </div>
 </template>

--- a/src/modules/menu/scss/menu-items.scss
+++ b/src/modules/menu/scss/menu-items.scss
@@ -33,7 +33,4 @@
 .menu-name {
     flex-grow: 1;
     text-align: left;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow-x: hidden;
 }


### PR DESCRIPTION
The content of the button did not always fit (e.g. for "actual"). To solve this
we use the TextTruncate everywhere in the menu entry which handle text truncate
with tippy.

Also make sure that the time selector button are always the same size

This solve the issue below 

![image](https://github.com/geoadmin/web-mapviewer/assets/67745584/912a8654-1939-4d3d-88f7-7d2cedb0bfd2)


[Test link with time enabled layers](https://sys-map.dev.bgdi.ch/preview/bug-year-selector-css/index.html#/map?lang=de&center=2643898.46,1193053.29&z=2&bgLayer=ch.swisstopo.pixelkarte-grau&topic=ech&layers=ch.swisstopo.lubis-luftbilder-dritte-kantone@year=9999;ch.swisstopo.swissimage-product_1946;ch.swisstopo.swissimage-product.metadata@year=2022;ch.swisstopo.swissimage-product_3d@year=9999,f;ch.swisstopo.pixelkarte-farbe-pk25.noscale@year=9999;ch.swisstopo.lubis-luftbilder-dritte-firmen@year=9999;ch.astra.unfaelle-personenschaeden_fahrraeder@year=9999;ch.swisstopo.lubis-terrestrische_aufnahmen@year=9999;ch.bafu.gewaesserschutz-chemischer_zustand_ammonium@year=9999)

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-year-selector-css/index.html)