### PR TITLE
PB-669 : separate html popup request from getFeature

### DIFF
--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -132,7 +132,7 @@ function dispatchLayersFromUrlIntoStore(to, store, urlParamValue) {
                                 store.getters.getLayerConfigById(parsedLayer.id),
                                 featureId,
                                 store.state.position.projection,
-                                { lang: store.state.i18n.lang }
+                                store.state.i18n.lang
                             )
                         )
                     })

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -12,6 +12,7 @@ import {
     parseLayersParam,
     transformLayerIntoUrlString,
 } from '@/router/storeSync/layersParamParser'
+import { flattenExtent } from '@/utils/coordinates/coordinateUtils.js'
 import { getExtentOfGeometries } from '@/utils/geoJsonUtils'
 import log from '@/utils/logging'
 
@@ -132,7 +133,12 @@ function dispatchLayersFromUrlIntoStore(to, store, urlParamValue) {
                                 store.getters.getLayerConfigById(parsedLayer.id),
                                 featureId,
                                 store.state.position.projection,
-                                store.state.i18n.lang
+                                {
+                                    lang: store.state.i18n.lang,
+                                    screenWidth: store.state.ui.width,
+                                    screenHeight: store.state.ui.height,
+                                    mapExtent: flattenExtent(store.getters.extent),
+                                }
                             )
                         )
                     })

--- a/src/store/modules/features.store.js
+++ b/src/store/modules/features.store.js
@@ -648,12 +648,12 @@ export default {
                 // we avoid requesting the drawings and external layers, they're not handled here
                 if (rootState.layers.config.find((layer) => layer.id === feature.layer.id)) {
                     featuresPromises.push(
-                        getFeature(
-                            feature.layer,
-                            feature.id,
-                            rootState.position.projection,
-                            rootState.i18n.lang
-                        )
+                        getFeature(feature.layer, feature.id, rootState.position.projection, {
+                            lang: rootState.i18n.lang,
+                            screenWidth: rootState.ui.width,
+                            screenHeight: rootState.ui.height,
+                            mapExtent: flattenExtent(rootState.getters.mapExtent),
+                        })
                     )
                 }
             })

--- a/tests/cypress/fixtures/features/features.fixture.json
+++ b/tests/cypress/fixtures/features/features.fixture.json
@@ -2,11 +2,11 @@
   "results": [
     {
       "geometry": {
-        "type": "Point",
-        "coordinates": [
+        "type": "MultiPoint",
+        "coordinates": [[
           2600000.0,
           1200000.0
-        ]
+        ]]
       },
       "layerBodId": "test.wms.layer",
       "bbox": [

--- a/tests/cypress/tests-e2e/featureSelection.cy.js
+++ b/tests/cypress/tests-e2e/featureSelection.cy.js
@@ -128,7 +128,7 @@ describe('Testing the feature selection', () => {
 
             cy.get(mapSelector).click()
             cy.wait(`@${standardLayer}_identify`)
-            cy.wait(`@featureDetail_${expectedFeatureIds[0]}`)
+            cy.wait(`@htmlPopup`)
 
             cy.url().should((url) => {
                 // the viewport is smaller than 400 px, 'bottompanel' is the only possible option for
@@ -156,7 +156,7 @@ describe('Testing the feature selection', () => {
 
             cy.get(mapSelector).click(100, 100)
             cy.wait(`@${standardLayer}_identify`)
-            cy.wait(`@featureDetail_${expectedFeatureIds[1]}`)
+            cy.wait(`@htmlPopup`)
 
             cy.url().should((url) => {
                 new URLSearchParams(url.split('map')[1])
@@ -203,7 +203,7 @@ describe('Testing the feature selection', () => {
 
             cy.get(mapSelector).click()
             cy.wait(`@${timeLayer}_identify`)
-            cy.wait(`@featureDetail_${expectedFeatureIds[0]}`)
+            cy.wait(`@htmlPopup`)
 
             cy.url().should((url) => {
                 new URLSearchParams(url.split('map')[1])
@@ -284,11 +284,11 @@ describe('Testing the feature selection', () => {
             // waiting for each feature detail to be loaded (can take a while with the stubbing, so it can lead to timeouts
             // with further selectors if not properly waited)
             for (
-                let featureId = 1;
-                featureId <= DEFAULT_FEATURE_COUNT_RECTANGLE_SELECTION;
-                featureId++
+                let featureCount = 0;
+                featureCount < DEFAULT_FEATURE_COUNT_RECTANGLE_SELECTION;
+                featureCount++
             ) {
-                cy.wait(`@featureDetail_${featureId}`)
+                cy.wait(`@htmlPopup`)
             }
 
             cy.log('scrolling down at the bottom of the list')
@@ -312,11 +312,11 @@ describe('Testing the feature selection', () => {
 
             // same as above, waiting for each feature deatil to be loaded
             for (
-                let featureId = DEFAULT_FEATURE_COUNT_RECTANGLE_SELECTION + 1;
-                featureId <= 2 * DEFAULT_FEATURE_COUNT_RECTANGLE_SELECTION;
-                featureId++
+                let featureCount = 0;
+                featureCount < DEFAULT_FEATURE_COUNT_RECTANGLE_SELECTION;
+                featureCount++
             ) {
-                cy.wait(`@featureDetail_${featureId}`)
+                cy.wait(`@htmlPopup`)
             }
             cy.get('@highlightedFeatures')
                 .find('[data-cy="feature-item"]')
@@ -345,7 +345,7 @@ describe('Testing the feature selection', () => {
                 y: -80,
             })
             cy.wait('@identifySingleFeature')
-            cy.wait('@featureDetail')
+            cy.wait(`@htmlPopup`)
 
             cy.get('@highlightedFeatures').should('be.visible')
             cy.get('@highlightedFeatures').find('[data-cy="feature-item"]').should('have.length', 1)


### PR DESCRIPTION
identify request already provides us with all what we need (feature data), the only thing missing is the HTML popup.

This means getFeature request is now only called when the app is loaded with pre-selected features.

This reduces the number of calls to our backend for an identify on the map (should be a bit faster)

[Test link](https://sys-map.dev.bgdi.ch/preview/feat_pb-669_less_get_feature_requests/index.html)