### PR TITLE
PB-703: Fix /index.html share embed - #patch

### DIFF
--- a/src/utils/__tests__/utils.spec.js
+++ b/src/utils/__tests__/utils.spec.js
@@ -47,6 +47,9 @@ describe('utils', () => {
 
     describe('transformUrlMapToEmbed', () => {
         it('transform #/map to #/embed', () => {
+            expect(transformUrlMapToEmbed('https://map.geo.admin.ch/index.html#/map')).to.equal(
+                'https://map.geo.admin.ch/index.html#/embed'
+            )
             expect(transformUrlMapToEmbed('https://map.geo.admin.ch/#/map')).to.equal(
                 'https://map.geo.admin.ch/#/embed'
             )
@@ -73,9 +76,6 @@ describe('utils', () => {
                 'https://map.geo.admin.ch/#/map/view',
                 'https://map.geo.admin.ch/#/hello',
                 'https://map.geo.admin.ch/#/hello?lang=de',
-                'https://map.geo.admin.ch/map',
-                'https://map.geo.admin.ch/map?de',
-                'https://map.geo.admin.ch/test#/map',
             ]
             urls.forEach((url) => expect(transformUrlMapToEmbed(url)).to.equal(url))
         })

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -219,9 +219,7 @@ export function parseUrlHashQuery(url) {
  */
 export function transformUrlMapToEmbed(url) {
     const { urlObj, hash, query } = parseUrlHashQuery(url)
-    if (urlObj.pathname !== '/') {
-        return url
-    }
+    log.debug(`Transform url from map to embed hash=${hash}`, urlObj)
     if (hash === '#/map') {
         urlObj.hash = `#/embed${query}`
     }


### PR DESCRIPTION
If you access the viewer using /index.html, then in the share embed the URL
for the iframe didn't used #/embed but still #/map view

This was because we return if the path was not the root `/`

[Test link](https://sys-map.int.bgdi.ch/preview/bug-pb-703-iframe-embed/index.html)