### PR TITLE
PB-705 : fix feature search on aggregate layers

### DIFF
--- a/src/api/layers/GeoAdminAggregateLayer.class.js
+++ b/src/api/layers/GeoAdminAggregateLayer.class.js
@@ -78,6 +78,8 @@ export default class GeoAdminAggregateLayer extends GeoAdminLayer {
      *   is `[]`
      * @param {Boolean} [layerData.hasLegend=false] Define if this layer has a legend that can be
      *   shown to users to explain its content. Default is `false`
+     * @param {Boolean} [layerData.searchable=false] Define if this layer's features can be searched
+     *   through the search bar. Default is `false`
      * @param {[AggregateSubLayer]} layerData.subLayers
      * @throws InvalidLayerDataError if no `layerData` is given or if it is invalid
      */
@@ -97,6 +99,7 @@ export default class GeoAdminAggregateLayer extends GeoAdminLayer {
             topics = [],
             subLayers = [],
             hasLegend = false,
+            searchable = false,
         } = layerData
         super({
             name,
@@ -113,6 +116,7 @@ export default class GeoAdminAggregateLayer extends GeoAdminLayer {
             topics,
             timeConfig,
             hasLegend,
+            searchable,
         })
         this.subLayers = [...subLayers]
     }

--- a/src/api/layers/layers.api.js
+++ b/src/api/layers/layers.api.js
@@ -187,6 +187,7 @@ const generateClassForLayerConfig = (layerConfig, id, allOtherLayers, lang) => {
                     topics,
                     subLayers,
                     hasLegend: !!hasLegend,
+                    searchable,
                 })
 
                 break

--- a/src/api/search.api.js
+++ b/src/api/search.api.js
@@ -163,6 +163,10 @@ function parseLocationResult(result, outputProjection) {
             extent.push(bottomLeft, topRight)
         }
     }
+    // when no zoom and no extent are given, we go 1:25'000 map by default
+    if (!zoom && extent.length === 0) {
+        zoom = outputProjection.get1_25000ZoomLevel()
+    }
     return {
         resultType: SearchResultTypes.LOCATION,
         id: featureId,
@@ -248,7 +252,7 @@ async function searchLayerFeatures(outputProjection, queryString, layer, lang, c
             resultWithAttrs.map((layerFeature) => {
                 const layerContent = parseLayerResult(layerFeature)
                 const locationContent = parseLocationResult(layerFeature, outputProjection)
-                const title = `<strong>${layer.name}</strong><br/>${layerContent.title}&nbsp;<small>${layerContent.description}</small>`
+                const title = `<strong>${layer.name}</strong><br/>${layerContent.title}`
                 return {
                     ...layerContent,
                     ...locationContent,


### PR DESCRIPTION
Using RegBL (RBD) as basis. Removing feature detail from search result, as it can be unformatted content in some cases (with RegBL it's the same as the title without formatting, so no benefit of showing it)