### PR TITLE
PB-707 : show tooltip on iframe - #patch

### DIFF
--- a/src/store/plugins/click-on-map-management.plugin.js
+++ b/src/store/plugins/click-on-map-management.plugin.js
@@ -35,11 +35,7 @@ const clickOnMapManagementPlugin = (store) => {
                         ...dispatcher,
                     })
                     .then(() => {
-                        // while embedded, we do not change the way the feature tooltip is shown after
-                        // app initialization, this way the user that embed our app can choose to disable
-                        // tooltip entirely (and manage feature selection through the postMessage API)
                         if (
-                            !state.ui.embed &&
                             store.getters.noFeatureInfo &&
                             state.features.selectedFeaturesByLayerId.length > 0
                         ) {


### PR DESCRIPTION
The old viewer had always shown tooltip when showing the app in embed mode. With our app we changed that a bit, and that breaks a lot of our customer's integrations (through iframe).

Revert that so that the first feature selection in an iFrame shows a tooltip, only the pre-selection of feature should be impacted by the featureInfo URL param (or showTooltip in legacy)

[Test link](https://sys-map.int.bgdi.ch/preview/bug-pb-707-tooltip-iframe/index.html)