### PR TITLE
PB-709 : also change 3D specific config timestamp - #patch

### DIFF
--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -481,6 +481,13 @@ const actions = {
             year: year,
             dispatcher,
         })
+        // if this layer has a 3D counterpart, we also update its timestamp (keep it in sync)
+        if (layer.idIn3d) {
+            const layerIn3d = getters.getLayerConfigById(layer.idIn3d)
+            if (layerIn3d?.timeConfig) {
+                commit('setLayerYear', { layer: layerIn3d, year, dispatcher })
+            }
+        }
     },
 
     /**


### PR DESCRIPTION
was forgotten when switching to this new approach that time config needs to be synced too (only the time config of the "parent" aka 2d config was changed through the UI)

[Test link](https://sys-map.int.bgdi.ch/preview/bug-pb-709-3d-config-timestamp/index.html)