### PR TITLE
PB-713: revert to use the same logic as in the old geoadmin. - #patch

### DIFF
--- a/src/modules/map/components/openlayers/utils/styleFromLiterals.js
+++ b/src/modules/map/components/openlayers/utils/styleFromLiterals.js
@@ -194,7 +194,7 @@ OlStyleForPropertyValue.prototype.initialize_ = function (properties) {
 
 OlStyleForPropertyValue.prototype.pushOrInitialize_ = function (geomType, key, styleSpec) {
     // Happens when styling is only resolution dependent (unique type only)
-    if (!key) {
+    if (key === undefined) {
         key = this.defaultVal
     }
     if (!this.styles[geomType][key]) {


### PR DESCRIPTION


[Test link](https://sys-map.int.bgdi.ch/preview/fix-713-missing-treasure-hunt-icons/index.html)