### PR TITLE
PB-716 : guess WGS84 coordinate order in the searchbar - #patch

### DIFF
--- a/src/utils/coordinates/__test__/coordinateExtractors.spec.js
+++ b/src/utils/coordinates/__test__/coordinateExtractors.spec.js
@@ -346,7 +346,9 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     acceptableDelta
                 )
             })
-            it('Returns coordinate with DMS format with cardinal point information in the south west hemisphere', () => {
+            // To be reactivated when supporting world-wide coverage (in the meantime the extractor will only output coordinate
+            // that are in Switzerland, inverting x/y -> y/x if necessary)
+            it.skip('Returns coordinate with DMS format with cardinal point information in the south west hemisphere', () => {
                 const pointInSouthAmericaInEPSG3857 = [-6504867, -4110554]
                 const pointInSouthAmericaInEPSG4326 = ['34°36\'23.937"S', '58°26\'3.172"W']
                 checkXY(
@@ -366,7 +368,9 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     acceptableDelta
                 )
             })
-            it('Returns coordinate with DMS format with cardinal point information in the north west hemisphere', () => {
+            // To be reactivated when supporting world-wide coverage (in the meantime the extractor will only output coordinate
+            // that are in Switzerland, inverting x/y -> y/x if necessary)
+            it.skip('Returns coordinate with DMS format with cardinal point information in the north west hemisphere', () => {
                 const pointInNorthAmericaInEPSG3857 = [-9457276, 4961988]
                 const pointInNorthAmericaInEPSG4326 = ['40°39\'27.846"N', '84°57\'22.161"W']
                 checkXY(
@@ -386,7 +390,9 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     acceptableDelta
                 )
             })
-            it('Returns coordinate with DMS format with cardinal point information in the south east hemisphere', () => {
+            // To be reactivated when supporting world-wide coverage (in the meantime the extractor will only output coordinate
+            // that are in Switzerland, inverting x/y -> y/x if necessary)
+            it.skip('Returns coordinate with DMS format with cardinal point information in the south east hemisphere', () => {
                 const pointInOceaniaInEPSG3857 = [12894439, -3757563]
                 const pointInOceaniaInEPSG4326 = ['31°57\'22.332"S', '115°49\'57.779"E']
                 checkXY(

--- a/src/utils/coordinates/coordinateExtractors.js
+++ b/src/utils/coordinates/coordinateExtractors.js
@@ -1,6 +1,6 @@
 import proj4 from 'proj4'
 
-import { WGS84 } from '@/utils/coordinates/coordinateSystems'
+import { LV95, WGS84 } from '@/utils/coordinates/coordinateSystems'
 import { reprojectUnknownSrsCoordsToWGS84 } from '@/utils/coordinates/coordinateUtils'
 import { toPoint as mgrsToWGS84 } from '@/utils/militaryGridProjection'
 
@@ -22,6 +22,8 @@ const REGEX_METRIC_COORDINATES =
 
 // Military Grid Reference System (MGRS)
 const REGEX_MILITARY_GRID = /^3[123][\sa-z]{3}[\s\d]*/i
+
+const LV95_BOUNDS_IN_WGS84 = LV95.getBoundsAs(WGS84)
 
 const numericalExtractor = (regexMatches) => {
     // removing thousand separators
@@ -96,8 +98,13 @@ const webmercatorExtractor = (regexMatches) => {
                 break
         }
     }
-    if (lon && lat && WGS84.isInBounds(lon, lat)) {
-        return [lon, lat]
+    if (lon && lat) {
+        if (LV95_BOUNDS_IN_WGS84.isInBounds(lon, lat)) {
+            return [lon, lat]
+        }
+        if (LV95_BOUNDS_IN_WGS84.isInBounds(lat, lon)) {
+            return [lat, lon]
+        }
     }
     return null
 }

--- a/tests/cypress/tests-e2e/search/coordinates-search.cy.js
+++ b/tests/cypress/tests-e2e/search/coordinates-search.cy.js
@@ -55,16 +55,24 @@ describe('Testing coordinates typing in search bar', () => {
             expect(feature[1]).to.be.approximately(expectedCenter[1], acceptableDelta)
         })
     }
-    const standardCheck = (x, y, acceptableDelta = 0.0) => {
+    const standardCheck = (x, y, options = {}) => {
+        const { acceptableDelta = 0.0, withInversion = false } = options
         cy.get(searchbarSelector).should('be.visible')
         cy.get(searchbarSelector).paste(`${x} ${y}`)
         checkCenterInStore(acceptableDelta)
         checkZoomLevelInStore()
         checkThatCoordinateAreHighlighted(acceptableDelta)
+        if (withInversion) {
+            cy.get(searchbarSelector).clear()
+            cy.get(searchbarSelector).paste(`${y} ${x}`)
+            checkCenterInStore(acceptableDelta)
+            checkZoomLevelInStore()
+            checkThatCoordinateAreHighlighted(acceptableDelta)
+        }
     }
 
     it('Paste and clear LV95 coordinates in search bar', () => {
-        standardCheck(expectedCenterLV95[0], expectedCenterLV95[1])
+        standardCheck(expectedCenterLV95[0], expectedCenterLV95[1], { withInversion: true })
         cy.get('[data-cy="searchbar-clear"]').click()
         // checking that search bar has been emptied
         cy.readStoreValue('state.search.query').should('be.empty')
@@ -79,21 +87,32 @@ describe('Testing coordinates typing in search bar', () => {
             return `${degree}° ${(minutes * 60.0).toFixed(4)}'`
         })
         const acceptableDelta = 0.25
-        standardCheck(expectedCenterWGS84[0], expectedCenterWGS84[1], acceptableDelta)
+        standardCheck(expectedCenterWGS84[0], expectedCenterWGS84[1], {
+            acceptableDelta,
+            withInversion: true,
+        })
         // clear the bar
         cy.get('[data-cy="searchbar-clear"]').click()
         // checking that search bar has been emptied
         cy.readStoreValue('state.search.query').should('be.empty')
-        standardCheck(expectedCenterWGS84_DD[0], expectedCenterWGS84_DD[1], acceptableDelta)
+        standardCheck(expectedCenterWGS84_DD[0], expectedCenterWGS84_DD[1], {
+            acceptableDelta,
+            withInversion: true,
+        })
     })
 
     it('Paste EPSG:3857 (Web-Mercator) coordinate', () => {
         const acceptableDelta = 0
-        standardCheck(expectedCenterWebMercator[0], expectedCenterWebMercator[1], acceptableDelta)
+        standardCheck(expectedCenterWebMercator[0], expectedCenterWebMercator[1], {
+            acceptableDelta,
+        })
     })
 
     it('Paste EPSG:21781 (LV03) coordinates', () => {
-        standardCheck(expectedCenterLV03[0], expectedCenterLV03[1], 0.1)
+        standardCheck(expectedCenterLV03[0], expectedCenterLV03[1], {
+            acceptableDelta: 0.1,
+            withInversion: true,
+        })
     })
 
     context('What3Words input', () => {


### PR DESCRIPTION
without world-wide coverage, it doesn't really make sense for our users that we do not do the same guessing as the old viewer was doing. So adding it back.

This will need to be discussed/re-thinked when we will be adding world-wide coverage, as an inverted WGS84 is still valid in this context (pointing to something outside CH...)

[Test link](https://sys-map.int.bgdi.ch/preview/fix-pb-716-inverted-wgs84-in-searchbar/index.html)