### PR TITLE
PB-717 : add current year to time slider years - #patch

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -313,7 +313,7 @@ export const OLDEST_YEAR = 1844
  *
  * @type {Number}
  */
-export const YOUNGEST_YEAR = new Date().getFullYear() - 1
+export const YOUNGEST_YEAR = new Date().getFullYear()
 
 /**
  * Don't show third party disclaimer for iframe with one of these hosts as src


### PR DESCRIPTION
some layers, such as ch.swisstopo.pixelkarte-farbe-pk25.noscale, uses the current year as a valid timestamp. Removing the "minus one" to the youngest year of the time slider to be able to show it.

[Test link](https://sys-map.int.bgdi.ch/preview/fix-pb-717-current-year-in-timeslider/index.html)