### PR TITLE
PB-718 : adding cardinal letter support for most WGS84 search input - #patch

### DIFF
--- a/src/utils/coordinates/__test__/coordinateExtractors.spec.js
+++ b/src/utils/coordinates/__test__/coordinateExtractors.spec.js
@@ -165,6 +165,10 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     undefined,
                     'must not accept text after the coordinates'
                 )
+                expect(coordinateFromString('47.0.3, 7.4,0')).to.eq(
+                    undefined,
+                    'must not accept text after the coordinates'
+                )
                 expect(coordinateFromString('test47.0, 7.4')).to.eq(
                     undefined,
                     'must not accept text before the coordinates'

--- a/src/utils/coordinates/__test__/coordinateExtractors.spec.js
+++ b/src/utils/coordinates/__test__/coordinateExtractors.spec.js
@@ -53,10 +53,14 @@ describe('Unit test functions from coordinateExtractors.js', () => {
          * @param {Number} xExpectedValue What coordinateFromString is expected to output as X
          * @param {Number} yExpectedValue What coordinateFromString is expected to output as Y
          * @param {CoordinateSystem} projection The output projection of the parsing
-         * @param {Number} acceptableDelta If a delta with the expected result is acceptable
-         *   (default is zero)
+         * @param {Object} options
+         * @param {Number} [options.acceptableDelta] If a delta with the expected result is
+         *   acceptable (default is zero)
+         * @param {Boolean} [options.testInverted] If the X and Y should also be tested inverted in
+         *   the test string. Default is true.
          */
-        const checkXY = (x, y, xExpectedValue, yExpectedValue, projection, acceptableDelta = 0) => {
+        const checkXY = (x, y, xExpectedValue, yExpectedValue, projection, options = {}) => {
+            const { acceptableDelta = 0, testInverted = true } = options
             const valueOutputInCaseOfErr = `x: ${x}, y: ${y}, expected x: ${xExpectedValue}, expected y: ${yExpectedValue}`
             // checking with simple space and tab
             checkText(
@@ -130,6 +134,12 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                 acceptableDelta,
                 projection
             )
+            if (testInverted) {
+                checkXY(y, x, xExpectedValue, yExpectedValue, projection, {
+                    acceptableDelta,
+                    testInverted: false,
+                })
+            }
         }
 
         const expectedCenterLV95 = LV95.bounds.center
@@ -191,24 +201,41 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                 val.replace(/[°'"]/g, '')
             )
 
-            it('Returns coordinates with degree decimal (DD) format', () => {
+            it(`Returns coordinates with degree decimal (DD) format : ${expectedCenterWGS84_DD.join(',')}`, () => {
                 checkXY(
                     expectedCenterWGS84_DD[0],
                     expectedCenterWGS84_DD[1],
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
+                )
+                // also checking with cardinals
+                checkXY(
+                    `${expectedCenterWGS84_DD[0]} E`,
+                    `${expectedCenterWGS84_DD[1]} N`,
+                    expectedCenterLV95[0],
+                    expectedCenterLV95[1],
+                    LV95,
+                    { acceptableDelta, testInverted: true }
+                )
+                checkXY(
+                    `E ${expectedCenterWGS84_DD[0]}`,
+                    `N ${expectedCenterWGS84_DD[1]}`,
+                    expectedCenterLV95[0],
+                    expectedCenterLV95[1],
+                    LV95,
+                    { acceptableDelta, testInverted: true }
                 )
             })
-            it('Returns coordinates with DM (degree/minutes) format', () => {
+            it(`Returns coordinates with DM (degree/minutes) format : ${expectedCenterWGS84_DMS.join(',')}`, () => {
                 checkXY(
                     expectedCenterWGS84_DMS[0],
                     expectedCenterWGS84_DMS[1],
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
                 )
                 // removing space between degrees and minutes
                 checkXY(
@@ -216,7 +243,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
                 )
                 // removing space between minutes and seconds
                 checkXY(
@@ -224,7 +251,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
                 )
                 // removing space between degrees, minutes and seconds
                 checkXY(
@@ -234,10 +261,10 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
                 )
             })
-            it('Returns coordinates with DMS (degree/minutes/seconds) format', () => {
+            it(`Returns coordinates with DMS (degree/minutes/seconds) format : ${expectedCenterWGS84_DMS_No_NE.join(',')}`, () => {
                 const latWithSpaceBetweenDegAndMin = expectedCenterWGS84_DMS_No_NE[0].replace(
                     /°/g,
                     '° '
@@ -263,7 +290,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
                 )
                 checkXY(
                     latWithSpaceBetweenDegAndMin,
@@ -271,7 +298,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
                 )
                 checkXY(
                     latWithSpaceBetweenDegAndMinAndSec,
@@ -279,7 +306,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
                 )
 
                 // two single quote notation for seconds
@@ -289,7 +316,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
                 )
                 checkXY(
                     latWithSpaceBetweenDegAndMin.replace(/"/g, "''"),
@@ -297,7 +324,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
                 )
                 checkXY(
                     latWithSpaceBetweenDegAndMinAndSec.replace(/"/g, "''"),
@@ -305,27 +332,44 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
                 )
             })
-            it('Returns coordinate with DM format (degree minutes without symbols, aka Google style)', () => {
+            it(`Returns coordinate with DM format (degree minutes without symbols, aka Google style) : ${expectedCenterWGS84_DD_NoSymbol.join(',')}`, () => {
                 checkXY(
                     expectedCenterWGS84_DD_NoSymbol[0],
                     expectedCenterWGS84_DD_NoSymbol[1],
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
+                )
+                // also checking with cardinals
+                checkXY(
+                    `${expectedCenterWGS84_DD_NoSymbol[0]} N`,
+                    `${expectedCenterWGS84_DD_NoSymbol[1]} E`,
+                    expectedCenterLV95[0],
+                    expectedCenterLV95[1],
+                    LV95,
+                    { acceptableDelta, testInverted: true }
+                )
+                checkXY(
+                    `N ${expectedCenterWGS84_DD_NoSymbol[0]}`,
+                    `E ${expectedCenterWGS84_DD_NoSymbol[1]}`,
+                    expectedCenterLV95[0],
+                    expectedCenterLV95[1],
+                    LV95,
+                    { acceptableDelta, testInverted: true }
                 )
             })
-            it('Returns coordinate with DMS format (degree minutes without symbols, aka Google style)', () => {
+            it(`Returns coordinate with DMS format (degree minutes without symbols, aka Google style) : ${expectedCenterWGS84_DMS_NoSymbol.join(',')}`, () => {
                 checkXY(
                     expectedCenterWGS84_DMS_NoSymbol[0],
                     expectedCenterWGS84_DMS_NoSymbol[1],
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
                 )
             })
             it('Returns coordinate with DMS format with cardinal point information', () => {
@@ -335,15 +379,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
-                )
-                checkXY(
-                    expectedCenterWGS84_DMS[1],
-                    expectedCenterWGS84_DMS[0],
-                    expectedCenterLV95[0],
-                    expectedCenterLV95[1],
-                    LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
                 )
             })
             // To be reactivated when supporting world-wide coverage (in the meantime the extractor will only output coordinate
@@ -357,7 +393,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     pointInSouthAmericaInEPSG3857[0],
                     pointInSouthAmericaInEPSG3857[1],
                     WEBMERCATOR,
-                    acceptableDelta
+                    { acceptableDelta }
                 )
                 checkXY(
                     pointInSouthAmericaInEPSG4326[1],
@@ -365,7 +401,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     pointInSouthAmericaInEPSG3857[0],
                     pointInSouthAmericaInEPSG3857[1],
                     WEBMERCATOR,
-                    acceptableDelta
+                    { acceptableDelta }
                 )
             })
             // To be reactivated when supporting world-wide coverage (in the meantime the extractor will only output coordinate
@@ -379,7 +415,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     pointInNorthAmericaInEPSG3857[0],
                     pointInNorthAmericaInEPSG3857[1],
                     WEBMERCATOR,
-                    acceptableDelta
+                    { acceptableDelta }
                 )
                 checkXY(
                     pointInNorthAmericaInEPSG4326[1],
@@ -387,7 +423,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     pointInNorthAmericaInEPSG3857[0],
                     pointInNorthAmericaInEPSG3857[1],
                     WEBMERCATOR,
-                    acceptableDelta
+                    { acceptableDelta }
                 )
             })
             // To be reactivated when supporting world-wide coverage (in the meantime the extractor will only output coordinate
@@ -401,7 +437,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     pointInOceaniaInEPSG3857[0],
                     pointInOceaniaInEPSG3857[1],
                     WEBMERCATOR,
-                    acceptableDelta
+                    { acceptableDelta }
                 )
                 checkXY(
                     pointInOceaniaInEPSG4326[1],
@@ -409,7 +445,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     pointInOceaniaInEPSG3857[0],
                     pointInOceaniaInEPSG3857[1],
                     WEBMERCATOR,
-                    acceptableDelta
+                    { acceptableDelta }
                 )
             })
         })
@@ -426,10 +462,16 @@ describe('Unit test functions from coordinateExtractors.js', () => {
          */
         const checkSwissCoordinateSystem = (x, y, acceptableDelta) => {
             it('Returns coordinates when input is valid', () => {
-                checkXY(x, y, expectedCenterLV95[0], expectedCenterLV95[1], LV95, acceptableDelta)
+                checkXY(x, y, expectedCenterLV95[0], expectedCenterLV95[1], LV95, {
+                    acceptableDelta,
+                    testInverted: true,
+                })
             })
             it('Returns coordinates when input is entered backward', () => {
-                checkXY(y, x, expectedCenterLV95[0], expectedCenterLV95[1], LV95, acceptableDelta)
+                checkXY(y, x, expectedCenterLV95[0], expectedCenterLV95[1], LV95, {
+                    acceptableDelta,
+                    testInverted: true,
+                })
             })
             it("Returns coordinates when there's thousands separator", () => {
                 checkXY(
@@ -438,7 +480,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
                 )
                 checkXY(
                     numberWithThousandSeparator(x, ' '),
@@ -446,7 +488,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
                 )
             })
             it("Returns coordinates when there's thousands separator and input is entered backward", () => {
@@ -456,7 +498,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
                 )
                 checkXY(
                     numberWithThousandSeparator(y, ' '),
@@ -464,7 +506,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    acceptableDelta
+                    { acceptableDelta, testInverted: true }
                 )
             })
         }

--- a/src/utils/coordinates/__test__/coordinateExtractors.spec.js
+++ b/src/utils/coordinates/__test__/coordinateExtractors.spec.js
@@ -54,26 +54,36 @@ describe('Unit test functions from coordinateExtractors.js', () => {
          * @param {Number} yExpectedValue What coordinateFromString is expected to output as Y
          * @param {CoordinateSystem} projection The output projection of the parsing
          * @param {Object} options
-         * @param {Number} [options.acceptableDelta] If a delta with the expected result is
-         *   acceptable (default is zero)
-         * @param {Boolean} [options.testInverted] If the X and Y should also be tested inverted in
-         *   the test string. Default is true.
+         * @param {Number} [options.acceptableDelta=0] If a delta with the expected result is
+         *   acceptable. Default is `0`
+         * @param {Boolean} [options.testInverted=true] If the X and Y should also be tested
+         *   inverted in. Default is `true`
+         * @param {Boolean} [options.thousandSpaceSeparator=false] If the X and Y are using space as
+         *   thousand separator. Default is `false`
          */
         const checkXY = (x, y, xExpectedValue, yExpectedValue, projection, options = {}) => {
-            const { acceptableDelta = 0, testInverted = true } = options
-            const valueOutputInCaseOfErr = `x: ${x}, y: ${y}, expected x: ${xExpectedValue}, expected y: ${yExpectedValue}`
-            // checking with simple space and tab
-            checkText(
-                `${x} ${y}`,
-                [xExpectedValue, yExpectedValue],
-                'fails with space in between\n' + valueOutputInCaseOfErr,
-                acceptableDelta,
-                projection
-            )
+            const {
+                acceptableDelta = 0,
+                testInverted = true,
+                thousandSpaceSeparator = false,
+            } = options
+            const expectedOutput = `Expected: x=${xExpectedValue}, y=${yExpectedValue}`
+            if (!thousandSpaceSeparator) {
+                // NOTE: if the coordinates uses space as thousand separator we cannot use space
+                // as well as coordinates separator
+                // checking with simple space and tab
+                checkText(
+                    `${x} ${y}`,
+                    [xExpectedValue, yExpectedValue],
+                    `fails with space as coordinate separator\nInput: ${x} ${y}\n${expectedOutput}`,
+                    acceptableDelta,
+                    projection
+                )
+            }
             checkText(
                 `${x}\t${y}`,
                 [xExpectedValue, yExpectedValue],
-                'fails with tabs\n' + valueOutputInCaseOfErr,
+                `fails with tabs as coordinate separator\nInput: ${x}\\t${y}\n${expectedOutput}`,
                 acceptableDelta,
                 projection
             )
@@ -81,56 +91,56 @@ describe('Unit test functions from coordinateExtractors.js', () => {
             checkText(
                 `${x},${y}`,
                 [xExpectedValue, yExpectedValue],
-                'fails with coma\n' + valueOutputInCaseOfErr,
-                acceptableDelta,
-                projection
-            )
-            checkText(
-                `${x} ,${y}`,
-                [xExpectedValue, yExpectedValue],
-                'fails with space and coma\n' + valueOutputInCaseOfErr,
+                `fails with coma as coordinate separator\nInput: ${x},${y}\n${expectedOutput}`,
                 acceptableDelta,
                 projection
             )
             checkText(
                 `${x}, ${y}`,
                 [xExpectedValue, yExpectedValue],
-                'fails with coma and space\n' + valueOutputInCaseOfErr,
+                `fails with coma and space as coordinate separator\nInput: ${x}, ${y}\n${expectedOutput}`,
+                acceptableDelta,
+                projection
+            )
+            checkText(
+                `${x} ,${y}`,
+                [xExpectedValue, yExpectedValue],
+                `fails with coma and space as coordinate separator\nInput: ${x} ,${y}\n${expectedOutput}`,
                 acceptableDelta,
                 projection
             )
             checkText(
                 `${x} , ${y}`,
                 [xExpectedValue, yExpectedValue],
-                'fails with space, coma and space\n' + valueOutputInCaseOfErr,
+                `fails with coma and space as coordinate separator\nInput: ${x} , ${y}\n${expectedOutput}`,
                 acceptableDelta,
                 projection
             )
             checkText(
                 `${x}/${y}`,
                 [xExpectedValue, yExpectedValue],
-                'fails with slash\n' + valueOutputInCaseOfErr,
+                `fails with slash as coordinate separator\nInput: ${x}/${y}\n${expectedOutput}`,
                 acceptableDelta,
                 projection
             )
             checkText(
                 `${x} /${y}`,
                 [xExpectedValue, yExpectedValue],
-                'fails with space and slash\n' + valueOutputInCaseOfErr,
+                `fails with slash and space as coordinate separator\nInput: ${x} /${y}\n${expectedOutput}`,
                 acceptableDelta,
                 projection
             )
             checkText(
                 `${x}/ ${y}`,
                 [xExpectedValue, yExpectedValue],
-                'fails with slash and space\n' + valueOutputInCaseOfErr,
+                `fails with slash and space as coordinate separator\nInput: ${x}/ ${y}\n${expectedOutput}`,
                 acceptableDelta,
                 projection
             )
             checkText(
                 `${x} / ${y}`,
                 [xExpectedValue, yExpectedValue],
-                'fails with space, slash and space\n' + valueOutputInCaseOfErr,
+                `fails with slash and space as coordinate separator\nInput: ${x} / ${y}\n${expectedOutput}`,
                 acceptableDelta,
                 projection
             )
@@ -138,6 +148,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                 checkXY(y, x, xExpectedValue, yExpectedValue, projection, {
                     acceptableDelta,
                     testInverted: false,
+                    thousandSpaceSeparator,
                 })
             }
         }
@@ -488,7 +499,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    { acceptableDelta, testInverted: true }
+                    { acceptableDelta, testInverted: true, thousandSpaceSeparator: true }
                 )
             })
             it("Returns coordinates when there's thousands separator and input is entered backward", () => {
@@ -506,7 +517,7 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     expectedCenterLV95[0],
                     expectedCenterLV95[1],
                     LV95,
-                    { acceptableDelta, testInverted: true }
+                    { acceptableDelta, testInverted: true, thousandSpaceSeparator: true }
                 )
             })
         }

--- a/src/utils/coordinates/coordinateExtractors.js
+++ b/src/utils/coordinates/coordinateExtractors.js
@@ -3,116 +3,131 @@ import proj4 from 'proj4'
 import { LV95, WGS84 } from '@/utils/coordinates/coordinateSystems'
 import { reprojectUnknownSrsCoordsToWGS84 } from '@/utils/coordinates/coordinateUtils'
 import { toPoint as mgrsToWGS84 } from '@/utils/militaryGridProjection'
-import { isNumber } from '@/utils/numberUtils.js'
 
-// 47.5 7.5
-const REGEX_WEB_MERCATOR = /^\s*([\d]{1,3}[.\d]+)\s*[ ,/]+\s*([\d]{1,3}[.\d]+)\s*$/i
-// 47.5N 7.5E
-const REGEX_WEB_MERCATOR_WITH_CARDINALS =
-    /^\s*([\d]{1,3}[.\d]+)\s*([NSEW]?)\s*[ ,/]+\s*([\d]{1,3}[.\d]+)\s*([NSEW]?)\s*$/i
-const REGEX_WEB_MERCATOR_WITH_PRE_FIXED_CARDINALS =
-    /^\s*([NSEW]?)\s*([\d]{1,3}[.\d]+)\s*[ ,/]+\s*([NSEW]?)\s*([\d]{1,3}[.\d]+)\s*$/i
-// 47°31.8' 7°31.8'
-const REGEX_MERCATOR_WITH_DEGREES =
-    /^\s*([\d]{1,3})[° ]+([\d]+[.,]?[\d]*)['′]?\s*[,/]?\s*([\d]{1,3})[° ]+([\d.,]+)['′]?\s*$/i
-// 47°31.8'N 7°31.8'E
-const REGEX_MERCATOR_WITH_DEGREES_WITH_CARDINALS =
-    /^\s*([\d]{1,3})[° ]+([\d]+[.,]?[\d]*)['′]?\s*([NSEW]?)\s*[,/]?\s*([\d]{1,3})[° ]+([\d.,]+)['′]?\s*([NSEW]?)\s*$/i
-// N47°31.8' E7°31.8'
-const REGEX_MERCATOR_WITH_DEGREES_WITH_PRE_FIXED_CARDINALS =
-    /^\s*([NSEW]?)\s*([\d]{1,3})[° ]+([\d]+[.,]?[\d]*)['′]?\s*[,/]?\s*([NSEW]?)\s*([\d]{1,3})[° ]+([\d.,]+)['′]?\s*$/i
-// 47°38'48'' 7°38'48'' or 47°38'48" 7°38'48"
-const REGEX_MERCATOR_WITH_DEGREES_MINUTES =
-    /^\s*([\d]{1,3})[° ]+([\d]{1,2})[' ]+([\d.]+)['′"″]{0,2}\s*[,/]?\s*([\d]{1,3})[° ]+([\d.]+)['′ ]+([\d.]+)['′"″]{0,2}\s*$/i
-// 47°38'48''N 7°38'48''E or 47°38'48"N 7°38'48"E
-const REGEX_MERCATOR_WITH_DEGREES_MINUTES_AND_CARDINAL_POINT =
-    /^\s*([\d]{1,3})[° ]+\s*([\d]{1,2})[′' ]+\s*([\d.]+)['′"″ ]*([NSEW]?)\s*[,/]?\s*([\d]{1,3})[° ]+\s*([\d.]+)['′ ]+\s*([\d.]+)['′"″ ]*([NSEW]?)\s*$/i
+const RE_DEGREE_IDENTIFIER = '\\s*°\\s*'
+const RE_DEGREE = `\\d{1,3}(\\.\\d+)?`
+const RE_MIN_IDENTIFIER = "\\s*['`´]\\s*"
+const RE_MIN = `\\d{1,2}(\\.\\d+)?`
+const RE_SEC_IDENTIFIER = '\\s*("|[\'`´]{2})\\s*'
+const RE_SEC = `\\d{1,2}(\\.\\d+)?`
+const RE_CARD = '[NSEW]'
+const RE_SEPARATOR = '\\s*?[ \\t,/]\\s*'
+
+// 47.5 7.5 or 47.5° 7.5°
+const REGEX_WGS_84 = new RegExp(
+    `^(?<degree1>${RE_DEGREE})(${RE_DEGREE_IDENTIFIER})?` +
+        `${RE_SEPARATOR}` +
+        `(?<degree2>${RE_DEGREE})(${RE_DEGREE_IDENTIFIER})?$`,
+    'i'
+)
+// 47.5N 7.5E or 47.5°N 7.5°E
+const REGEX_WGS_84_WITH_CARDINALS = new RegExp(
+    `^(?<degree1>${RE_DEGREE})(${RE_DEGREE_IDENTIFIER})?` +
+        `\\s*(?<card1>${RE_CARD})` +
+        `${RE_SEPARATOR}` +
+        `(?<degree2>${RE_DEGREE})(${RE_DEGREE_IDENTIFIER})?` +
+        `\\s*(?<card2>${RE_CARD})$`,
+    'i'
+)
+// N47.5 E7.5 or N47.5 E7.5
+const REGEX_WGS_84_WITH_PRE_FIXED_CARDINALS = new RegExp(
+    `^(?<card1>${RE_CARD})\\s*` +
+        `(?<degree1>${RE_DEGREE})(${RE_DEGREE_IDENTIFIER})?` +
+        `${RE_SEPARATOR}` +
+        `(?<card2>${RE_CARD})\\s*` +
+        `(?<degree2>${RE_DEGREE})(${RE_DEGREE_IDENTIFIER})?$`,
+    'i'
+)
+// 47°31.8' 7°31.8' or 47°31.8' 7°31.8' or 47°31.8'30"N 7°31.8'30.4"E or 47°31.8'N 7°31.8'E or without °'" 47 31.8 30 N 7 31.8 30.4 E
+const REGEX_WGS_84_WITH_MIN = new RegExp(
+    `^(?<degree1>${RE_DEGREE})(${RE_DEGREE_IDENTIFIER}|\\s+)(?<min1>${RE_MIN})(${RE_MIN_IDENTIFIER})?` +
+        `(\\s*(?<card1>${RE_CARD}))?` +
+        `${RE_SEPARATOR}` +
+        `(?<degree2>${RE_DEGREE})(${RE_DEGREE_IDENTIFIER}|\\s+)(?<min2>${RE_MIN})(${RE_MIN_IDENTIFIER})?` +
+        `(\\s*(?<card2>${RE_CARD}))?$`,
+    'i'
+)
+// N47°31.8' E7°31.8'or without °'" N 47 31.8 E 7 31.8
+const REGEX_WGS_84_WITH_MIN_PREFIXED = new RegExp(
+    `^(?<card1>${RE_CARD})\\s*` +
+        `(?<degree1>${RE_DEGREE})(${RE_DEGREE_IDENTIFIER}|\\s+)(?<min1>${RE_MIN})(${RE_MIN_IDENTIFIER})?` +
+        `${RE_SEPARATOR}` +
+        `(?<card2>${RE_CARD})\\s*` +
+        `(?<degree2>${RE_DEGREE})(${RE_DEGREE_IDENTIFIER}|\\s+)(?<min2>${RE_MIN})(${RE_MIN_IDENTIFIER})?$`,
+    'i'
+)
+// 47°31.8'30" 7°31.8'30.4" or 47°31.8'30"N 7°31.8'30.4"E or without °'" 47 31.8 30 N 7 31.8 30.4 E
+const REGEX_WGS_84_WITH_SECONDS = new RegExp(
+    `^(?<degree1>${RE_DEGREE})(${RE_DEGREE_IDENTIFIER}|\\s+)(?<min1>${RE_MIN})(${RE_MIN_IDENTIFIER}|\\s+)(?<sec1>${RE_SEC})(${RE_SEC_IDENTIFIER})?` +
+        `(\\s*(?<card1>${RE_CARD}))?` +
+        `${RE_SEPARATOR}` +
+        `(?<degree2>${RE_DEGREE})(${RE_DEGREE_IDENTIFIER}|\\s+)(?<min2>${RE_MIN})(${RE_MIN_IDENTIFIER}|\\s+)(?<sec2>${RE_SEC})(${RE_SEC_IDENTIFIER})?` +
+        `(\\s*(?<card2>${RE_CARD}))?$`,
+    'i'
+)
+// same as REGEX_WGS_84_WITH_SECONDS but with prefixed cardinal: N 47°31.8'30" E 7°31.8'30.4"
+const REGEX_WGS_84_WITH_SECONDS_PREFIXED = new RegExp(
+    `^(?<card1>${RE_CARD})\\s*` +
+        `(?<degree1>${RE_DEGREE})(${RE_DEGREE_IDENTIFIER}|\\s+)(?<min1>${RE_MIN})(${RE_MIN_IDENTIFIER}|\\s+)(?<sec1>${RE_SEC})(${RE_SEC_IDENTIFIER})?` +
+        `${RE_SEPARATOR}` +
+        `(?<card2>${RE_CARD})\\s*` +
+        `(?<degree2>${RE_DEGREE})(${RE_DEGREE_IDENTIFIER}|\\s+)(?<min2>${RE_MIN})(${RE_MIN_IDENTIFIER}|\\s+)(?<sec2>${RE_SEC})(${RE_SEC_IDENTIFIER})?$`,
+    'i'
+)
 
 // LV95, LV03, metric WebMercator (EPSG:3857)
 const REGEX_METRIC_COORDINATES =
-    /^\s*([\d]{1,3}[ ']?[\d]{1,3}[ ']?[\d.]{3,})[\t ,./]+([\d]{1,3}[ ']?[\d]{1,3}[ ']?[\d.]{3,})/i
+    /^(?<coord1>\d{1,3}(['`´ ]?\d{3})*(\.\d+)?)\s*[,/ \t]\s*(?<coord2>\d{1,3}(['`´ ]?\d{3})*(\.\d+)?)$/i
 
-// Military Grid Reference System (MGRS)
-const REGEX_MILITARY_GRID = /^3[123][\sa-z]{3}[\s\d]*/i
+// Military Grid Reference System (MGRS) (e.g. 32TMS 40959 89723)
+const REGEX_MILITARY_GRID = /^3[123]\s*[a-z]{3}\s*\d{1,5}\s*\d{1,5}$/i
 
 const LV95_BOUNDS_IN_WGS84 = LV95.getBoundsAs(WGS84)
 
+const thousandSeparatorRegex = /['`´ ]/g
+
 const numericalExtractor = (regexMatches) => {
     // removing thousand separators
-    const x = Number(regexMatches[1].replace(/[' ]/g, ''))
-    const y = Number(regexMatches[2].replace(/[' ]/g, ''))
+    const x = Number(regexMatches.groups.coord1.replace(thousandSeparatorRegex, ''))
+    const y = Number(regexMatches.groups.coord2.replace(thousandSeparatorRegex, ''))
     if (Number.isNaN(x) || Number.isNaN(y)) {
         return undefined
     }
     return reprojectUnknownSrsCoordsToWGS84(x, y)
 }
 
-const webmercatorExtractor = (regexMatches) => {
-    if (regexMatches.length === 3) {
-        // 2 matches + global match i.e. : (45.12), (7.12)
-        return numericalExtractor(regexMatches)
-    }
+const wgs84Extractor = (regexMatches) => {
     let firstNumber, secondNumber
     let firstCardinal, secondCardinal
-    if (regexMatches.length === 5) {
-        // 4 matches + global match, 3 possibilities
-        // (47)°(5.123)', (8)°(4.154)'
-        // (45.12)(N), (7.12)(E)
-        // (N)(45.12), (E)(7.12)
-        if (isNumber(regexMatches[1]) && isNumber(regexMatches[2])) {
-            firstNumber = Number(regexMatches[1]) + Number(regexMatches[2]) / 60.0
-            secondNumber = Number(regexMatches[3]) + Number(regexMatches[4]) / 60.0
-        } else if (isNumber(regexMatches[1])) {
-            firstNumber = Number(regexMatches[1])
-            firstCardinal = regexMatches[2]
-            secondNumber = Number(regexMatches[3])
-            secondCardinal = regexMatches[4]
-        } else {
-            firstCardinal = regexMatches[1]
-            firstNumber = Number(regexMatches[2])
-            secondCardinal = regexMatches[3]
-            secondNumber = Number(regexMatches[4])
-        }
+
+    // Extract degrees
+    firstNumber = Number(regexMatches.groups.degree1)
+    secondNumber = Number(regexMatches.groups.degree2)
+
+    // Extract minutes if any
+    if (regexMatches.groups.min1) {
+        firstNumber += Number(regexMatches.groups.min1) / 60
     }
-    if (regexMatches.length === 7) {
-        // 6 matches + global match, 3 possibilities
-        // (47)°(5)'(41.61)", (8)°(4)'(6.32)"
-        // (47)°(5.123)'(N), (8)°(4.154)'(E)
-        // (N)(47)°(5.123)', (E)(8)°(4.154)'
-        if (isNumber(regexMatches[1]) && isNumber(regexMatches[3])) {
-            firstNumber =
-                Number(regexMatches[1]) +
-                Number(regexMatches[2]) / 60.0 +
-                Number(regexMatches[3]) / 3600.0
-            secondNumber =
-                Number(regexMatches[4]) +
-                Number(regexMatches[5]) / 60.0 +
-                Number(regexMatches[6]) / 3600.0
-        } else if (isNumber(regexMatches[1])) {
-            firstNumber = Number(regexMatches[1]) + Number(regexMatches[2]) / 60.0
-            firstCardinal = regexMatches[3]
-            secondNumber = Number(regexMatches[4]) + Number(regexMatches[5]) / 60.0
-            secondCardinal = regexMatches[6]
-        } else {
-            firstCardinal = regexMatches[1]
-            firstNumber = Number(regexMatches[2]) + Number(regexMatches[3]) / 60.0
-            secondCardinal = regexMatches[4]
-            secondNumber = Number(regexMatches[5]) + Number(regexMatches[6]) / 60.0
-        }
+    if (regexMatches.groups.min2) {
+        secondNumber += Number(regexMatches.groups.min2) / 60
     }
-    if (regexMatches.length === 9) {
-        // 8 matches + global match, i.e. (47)°(5)'(41.61)"(N), (8)°(4)'(6.32)"(E)
-        firstNumber =
-            Number(regexMatches[1]) +
-            Number(regexMatches[2]) / 60.0 +
-            Number(regexMatches[3]) / 3600.0
-        firstCardinal = regexMatches[4]
-        secondNumber =
-            Number(regexMatches[5]) +
-            Number(regexMatches[6]) / 60.0 +
-            Number(regexMatches[7]) / 3600.0
-        secondCardinal = regexMatches[8]
+
+    // Extract seconds if any
+    if (regexMatches.groups.sec1) {
+        firstNumber += Number(regexMatches.groups.sec1) / 3600
     }
+    if (regexMatches.groups.sec2) {
+        secondNumber += Number(regexMatches.groups.sec2) / 3600
+    }
+
+    // Extract cardinal if any
+    if (regexMatches.groups.card1) {
+        firstCardinal = regexMatches.groups.card1
+    }
+    if (regexMatches.groups.card2) {
+        secondCardinal = regexMatches.groups.card2
+    }
+
     if (firstNumber && secondNumber) {
         let lon = firstNumber,
             lat = secondNumber
@@ -171,7 +186,7 @@ const executeAndReturn = (regex, text, outputProjection, extractor = numericalEx
         return undefined
     }
 
-    const matches = regex.exec(text)
+    const matches = regex.exec(text.trim())
     if (matches) {
         const extractedCoordinates = extractor(matches)
         if (!extractedCoordinates) {
@@ -208,7 +223,7 @@ const executeAndReturn = (regex, text, outputProjection, extractor = numericalEx
  *
  * - With or without thousands separator (`600'000 200'000` or `600000 200000`)
  *
- * WGS84 (Web Mercator):
+ * WGS84:
  *
  * - Numerical (`46.97984 6.60757`)
  * - DegreesMinutes (`46°58.7904' 6°36.4542'`)
@@ -236,34 +251,20 @@ const coordinateFromString = (text, toProjection) => {
     // creating a config array with each entry being an object with a regex attribute
     // and the corresponding extractor when this regex matches the input
     return [
-        { regex: REGEX_WEB_MERCATOR, extractor: webmercatorExtractor },
-        { regex: REGEX_WEB_MERCATOR_WITH_CARDINALS, extractor: webmercatorExtractor },
-        { regex: REGEX_WEB_MERCATOR_WITH_PRE_FIXED_CARDINALS, extractor: webmercatorExtractor },
+        { regex: REGEX_WGS_84, extractor: wgs84Extractor },
+        { regex: REGEX_WGS_84_WITH_CARDINALS, extractor: wgs84Extractor },
+        { regex: REGEX_WGS_84_WITH_PRE_FIXED_CARDINALS, extractor: wgs84Extractor },
+        { regex: REGEX_WGS_84_WITH_MIN, extractor: wgs84Extractor },
+        { regex: REGEX_WGS_84_WITH_MIN_PREFIXED, extractor: wgs84Extractor },
+        { regex: REGEX_WGS_84_WITH_SECONDS, extractor: wgs84Extractor },
+        { regex: REGEX_WGS_84_WITH_SECONDS_PREFIXED, extractor: wgs84Extractor },
+
         { regex: REGEX_METRIC_COORDINATES, extractor: numericalExtractor },
-        { regex: REGEX_MERCATOR_WITH_DEGREES, extractor: webmercatorExtractor },
-        { regex: REGEX_MERCATOR_WITH_DEGREES_WITH_CARDINALS, extractor: webmercatorExtractor },
-        {
-            regex: REGEX_MERCATOR_WITH_DEGREES_WITH_PRE_FIXED_CARDINALS,
-            extractor: webmercatorExtractor,
-        },
-        {
-            regex: REGEX_MERCATOR_WITH_DEGREES_MINUTES,
-            extractor: webmercatorExtractor,
-        },
-        {
-            regex: REGEX_MERCATOR_WITH_DEGREES_MINUTES_AND_CARDINAL_POINT,
-            extractor: webmercatorExtractor,
-        },
         { regex: REGEX_MILITARY_GRID, extractor: mgrsExtractor },
     ]
         .map((config) => {
             // going through each config and extracting the result (can be undefined if not a match)
-            return executeAndReturn(
-                config.regex,
-                text.replace(/\t/, ' '),
-                toProjection,
-                config.extractor
-            )
+            return executeAndReturn(config.regex, text, toProjection, config.extractor)
         })
         .find((result) => Array.isArray(result)) // returning the first value that is a coordinate array (will return undefined if nothing is found)
 }

--- a/tests/cypress/tests-e2e/search/coordinates-search.cy.js
+++ b/tests/cypress/tests-e2e/search/coordinates-search.cy.js
@@ -31,6 +31,7 @@ describe('Testing coordinates typing in search bar', () => {
     )
 
     const checkCenterInStore = (acceptableDelta = 0.0) => {
+        cy.log(`Check that center is at ${JSON.stringify(expectedCenter)}`)
         cy.readStoreValue('state.position.center').should((center) => {
             expect(center[0]).to.be.approximately(expectedCenter[0], acceptableDelta)
             expect(center[1]).to.be.approximately(expectedCenter[1], acceptableDelta)
@@ -143,9 +144,9 @@ describe('Testing coordinates typing in search bar', () => {
     it('Paste MGRS input', () => {
         // as MGRS is a 1m based grid, the point could be anywhere in the square of 1m x 1m, we then accept a 1m delta
         const acceptableDeltaForMGRS = 1
-        cy.get(searchbarSelector).paste(
-            latLonToMGRS(expectedCenterWGS84[1], expectedCenterWGS84[0])
-        )
+        const mgrsCoordinates = latLonToMGRS(expectedCenterWGS84[1], expectedCenterWGS84[0])
+        cy.log(`Enter MGRS ${mgrsCoordinates} in search bar`)
+        cy.get(searchbarSelector).paste(mgrsCoordinates)
         checkCenterInStore(acceptableDeltaForMGRS)
         checkZoomLevelInStore()
         checkThatCoordinateAreHighlighted(acceptableDeltaForMGRS)


### PR DESCRIPTION
now supports most input (inverted or not) with cardinal letters, such as :

- 47° 43.813' N 8° 37.738' E
- N 46° 59.000 E 006° 44.000
- E7.297165 N46.791657 

[Test link](https://sys-map.int.bgdi.ch/preview/fix-pb-718-wgs84-search-bar/index.html)