### PR TITLE
PB-734 : search all layers with ID before fallback to technical name - #patch

### DIFF
--- a/src/api/topics.api.js
+++ b/src/api/topics.api.js
@@ -62,9 +62,12 @@ const readTopicTreeRecursive = (node, availableLayers) => {
         })
         return new GeoAdminGroupOfLayers({ id: `${node.id}`, name: node.label, layers: children })
     } else if (node.category === 'layer') {
-        const matchingLayer = availableLayers.find(
-            (layer) => layer.technicalName === node.layerBodId || layer.id === node.layerBodId
-        )
+        // we have to match IDs first, some layers have the same technicalNames (when 3D counterpart config exist for instance), and
+        // matching both together will result sometimes in the 3D config being displayed in the topic instead of the correct layer
+        let matchingLayer = availableLayers.find((layer) => layer.id === node.layerBodId)
+        if (!matchingLayer) {
+            matchingLayer = availableLayers.find((layer) => layer.technicalName === node.layerBodId)
+        }
         if (matchingLayer) {
             return matchingLayer
         }


### PR DESCRIPTION
so that 3D config don't get shown in the catalogue (they have the same technical name as the one that should be shown)

[Test link](https://sys-map.int.bgdi.ch/preview/fix-pb-734-topic-layers-config-mismatch/index.html)