### PR TITLE
PB-741: Added support for external WMS extra url parameters - #patch

### DIFF
--- a/src/api/layers/AbstractLayer.class.js
+++ b/src/api/layers/AbstractLayer.class.js
@@ -73,6 +73,9 @@ export default class AbstractLayer {
      *   metadata) are still loading. Default is `false`
      * @param {LayerTimeConfig | null} [layerData.timeConfig=null] Time series config (if
      *   available). Default is `null`
+     * @param {Object | null} [layerData.customAttributes=null] The custom attributes (except the
+     *   well known updateDelays, adminId, features and year) passed with the layer id in url.
+     *   Default is `null`
      * @throws InvalidLayerDataError if no `layerData` is given, or if `layerData.name` or
      *   `layerData.type` or `layer.baseUrl` aren't valid
      */
@@ -95,6 +98,7 @@ export default class AbstractLayer {
             isExternal = false,
             isLoading = false,
             timeConfig = null,
+            customAttributes = null,
         } = layerData
         if (name === null) {
             throw new InvalidLayerDataError('Missing layer name', layerData)
@@ -127,6 +131,7 @@ export default class AbstractLayer {
         this.hasError = false
         this.timeConfig = timeConfig
         this.hasMultipleTimestamps = this.timeConfig?.timeEntries?.length > 1
+        this.setCustomAttributes(customAttributes)
     }
 
     hasErrorKey(key) {
@@ -150,6 +155,33 @@ export default class AbstractLayer {
     clearErrorKeys() {
         this.errorKeys.clear()
         this.hasError = false
+    }
+
+    setCustomAttributes(customAttributes) {
+        if (customAttributes !== null) {
+            if (typeof customAttributes !== 'object') {
+                throw new Error(
+                    `Invalid layer ${this.id} customAttributes ${customAttributes}: not an object`
+                )
+            }
+            for (const [key, value] of Object.entries(customAttributes)) {
+                if (typeof key !== 'string') {
+                    throw new Error(
+                        `Invalid layer ${this.id} customAttributes ${customAttributes}: contains invalid key`
+                    )
+                }
+                if (typeof value !== 'string') {
+                    throw new Error(
+                        `Invalid layer ${this.id} customAttributes ${customAttributes}: contains invalid value`
+                    )
+                }
+            }
+        }
+        if (customAttributes && Object.keys(customAttributes).length > 0) {
+            this.customAttributes = customAttributes
+        } else {
+            this.customAttributes = null
+        }
     }
 
     clone() {

--- a/src/api/layers/ExternalLayer.class.js
+++ b/src/api/layers/ExternalLayer.class.js
@@ -94,9 +94,12 @@ export default class ExternalLayer extends AbstractLayer {
      *   Default is `null`
      * @param {LayerTimeConfig | null} [externalLayerData.timeConfig=null] Time series config (if
      *   available). Default is `null`
-     * @param {Number} [externalWmtsData.currentYear=null] Current year of the time series config to
-     *   use. This parameter is needed as it is set in the URL while the timeConfig parameter is not
-     *   yet available and parse later on from the GetCapabilities. Default is `null`
+     * @param {Number} [externalLayerData.currentYear=null] Current year of the time series config
+     *   to use. This parameter is needed as it is set in the URL while the timeConfig parameter is
+     *   not yet available and parse later on from the GetCapabilities. Default is `null`
+     * @param {Object | null} [externalLayerData.customAttributes=null] The custom attributes
+     *   (except the well known updateDelays, adminId, features and year) passed with the layer id
+     *   in url. Default is `null`
      * @throws InvalidLayerDataError if no `externalLayerData` is given or if it is invalid
      */
     constructor(externalLayerData) {
@@ -120,6 +123,7 @@ export default class ExternalLayer extends AbstractLayer {
             getFeatureInfoCapability = null,
             timeConfig = null,
             currentYear = null,
+            customAttributes,
         } = externalLayerData
         // keeping this checks, even though it will be checked again by the super constructor, because we use the baseUrl
         // to build our call to the super constructor (with a URL construction, which could raise an error if baseUrl is
@@ -141,6 +145,7 @@ export default class ExternalLayer extends AbstractLayer {
             hasDescription: abstract?.length > 0 || legends?.length > 0,
             hasLegend: legends?.length > 0,
             timeConfig,
+            customAttributes,
         })
         this.abstract = abstract
         this.extent = extent

--- a/src/api/layers/ExternalWMSLayer.class.js
+++ b/src/api/layers/ExternalWMSLayer.class.js
@@ -75,6 +75,9 @@ export default class ExternalWMSLayer extends ExternalLayer {
      * @param {Number} [externalWmsData.currentYear=null] Current year of the time series config to
      *   use. This parameter is needed as it is set in the URL while the timeConfig parameter is not
      *   yet available and parse later on from the GetCapabilities. Default is `null`
+     * @param {Object | null} [externalWmsData.customAttributes=null] The custom attributes (except
+     *   the well known updateDelays, adminId, features and year) passed with the layer id in url.
+     *   Default is `null`
      * @throws InvalidLayerDataError if no `externalWmsData` is given or if it is invalid
      */
     constructor(externalWmsData) {
@@ -100,6 +103,7 @@ export default class ExternalWMSLayer extends ExternalLayer {
             dimensions = [],
             timeConfig = null,
             currentYear = null,
+            customAttributes = null,
         } = externalWmsData
         super({
             name,
@@ -118,6 +122,7 @@ export default class ExternalWMSLayer extends ExternalLayer {
             getFeatureInfoCapability,
             timeConfig,
             currentYear,
+            customAttributes,
         })
         this.wmsVersion = wmsVersion
         this.format = format

--- a/src/api/layers/GeoAdminLayer.class.js
+++ b/src/api/layers/GeoAdminLayer.class.js
@@ -61,6 +61,9 @@ export default class GeoAdminLayer extends AbstractLayer {
      *   shown to users to explain its content. Default is `false`
      * @param {Boolean} [layerData.searchable=false] Define if this layer's features can be searched
      *   through the search bar. Default is `false`
+     * @param {Object | null} [layerData.customAttributes=null] The custom attributes (except the
+     *   well known updateDelays, adminId, features and year) passed with the layer id in url.
+     *   Default is `null`
      * @throws InvalidLayerDataError if no `layerData` is given or if it is invalid
      */
     constructor(layerData) {
@@ -87,6 +90,7 @@ export default class GeoAdminLayer extends AbstractLayer {
             hasDescription = true,
             hasLegend = false,
             searchable = false,
+            customAttributes = null,
         } = layerData
         if (id === null) {
             throw new InvalidLayerDataError('Missing geoadmin layer ID', layerData)
@@ -117,6 +121,7 @@ export default class GeoAdminLayer extends AbstractLayer {
             hasDescription,
             hasLegend,
             timeConfig,
+            customAttributes,
         })
         this.technicalName = technicalName
         this.isBackground = isBackground

--- a/src/api/layers/GeoAdminWMSLayer.class.js
+++ b/src/api/layers/GeoAdminWMSLayer.class.js
@@ -56,6 +56,9 @@ export default class GeoAdminWMSLayer extends GeoAdminLayer {
      *   shown to users to explain its content. Default is `false`
      * @param {Boolean} [layerData.searchable=false] Define if this layer's features can be searched
      *   through the search bar. Default is `false`
+     * @param {Object | null} [layerData.customAttributes=null] The custom attributes (except the
+     *   well known updateDelays, adminId, features and year) passed with the layer id in url.
+     *   Default is `null`
      * @throws InvalidLayerDataError if no `layerData` is given or if it is invalid
      */
     constructor(layerData) {
@@ -81,6 +84,7 @@ export default class GeoAdminWMSLayer extends GeoAdminLayer {
             topics = [],
             hasLegend = false,
             searchable = false,
+            customAttributes = null,
         } = layerData
         super({
             name,
@@ -100,6 +104,7 @@ export default class GeoAdminWMSLayer extends GeoAdminLayer {
             timeConfig,
             hasLegend,
             searchable,
+            customAttributes,
         })
         this.format = format
         this.lang = lang

--- a/src/api/layers/WMSCapabilitiesParser.class.js
+++ b/src/api/layers/WMSCapabilitiesParser.class.js
@@ -113,6 +113,7 @@ export default class WMSCapabilitiesParser {
      * @param {Number | null} [currentYear=null] Current year to select for the time config. Only
      *   needed when a time config is present a year is pre-selected in the url parameter. Default
      *   is `null`
+     * @param {Object | null} [params=null] URL parameters to pass to WMS server. Default is `null`
      * @param {boolean} [ignoreError=true] Don't throw exception in case of error, but return a
      *   default value or null. Default is `true`
      * @returns {ExternalWMSLayer | null} ExternalWMSLayer object or null in case of error
@@ -123,6 +124,7 @@ export default class WMSCapabilitiesParser {
         opacity = 1,
         visible = true,
         currentYear = null,
+        params = null,
         ignoreError = true
     ) {
         const { layer, parents } = this.findLayer(layerId)
@@ -141,6 +143,7 @@ export default class WMSCapabilitiesParser {
             opacity,
             visible,
             currentYear,
+            params,
             ignoreError
         )
     }
@@ -154,6 +157,7 @@ export default class WMSCapabilitiesParser {
      * @param {Number | null} [currentYear=null] Current year to select for the time config. Only
      *   needed when a time config is present a year is pre-selected in the url parameter. Default
      *   is `null`
+     * @param {Object | null} [params=null] URL parameters to pass to WMS server. Default is `null`
      * @param {boolean} ignoreError Don't throw exception in case of error, but return a default
      *   value or null
      * @returns {[ExternalWMSLayer | ExternalGroupOfLayers]} List of
@@ -164,6 +168,7 @@ export default class WMSCapabilitiesParser {
         opacity = 1,
         visible = true,
         currentYear = null,
+        params = null,
         ignoreError = true
     ) {
         return this.Capability.Layer.Layer.map((layer) =>
@@ -174,6 +179,7 @@ export default class WMSCapabilitiesParser {
                 opacity,
                 visible,
                 currentYear,
+                params,
                 ignoreError
             )
         ).filter((layer) => !!layer)
@@ -186,6 +192,7 @@ export default class WMSCapabilitiesParser {
         opacity,
         visible,
         currentYear,
+        params,
         ignoreError
     ) {
         const {
@@ -216,6 +223,8 @@ export default class WMSCapabilitiesParser {
                     projection,
                     opacity,
                     visible,
+                    currentYear,
+                    params,
                     ignoreError
                 )
             ).filter((layer) => !!layer)
@@ -253,6 +262,7 @@ export default class WMSCapabilitiesParser {
             hasTooltip: queryable,
             getFeatureInfoCapability: this.getFeatureInfoCapability(ignoreError),
             currentYear,
+            customAttributes: params,
             dimensions: dimensions,
             timeConfig: this._getTimeConfig(layerId, dimensions),
         })

--- a/src/modules/map/components/cesium/CesiumWMSLayer.vue
+++ b/src/modules/map/components/cesium/CesiumWMSLayer.vue
@@ -4,6 +4,7 @@
 
 <script>
 import { ImageryLayer, Rectangle, WebMapServiceImageryProvider } from 'cesium'
+import { cloneDeep } from 'lodash'
 import { mapState } from 'vuex'
 
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
@@ -63,6 +64,9 @@ export default {
         timestamp() {
             return getTimestampFromConfig(this.wmsLayerConfig)
         },
+        customAttributes() {
+            return cloneDeep(this.wmsLayerConfig.customAttributes)
+        },
         /**
          * Definition of all relevant URL param for our WMS backends. Passes as parameters to
          * https://cesium.com/learn/cesiumjs/ref-doc/WebMapServiceImageryProvider.html#.ConstructorOptions
@@ -74,7 +78,7 @@ export default {
          * @returns Object
          */
         wmsUrlParams() {
-            const params = {
+            let params = {
                 SERVICE: 'WMS',
                 REQUEST: 'GetMap',
                 TRANSPARENT: true,
@@ -85,6 +89,9 @@ export default {
             }
             if (this.timestamp && this.timestamp !== ALL_YEARS_TIMESTAMP) {
                 params.TIME = this.timestamp
+            }
+            if (this.customAttributes) {
+                params = { ...params, ...this.customAttributes }
             }
             return params
         },

--- a/src/modules/map/components/openlayers/OpenLayersWMSLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersWMSLayer.vue
@@ -1,6 +1,7 @@
 <script setup>
 /** Renders a WMS layer on the map */
 
+import { cloneDeep } from 'lodash'
 import { Image as ImageLayer, Tile as TileLayer } from 'ol/layer'
 import { ImageWMS, TileWMS } from 'ol/source'
 import TileGrid from 'ol/tilegrid/TileGrid'
@@ -16,7 +17,6 @@ import { LV95 } from '@/utils/coordinates/coordinateSystems.js'
 import { flattenExtent } from '@/utils/coordinates/coordinateUtils'
 import CustomCoordinateSystem from '@/utils/coordinates/CustomCoordinateSystem.class'
 import { getTimestampFromConfig } from '@/utils/layerUtils'
-
 const props = defineProps({
     wmsLayerConfig: {
         type: [GeoAdminWMSLayer, ExternalWMSLayer],
@@ -46,6 +46,7 @@ const gutter = computed(() => wmsLayerConfig.value.gutter || -1)
 const opacity = computed(() => parentLayerOpacity.value ?? wmsLayerConfig.value.opacity)
 const url = computed(() => wmsLayerConfig.value.baseUrl)
 const timestamp = computed(() => getTimestampFromConfig(wmsLayerConfig.value))
+const urlParams = computed(() => cloneDeep(wmsLayerConfig.value.customAttributes) ?? null)
 
 /**
  * Definition of all relevant URL param for our WMS backends. This is because both
@@ -57,7 +58,7 @@ const timestamp = computed(() => getTimestampFromConfig(wmsLayerConfig.value))
  * most of our wanted params will be doubled, resulting in longer and more difficult to read URLs
  */
 const wmsUrlParams = computed(() => {
-    const params = {
+    let params = {
         SERVICE: 'WMS',
         REQUEST: 'GetMap',
         TRANSPARENT: format.value === 'png',
@@ -72,6 +73,9 @@ const wmsUrlParams = computed(() => {
         // To request all timestamp we need to set the TIME to null which will force openlayer
         // to send a request without TIME param, otherwise openlayer takes the previous TIME param.
         params.TIME = null
+    }
+    if (urlParams.value !== null) {
+        params = { ...params, ...urlParams.value }
     }
     return params
 })

--- a/src/router/storeSync/layersParamParser.js
+++ b/src/router/storeSync/layersParamParser.js
@@ -163,9 +163,11 @@ export function transformLayerIntoUrlString(layer, defaultLayerConfig, featuresI
         // default timestamp. This can happen for External layer using a non ISO timestamp.
     }
 
+    // Add features ID attributes
     if (featuresIds) {
         layerUrlString += `@features=${featuresIds.join(':')}`
     }
+
     // Storing the update delay if different from the default config (or if no default config is present and there's an update delay)
     // this currently only applies to GeoJSON layer
     if (
@@ -174,6 +176,15 @@ export function transformLayerIntoUrlString(layer, defaultLayerConfig, featuresI
     ) {
         layerUrlString += `@updateDelay=${layer.updateDelay}`
     }
+
+    // Add custom attributes if any
+    if (layer.customAttributes !== null) {
+        for (const [key, value] of Object.entries(layer.customAttributes)) {
+            layerUrlString += `@${key}${value ? '=' + encodeLayerParam(value) : ''}`
+        }
+    }
+
+    // Add visibility flag
     if (!layer.visible) {
         layerUrlString += `,f`
     }

--- a/src/store/plugins/external-layers.plugin.js
+++ b/src/store/plugins/external-layers.plugin.js
@@ -104,6 +104,7 @@ async function updateExternalLayer(store, capabilities, layer, projection) {
             layer.opacity,
             layer.visible,
             layer.currentYear,
+            layer.customAttributes,
             false /* throw Error in case of  error */
         )
         updated.isLoading = false

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -122,11 +122,24 @@ export function getLayersFromLegacyUrlParams(
             const [_layerType, name, url, id, version] = layerId.split('||')
             // we only decode if we have enough material
             if (url && id) {
+                const customAttributes = {}
+                try {
+                    const parsedUrl = new URL(url)
+                    for (const [key, value] of parsedUrl.searchParams) {
+                        // ignore well known params to avoid conflict with the service
+                        if (!['SERVICE', 'REQUEST', 'VERSION'].includes(key.toUpperCase())) {
+                            customAttributes[key] = value
+                        }
+                    }
+                } catch (error) {
+                    log.error(`Invalid URL ${url}`)
+                }
                 layer = new ExternalWMSLayer({
                     id,
                     name: name ? name : id,
                     baseUrl: url,
                     wmsVersion: version,
+                    customAttributes,
                 })
             }
         }


### PR DESCRIPTION
One Geoadmin layer had support for a special extra URL query parameter `item=...`
that was passed from URL to the WMS server, see legacy URL example below

https://map.geo.admin.ch/index.html?layers=WMS||s2-sr_v100_2024-05-10t102021||https://wms.geo.admin.ch/?item=2024-05-10t102021||ch.swisstopo.swisseo_s2-sr_v100||1.3.0

To solve this issue that user were used to (even though here we should have
used the well known TIME parameter) I added support for extra WMS param in
our URL syntax using the custom attributes @key=VALUE. So now all custom
attributes @key=VALUE that are not part of the following well defined attributes

- year
- updateDelay
- features
- adminId

Are passed along to the WMS server (for internal GeoAdmin layer and external layers)

[Test Legacy link](https://sys-map.int.bgdi.ch/preview/bug-pb-741-url-parsing-sat-data/index.html?layers=WMS||s2-sr_v100_2024-05-10t102021||https://wms.geo.admin.ch/?item=2024-05-10t102021||ch.swisstopo.swisseo_s2-sr_v100||1.3.0)
[Test Legacy link on legacy viewer](https://rusty.map.geo.admin.ch/index.html?layers=WMS||s2-sr_v100_2024-05-10t102021||https://wms.geo.admin.ch/?item=2024-05-10t102021||ch.swisstopo.swisseo_s2-sr_v100||1.3.0)
[Test link with param](https://sys-map.int.bgdi.ch/preview/bug-pb-741-url-parsing-sat-data/index.html?#/map?layers=ch.swisstopo.swisseo_s2-sr_v100@item=2024-05-10t102021)

[Test link](https://sys-map.int.bgdi.ch/preview/bug-pb-741-url-parsing-sat-data/index.html)