### PR TITLE
Put location popup below the menu and header - #patch

### DIFF
--- a/src/scss/variables.module.scss
+++ b/src/scss/variables.module.scss
@@ -26,7 +26,7 @@ $zindex-loading-screen: 101;
 // Menu stacking context
 $zindex-menu-tray: $zindex-menu; // one step behind the header so that it can slip behind when closed, but above the toolbox buttons
 $zindex-menu-header: $zindex-menu + 1;
-$zindex-map-popover: $zindex-menu-header + 1;
+$zindex-map-popover: $zindex-menu - 1;
 /* in order to have the header slip behind the drawing toolbox when the hiding animation
 occurs (teleported in the menu context)*/
 $zindex-drawing-toolbox: 3;


### PR DESCRIPTION
It was on top of the menu and header which don't make sense in my opinion
and was quite annoying.

It is still on top of the map toolbox but under the background selector.

On the old viewer it was under all elements (menu, header, toolbox, footer,
background selector)

[Test link](https://sys-map.int.bgdi.ch/preview/bug-location-popup-zindex/index.html)