### PR TITLE
Add app version in settings menu on phone layout - #patch

### DIFF
--- a/src/modules/menu/components/settings/MenuSettings.vue
+++ b/src/modules/menu/components/settings/MenuSettings.vue
@@ -1,6 +1,13 @@
 <script setup>
+import { computed } from 'vue'
+import { useStore } from 'vuex'
+
 import LangSwitchToolbar from '@/modules/i18n/components/LangSwitchToolbar.vue'
+import MapFooterAppVersion from '@/modules/map/components/footer/MapFooterAppVersion.vue'
 import LinksToolbar from '@/modules/menu/components/settings/LinksToolbar.vue'
+
+const store = useStore()
+const isPhoneMode = computed(() => store.getters.isPhoneMode)
 </script>
 
 <template>
@@ -11,5 +18,6 @@ import LinksToolbar from '@/modules/menu/components/settings/LinksToolbar.vue'
         <div id="menu-links">
             <LinksToolbar />
         </div>
+        <MapFooterAppVersion v-if="isPhoneMode" />
     </div>
 </template>

--- a/src/modules/menu/components/settings/MenuSettings.vue
+++ b/src/modules/menu/components/settings/MenuSettings.vue
@@ -3,21 +3,30 @@ import { computed } from 'vue'
 import { useStore } from 'vuex'
 
 import LangSwitchToolbar from '@/modules/i18n/components/LangSwitchToolbar.vue'
-import MapFooterAppVersion from '@/modules/map/components/footer/MapFooterAppVersion.vue'
 import LinksToolbar from '@/modules/menu/components/settings/LinksToolbar.vue'
+import AppVersion from '@/utils/components/AppVersion.vue'
 
 const store = useStore()
 const isPhoneMode = computed(() => store.getters.isPhoneMode)
 </script>
 
 <template>
-    <div id="menu-settings" class="pb-1 text-center" data-cy="menu-settings-content">
-        <div id="menu-lang-selector">
+    <div class="pb-1 text-center position-relative" data-cy="menu-settings-content">
+        <div class="position-relative z-1">
             <LangSwitchToolbar />
         </div>
-        <div id="menu-links">
+        <div class="position-relative z-1" :class="{ 'mb-3': isPhoneMode }">
             <LinksToolbar />
         </div>
-        <MapFooterAppVersion v-if="isPhoneMode" />
+        <AppVersion
+            v-if="isPhoneMode"
+            class="position-absolute bottom-0 left-0 z-0 ms-1 mobile-app-version"
+        />
     </div>
 </template>
+
+<style lang="scss" scoped>
+.mobile-app-version {
+    font-size: 0.75rem;
+}
+</style>

--- a/src/utils/components/AppVersion.vue
+++ b/src/utils/components/AppVersion.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from 'vue'
 import { useStore } from 'vuex'
 
-import { APP_VERSION } from '@/config'
+import { APP_VERSION } from '@/config.js'
 
 const store = useStore()
 const appVersion = ref(APP_VERSION)

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -8,7 +8,6 @@ import CesiumMouseTracker from '@/modules/map/components/cesium/CesiumMouseTrack
 import BackgroundSelector from '@/modules/map/components/footer/backgroundSelector/BackgroundSelector.vue'
 import MapFooter from '@/modules/map/components/footer/MapFooter.vue'
 import MapFooterAppCopyright from '@/modules/map/components/footer/MapFooterAppCopyright.vue'
-import MapFooterAppVersion from '@/modules/map/components/footer/MapFooterAppVersion.vue'
 import MapFooterAttributionList from '@/modules/map/components/footer/MapFooterAttributionList.vue'
 import OpenLayersMouseTracker from '@/modules/map/components/openlayers/OpenLayersMouseTracker.vue'
 import OpenLayersScale from '@/modules/map/components/openlayers/OpenLayersScale.vue'
@@ -17,6 +16,7 @@ import TimeSliderButton from '@/modules/map/components/toolbox/TimeSliderButton.
 import MapModule from '@/modules/map/MapModule.vue'
 import MenuModule from '@/modules/menu/MenuModule.vue'
 import { UIModes } from '@/store/modules/ui.store'
+import AppVersion from '@/utils/components/AppVersion.vue'
 import DragDropOverlay from '@/utils/components/DragDropOverlay.vue'
 import LoadingBar from '@/utils/components/LoadingBar.vue'
 import log from '@/utils/logging'
@@ -90,7 +90,7 @@ onMounted(() => {
                         </template>
                     </template>
                     <template v-if="!isPhoneMode" #bottom-right>
-                        <MapFooterAppVersion />
+                        <AppVersion />
                         <MapFooterAppCopyright />
                     </template>
                 </MapFooter>

--- a/tests/cypress/tests-e2e/menuTray.cy.js
+++ b/tests/cypress/tests-e2e/menuTray.cy.js
@@ -114,7 +114,7 @@ function measureMenu(shouldHaveMaxSize) {
         if (shouldHaveMaxSize) {
             cy.get('@menuTrayBottom').should('be.equal', expectedMenuTrayBottom)
         } else {
-            cy.get('@menuTrayBottom').should('be.lt', expectedMenuTrayBottom)
+            cy.get('@menuTrayBottom').should('be.lte', expectedMenuTrayBottom)
         }
     })
 }


### PR DESCRIPTION
it isn't possible to read the version anywhere on phone, making it a bit hard to know if we are testing on the correct version

[Test link](https://sys-map.int.bgdi.ch/preview/fix-add-version-on-phone/index.html)