### PR TITLE
Revert "PB-747: Enabled logs on PROD to try to understand the blank screen issue" - #patch

### DIFF
--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -25,11 +25,7 @@ export const LogLevel = {
  */
 const log = (level, ...message) => {
     // In production we don't log debug level and info level
-    // TODO PB-747: remove info and debug level once we found the blank screen issue
-    if (
-        ENVIRONMENT === 'production' &&
-        ![LogLevel.ERROR, LogLevel.WARNING, LogLevel.INFO, LogLevel.DEBUG].includes(level)
-    ) {
+    if (ENVIRONMENT === 'production' && ![LogLevel.ERROR, LogLevel.WARNING].includes(level)) {
         return
     }
 


### PR DESCRIPTION
Reverts geoadmin/web-mapviewer#984

[Test link](https://sys-map.int.bgdi.ch/preview/revert-984-bug-pb-747-logs-2/index.html)