### PR TITLE
PB-729 : fix recent earthquake tooltip - #patch

### DIFF
--- a/src/modules/infobox/components/FeatureDetail.vue
+++ b/src/modules/infobox/components/FeatureDetail.vue
@@ -134,6 +134,10 @@ function getIframeHosts(value) {
 :global(.htmlpopup-content) {
     padding: 7px;
 }
+// fix for layer HTML containing table, such as ch.bafu.gefahren-aktuelle_erdbeben
+:global(.t_list) {
+    width: 100%;
+}
 td {
     vertical-align: top;
 }

--- a/src/modules/infobox/components/FeatureListCategoryItem.vue
+++ b/src/modules/infobox/components/FeatureListCategoryItem.vue
@@ -15,7 +15,7 @@ const dispatcher = { dispatcher: 'FeatureListCategoryItem.vue' }
 
 const props = defineProps({
     name: {
-        type: String,
+        type: [String, Number],
         required: true,
     },
     item: {
@@ -91,7 +91,7 @@ function showContentAndScrollIntoView(event) {
         @mouseleave.passive="clearHighlightedFeature"
     >
         <FontAwesomeIcon :icon="`caret-${showContent ? 'down' : 'right'}`" class="mx-2" />
-        <TextTruncate :text="name" class="flex-grow-1">
+        <TextTruncate :text="`${name}`" class="flex-grow-1">
             <strong>{{ name }}</strong>
         </TextTruncate>
 

--- a/src/modules/map/components/openlayers/OpenLayersHighlightedFeatures.vue
+++ b/src/modules/map/components/openlayers/OpenLayersHighlightedFeatures.vue
@@ -67,6 +67,7 @@ const popoverCoordinate = computed(() => {
     // If no editable feature is selected while drawing, we place the popover depending on the geometry of all
     // selected features. We will find the most southern coordinate present in all features and use it as anchor.
     const mostSouthernFeature = selectedFeatures.value
+        .filter((feature) => feature.geometry !== null)
         .map((feature) => feature.geometry)
         .map((geometry) => transformIntoTurfEquivalent(geometry, projection.value))
         .map((turfGeom) => explode(turfGeom))

--- a/src/modules/map/components/openlayers/OpenLayersPopover.vue
+++ b/src/modules/map/components/openlayers/OpenLayersPopover.vue
@@ -11,7 +11,7 @@ import MapPopover, { MapPopoverMode } from '@/modules/map/components/MapPopover.
 const props = defineProps({
     coordinates: {
         type: Array,
-        required: true,
+        default: null,
     },
     authorizePrint: {
         type: Boolean,
@@ -38,17 +38,20 @@ const popoverAnchor = ref(null)
 
 const olMap = inject('olMap')
 
-watch(coordinates, getPixelForCoordinateFromMap)
+watch(coordinates, calculateAnchorPosition)
 
 onMounted(() => {
-    getPixelForCoordinateFromMap()
-    olMap.on('postrender', getPixelForCoordinateFromMap)
+    calculateAnchorPosition()
+    olMap.on('postrender', calculateAnchorPosition)
 })
 onUnmounted(() => {
-    olMap.un('postrender', getPixelForCoordinateFromMap)
+    olMap.un('postrender', calculateAnchorPosition)
 })
 
-function getPixelForCoordinateFromMap() {
+function calculateAnchorPosition() {
+    if (!coordinates.value) {
+        return
+    }
     const computedPixel = olMap.getPixelFromCoordinate(coordinates.value)
     // when switching back from Cesium (or any other map framework), there can be a very small
     // period where the map isn't yet able to process a pixel, this if is there to defend against that

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -122,23 +122,20 @@ export function createLayerObject(parsedLayer, currentLayer, store, featuresRequ
             layer.updateDelay = updateDelay
         }
 
-        if (features !== undefined) {
+        // only highlightable feature will output something, for the others a click coordinate is required
+        // (and we don't have it if we are here, as we are dealing with pre-selected feature in the URL at app startup)
+        if (layer.isHighlightable && features !== undefined) {
             features
                 .toString()
                 .split(':')
                 .forEach((featureId) => {
                     featuresRequests.push(
-                        getFeature(
-                            store.getters.getLayerConfigById(parsedLayer.id),
-                            featureId,
-                            store.state.position.projection,
-                            {
-                                lang: store.state.i18n.lang,
-                                screenWidth: store.state.ui.width,
-                                screenHeight: store.state.ui.height,
-                                mapExtent: flattenExtent(store.getters.extent),
-                            }
-                        )
+                        getFeature(layer, featureId, store.state.position.projection, {
+                            lang: store.state.i18n.lang,
+                            screenWidth: store.state.ui.width,
+                            screenHeight: store.state.ui.height,
+                            mapExtent: flattenExtent(store.getters.extent),
+                        })
                     )
                 })
         }

--- a/src/store/modules/features.store.js
+++ b/src/store/modules/features.store.js
@@ -17,10 +17,11 @@ import log from '@/utils/logging'
 /** @param {SelectableFeature} feature */
 export function canFeatureShowProfile(feature) {
     return (
-        (feature?.geometry?.type && ['LineString', 'Polygon'].includes(feature.geometry.type)) ||
-        // if MultiLineString or MultiPolygon but only contains one "feature", that's fine too (mislabeled as "multi")
-        (['MultiLineString', 'MultiPolygon'].includes(feature.geometry.type) &&
-            feature.geometry.coordinates.length === 1)
+        feature?.geometry?.type &&
+        (['LineString', 'Polygon'].includes(feature.geometry.type) ||
+            // if MultiLineString or MultiPolygon but only contains one "feature", that's fine too (mislabeled as "multi")
+            (['MultiLineString', 'MultiPolygon'].includes(feature.geometry.type) &&
+                feature.geometry.coordinates.length === 1))
     )
 }
 
@@ -653,6 +654,7 @@ export default {
                             screenWidth: rootState.ui.width,
                             screenHeight: rootState.ui.height,
                             mapExtent: flattenExtent(rootState.getters.mapExtent),
+                            coordinate: rootState.map.clickInfo?.coordinate,
                         })
                     )
                 }


### PR DESCRIPTION
We were missing a `coord` param for the HTML popup endpoint (undocumented) so that the HTML endpoint can select features for us instead of giving feature IDs (not optimal, but that's the way it is for now)

Also not requesting geometries (in identify requests) when the layer isn't highligtable, it was returning the extent of the whole layer as geom. Using instead the click coordinate as a geometry (adapting the code to be able to handle no geom)

[Test link with recent earthquakes](https://sys-map.int.bgdi.ch/preview/fix-pb-729-recent-earthquake-tooltip/index.html?layers=ch.bafu.gefahren-aktuelle_erdbeben)

[Test link](https://sys-map.int.bgdi.ch/preview/fix-pb-729-recent-earthquake-tooltip/index.html)