### PR TITLE
PB-747: Fix race condition in startup - #patch

### DIFF
--- a/src/store/plugins/app-readiness.plugin.js
+++ b/src/store/plugins/app-readiness.plugin.js
@@ -38,13 +38,14 @@ const appReadinessPlugin = (store) => {
 
         if (mutation.type === 'mapModuleReady') {
             store.dispatch('clearLoadingBar4MapLoading', { dispatcher })
-
-            // In production build we are not interested anymore in the mutation logs
-            // therefore unsubscribe here
-            if (ENVIRONMENT === 'production') {
-                unsubscribe()
-            }
         }
+
+        // In production build we are not interested anymore in the mutation logs
+        // therefore unsubscribe when the app is ready and map is ready
+        if (state.app.isReady && state.app.isMapReady && ENVIRONMENT === 'production') {
+            unsubscribe()
+        }
+
         // otherwise we ignore all mutations, our job is already done
     })
 


### PR DESCRIPTION
It happened that the URL query watcher could not be called because the app
is not yet ready in the router sync and should therefore be postpone in the
store mutation when app is ready, but in this case the map was ready before
the app was ready and the readiness plugin de-register itself and we never
set the app is ready flag never triggering the initial query watcher.

[Test link](https://sys-map.int.bgdi.ch/preview/bug-pb-747-app-not-ready/index.html)