### PR TITLE
PB-783 : adding legacy GPX parsing - #patch

### DIFF
--- a/src/store/plugins/load-gpx-data.plugin.js
+++ b/src/store/plugins/load-gpx-data.plugin.js
@@ -6,6 +6,7 @@
 import axios from 'axios'
 import GPX from 'ol/format/GPX'
 
+import { proxifyUrl } from '@/api/file-proxy.api'
 import GPXLayer from '@/api/layers/GPXLayer.class'
 import log from '@/utils/logging'
 
@@ -19,7 +20,7 @@ const dispatcher = { dispatcher: 'load-gpx-data.plugin' }
 async function loadGpx(store, gpxLayer) {
     log.debug(`Loading data for added GPX layer`, gpxLayer)
     try {
-        const response = await axios.get(gpxLayer.gpxFileUrl)
+        const response = await axios.get(proxifyUrl(gpxLayer.gpxFileUrl))
         const gpxContent = response.data
         const gpxParser = new GPX()
         const metadata = gpxParser.readMetadata(gpxContent)

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -1,6 +1,7 @@
 import { getKmlMetadataByAdminId } from '@/api/files.api'
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
+import GPXLayer from '@/api/layers/GPXLayer.class'
 import KMLLayer from '@/api/layers/KMLLayer.class'
 import storeSyncConfig from '@/router/storeSync/storeSync.config'
 import log from '@/utils/logging'
@@ -111,6 +112,10 @@ export function getLayersFromLegacyUrlParams(
         if (layerId.startsWith('KML||')) {
             const [_layerType, url] = layerId.split('||')
             layer = new KMLLayer({ kmlFileUrl: url, visible: true })
+        }
+        if (layerId.startsWith('GPX||')) {
+            const [_layerType, url] = layerId.split('||')
+            layer = new GPXLayer({ gpxFileUrl: url, visible: true })
         }
         if (layerId.startsWith('WMTS||')) {
             const [_layerType, id, url] = layerId.split('||')

--- a/tests/cypress/tests-e2e/importToolFile.cy.js
+++ b/tests/cypress/tests-e2e/importToolFile.cy.js
@@ -1,5 +1,7 @@
 /// <reference types="cypress" />
 
+import { proxifyUrl } from '@/api/file-proxy.api.js'
+
 describe('The Import File Tool', () => {
     it('Import KML file', () => {
         cy.goToMapView({}, true)
@@ -501,7 +503,7 @@ describe('The Import File Tool', () => {
         cy.log('Test online import')
         const validOnlineUrl = 'http://example.com/valid-gpx-file.gpx'
         const gpxOnlineLayerId = `GPX|${validOnlineUrl}`
-        cy.intercept('GET', validOnlineUrl, {
+        cy.intercept('GET', proxifyUrl(validOnlineUrl), {
             fixture: gpxFileFixture,
         }).as('getGpxFile')
 


### PR DESCRIPTION
And use service-proxy to get GPX file data

[Test link with legacy GPX](https://sys-map.int.bgdi.ch/preview/fix-pb-783-legacy-gpx/index.html?lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,ch.astra.wanderland-sperrungen_umleitungen,GPX%7C%7Chttps:%2F%2Fdrive.google.com%2Fuc%3Fexport%3Ddownload%26id%3D1CB3V6M42ysJttjulzQPygtnAVRzguQhK&layers_opacity=1,1,1,0.8,0.8,1&layers_visibility=false,false,false,false,false,true&layers_timestamp=18641231,,,,,&E=2678974.87&N=1197370.66&zoom=6.3999999999999995)

[Test link](https://sys-map.int.bgdi.ch/preview/fix-pb-783-legacy-gpx/index.html)