### PR TITLE
PB-750 : adapt CSS to enable browser print of the map - #patch

### DIFF
--- a/src/modules/map/components/footer/MapFooterAppCopyright.vue
+++ b/src/modules/map/components/footer/MapFooterAppCopyright.vue
@@ -1,13 +1,16 @@
 <template>
-    <a
-        v-for="(link, index) in links"
-        :key="index"
-        :href="link.url"
-        target="_blank"
-        :data-cy="`app-copyright-${index}`"
-    >
-        {{ $t(link.label) }}
-    </a>
+    <div class="app-copyright">
+        <a
+            v-for="(link, index) in links"
+            :key="index"
+            :href="link.url"
+            target="_blank"
+            class="app-copyright-link"
+            :data-cy="`app-copyright-${index}`"
+        >
+            {{ $t(link.label) }}
+        </a>
+    </div>
 </template>
 
 <script>
@@ -36,12 +39,16 @@ export default {
 
 <style lang="scss" scoped>
 @import '@/scss/variables-admin.module';
-a {
-    color: $black;
-    text-decoration: initial;
-}
-a:hover,
-a:focus {
-    text-decoration: underline;
+.app-copyright {
+    display: flex;
+    gap: 5px;
+    &-link {
+        color: $black;
+        text-decoration: initial;
+    }
+    &-link:hover,
+    &-link:focus {
+        text-decoration: underline;
+    }
 }
 </style>

--- a/src/modules/map/components/openlayers/OpenLayersMouseTracker.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMouseTracker.vue
@@ -64,29 +64,39 @@ function setDisplayedFormatWithId() {
 </script>
 
 <template>
-    <select
-        v-model="displayedFormatId"
-        class="map-projection form-control-xs"
-        data-cy="mouse-position-select"
-        @change="setDisplayedFormatWithId"
-    >
-        <option v-for="format in allFormats" :key="format.id" :value="format.id">
-            {{ format.label }}
-        </option>
-    </select>
-    <div ref="mousePosition" class="mouse-position" data-cy="mouse-position"></div>
+    <div class="mouse-tracker">
+        <select
+            v-model="displayedFormatId"
+            class="mouse-tracker-projection form-control-xs"
+            data-cy="mouse-position-select"
+            @change="setDisplayedFormatWithId"
+        >
+            <option v-for="format in allFormats" :key="format.id" :value="format.id">
+                {{ format.label }}
+            </option>
+        </select>
+        <div ref="mousePosition" class="mouse-tracker-position" data-cy="mouse-position"></div>
+    </div>
 </template>
 
 <style lang="scss" scoped>
-.mouse-position {
-    display: none;
-    min-width: 10em;
-    text-align: left;
-    white-space: nowrap;
+.mouse-tracker {
+    display: flex;
+    height: 100%;
+    align-items: center;
+    justify-items: center;
+    gap: 5px;
+    &-position {
+        display: none;
+        text-align: left;
+        white-space: nowrap;
+    }
 }
 @media (any-hover: hover) {
-    .mouse-position {
-        display: block;
+    .mouse-tracker {
+        &-position {
+            display: block;
+        }
     }
 }
 </style>

--- a/src/scss/webmapviewer-bootstrap-theme.scss
+++ b/src/scss/webmapviewer-bootstrap-theme.scss
@@ -65,3 +65,9 @@ $nav-tabs-link-active-bg: $primary;
 .w-13 {
     width: 13%;
 }
+
+@media print {
+    .no-print {
+        display: none !important;
+    }
+}

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -46,11 +46,12 @@ onMounted(() => {
 </script>
 
 <template>
-    <div id="map-view" class="no-print">
-        <LoadingBar v-show="showLoadingBar" />
+    <div id="map-view">
+        <LoadingBar v-show="showLoadingBar" class="no-print" />
         <MapModule>
-            <MenuModule />
+            <MenuModule class="no-print" />
             <MapToolbox
+                class="no-print"
                 geoloc-button
                 :full-screen-button="!isDrawingMode"
                 :toggle3d-button="!isDrawingMode"
@@ -59,9 +60,9 @@ onMounted(() => {
                 <TimeSliderButton v-if="!is3DActive" />
             </MapToolbox>
             <!-- we place the drawing module here so that it can receive the OpenLayers map instance through provide/inject -->
-            <DrawingModule v-if="loadDrawingModule" />
+            <DrawingModule v-if="loadDrawingModule" class="no-print" />
             <template #footer>
-                <MapFooter>
+                <MapFooter class="no-print">
                     <template v-if="isPhoneMode" #top-left>
                         <div class="d-flex flex-column align-items-start">
                             <BackgroundSelector class="p-2 background-selector" />
@@ -94,6 +95,10 @@ onMounted(() => {
                         <MapFooterAppCopyright />
                     </template>
                 </MapFooter>
+                <div class="printing-footer">
+                    <OpenLayersScale />
+                    <MapFooterAttributionList />
+                </div>
             </template>
         </MapModule>
         <I18nModule />
@@ -102,9 +107,30 @@ onMounted(() => {
 </template>
 
 <style lang="scss" scoped>
+@import '@/scss/webmapviewer-bootstrap-theme';
 #map-view {
     .background-selector {
         pointer-events: all;
+    }
+
+    .printing-footer {
+        display: none;
+    }
+}
+
+@media print {
+    #map-view {
+        .printing-footer {
+            display: flex;
+            justify-content: space-between;
+            z-index: $zindex-footer;
+            padding: $screen-padding-for-ui-elements;
+
+            position: absolute;
+            left: 0;
+            bottom: 0;
+            right: 0;
+        }
     }
 }
 </style>


### PR DESCRIPTION
with only the layer attributions and eventual feature tooltip visible (no menu, no footer)

Had to adapt a bit the OpenLayerMouseTracker component so that it has a root HTML element (on which we can apply a class from the component using it)

[Test link](https://sys-map.int.bgdi.ch/preview/fix-pb-750-browser-printing/index.html)