### PR TITLE
PB-714: Update regex to allow comments in kml before kml tag - #patch

### DIFF
--- a/src/modules/menu/components/advancedTools/ImportFile/utils.js
+++ b/src/modules/menu/components/advancedTools/ImportFile/utils.js
@@ -16,7 +16,7 @@ const dispatcher = { dispatcher: 'ImportFile/utils' }
  * @returns {boolean}
  */
 export function isKml(fileContent) {
-    return /^\s*(<\?xml\b[^>]*\?>)?\s*<(kml:)?kml\b[^>]*>[\s\S.]*<\/(kml:)?kml\s*>/g.test(
+    return /^\s*(<\?xml\b[^>]*\?>)?\s*(<!--(.*?)-->\s*)*<(kml:)?kml\b[^>]*>[\s\S.]*<\/(kml:)?kml\s*>/g.test(
         fileContent
     )
 }


### PR DESCRIPTION


[Test link](https://sys-map.int.bgdi.ch/preview/fix-pb-714-kml-file-with-comments/index.html)