### PR TITLE
PB-786: Fix geolocation error management - #patch

### DIFF
--- a/src/store/plugins/geolocation-management.plugin.js
+++ b/src/store/plugins/geolocation-management.plugin.js
@@ -103,13 +103,6 @@ const activeGeolocation = (store, state) => {
                 position,
                 `firstTimeActivatingGeolocation=${firstTimeActivatingGeolocation}`
             )
-            // if geoloc was previously denied, we clear the flag
-            if (state.geolocation.denied) {
-                store.dispatch('setGeolocationDenied', {
-                    denied: false,
-                    ...dispatcher,
-                })
-            }
             // register a watcher
             geolocationWatcher = navigator.geolocation.watchPosition(
                 (position) => handlePositionAndDispatchToStore(position, store),

--- a/src/store/plugins/geolocation-management.plugin.js
+++ b/src/store/plugins/geolocation-management.plugin.js
@@ -12,6 +12,7 @@ const ENABLE_HIGH_ACCURACY = true
 
 let geolocationWatcher = null
 let firstTimeActivatingGeolocation = true
+let errorCount = 0
 
 function setCenterIfInBounds(store, center) {
     if (
@@ -38,7 +39,13 @@ const readPosition = (position, projection) => {
 }
 
 const handlePositionAndDispatchToStore = (position, store) => {
-    log.debug(`Received position from geolocation`, position, store.state.geolocation)
+    log.debug(
+        `Received position from geolocation`,
+        position,
+        store.state.geolocation,
+        `error count=${errorCount}`
+    )
+    errorCount = 0 // reset the error count on each successfull position
     const positionProjected = readPosition(position, store.state.position.projection)
     store.dispatch('setGeolocationPosition', {
         position: positionProjected,
@@ -59,8 +66,12 @@ const handlePositionAndDispatchToStore = (position, store) => {
  *
  * @param {GeolocationPositionError} error
  * @param {Vuex.Store} store
+ * @param {Vuex.State} state
+ * @param {Boolean} [options.reactivate=false] Re-activate initial geolocation in case of unknown
+ *   failure. Default is `false`
  */
-const handlePositionError = (error, store) => {
+const handlePositionError = (error, store, state, options = {}) => {
+    const { reactivate = false } = options
     log.error('Geolocation activation failed', error)
     switch (error.code) {
         case error.PERMISSION_DENIED:
@@ -71,6 +82,7 @@ const handlePositionError = (error, store) => {
             store.dispatch('setErrorText', { errorText: 'geoloc_permission_denied', ...dispatcher })
             break
         case error.TIMEOUT:
+            store.dispatch('setGeolocation', { active: false, ...dispatcher })
             store.dispatch('setErrorText', { errorText: 'geoloc_time_out', ...dispatcher })
             break
         default:
@@ -81,13 +93,39 @@ const handlePositionError = (error, store) => {
                 // the position will be returned by a mocked up function by Cypress we can ignore this error
                 // we do nothing...
             } else {
-                store.dispatch('setErrorText', { errorText: 'geoloc_unknown', ...dispatcher })
+                // It can happen that the position is not yet available so we retry the api call silently for the first
+                // 3 call
+                errorCount += 1
+                if (errorCount < 3) {
+                    if (reactivate) {
+                        activeGeolocation(store, state, { useInitial: false })
+                    }
+                } else {
+                    store.dispatch('setErrorText', { errorText: 'geoloc_unknown', ...dispatcher })
+                    if (reactivate) {
+                        // If after 3 retries we failed to re-activate, set the geolocation to false
+                        // so that the user can manually retry the geolocation later on. This can
+                        // mean that the device don't support geolocation so it doesn't make sense
+                        // to retry for ever.
+                        // In the case where we are in the watcher, this means that we had at least
+                        // one successful location and that geolocation is supported by the device.
+                        // So we let the watcher continue has he might recover itself later on, if
+                        // not the error will kept showing and the user will have to manually stop
+                        // geolocation.
+                        store.dispatch('setGeolocation', { active: false, ...dispatcher })
+                    }
+                }
             }
     }
 }
 
-const activeGeolocation = (store, state) => {
-    if (store.state.geolocation.position[0] !== 0 && store.state.geolocation.position[1] !== 0) {
+const activeGeolocation = (store, state, options = {}) => {
+    const { useInitial = false } = options
+    if (
+        useInitial &&
+        store.state.geolocation.position[0] !== 0 &&
+        store.state.geolocation.position[1] !== 0
+    ) {
         // if we have a previous position use it first to be more reactive but set a
         // bad accuracy as we don't know how exact it is.
         setCenterIfInBounds(store, store.state.geolocation.position)
@@ -125,7 +163,7 @@ const activeGeolocation = (store, state) => {
                 ...dispatcher,
             })
         },
-        (error) => handlePositionError(error, store),
+        (error) => handlePositionError(error, store, state, { reactivate: true }),
         {
             enableHighAccuracy: ENABLE_HIGH_ACCURACY,
             maximumAge: 5 * 60 * 1000, // 5 minutes
@@ -145,6 +183,7 @@ const geolocationManagementPlugin = (store) => {
         // listening to the start/stop of geolocation
         if (mutation.type === 'setGeolocationActive') {
             if (state.geolocation.active) {
+                errorCount = 0 // reset the error counter when starting the geolocation
                 activeGeolocation(store, state)
             } else if (geolocationWatcher) {
                 log.debug(`Geolocation clear watcher`)


### PR DESCRIPTION
While using the geolocation you have time to times the `Unknown error` window
that appears. This is due to the fact that the geolocation can return an error,
but  while using the app on the field I noticed that it happens sometimes just
once and then everything seems to work fine. In this case the error windows is
quite annoying as you have to close it and if it happened during the initial
get current position you had to disable and re-enable the geolocation.

So now I improved the error management and do some automatic retries until 3 times
if we are the get current position phase, while in the watcher phase the error
is ignored unless it happens more that 3 times in a row.

[Test link](https://sys-map.int.bgdi.ch/preview/bug-pb-786-geolocation/index.html)