### PR TITLE
PB-395: enhancing highest zoom level - #patch

### DIFF
--- a/src/modules/map/components/openlayers/OpenLayersWMTSLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersWMTSLayer.vue
@@ -86,9 +86,9 @@ function createTileGridForProjection() {
     const maxResolutionIndex = indexOfMaxResolution(projection.value, maxResolution.value)
     let resolutions = projection.value.getResolutions()
     let matrixIds = projection.value.getMatrixIds()
-    if (resolutions.length - 1 > maxResolutionIndex) {
-        resolutions = resolutions.slice(0, maxResolutionIndex)
-        matrixIds = matrixIds.slice(0, maxResolutionIndex)
+    if (resolutions.length > maxResolutionIndex) {
+        resolutions = resolutions.slice(0, maxResolutionIndex + 1)
+        matrixIds = matrixIds.slice(0, maxResolutionIndex + 1)
     }
     return new WMTSTileGrid({
         resolutions,


### PR DESCRIPTION
Issue : At the highest zoom level, the mapviewer would not load the highest possible resolution, but the one right before it.
Cause : When we introduced the max resolution to handle client side zoom, we made a slight error in the slicing, and it caused the possible resolutions client side to be smaller (by 1).
Fix : We slice at the correct place.
Bonus Fix : when trying to print at the 1:500 and 1:1000 scales, since the matrixes were sent as parameter by the viewer, we now request the correct tiles. I will deploy the print with the updated capabilities to int once both PR are merged and when we are confident this works, we can deploy the new print to prod.

[Test link](https://sys-map.int.bgdi.ch/preview/bugfix-pb-395_print-1_500/index.html)