### PR TITLE
PB-802: Edit the geoadmin drawing on top - #patch

### DIFF
--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -132,8 +132,9 @@ const getters = {
      * @returns {KMLLayer | null}
      */
     activeKmlLayer: (state) =>
-        state.activeLayers.find((layer) => layer.type === LayerTypes.KML && !layer.isExternal) ??
-        null,
+        state.activeLayers.findLast(
+            (layer) => layer.visible && layer.type === LayerTypes.KML && !layer.isExternal
+        ) ?? null,
 
     /**
      * All layers in the config that have the flag `background` to `true` (that can be shown as a


### PR DESCRIPTION
On the old viewer if you would manually import multiple geoadmin drawing (drawing
from our prod backend), going in the drawing menu would copy the drawing
on top of the layer list.

On the old viewer however it would take the top drawing layer even if it is
not visible. However this don't make sense and is disturbing because in this
case if the drawing is invisilbe when opening the drawing mode it is still invisible
until you add the first feature and then the copied feature would sundely appear
making very unintuitive. Therefore now we only looks for visible drawings.

[Test link](https://sys-map.int.bgdi.ch/preview/bug-pb-802-multiple-drawing/index.html)