### PR TITLE
PB-761: Don't override text scale if it is zero - #patch

### DIFF
--- a/src/utils/ol/format/KML.js
+++ b/src/utils/ol/format/KML.js
@@ -1,3 +1,5 @@
+// NOTE: This file can be removed and we can use the ol/format/KML.js once the PR
+// https://github.com/openlayers/openlayers/pull/15964 has been merged and released.
 /* eslint-disable */
 // @ts-nocheck
 

--- a/src/utils/ol/format/KML.js
+++ b/src/utils/ol/format/KML.js
@@ -983,7 +983,7 @@ function createNameStyleFunction(foundStyle, name) {
         // Note that kml does not support many text options that OpenLayers does (rotation, textBaseline).
         textStyle = textStyle.clone()
         textStyle.setFont(textStyle.getFont() || DEFAULT_TEXT_STYLE.getFont())
-        textStyle.setScale(textStyle.getScale() || DEFAULT_TEXT_STYLE.getScale())
+        textStyle.setScale(textStyle.getScale() ?? DEFAULT_TEXT_STYLE.getScale())
         textStyle.setFill(textStyle.getFill() || DEFAULT_TEXT_STYLE.getFill())
         textStyle.setStroke(textStyle.getStroke() || DEFAULT_TEXT_STROKE_STYLE)
     } else {


### PR DESCRIPTION


[Test link](https://sys-map.int.bgdi.ch/preview/fix-pb-761-default-text-size-if-text-size-equal-zero/index.html)