### PR TITLE
PB-811: Fix go to position if geolocation is active at startup - #patch

### DIFF
--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -147,18 +147,23 @@ const handleLegacyParam = (
             break
         // if no special work to do, we just copy past legacy params to the new viewer
         default:
+            // NOTE: legacyValue is parsed using URLSearchParams which don't make any difference
+            // between &foo and &foo=
             newValue = legacyValue
             break
     }
 
-    if (newValue) {
+    if (newValue !== undefined) {
         // When receiving a query, the application will encode the URI components
         // We decode those so that the new query won't encode encoded character
         // for example, we avoid having " " becoming %2520 in the URI
         newQuery[key] = decodeURIComponent(newValue)
         log.info(
-            `[Legacy URL] ${param}=${legacyValue} parameter changed to ${key}=${decodeURIComponent(newValue)}`
+            `[Legacy URL] ${param}=${legacyValue} parameter changed to ${key}=${decodeURIComponent(newValue)}`,
+            newQuery
         )
+    } else {
+        log.error(`[Legacy URL] ${param}=${legacyValue} parameter not processed`)
     }
 }
 

--- a/src/router/storeSync/__tests__/abstractParamConfig.class.spec.js
+++ b/src/router/storeSync/__tests__/abstractParamConfig.class.spec.js
@@ -80,7 +80,7 @@ describe('Test all AbstractParamConfig class functionalities', () => {
                 })
                 expect(testInstance.readValueFromQuery({ test: 'true' })).to.be.true
                 expect(testInstance.readValueFromQuery({ test: 'false' })).to.be.false
-                expect(testInstance.readValueFromQuery({ test: '' })).to.be.false
+                expect(testInstance.readValueFromQuery({ test: '' })).to.be.true
                 // null value means the param without value, we want it to be true
                 expect(testInstance.readValueFromQuery({ test: null })).to.be.true
                 expect(testInstance.readValueFromQuery({})).to.be.undefined
@@ -135,7 +135,7 @@ describe('Test all AbstractParamConfig class functionalities', () => {
                 })
                 expect(testInstance.readValueFromQuery({ test: 'true' })).to.be.true
                 expect(testInstance.readValueFromQuery({ test: 'false' })).to.be.false
-                expect(testInstance.readValueFromQuery({ test: '' })).to.be.false
+                expect(testInstance.readValueFromQuery({ test: '' })).to.be.true
                 // null value means the param without value, we want it to be true
                 expect(testInstance.readValueFromQuery({ test: null })).to.be.true
                 expect(testInstance.readValueFromQuery({})).to.be.true

--- a/src/router/storeSync/abstractParamConfig.class.js
+++ b/src/router/storeSync/abstractParamConfig.class.js
@@ -79,7 +79,8 @@ export default class AbstractParamConfig {
             // is present in the query (without a boolean value attached)
             return (
                 queryValue === null ||
-                (typeof queryValue === 'string' && queryValue === 'true') ||
+                queryValue === 'true' ||
+                queryValue === '' ||
                 (typeof queryValue === 'boolean' && !!queryValue)
             )
         } else if (queryValue === null) {

--- a/src/store/modules/geolocation.store.js
+++ b/src/store/modules/geolocation.store.js
@@ -19,7 +19,7 @@ const state = {
      *
      * @type Boolean
      */
-    tracking: false,
+    tracking: true,
     /**
      * Device position in the current application projection [x, y]
      *

--- a/src/store/plugins/geolocation-management.plugin.js
+++ b/src/store/plugins/geolocation-management.plugin.js
@@ -120,7 +120,7 @@ const handlePositionError = (error, store, state, options = {}) => {
 }
 
 const activeGeolocation = (store, state, options = {}) => {
-    const { useInitial = false } = options
+    const { useInitial = true } = options
     if (
         useInitial &&
         store.state.geolocation.position[0] !== 0 &&


### PR DESCRIPTION
If the geolocation was activated at startup using the goelocation query parameter
the application would not re-center to the position. This would break some legacy
links that use this parameter like the swisstopo "you are here" T-shirt.

This was also an issue when entering the parameter in the new query format.

We had several issue here, first the legacy parameter was totally ignored because
URLSearchParams parsed the geolocation to an empty string which was not supported
by our boolean query param.

Another issue was that per default tracking was off unless you explicitely click
on the geolocation button.

[Test link](https://sys-map.int.bgdi.ch/preview/bug-pb-811-geolocalisation/index.html)