### PR TITLE
PB-790: Fix failed to print on empty string text drawing. - #minor

### DIFF
--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -351,6 +351,15 @@ async function transformOlMapToPrintParams(olMap, config) {
             dpi: dpi,
             customizer: customizer,
         })
+        // Note (IS): This is a dirty fix to handle empty text annotation. See PB-790
+        // It should be removed once the issue is fixed in the mapfishprint library
+        encodedMap.layers.forEach((layer) => {
+            layer.geoJson?.features?.forEach((feature) => {
+                // Delete the editableFeature property because it will cause an error in the mapfishprint
+                // Should be handled inside GeoAdminCustomizer.feature but it skip the feature with empty text
+                delete feature.properties?.editableFeature
+            })
+        })
         if (printGrid) {
             encodedMap.layers.unshift({
                 baseURL: WMS_BASE_URL,


### PR DESCRIPTION
This is a dirty fix while waiting this bug fix is merged https://github.com/geoblocks/mapfishprint/pull/35. The https://github.com/geoadmin/web-mapviewer/pull/1011 contains the proper fix.

The bug:
- customizer.feature skips an empty text annotation feature

To reproduce:
- create an empty text and another drawing item
- print


[Test link](https://sys-map.int.bgdi.ch/preview/pb-790-fix-print-editablefeature-error-empty-annotation/index.html)