### PR TITLE
PB-800 : simplify GPXs geometry - #patch

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -349,3 +349,14 @@ export const DEFAULT_FEATURE_COUNT_RECTANGLE_SELECTION = 50
  * @type {Number}
  */
 export const MAX_WIDTH_SHOW_FLOATING_TOOLTIP = 400
+
+/**
+ * 12.5 meters is what was used in the old viewer, see
+ * https://github.com/geoadmin/mf-geoadmin3/blob/ce24a27b0ca8192a0f78f7b8cc07f4e231031304/src/components/GeomUtilsService.js#L207
+ *
+ * I tried lowering the value, but with the test GPX that were attached to the ticket PB-800 I get
+ * worst hiking time estimation when using something like 5m than if I use this 12.5 meters.
+ *
+ * @type {Number}
+ */
+export const GPX_GEOMETRY_SIMPLIFICATION_TOLERANCE = 12.5 // meters

--- a/src/utils/gpxUtils.js
+++ b/src/utils/gpxUtils.js
@@ -3,6 +3,7 @@ import bbox from '@turf/bbox'
 import { isEmpty as isExtentEmpty } from 'ol/extent'
 import GPX from 'ol/format/GPX'
 
+import { GPX_GEOMETRY_SIMPLIFICATION_TOLERANCE } from '@/config'
 import CoordinateSystem from '@/utils/coordinates/CoordinateSystem.class'
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
 import { gpxStyles } from '@/utils/styleUtils'
@@ -46,8 +47,7 @@ export function parseGpx(gpxData, projection) {
     features.forEach((feature) => {
         const geom = feature.getGeometry()
         // PB-800 : to avoid a coastline paradox we simplify the geometry of GPXs
-        // 12.5 meters is what was used in the old viewer, see https://github.com/geoadmin/mf-geoadmin3/blob/ce24a27b0ca8192a0f78f7b8cc07f4e231031304/src/components/GeomUtilsService.js#L207
-        feature.setGeometry(geom.simplify(12.5))
+        feature.setGeometry(geom.simplify(GPX_GEOMETRY_SIMPLIFICATION_TOLERANCE))
         feature.setStyle(gpxStyles[geom.getType()])
     })
     return features

--- a/src/utils/gpxUtils.js
+++ b/src/utils/gpxUtils.js
@@ -44,7 +44,11 @@ export function parseGpx(gpxData, projection) {
         featureProjection: projection.epsg,
     })
     features.forEach((feature) => {
-        feature.setStyle(gpxStyles[feature.getGeometry().getType()])
+        const geom = feature.getGeometry()
+        // PB-800 : to avoid a coastline paradox we simplify the geometry of GPXs
+        // 12.5 meters is what was used in the old viewer, see https://github.com/geoadmin/mf-geoadmin3/blob/ce24a27b0ca8192a0f78f7b8cc07f4e231031304/src/components/GeomUtilsService.js#L207
+        feature.setGeometry(geom.simplify(12.5))
+        feature.setStyle(gpxStyles[geom.getType()])
     })
     return features
 }


### PR DESCRIPTION
so that we diminish, or totally avoid, the coastal paradox we've encounter so far with GPX that contains points close together, following a steep mountain (with the GPS error, that would mean it would jump back and forth on the hill, creating fake height distance, and thus giving a very VERY poor hiking time estimation)

[Test link](https://sys-map.int.bgdi.ch/preview/bug-pb-800-profile-discrepancy/index.html)