### PR TITLE
Fix 790 update mapfishprint with replacer - #patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@fortawesome/free-solid-svg-icons": "^6.6.0",
                 "@fortawesome/vue-fontawesome": "^3.0.8",
                 "@geoblocks/cesium-compass": "^0.5.0",
-                "@geoblocks/mapfishprint": "^0.2.15",
+                "@geoblocks/mapfishprint": "^0.2.16",
                 "@geoblocks/ol-maplibre-layer": "^1.0.0",
                 "@ivanv/vue-collapse-transition": "^1.0.2",
                 "@mapbox/togeojson": "^0.16.2",
@@ -861,14 +861,15 @@
             }
         },
         "node_modules/@geoblocks/mapfishprint": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/@geoblocks/mapfishprint/-/mapfishprint-0.2.15.tgz",
-            "integrity": "sha512-hfQKcYnug7LBHZ6/BDN1jrU557HHx4GrHrlwz2/wf3Piiz6IcIduZGCJRBQg63LX9xnCcnZCqozGqUOFaqxnLw==",
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/@geoblocks/mapfishprint/-/mapfishprint-0.2.16.tgz",
+            "integrity": "sha512-Vle+ZILd9B60YcnLzmRz+xyuGq++Twj6A2QU4p+ig766ayEztq22MoXlTYOIsDFL298MokDD80j+23oIMBYyMw==",
+            "license": "BSD-3-Clause",
             "optionalDependencies": {
-                "@geoblocks/print": "0.7.8"
+                "@geoblocks/print": "0.7.9"
             },
             "peerDependencies": {
-                "ol": "7 || 8 || 9"
+                "ol": "7 || 8 || 9 || 10"
             }
         },
         "node_modules/@geoblocks/ol-maplibre-layer": {
@@ -881,12 +882,13 @@
             }
         },
         "node_modules/@geoblocks/print": {
-            "version": "0.7.8",
-            "resolved": "https://registry.npmjs.org/@geoblocks/print/-/print-0.7.8.tgz",
-            "integrity": "sha512-yPMG1fv8DKX8D1qHhibnTOQusCwIy06KVAaZa+FMzuQeUBW5E79C13W5v5DgyJ+Y471adM3vlCibptnxt+XdLA==",
+            "version": "0.7.9",
+            "resolved": "https://registry.npmjs.org/@geoblocks/print/-/print-0.7.9.tgz",
+            "integrity": "sha512-tEyCoT51CUhcLt3UX1H/XaJADXGSZWCDX4YZl+kVqtPVstbQ9rgXj8td0cVCi/8fAe/95agL4JfA160MmRHkiw==",
+            "license": "BSD-2-Clause",
             "optional": true,
             "peerDependencies": {
-                "ol": "7 || 8 || 9"
+                "ol": "7 || 8 || 9 || 10"
             }
         },
         "node_modules/@hapi/hoek": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.6.0",
         "@fortawesome/vue-fontawesome": "^3.0.8",
         "@geoblocks/cesium-compass": "^0.5.0",
-        "@geoblocks/mapfishprint": "^0.2.15",
+        "@geoblocks/mapfishprint": "^0.2.16",
         "@geoblocks/ol-maplibre-layer": "^1.0.0",
         "@ivanv/vue-collapse-transition": "^1.0.2",
         "@mapbox/togeojson": "^0.16.2",


### PR DESCRIPTION
~UPDATE:
**DO NOT MERGE** this PR before a new version of mapfishprint is released that includes the fix.~


This is a better way to fix the issue.

This fix should be updated after https://github.com/geoblocks/mapfishprint/pull/37 is merged and new version is released.

[Test link](https://sys-map.int.bgdi.ch/preview/fix-790-update-mapfishprint-with-replacer/index.html)