### PR TITLE
PB-806: Use center as the default alignment for text without icon. - #patch

### DIFF
--- a/src/utils/ol/format/KML.js
+++ b/src/utils/ol/format/KML.js
@@ -960,7 +960,7 @@ class KML extends XMLFeature {
 function createNameStyleFunction(foundStyle, name) {
     const textOffset = [0, 0]
     /** @type {CanvasTextAlign} */
-    let textAlign = 'start'
+    let textAlign = 'center'
     const imageStyle = foundStyle.getImage()
     if (imageStyle) {
         const imageSize = imageStyle.getSize()


### PR DESCRIPTION


[Test link](https://sys-map.int.bgdi.ch/preview/fix-806-text-label-alignment/index.html)