### PR TITLE
add DOM elements for sync with puppeteer browser automation - #minor

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -78,6 +78,6 @@ function refreshPageTitle() {
     </div>
 </template>
 
-<!-- this style is not scoped in order to enable the distribution of bootstrap's
+<!-- touch this style is not scoped in order to enable the distribution of bootstrap's
 CSS rules to the whole app (otherwise it would be limited to this component) -->
 <style lang="scss" src="./scss/main.scss" />

--- a/src/modules/map/components/openlayers/OpenLayersMap.vue
+++ b/src/modules/map/components/openlayers/OpenLayersMap.vue
@@ -54,6 +54,12 @@ map.once('rendercomplete', () => {
     store.dispatch('mapModuleReady', dispatcher)
     log.info('Openlayer map rendered')
 })
+map.once('loadend', () => {
+    const span = document.createElement('span')
+    span.id = 'openlayer_complete'
+    document.body.appendChild(span)
+    log.info('openlayer complete')
+})
 
 onMounted(() => {
     map.setTarget(mapElement.value)

--- a/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
@@ -45,6 +45,13 @@ const layer = new MapLibreLayer({
     id: layerId.value,
     opacity: opacity.value,
 })
+layer.once('load', () => {
+    const span = document.createElement('span')
+    span.id = 'maplibre_complete'
+    document.body.appendChild(span)
+
+    console.log('maplibre complete')
+})
 setMapLibreStyle(styleUrl.value)
 
 const olMap = inject('olMap')


### PR DESCRIPTION
Experimentation with headless chrome printing via puppeteer has brought the need to detect the end of rendering.

The webviewer acan be opened in an automated browser window (headless) via puppeteer:
```
const browser = await puppeteer.launch({
    headless: false,
    defaultViewport: {width, height, deviceScaleFactor},
    executablePath: '/usr/bin/google-chrome',
    args: [
        "--no-sandbox",
    ]
});
const page = await browser.newPage();
await page.goto(webviewer_url);
```
Puppeteer can monitor the DOM and wait until the sync elements appear in the document:
```
await page.waitForFunction(
    "document.getElementById('maplibre_complete') && document.getElementById('openlayer_complete')",
    {timeout: 10000}
).catch(()=>console.log('timeout after 10s, the web page has not finished rendering'))
```

[Test link](https://sys-map.int.bgdi.ch/preview/patch-pb-310_sync_for_print/index.html)