### PR TITLE
PB-492: Add description to exported GPX file.

### DIFF
--- a/src/modules/drawing/lib/export-utils.js
+++ b/src/modules/drawing/lib/export-utils.js
@@ -55,6 +55,10 @@ export function generateGpxString(projection, features = []) {
             const coordinates = geom.getLinearRing().getCoordinates()
             clone.setGeometry(new LineString(coordinates))
         }
+        // Set the desc attribute from description property so that it is exported to GPX in desc tag
+        if (clone.getProperties().description) {
+            clone.set('desc', clone.getProperties().description)
+        }
         return clone
     })
     return gpxFormat.writeFeatures(normalizedFeatures, {


### PR DESCRIPTION
[Test link](https://sys-map.dev.bgdi.ch/preview/pb-492-add-description-to-exported-gpx/index.html)

Sample exported GPX file (see the new `desc` tag):
```xml
<gpx xmlns="http://www.topografix.com/GPX/1/1"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers">
    <wpt lat="46.854351415606935" lon="7.353402894159358">
        <name>With desc</name>
        <desc>bla bla</desc>
        <type>marker</type>
    </wpt>
    <rte>
        <name></name>
        <desc>WIth desc</desc>
        <type>linepolygon</type>
        <rtept lat="47.29016724654342" lon="7.769117763897004"/>
        <rtept lat="46.701234266331284" lon="7.667454407858695"/>
    </rte>
    <rte>
        <type>linepolygon</type>
        <rtept lat="47.32555323948249" lon="7.934693728031257"/>
        <rtept lat="47.18596352534941" lon="7.972983046569148"/>
        <rtept lat="47.08597816401732" lon="8.162946834718726"/>
    </rte>
    <wpt lat="46.835224315007764" lon="7.956397668860221">
        <name>No desc</name>
        <type>marker</type>
    </wpt>
</gpx>
```

[Test link](https://sys-map.dev.bgdi.ch/preview/pb-492-add-description-to-exported-gpx/index.html)