### PR TITLE
PB-807: Do not use conflict resolution in text printing and adjust font size.

### DIFF
--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -82,6 +82,9 @@ class GeoAdminCustomizer extends BaseCustomizer {
         symbolizer.pointRadius = adjustWidth(symbolizer.pointRadius, this.printResolution)
         symbolizer.strokeWidth = adjustWidth(symbolizer.strokeWidth, this.printResolution)
         symbolizer.haloRadius = adjustWidth(symbolizer.haloRadius, this.printResolution)
+        symbolizer.conflictResolution = false
+        symbolizer.fontSize =
+            Math.ceil(2 * adjustWidth(parseInt(symbolizer.fontSize), this.printResolution)) + 'px'
     }
 
     /**

--- a/tests/cypress/tests-e2e/print.cy.js
+++ b/tests/cypress/tests-e2e/print.cy.js
@@ -487,7 +487,7 @@ describe('Testing print', () => {
                     type: 'text',
                     label: 'Sample Label',
                     fontFamily: 'Helvetica',
-                    fontSize: '16px',
+                    fontSize: '12px',
                     fontWeight: 'normal',
                     labelYOffset: 44.75,
                 }
@@ -558,7 +558,7 @@ describe('Testing print', () => {
                     type: 'text',
                     label: 'Old Label',
                     fontFamily: 'Helvetica',
-                    fontSize: '16px',
+                    fontSize: '12px',
                     fontWeight: 'normal',
                     labelYOffset: 0,
                 }


### PR DESCRIPTION
OpenLayers rendering:
![image](https://github.com/user-attachments/assets/392ca500-9a06-41e5-ac35-f3de8d031c02)
Print with conflictResolution = False, and adjusted font size (e.g. previously 16px now 12px)
![image](https://github.com/user-attachments/assets/79950808-4897-4d15-ba21-bbcb60f9d976)


[Test link](https://sys-map.dev.bgdi.ch/preview/pb-870-missing-kml/index.html)