### PR TITLE
PB-843 : use LV03 to LV95 reframe services

### DIFF
--- a/src/api/lv03Reframe.api.js
+++ b/src/api/lv03Reframe.api.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
-import proj4 from 'proj4'
 
 import { LV03, LV95 } from '@/utils/coordinates/coordinateSystems'
+import { reprojectAndRound } from '@/utils/coordinates/coordinateUtils'
 import log from '@/utils/logging'
 
 const REFRAME_BASE_URL = 'https://geodesy.geo.admin.ch/reframe/'
@@ -14,22 +14,25 @@ const REFRAME_BASE_URL = 'https://geodesy.geo.admin.ch/reframe/'
  *   in the other coordinate system
  * @param {CoordinateSystem} config.inputProjection Which projection is used to describe the input
  *   coordinate, must be either LV03 or LV95.
- * @returns {Promise<[Number, Number]>} Input coordinates re-framed by the backend service.
- *   Coordinate system will depend on the input. If LV03 coordinates are given, the output will be
- *   LV95 coordinates (and vice-versa)
+ * @param {CoordinateSystem} config.outputProjection In which projection the output coordinates
+ *   should be expressed into. If nothing is given, the "opposite" swiss projection of the input
+ *   will be chosen (if LV03 coordinates are given, the output will be LV95 coordinates (and
+ *   vice-versa))
+ * @returns {Promise<[Number, Number]>} Input coordinates re-framed by the backend service, and
+ *   re-projected in the output projection.
  * @see https://www.swisstopo.admin.ch/en/rest-api-geoservices-reframe-web
  * @see https://github.com/geoadmin/mf-geoadmin3/blob/master/src/components/ReframeService.js
  */
 export default function reframe(config = {}) {
     return new Promise((resolve, reject) => {
-        const { inputCoordinates, inputProjection } = config
+        const { inputCoordinates, inputProjection, outputProjection = null } = config
         if (!Array.isArray(inputCoordinates) || inputCoordinates.length !== 2) {
             reject(new Error('inputCoordinates must be an array with length of 2'))
         }
         if (![LV03.epsg, LV95.epsg].includes(inputProjection?.epsg)) {
             reject(new Error('inputProjection must be LV03 or LV95'))
         }
-        const outputProjection = inputProjection === LV03 ? LV95 : LV03
+        const backendResponseProjection = inputProjection === LV03 ? LV95 : LV03
         axios({
             method: 'GET',
             url: `${REFRAME_BASE_URL}${inputProjection === LV95 ? 'lv95tolv03' : 'lv03tolv95'}`,
@@ -40,7 +43,15 @@ export default function reframe(config = {}) {
         })
             .then((response) => {
                 if (response.data?.coordinates) {
-                    resolve(response.data.coordinates.map(outputProjection.roundCoordinateValue))
+                    let outputCoordinates = [...response.data.coordinates]
+                    if (outputProjection && outputProjection !== backendResponseProjection) {
+                        outputCoordinates = reprojectAndRound(
+                            backendResponseProjection,
+                            outputProjection,
+                            outputCoordinates
+                        )
+                    }
+                    resolve(outputCoordinates)
                 } else {
                     log.error(
                         'Error while re-framing coordinate',
@@ -48,8 +59,10 @@ export default function reframe(config = {}) {
                         'fallback to proj4'
                     )
                     resolve(
-                        proj4(inputProjection.epsg, outputProjection.epsg, inputCoordinates).map(
-                            outputProjection.roundCoordinateValue
+                        reprojectAndRound(
+                            inputProjection,
+                            outputProjection ?? backendResponseProjection,
+                            inputCoordinates
                         )
                     )
                 }

--- a/src/modules/map/components/LocationPopupPosition.vue
+++ b/src/modules/map/components/LocationPopupPosition.vue
@@ -91,7 +91,10 @@ watch(currentLang, () => {
 async function updateLV03Coordinate() {
     try {
         const lv95coordinate = proj4(projection.value.epsg, LV95.epsg, coordinate.value)
-        lv03Coordinate.value = await reframe(lv95coordinate)
+        lv03Coordinate.value = await reframe({
+            inputCoordinates: lv95coordinate,
+            inputProjection: LV95,
+        })
     } catch (error) {
         log.error('Failed to retrieve LV03 coordinate', error)
         lv03Coordinate.value = null

--- a/src/modules/map/components/LocationPopupPosition.vue
+++ b/src/modules/map/components/LocationPopupPosition.vue
@@ -1,7 +1,6 @@
 <script setup>
 /** Right click pop up which shows the coordinates of the position under the cursor. */
 
-import proj4 from 'proj4'
 import { computed, onMounted, ref, toRefs, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -17,6 +16,7 @@ import {
     WGS84Format,
 } from '@/utils/coordinates/coordinateFormat'
 import { LV03, LV95, WGS84 } from '@/utils/coordinates/coordinateSystems'
+import { reprojectAndRound } from '@/utils/coordinates/coordinateUtils'
 import log from '@/utils/logging'
 
 const props = defineProps({
@@ -46,7 +46,7 @@ const height = ref(null)
 const i18n = useI18n()
 
 const coordinateWGS84Metric = computed(() => {
-    return proj4(projection.value.epsg, WGS84.epsg, coordinate.value)
+    return reprojectAndRound(projection.value, WGS84, coordinate.value)
 })
 const coordinateWGS84Plain = computed(() => {
     // we want to output lat / lon, meaning we have to give the coordinate as y / x
@@ -90,10 +90,11 @@ watch(currentLang, () => {
 
 async function updateLV03Coordinate() {
     try {
-        const lv95coordinate = proj4(projection.value.epsg, LV95.epsg, coordinate.value)
+        const lv95coordinate = reprojectAndRound(projection.value, LV95, coordinate.value)
         lv03Coordinate.value = await reframe({
             inputCoordinates: lv95coordinate,
             inputProjection: LV95,
+            outputProjection: LV03,
         })
     } catch (error) {
         log.error('Failed to retrieve LV03 coordinate', error)

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -1,6 +1,7 @@
 import proj4 from 'proj4'
 import { START_LOCATION } from 'vue-router'
 
+import reframe from '@/api/lv03Reframe.api'
 import { transformLayerIntoUrlString } from '@/router/storeSync/layersParamParser'
 import {
     EMBED_VIEW,
@@ -217,7 +218,10 @@ const handleLegacyParams = async (legacyParams, store, originView) => {
             )
         } else if (LV03.isInBounds(...legacyCoordinates) && projection.epsg !== LV03.epsg) {
             // if the current projection is not LV03, we also need to re-project x/y or N/E
-            newCoordinates = proj4(LV03.epsg, projection.epsg, legacyCoordinates)
+            newCoordinates = await reframe({
+                inputCoordinates: legacyCoordinates,
+                inputProjection: LV03,
+            })
             log.info(
                 `[Legacy URL] converting LV03 X/Y|E/N=${JSON.stringify(legacyCoordinates)} to ${projection.epsg} => ${JSON.stringify(newCoordinates)}`
             )

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -221,6 +221,7 @@ const handleLegacyParams = async (legacyParams, store, originView) => {
             newCoordinates = await reframe({
                 inputCoordinates: legacyCoordinates,
                 inputProjection: LV03,
+                outputProjection: projection,
             })
             log.info(
                 `[Legacy URL] converting LV03 X/Y|E/N=${JSON.stringify(legacyCoordinates)} to ${projection.epsg} => ${JSON.stringify(newCoordinates)}`

--- a/src/store/modules/position.store.js
+++ b/src/store/modules/position.store.js
@@ -241,7 +241,7 @@ const actions = {
             return
         }
         if (Array.isArray(center)) {
-            if (state.projection.epsg != LV95.epsg || LV95.isInBounds(center[0], center[1])) {
+            if (state.projection.epsg !== LV95.epsg || LV95.isInBounds(center[0], center[1])) {
                 commit('setCenter', {
                     x: center[0],
                     y: center[1],
@@ -251,7 +251,7 @@ const actions = {
                 log.warn('center received is out of bounds, ignoring')
             }
         } else {
-            if (state.projection.epsg != LV95.epsg || LV95.isInBounds(center.x, center.y)) {
+            if (state.projection.epsg !== LV95.epsg || LV95.isInBounds(center.x, center.y)) {
                 const { x, y } = center
                 commit('setCenter', { x, y, dispatcher })
             } else {

--- a/src/store/modules/search.store.js
+++ b/src/store/modules/search.store.js
@@ -1,11 +1,10 @@
-import proj4 from 'proj4'
-
 import reframe from '@/api/lv03Reframe.api'
 import search, { SearchResultTypes } from '@/api/search.api'
 import { isWhat3WordsString, retrieveWhat3WordsLocation } from '@/api/what3words.api'
 import coordinateFromString from '@/utils/coordinates/coordinateExtractors'
 import { STANDARD_ZOOM_LEVEL_1_25000_MAP } from '@/utils/coordinates/CoordinateSystem.class'
-import { LV03, LV95 } from '@/utils/coordinates/coordinateSystems'
+import { LV03 } from '@/utils/coordinates/coordinateSystems'
+import { reprojectAndRound } from '@/utils/coordinates/coordinateUtils'
 import CustomCoordinateSystem from '@/utils/coordinates/CustomCoordinateSystem.class'
 import log from '@/utils/logging'
 
@@ -66,16 +65,14 @@ const actions = {
                         coordinates = await reframe({
                             inputProjection: LV03,
                             inputCoordinates: coordinates,
+                            outputProjection: currentProjection,
                         })
-                        coordinates = proj4(LV95.epsg, currentProjection.epsg, coordinates).map(
-                            currentProjection.roundCoordinateValue
-                        )
                     } else {
-                        coordinates = proj4(
-                            extractedCoordinate.coordinateSystem.epsg,
-                            currentProjection.epsg,
+                        coordinates = reprojectAndRound(
+                            extractedCoordinate.coordinateSystem,
+                            currentProjection,
                             coordinates
-                        ).map(currentProjection.roundCoordinateValue)
+                        )
                     }
                 }
                 const dispatcherCoordinate = `${dispatcher}/search.store/setSearchQuery/coordinate`

--- a/src/utils/__tests__/extentUtils.spec.js
+++ b/src/utils/__tests__/extentUtils.spec.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai'
-import proj4 from 'proj4'
 import { describe, it } from 'vitest'
 
 import { LV95, WGS84 } from '@/utils/coordinates/coordinateSystems'
+import { reprojectAndRound } from '@/utils/coordinates/coordinateUtils'
 import { getExtentForProjection } from '@/utils/extentUtils'
 
 describe('Test extent utils', () => {
@@ -16,9 +16,7 @@ describe('Test extent utils', () => {
         })
         it('reproject extent of a single coordinate inside the bounds of the projection', () => {
             const singleCoordinate = [8.2, 47.5]
-            const singleCoordinateInLV95 = proj4(WGS84.epsg, LV95.epsg, singleCoordinate).map(
-                LV95.roundCoordinateValue
-            )
+            const singleCoordinateInLV95 = reprojectAndRound(WGS84, LV95, singleCoordinate)
             const extent = [singleCoordinate, singleCoordinate].flat()
             expect(getExtentForProjection(LV95, extent)).to.deep.equal([
                 singleCoordinateInLV95,
@@ -40,11 +38,11 @@ describe('Test extent utils', () => {
         })
         it('only gives back the portion of an extent that is within LV95 bounds', () => {
             const singleCoordinateInsideLV95 = [7.54, 48.12]
-            const singleCoordinateInLV95 = proj4(
-                WGS84.epsg,
-                LV95.epsg,
+            const singleCoordinateInLV95 = reprojectAndRound(
+                WGS84,
+                LV95,
                 singleCoordinateInsideLV95
-            ).map(LV95.roundCoordinateValue)
+            )
             const overlappingExtent = [0, 0, ...singleCoordinateInsideLV95]
             expect(getExtentForProjection(LV95, overlappingExtent)).to.deep.equal([
                 LV95.bounds.bottomLeft,

--- a/src/utils/coordinates/__test__/coordinateExtractors.spec.js
+++ b/src/utils/coordinates/__test__/coordinateExtractors.spec.js
@@ -29,8 +29,8 @@ describe('Unit test functions from coordinateExtractors.js', () => {
          *   (default is zero)
          * @param {CoordinateSystem} projection Which projection is the output of the parsing
          */
-        const checkText = async (text, expected, message, acceptableDelta = 0, projection) => {
-            const result = await coordinateFromString(text)
+        const checkText = (text, expected, message, acceptableDelta = 0, projection) => {
+            const result = coordinateFromString(text)
             expect(result).to.be.an('Object', message)
             expect(result['coordinate']).to.be.an('Array')
             expect(result['coordinateSystem']).to.be.an('Object')
@@ -163,35 +163,35 @@ describe('Unit test functions from coordinateExtractors.js', () => {
         )
 
         describe('Testing non valid inputs', () => {
-            it('Returns undefined when anything else than numbers, coma, whitespaces and point is in the text', async () => {
-                expect(await coordinateFromString('test')).to.be.undefined
-                expect(await coordinateFromString('47.0, 7.4test')).to.eq(
+            it('Returns undefined when anything else than numbers, coma, whitespaces and point is in the text', () => {
+                expect(coordinateFromString('test')).to.be.undefined
+                expect(coordinateFromString('47.0, 7.4test')).to.eq(
                     undefined,
                     'must not accept text after the coordinates'
                 )
-                expect(await coordinateFromString('47.0.3, 7.4,0')).to.eq(
+                expect(coordinateFromString('47.0.3, 7.4,0')).to.eq(
                     undefined,
                     'must not accept text after the coordinates'
                 )
-                expect(await coordinateFromString('test47.0, 7.4')).to.eq(
+                expect(coordinateFromString('test47.0, 7.4')).to.eq(
                     undefined,
                     'must not accept text before the coordinates'
                 )
             })
-            it('Returns undefined when the given text is invalid (null or not a string)', async () => {
-                expect(await coordinateFromString(null)).to.be.undefined
-                expect(await coordinateFromString(1234)).to.be.undefined
-                expect(await coordinateFromString([45.6, 7.4])).to.be.undefined
-                expect(await coordinateFromString({ lon: 7, lat: 45 })).to.be.undefined
+            it('Returns undefined when the given text is invalid (null or not a string)', () => {
+                expect(coordinateFromString(null)).to.be.undefined
+                expect(coordinateFromString(1234)).to.be.undefined
+                expect(coordinateFromString([45.6, 7.4])).to.be.undefined
+                expect(coordinateFromString({ lon: 7, lat: 45 })).to.be.undefined
             })
-            it('Returns undefined when the given text is not two numbers separated by a coma, a space or a slash', async () => {
-                expect(await coordinateFromString('47.0')).to.be.undefined
-                expect(await coordinateFromString('47.0,')).to.be.undefined
-                expect(await coordinateFromString('47.0,test')).to.be.undefined
-                expect(await coordinateFromString('47.0, test')).to.be.undefined
+            it('Returns undefined when the given text is not two numbers separated by a coma, a space or a slash', () => {
+                expect(coordinateFromString('47.0')).to.be.undefined
+                expect(coordinateFromString('47.0,')).to.be.undefined
+                expect(coordinateFromString('47.0,test')).to.be.undefined
+                expect(coordinateFromString('47.0, test')).to.be.undefined
             })
-            it("Returns undefined when coordinates entered don't match any projection bur are technically valid (two numbers)", async () => {
-                expect(await coordinateFromString('600000, 20000')).to.be.undefined
+            it("Returns undefined when coordinates entered don't match any projection bur are technically valid (two numbers)", () => {
+                expect(coordinateFromString('600000, 20000')).to.be.undefined
             })
         })
         describe('EPSG:4326 (WGS84)', () => {
@@ -477,17 +477,18 @@ describe('Unit test functions from coordinateExtractors.js', () => {
          *
          * @param {Number} x
          * @param {Number} y
+         * @param {CoordinateSystem} expectedProjection
          * @param {Number} acceptableDelta
          */
-        const checkSwissCoordinateSystem = (x, y, acceptableDelta) => {
+        const checkSwissCoordinateSystem = (x, y, expectedProjection, acceptableDelta) => {
             it('Returns coordinates when input is valid', () => {
-                checkXY(x, y, expectedCenterLV95[0], expectedCenterLV95[1], LV95, {
+                checkXY(x, y, x, y, expectedProjection, {
                     acceptableDelta,
                     testInverted: true,
                 })
             })
             it('Returns coordinates when input is entered backward', () => {
-                checkXY(y, x, expectedCenterLV95[0], expectedCenterLV95[1], LV95, {
+                checkXY(y, x, x, y, expectedProjection, {
                     acceptableDelta,
                     testInverted: true,
                 })
@@ -496,17 +497,17 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                 checkXY(
                     numberWithThousandSeparator(x),
                     numberWithThousandSeparator(y),
-                    expectedCenterLV95[0],
-                    expectedCenterLV95[1],
-                    LV95,
+                    x,
+                    y,
+                    expectedProjection,
                     { acceptableDelta, testInverted: true }
                 )
                 checkXY(
                     numberWithThousandSeparator(x, ' '),
                     numberWithThousandSeparator(y, ' '),
-                    expectedCenterLV95[0],
-                    expectedCenterLV95[1],
-                    LV95,
+                    x,
+                    y,
+                    expectedProjection,
                     { acceptableDelta, testInverted: true, thousandSpaceSeparator: true }
                 )
             })
@@ -514,33 +515,31 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                 checkXY(
                     numberWithThousandSeparator(y),
                     numberWithThousandSeparator(x),
-                    expectedCenterLV95[0],
-                    expectedCenterLV95[1],
-                    LV95,
+                    x,
+                    y,
+                    expectedProjection,
                     { acceptableDelta, testInverted: true }
                 )
                 checkXY(
                     numberWithThousandSeparator(y, ' '),
                     numberWithThousandSeparator(x, ' '),
-                    expectedCenterLV95[0],
-                    expectedCenterLV95[1],
-                    LV95,
+                    x,
+                    y,
+                    expectedProjection,
                     { acceptableDelta, testInverted: true, thousandSpaceSeparator: true }
                 )
             })
         }
 
         describe('EPSG:2056 (LV95)', () => {
-            checkSwissCoordinateSystem(expectedCenterLV95[0], expectedCenterLV95[1], 0.1)
+            checkSwissCoordinateSystem(expectedCenterLV95[0], expectedCenterLV95[1], LV95, 0.1)
         })
 
-        // After https://jira.swisstopo.ch/browse/PB-843 a backend service is used to reproject LV03 to LV95 coordinates.
-        // It then doesn't really make sense to test that in unit tests, so I skip it
-        describe.skip('EPSG:21781 (LV03)', () => {
+        describe('EPSG:21781 (LV03)', () => {
             const expectedCenterLV03 = proj4(LV95.epsg, LV03.epsg, expectedCenterLV95).map(
                 (value) => LV03.roundCoordinateValue(value)
             )
-            checkSwissCoordinateSystem(expectedCenterLV03[0], expectedCenterLV03[1], 0.1)
+            checkSwissCoordinateSystem(expectedCenterLV03[0], expectedCenterLV03[1], LV03, 0.1)
         })
 
         describe('Military Grid Reference System (MGRS)', () => {

--- a/src/utils/coordinates/__test__/coordinateUtils.spec.js
+++ b/src/utils/coordinates/__test__/coordinateUtils.spec.js
@@ -1,113 +1,15 @@
 import { expect } from 'chai'
-import proj4 from 'proj4'
 import { describe, it } from 'vitest'
 
-import { LV03, LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
+import { LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 import {
-    flattenExtent,
-    normalizeExtent,
     removeZValues,
-    reprojectUnknownSrsCoordsToWGS84,
     toLv95,
     unwrapGeometryCoordinates,
+    wrapXCoordinates,
 } from '@/utils/coordinates/coordinateUtils'
-import { wrapXCoordinates } from '@/utils/coordinates/coordinateUtils'
 
 describe('Unit test functions from coordinateUtils.js', () => {
-    describe('reprojectUnknownSrsCoordsToWGS84(x,y)', () => {
-        const coordinatesLV95 = [2600000, 1190000]
-        const coordinatesLV03 = proj4(LV95.epsg, LV03.epsg, coordinatesLV95)
-        const coordinatesWebMercator = proj4(LV95.epsg, WEBMERCATOR.epsg, coordinatesLV95)
-        const coordinatesWGS84 = proj4(LV95.epsg, WGS84.epsg, coordinatesLV95)
-        const checkFunctionOutputs = (output, expectedOutput, acceptableDelta = 0.00001) => {
-            if (expectedOutput) {
-                expect(output).to.be.an('Array').lengthOf(2)
-                const [x, y] = output
-                expect(x).to.be.approximately(expectedOutput[0], acceptableDelta)
-                expect(y).to.be.approximately(expectedOutput[1], acceptableDelta)
-            } else {
-                expect(output).to.be.undefined
-            }
-        }
-        it('handles LV03 coordinates', () => {
-            checkFunctionOutputs(
-                reprojectUnknownSrsCoordsToWGS84(coordinatesLV03[0], coordinatesLV03[1]),
-                coordinatesWGS84
-            )
-        })
-        it('handles inverted LV03 coordinates', () => {
-            checkFunctionOutputs(
-                reprojectUnknownSrsCoordsToWGS84(coordinatesLV03[1], coordinatesLV03[0]),
-                coordinatesWGS84
-            )
-        })
-        it('handles LV95 coordinates', () => {
-            checkFunctionOutputs(
-                reprojectUnknownSrsCoordsToWGS84(coordinatesLV95[0], coordinatesLV95[1]),
-                coordinatesWGS84
-            )
-        })
-        it('handles inverted LV95 coordinates', () => {
-            // trying the same thing but with inverted X,Y
-            checkFunctionOutputs(
-                reprojectUnknownSrsCoordsToWGS84(coordinatesLV95[1], coordinatesLV95[0]),
-                coordinatesWGS84
-            )
-        })
-        it('handles WebMercator coordinates (in LV95 bounds)', () => {
-            checkFunctionOutputs(
-                reprojectUnknownSrsCoordsToWGS84(
-                    coordinatesWebMercator[0],
-                    coordinatesWebMercator[1]
-                ),
-                coordinatesWGS84
-            )
-        })
-        it('rejects WebMercator coordinates that are out of LV95 bounds', () => {
-            // roughly equivalent to 5° lon, 45° lat in WGS84
-            checkFunctionOutputs(reprojectUnknownSrsCoordsToWGS84(556597.45, 4865942.27), undefined)
-        })
-        it('handles WGS84 coordinates', () => {
-            checkFunctionOutputs(
-                reprojectUnknownSrsCoordsToWGS84(coordinatesWGS84[0], coordinatesWGS84[1]),
-                coordinatesWGS84
-            )
-        })
-        it('handles inverted WGS84 coordinates', () => {
-            // Here the function will not be able to detect that we have inverted lat/lon as values for both of them
-            // are under latitude limits. So no way of telling which one is lat or lon, thus the function will output
-            // them inverted
-            checkFunctionOutputs(
-                reprojectUnknownSrsCoordsToWGS84(coordinatesWGS84[1], coordinatesWGS84[0]),
-                coordinatesWGS84
-            )
-        })
-        it('normalize an extent', () => {
-            const flatExtent = [1, 2, 3, 4]
-            const result = normalizeExtent(flatExtent)
-            expect(result).to.have.length(2)
-            expect(result[0]).to.have.length(2)
-            expect(result[1]).to.have.length(2)
-            expect(result[0][0]).to.equal(1)
-            expect(result[0][1]).to.equal(2)
-            expect(result[1][0]).to.equal(3)
-            expect(result[1][1]).to.equal(4)
-
-            expect(normalizeExtent(result)).to.deep.equal(result)
-        })
-        it('flattern an extent', () => {
-            const normalizedExtent = [
-                [1, 2],
-                [3, 4],
-            ]
-            const flatExtent = flattenExtent(normalizedExtent)
-            expect(flatExtent).to.have.length(4)
-            expect(flatExtent).to.deep.equal([1, 2, 3, 4])
-
-            expect(flattenExtent(flatExtent)).to.deep.equal([1, 2, 3, 4])
-        })
-    })
-
     describe('toLv95(coordinate, "EPSG:4326")', () => {
         it('reprojects points from EPSG:4326', () => {
             expect(LV95.isInBounds(...toLv95([6.57268, 46.51333], WGS84.epsg))).to.be.true

--- a/src/utils/coordinates/coordinateExtractors.js
+++ b/src/utils/coordinates/coordinateExtractors.js
@@ -1,4 +1,3 @@
-import reframe from '@/api/lv03Reframe.api'
 import { LV03, LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
 import { toPoint as mgrsToWGS84 } from '@/utils/militaryGridProjection'
 
@@ -117,21 +116,15 @@ function extractLV95Coordinates(text) {
 
 /**
  * @param {String} text
- * @returns {Promise<[Number, Number] | undefined>}
+ * @returns {[Number, Number] | undefined}
  */
-async function extractLV03Coordinates(text) {
+function extractLV03Coordinates(text) {
     const coordinates = numericalExtractor(REGEX_METRIC_COORDINATES.exec(text.trim()))
     if (coordinates) {
         if (LV03.isInBounds(coordinates[0], coordinates[1])) {
-            return reframe({
-                inputCoordinates: [coordinates[0], coordinates[1]],
-                inputProjection: LV03,
-            })
+            return [coordinates[0], coordinates[1]].map(LV03.roundCoordinateValue)
         } else if (LV03.isInBounds(coordinates[1], coordinates[0])) {
-            return reframe({
-                inputCoordinates: [coordinates[1], coordinates[0]],
-                inputProjection: LV03,
-            })
+            return [coordinates[1], coordinates[0]].map(LV03.roundCoordinateValue)
         }
     }
     return undefined
@@ -322,33 +315,32 @@ const mgrsExtractor = (regexMatches) => {
  * - I.e. `zufall.anders.blaumeise`
  *
  * @param {String} text The text in which we want to find coordinates
- * @returns {Promise<ExtractedCoordinate | undefined>} Coordinates in the given order in text with
+ * @returns {ExtractedCoordinate | undefined} Coordinates in the given order in text with
  *   information about which projection they are expressed in, or `undefined` if nothing was found
  */
-const coordinateFromString = async (text) => {
+const coordinateFromString = (text) => {
     if (typeof text !== 'string') {
         return undefined
     }
-    const wgs84result = extractWGS84Coordinates(text)
-    if (wgs84result) {
+    const wgs84Result = extractWGS84Coordinates(text)
+    if (wgs84Result) {
         return {
             coordinateSystem: WGS84,
-            coordinate: wgs84result,
+            coordinate: wgs84Result,
         }
     }
-    const lv95result = extractLV95Coordinates(text)
-    if (lv95result) {
+    const lv95Result = extractLV95Coordinates(text)
+    if (lv95Result) {
         return {
             coordinateSystem: LV95,
-            coordinate: lv95result,
+            coordinate: lv95Result,
         }
     }
-    const lv03result = await extractLV03Coordinates(text)
-    if (lv03result) {
+    const lv03Result = extractLV03Coordinates(text)
+    if (lv03Result) {
         return {
-            // coordinates have been reframed to LV95
-            coordinateSystem: LV95,
-            coordinate: lv03result,
+            coordinateSystem: LV03,
+            coordinate: lv03Result,
         }
     }
     const mercatorResult = extractMetricMercatorCoordinates(text)

--- a/src/utils/coordinates/coordinateUtils.js
+++ b/src/utils/coordinates/coordinateUtils.js
@@ -2,51 +2,8 @@ import { wrapX } from 'ol/coordinate'
 import { get as getProjection } from 'ol/proj'
 import proj4 from 'proj4'
 
-import log from '../logging'
 import { formatThousand } from '../numberUtils'
-import { LV03, LV95, WEBMERCATOR, WGS84 } from './coordinateSystems'
-
-const LV95BoundsAsWebMercator = LV95.getBoundsAs(WEBMERCATOR)
-const LV95BoundsAsWGS84 = LV95.getBoundsAs(WGS84)
-
-/**
- * Attempts to re-project given coordinates to WebMercator (WGS84). Will return a tuple containing
- * [lat, lon] even if input is given as [lon, lat] (as this is what OpenLayers wants to be fed.
- *
- * This function supports input from LV95, LV03 or WebMercator input (no other projection supported)
- *
- * @param x {Number} X part of the coordinate (Easting/Longitude)
- * @param y {Number} Y part of the coordinate (Northing/Latitude)
- * @returns {Number[]} Re-projected coordinate as [lon, lat], or undefined if the input was not
- *   convertible to WebMercator
- */
-export const reprojectUnknownSrsCoordsToWGS84 = (x, y) => {
-    // guessing if this is already WGS84, or Mercator or a Swiss projection (if so, we need to reproject it to WGS84)
-    if (LV95BoundsAsWebMercator.isInBounds(x, y)) {
-        return proj4(WEBMERCATOR.epsg, WGS84.epsg, [x, y])
-        // checking LV95 bounds
-    } else if (LV95.isInBounds(x, y)) {
-        return proj4(LV95.epsg, WGS84.epsg, [x, y])
-        // checking LV95 backward
-    } else if (LV95.isInBounds(y, x)) {
-        return proj4(LV95.epsg, WGS84.epsg, [y, x])
-        // checking LV03 bounds
-    } else if (LV03.isInBounds(x, y)) {
-        return proj4(LV03.epsg, WGS84.epsg, [x, y])
-        // checking LV03 backward
-    } else if (LV03.isInBounds(y, x)) {
-        return proj4(LV03.epsg, WGS84.epsg, [y, x])
-        // checking for WGS84 bounds
-    } else if (LV95BoundsAsWGS84.isInBounds(x, y)) {
-        return [x, y]
-        // checking for WGS84 backward
-    } else if (LV95BoundsAsWGS84.isInBounds(y, x)) {
-        return [y, x]
-    } else {
-        log.error('Unknown coordinate type', [x, y])
-        return undefined
-    }
-}
+import { LV95 } from './coordinateSystems'
 
 /**
  * Returns rounded coordinate with thousands separator and comma.

--- a/src/utils/coordinates/coordinateUtils.js
+++ b/src/utils/coordinates/coordinateUtils.js
@@ -155,3 +155,16 @@ export function removeZValues(coordinates) {
     }
     return unwrapped.map((coordinate) => [coordinate[0], coordinate[1]])
 }
+
+/**
+ * @param {CoordinateSystem} from
+ * @param {CoordinateSystem} into
+ * @param {[Number, Number]} coordinates
+ * @returns {[Number, Number] | null}
+ */
+export function reprojectAndRound(from, into, coordinates) {
+    if (!from || !into || !Array.isArray(coordinates)) {
+        return null
+    }
+    return proj4(from.epsg, into.epsg, coordinates).map(into.roundCoordinateValue)
+}

--- a/src/utils/militaryGridProjection.js
+++ b/src/utils/militaryGridProjection.js
@@ -78,6 +78,10 @@ export function inverse(mgrs) {
     return [bbox.left, bbox.bottom, bbox.right, bbox.top]
 }
 
+/**
+ * @param {String} mgrs
+ * @returns {[Number, Number]}
+ */
 export function toPoint(mgrs) {
     if (mgrs === '') {
         throw new TypeError('toPoint received a blank string')

--- a/tests/cypress/tests-e2e/search/coordinates-search.cy.js
+++ b/tests/cypress/tests-e2e/search/coordinates-search.cy.js
@@ -110,6 +110,9 @@ describe('Testing coordinates typing in search bar', () => {
     })
 
     it('Paste EPSG:21781 (LV03) coordinates', () => {
+        cy.intercept('**/lv03tolv95**', {
+            coordinates: expectedCenter,
+        })
         standardCheck(expectedCenterLV03[0], expectedCenterLV03[1], {
             acceptableDelta: 0.1,
             withInversion: true,

--- a/tests/cypress/tests-e2e/search/coordinates-search.cy.js
+++ b/tests/cypress/tests-e2e/search/coordinates-search.cy.js
@@ -1,10 +1,9 @@
 /// <reference types="cypress" />
 
-import proj4 from 'proj4'
-
 import { DEFAULT_PROJECTION } from '@/config/map.config'
 import { STANDARD_ZOOM_LEVEL_1_25000_MAP } from '@/utils/coordinates/CoordinateSystem.class'
 import { LV03, LV95, WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
+import { reprojectAndRound } from '@/utils/coordinates/coordinateUtils'
 import CustomCoordinateSystem from '@/utils/coordinates/CustomCoordinateSystem.class'
 import { latLonToMGRS } from '@/utils/militaryGridProjection'
 
@@ -15,20 +14,14 @@ describe('Testing coordinates typing in search bar', () => {
         cy.goToMapView()
     })
     const expectedCenter = DEFAULT_PROJECTION.bounds.center.map((value) => value - 1000)
-    const expectedCenterLV95 = proj4(DEFAULT_PROJECTION.epsg, LV95.epsg, expectedCenter).map(
-        LV95.roundCoordinateValue
-    )
-    const expectedCenterLV03 = proj4(DEFAULT_PROJECTION.epsg, LV03.epsg, expectedCenter).map(
-        LV03.roundCoordinateValue
-    )
-    const expectedCenterWebMercator = proj4(
-        DEFAULT_PROJECTION.epsg,
-        WEBMERCATOR.epsg,
+    const expectedCenterLV95 = reprojectAndRound(DEFAULT_PROJECTION, LV95, expectedCenter)
+    const expectedCenterLV03 = reprojectAndRound(DEFAULT_PROJECTION, LV03, expectedCenter)
+    const expectedCenterWebMercator = reprojectAndRound(
+        DEFAULT_PROJECTION,
+        WEBMERCATOR,
         expectedCenter
-    ).map(WEBMERCATOR.roundCoordinateValue)
-    const expectedCenterWGS84 = proj4(DEFAULT_PROJECTION.epsg, WGS84.epsg, expectedCenter).map(
-        WGS84.roundCoordinateValue
     )
+    const expectedCenterWGS84 = reprojectAndRound(DEFAULT_PROJECTION, WGS84, expectedCenter)
 
     const checkCenterInStore = (acceptableDelta = 0.0) => {
         cy.log(`Check that center is at ${JSON.stringify(expectedCenter)}`)


### PR DESCRIPTION
instead of reprojecting through proj4, which led to poor precision

[Test link with legacy E and N param](https://sys-map.dev.bgdi.ch/preview/fix-pb-843-lv03-reframe/index.html?E=559224&N=101520&crosshair=marker&z=13)
[Same link on PROD](https://map.geo.admin.ch/?E=559224&N=101520&crosshair=marker&z=13)

The difference is about a meter, no more. But for some users, that was a big deal

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-843-lv03-reframe/index.html)