### PR TITLE
PB 898 Fix rumantsch footer link to geo.admin.ch - #patch

### DIFF
--- a/src/modules/i18n/locales/rm.json
+++ b/src/modules/i18n/locales/rm.json
@@ -155,7 +155,7 @@
     "drop_me_here": "Trair vi la datoteca KML nà qua",
     "east": "ost",
     "ech": "Catalog da geodatas",
-    "ech_service_link_href": "https://www.geo.admin.ch/rm/home.html",
+    "ech_service_link_href": "https://www.geo.admin.ch/de/home.html",
     "ech_service_link_label": "geo.admin.ch",
     "edit_back": "Enavos / finir dissegnar",
     "edit_mode_title": "Edition",

--- a/src/modules/map/components/footer/MapFooterAppCopyright.vue
+++ b/src/modules/map/components/footer/MapFooterAppCopyright.vue
@@ -11,29 +11,13 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
-
 export default {
     computed: {
-        ...mapState({
-            currentLang: (state) => state.i18n.lang,
-        }),
-        /**
-         * The language used for the geo.admin.ch link. Since there is no RM version of the page, we
-         * fall back to DE here
-         */
-        linkLang() {
-            const lang = this.currentLang
-            if (lang.toLowerCase() == 'rm') {
-                return 'de'
-            }
-            return lang
-        },
         links() {
             return [
                 {
                     label: 'ech_service_link_label',
-                    url: `https://www.geo.admin.ch/${this.linkLang}/home.html`,
+                    url: this.$t('ech_service_link_href'),
                 },
                 {
                     label: 'copyright_label',

--- a/src/modules/map/components/footer/MapFooterAppCopyright.vue
+++ b/src/modules/map/components/footer/MapFooterAppCopyright.vue
@@ -18,11 +18,22 @@ export default {
         ...mapState({
             currentLang: (state) => state.i18n.lang,
         }),
+        /**
+         * The language used for the geo.admin.ch link. Since there is no RM version of the page, we
+         * fall back to DE here
+         */
+        linkLang() {
+            const lang = this.currentLang
+            if (lang.toLowerCase() == 'rm') {
+                return 'de'
+            }
+            return lang
+        },
         links() {
             return [
                 {
                     label: 'ech_service_link_label',
-                    url: `https://www.geo.admin.ch/${this.currentLang}/home.html`,
+                    url: `https://www.geo.admin.ch/${this.linkLang}/home.html`,
                 },
                 {
                     label: 'copyright_label',


### PR DESCRIPTION
There's no RM version of the page, so we fall back to DE for that link

[Test link](https://sys-map.int.bgdi.ch/preview/bug-pb-898-fix-rumantsch-footer-link/index.html)

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-898-fix-rumantsch-footer-link/index.html)