### PR TITLE
PB-856 : add a style selector for KML in layer settings

### DIFF
--- a/src/api/layers/KMLLayer.class.js
+++ b/src/api/layers/KMLLayer.class.js
@@ -1,5 +1,6 @@
 import AbstractLayer, { LayerAttribution } from '@/api/layers/AbstractLayer.class'
 import { InvalidLayerDataError } from '@/api/layers/InvalidLayerData.error'
+import KmlStyles from '@/api/layers/KmlStyles.enum'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
 import { getServiceKmlBaseUrl } from '@/config/baseUrl.config'
 import { EMPTY_KML_DATA, parseKmlName } from '@/utils/kmlUtils'
@@ -35,6 +36,7 @@ export default class KMLLayer extends AbstractLayer {
      *   files are usually sent with the kml inside a KMZ archive and can be referenced inside the
      *   KML (e.g. icon, image, ...). Default is `Map()`
      * @param {[Number, Number, Number, Number] | null} kmlLayerData.extent
+     * @param {KmlStyles} kmlLayerData.style
      * @throws InvalidLayerDataError if no `gpxLayerData` is given or if it is invalid
      */
     constructor(kmlLayerData) {
@@ -51,6 +53,7 @@ export default class KMLLayer extends AbstractLayer {
             kmlMetadata = null,
             linkFiles = new Map(),
             extent = null,
+            style = null,
         } = kmlLayerData
         if (kmlFileUrl === null) {
             throw new InvalidLayerDataError('Missing KML file URL', kmlLayerData)
@@ -96,6 +99,16 @@ export default class KMLLayer extends AbstractLayer {
         this.kmlData = kmlData
         this.linkFiles = linkFiles
         this.extent = extent
+        if (style === null) {
+            // if no style was given, we select the default style depending on the origin of the KML
+            if (isExternal) {
+                this.style = KmlStyles.DEFAULT
+            } else {
+                this.style = KmlStyles.GEOADMIN
+            }
+        } else {
+            this.style = style
+        }
     }
 
     /**

--- a/src/api/layers/KmlStyles.enum.js
+++ b/src/api/layers/KmlStyles.enum.js
@@ -1,0 +1,16 @@
+/**
+ * List of available styles to be applied to KMLs features.
+ *
+ * For the time being, this can be either the default style (meaning what Google Earth does) or our
+ * custom-made Geoadmin style (everything red)
+ *
+ * @enum
+ */
+const KmlStyles = {
+    DEFAULT: 'DEFAULT',
+    GEOADMIN: 'GEOADMIN',
+}
+
+export const allKmlStyles = [KmlStyles.DEFAULT, KmlStyles.GEOADMIN]
+
+export default KmlStyles

--- a/src/modules/drawing/components/DrawingSelectInteraction.vue
+++ b/src/modules/drawing/components/DrawingSelectInteraction.vue
@@ -48,7 +48,7 @@ watch(selectedFeatures, (newSelectedFeatures) => {
     }
 })
 watch(currentlySelectedFeature, (newFeature, oldFeature) => {
-    if (newFeature) {
+    if (newFeature && newFeature.get('editableFeature')) {
         const editableFeature = newFeature.get('editableFeature')
         editableFeature.setCoordinatesFromFeature(newFeature)
         // binding store feature change events to our handlers
@@ -66,7 +66,7 @@ watch(currentlySelectedFeature, (newFeature, oldFeature) => {
     } else {
         store.dispatch('clearAllSelectedFeatures', dispatcher)
     }
-    if (oldFeature) {
+    if (oldFeature && oldFeature.get('editableFeature')) {
         // editableFeature was removed from the state just before, so we can edit it directly again.
         oldFeature.get('editableFeature').removeListener('change:style', onFeatureChange)
     }

--- a/src/modules/drawing/components/useDrawingModeInteraction.composable.js
+++ b/src/modules/drawing/components/useDrawingModeInteraction.composable.js
@@ -13,7 +13,7 @@ import { DEFAULT_MARKER_TITLE_OFFSET } from '@/api/icon.api'
 import { editingFeatureStyleFunction } from '@/modules/drawing/lib/style'
 import useSaveKmlOnChange from '@/modules/drawing/useKmlDataManagement.composable'
 import { wrapXCoordinates } from '@/utils/coordinates/coordinateUtils'
-import { featureStyleFunction } from '@/utils/featureStyleUtils'
+import { geoadminStyleFunction } from '@/utils/featureStyleUtils'
 import { GeodesicGeometries } from '@/utils/geodesicManager'
 import log from '@/utils/logging'
 
@@ -178,7 +178,7 @@ export default function useDrawingModeInteraction({
         // setting the definitive style function for this feature (thus replacing the editing style from the interaction)
         // This function will be automatically recalled every time the feature object is modified or rerendered.
         // (so there is no need to recall setstyle after modifying an extended property)
-        feature.setStyle(featureStyleFunction)
+        feature.setStyle(geoadminStyleFunction)
         // see https://openlayers.org/en/latest/apidoc/module-ol_interaction_Draw-Draw.html#finishDrawing
         interaction.finishDrawing()
         store.dispatch('addDrawingFeature', { featureId: feature.getId(), ...dispatcher })

--- a/src/modules/drawing/lib/export-utils.js
+++ b/src/modules/drawing/lib/export-utils.js
@@ -6,7 +6,7 @@ import Style from 'ol/style/Style'
 
 import i18n from '@/modules/i18n/index'
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
-import { featureStyleFunction } from '@/utils/featureStyleUtils'
+import { geoadminStyleFunction } from '@/utils/featureStyleUtils'
 import { EMPTY_KML_DATA } from '@/utils/kmlUtils'
 import log from '@/utils/logging'
 // FIXME: as soon as https://github.com/openlayers/openlayers/pull/15964 is merged and released, go back to using OL files
@@ -87,7 +87,7 @@ export function generateKmlString(projection, features = [], fileName) {
         const clone = f.clone()
         clone.setId(f.getId())
         clone.getGeometry().setProperties(f.getGeometry().getProperties())
-        const styles = featureStyleFunction(clone)
+        const styles = geoadminStyleFunction(clone)
         const newStyle = {
             fill: styles[0].getFill(),
             stroke: styles[0].getStroke(),

--- a/src/modules/drawing/lib/style.js
+++ b/src/modules/drawing/lib/style.js
@@ -1,7 +1,7 @@
 import { LineString, MultiPoint, Point, Polygon } from 'ol/geom'
 import { Circle, Fill, Style } from 'ol/style'
 
-import { featureStyleFunction } from '@/utils/featureStyleUtils'
+import { geoadminStyleFunction } from '@/utils/featureStyleUtils'
 import {
     dashedRedStroke,
     redStroke,
@@ -39,7 +39,7 @@ export const editingVertexStyleFunction = (vertex) => {
  * edited by our drawing module.
  *
  * Note that the style differs when the feature is selected (or drawn for the first time) or when
- * displayed without interaction (see {@link featureStyleFunction} for this case)
+ * displayed without interaction (see {@link geoadminStyleFunction} for this case)
  */
 export const editingFeatureStyleFunction = (feature, resolution) => {
     /* This style (image tag) will only be shown for point geometries. So this style will display
@@ -71,7 +71,7 @@ export const editingFeatureStyleFunction = (feature, resolution) => {
             })
         )
     }
-    const defStyle = featureStyleFunction(feature, resolution)
+    const defStyle = geoadminStyleFunction(feature, resolution)
     if (defStyle) {
         styles.push(...defStyle)
     }

--- a/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
@@ -44,12 +44,14 @@ const layerName = computed(() => kmlLayerConfig.value.name)
 const opacity = computed(() => parentLayerOpacity.value ?? kmlLayerConfig.value.opacity)
 const url = computed(() => kmlLayerConfig.value.baseUrl)
 const kmlData = computed(() => kmlLayerConfig.value.kmlData)
+const kmlStyle = computed(() => kmlLayerConfig.value.style)
 
 watch(opacity, (newOpacity) => layer.setOpacity(newOpacity))
 watch(projection, createSourceForProjection)
 watch(iconsArePresent, createSourceForProjection)
 watch(availableIconSets, createSourceForProjection)
 watch(kmlData, createSourceForProjection)
+watch(kmlStyle, createSourceForProjection)
 
 /* We cannot directly let the vectorSource load the URL. We need to run the deserialize
 function on each feature before it is added to the vectorsource, as it may overwrite

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -59,6 +59,7 @@ export function createLayerObject(parsedLayer, currentLayer, store, featuresRequ
                 visible: parsedLayer.visible,
                 opacity: parsedLayer.opacity ?? defaultOpacity,
                 adminId: adminId,
+                style: parsedLayer.customAttributes?.style,
             })
         } else {
             // If the url does not start with http, then it is a local file and we don't add it
@@ -312,6 +313,7 @@ export default class LayerParamConfig extends AbstractParamConfig {
                 'setLayers',
                 'setSelectedFeatures',
                 'addSelectedFeatures',
+                'updateLayer',
             ],
             setValuesInStore: dispatchLayersFromUrlIntoStore,
             extractValueFromStore: generateLayerUrlParamFromStoreValues,

--- a/src/router/storeSync/layersParamParser.js
+++ b/src/router/storeSync/layersParamParser.js
@@ -1,4 +1,5 @@
 import LayerFeature from '@/api/features/LayerFeature.class'
+import KmlStyles from '@/api/layers/KmlStyles.enum'
 import {
     decodeExternalLayerParam,
     encodeExternalLayerParam,
@@ -118,6 +119,11 @@ export function parseLayersParam(queryValue) {
                         parsedValue = Number(value)
                     } else if (key === 'year' && value.toLowerCase() === 'none') {
                         parsedValue = null
+                    } else if (
+                        key === 'style' &&
+                        Object.values(KmlStyles).includes(value?.toUpperCase())
+                    ) {
+                        parsedValue = value.toUpperCase()
                     } else {
                         parsedValue = value
                     }
@@ -175,6 +181,14 @@ export function transformLayerIntoUrlString(layer, defaultLayerConfig, featuresI
         (!defaultLayerConfig || defaultLayerConfig.updateDelay !== layer.updateDelay)
     ) {
         layerUrlString += `@updateDelay=${layer.updateDelay}`
+    }
+
+    if (layer.type === LayerTypes.KML) {
+        // for our own files, the default style is GeoAdmin (and we don't want to write that in the URL)
+        const defaultKmlStyle = layer.isExternal ? KmlStyles.DEFAULT : KmlStyles.GEOADMIN
+        if (layer.style !== defaultKmlStyle) {
+            layerUrlString += `@style=${layer.style.toLowerCase()}`
+        }
     }
 
     // Add custom attributes if any

--- a/src/utils/components/DropdownButton.vue
+++ b/src/utils/components/DropdownButton.vue
@@ -5,7 +5,7 @@
             ref="dropdownMainButton"
             :disabled="disabled"
             class="btn btn-light"
-            :class="{ 'dropdown-toggle': !withToggleButton }"
+            :class="{ 'dropdown-toggle': !withToggleButton, 'btn-sm': small }"
             type="button"
             data-cy="dropdown-main-button"
             :data-bs-toggle="withToggleButton ? null : 'dropdown'"
@@ -115,6 +115,10 @@ export default {
             default: false,
         },
         disabled: {
+            type: Boolean,
+            default: false,
+        },
+        small: {
             type: Boolean,
             default: false,
         },

--- a/src/utils/layerUtils.js
+++ b/src/utils/layerUtils.js
@@ -3,7 +3,7 @@ import GeoJSON from 'ol/format/GeoJSON'
 import LayerFeature from '@/api/features/LayerFeature.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
 import GeoAdminWMTSLayer from '@/api/layers/GeoAdminWMTSLayer.class'
-import LayerTypes from '@/api/layers/LayerTypes.enum.js'
+import LayerTypes from '@/api/layers/LayerTypes.enum'
 import { getBaseUrlOverride } from '@/config/baseUrl.config'
 import { normalizeExtent } from '@/utils/extentUtils'
 
@@ -42,6 +42,8 @@ import { normalizeExtent } from '@/utils/extentUtils'
  *   feature IDs to select. Default is `undefined`
  * @property {String | undefined} [customAttributes.adminId=undefined] KML admin ID required to edit
  *   a KML drawing. Default is `undefined`
+ * @property {KmlStyles | undefined} [customAttributes.style=undefined] KML style to be applied to
+ *   its features, can be one of the value from KmlStyles.enum.js. Default is `undefined`
  */
 
 /**

--- a/src/utils/styleUtils.js
+++ b/src/utils/styleUtils.js
@@ -17,6 +17,8 @@ function hexToRgba(hexValue, alpha = 1.0) {
     ]
 }
 
+const STROKE_WIDTH = 3
+
 export const whiteSketchFill = new Fill({
     color: hexToRgba(white, 0.4),
 })
@@ -26,23 +28,23 @@ export const redFill = new Fill({
 })
 /** Standard line styling */
 export const redStroke = new Stroke({
-    width: 3,
+    width: STROKE_WIDTH,
     color: hexToRgba(red),
 })
 
 export const malibuStroke = new Stroke({
-    width: 3,
+    width: STROKE_WIDTH,
     color: hexToRgba(malibu),
 })
 
 /** Styling specific for measurement, with a dashed red line */
 export const dashedRedStroke = new Stroke({
     color: hexToRgba(red),
-    width: 3,
+    width: STROKE_WIDTH,
     lineDash: [8],
 })
 
-export const gpxStrokeStyle = new Stroke({ width: 1.5, color: hexToRgba(red, 1) })
+export const gpxStrokeStyle = new Stroke({ width: STROKE_WIDTH, color: hexToRgba(red, 1) })
 
 export const pointStyle = {
     radius: 7,
@@ -78,7 +80,7 @@ export const gpxStyles = {
 
 export const geolocationPointWidth = 10
 export const geolocationPointFillColor = hexToRgba(red, 0.9)
-export const geolocationPointBorderWidth = 3
+export const geolocationPointBorderWidth = STROKE_WIDTH
 export const geolocationPointBorderColor = hexToRgba(white, 1.0)
 
 export const geolocationPointStyle = new Style({
@@ -118,7 +120,7 @@ export const highlightedFill = new Fill({
 })
 export const highlightedStroke = new Stroke({
     color: hexToRgba(mocassinToRed2, 1.0),
-    width: 3,
+    width: STROKE_WIDTH,
 })
 
 export const hoveredFill = new Fill({
@@ -126,7 +128,7 @@ export const hoveredFill = new Fill({
 })
 export const hoveredStroke = new Stroke({
     color: hexToRgba(red, 1.0),
-    width: 3,
+    width: STROKE_WIDTH,
 })
 
 export const hoveredLinePolygonStyle = new Style({

--- a/tests/cypress/tests-e2e/print.cy.js
+++ b/tests/cypress/tests-e2e/print.cy.js
@@ -423,7 +423,7 @@ describe('Testing print', () => {
                 )
                 expect(
                     gpxLayer['style']["[_mfp_style = '2']"]['symbolizers'][0]['strokeWidth']
-                ).to.lessThan(1.5) // thinner than the drawn in the OL map.
+                ).to.lessThan(2) // thinner than the drawn in the OL map.
             })
         })
         /** We need to ensure the structure of the query sent is correct */


### PR DESCRIPTION
this enables users to opt-out of the default style (Google Earth like) we apply by default to external KML, and let them go back to the GeoAdmin (all red) style that was previously (on mf-geoadmin3) applied across the board.

adding this choice to the layer URL extra attributes

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-856-add-kml-style-selector/index.html)