### PR TITLE
PB-912 Fix language of background layer attribution

### DIFF
--- a/src/modules/map/components/common/z-index.composable.js
+++ b/src/modules/map/components/common/z-index.composable.js
@@ -12,7 +12,7 @@ export function useLayerZIndexCalculation() {
         if (is3dActive.value) {
             return store.getters.backgroundLayersFor3D
         }
-        return [store.state.layers.currentBackgroundLayer]
+        return [store.getters.currentBackgroundLayer]
     })
 
     const visibleLayers = computed(() => {

--- a/src/modules/map/components/footer/MapFooterAttributionList.vue
+++ b/src/modules/map/components/footer/MapFooterAttributionList.vue
@@ -39,9 +39,13 @@ export default {
     computed: {
         ...mapState({
             layersConfig: (state) => state.layers.config,
-            currentBackgroundLayer: (state) => state.layers.currentBackgroundLayer,
         }),
-        ...mapGetters(['visibleLayers', 'hasDataDisclaimer', 'isLocalFile']),
+        ...mapGetters([
+            'visibleLayers',
+            'hasDataDisclaimer',
+            'isLocalFile',
+            'currentBackgroundLayer',
+        ]),
         layers() {
             const layers = []
             // when the background is void, we receive `undefined` here

--- a/src/modules/map/components/footer/backgroundSelector/BackgroundSelector.vue
+++ b/src/modules/map/components/footer/backgroundSelector/BackgroundSelector.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import { useStore } from 'vuex'
 
 import BackgroundSelectorSquared from '@/modules/map/components/footer/backgroundSelector/BackgroundSelectorSquared.vue'
@@ -51,6 +51,19 @@ function selectBackground(backgroundLayer) {
         ...dispatcher,
     })
 }
+
+/**
+ * This is a bit of a hack to force the reactive system to update the attributions when the language
+ * changes, so that the url will be updated on language selection: On language change the background
+ * layers are being updated, which changes the link to the correct (current) language. For the
+ * change to propagate through to the UI, we push it here again
+ */
+watch(
+    () => backgroundLayers.value,
+    () => {
+        selectBackground(currentBackgroundLayer.value)
+    }
+)
 </script>
 
 <template>

--- a/src/modules/map/components/footer/backgroundSelector/BackgroundSelector.vue
+++ b/src/modules/map/components/footer/backgroundSelector/BackgroundSelector.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, watch } from 'vue'
+import { computed } from 'vue'
 import { useStore } from 'vuex'
 
 import BackgroundSelectorSquared from '@/modules/map/components/footer/backgroundSelector/BackgroundSelectorSquared.vue'
@@ -9,7 +9,7 @@ const dispatcher = { dispatcher: 'BackgroundSelector.vue' }
 
 const store = useStore()
 const backgroundLayers = computed(() => store.getters.backgroundLayers)
-const currentBackgroundLayer = computed(() => store.state.layers.currentBackgroundLayer)
+const currentBackgroundLayer = computed(() => store.getters.currentBackgroundLayer)
 const squaredDesign = computed(() => store.getters.isDesktopMode)
 
 function generateBackgroundCategories(bg) {
@@ -45,25 +45,12 @@ const sortedBackgroundLayersWithVoid = computed(() =>
     })
 )
 
-function selectBackground(backgroundLayer) {
+function selectBackground(backgroundLayerId) {
     store.dispatch('setBackground', {
-        bgLayer: backgroundLayer,
+        bgLayerId: backgroundLayerId,
         ...dispatcher,
     })
 }
-
-/**
- * This is a bit of a hack to force the reactive system to update the attributions when the language
- * changes, so that the url will be updated on language selection: On language change the background
- * layers are being updated, which changes the link to the correct (current) language. For the
- * change to propagate through to the UI, we push it here again
- */
-watch(
-    () => backgroundLayers.value,
-    () => {
-        selectBackground(currentBackgroundLayer.value)
-    }
-)
 </script>
 
 <template>

--- a/src/modules/map/components/footer/backgroundSelector/BackgroundSelectorSquared.vue
+++ b/src/modules/map/components/footer/backgroundSelector/BackgroundSelectorSquared.vue
@@ -1,15 +1,14 @@
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
-import AbstractLayer from '@/api/layers/AbstractLayer.class'
 import useBackgroundSelector from '@/modules/map/components/footer/backgroundSelector/useBackgroundSelector'
 import useBackgroundLayerProps from '@/modules/map/components/footer/backgroundSelector/useBackgroundSelectorProps'
 
 const { backgroundLayers, currentBackgroundLayer } = defineProps(useBackgroundLayerProps())
 
 const emit = defineEmits({
-    selectBackground: (backgroundLayer) => {
-        return backgroundLayer === null || backgroundLayer instanceof AbstractLayer
+    selectBackground: (backgroundLayerId) => {
+        return backgroundLayerId === null || typeof backgroundLayerId === 'string'
     },
 })
 
@@ -30,7 +29,7 @@ const { show, animate, getImageForBackgroundLayer, toggleShowSelector, onSelectB
                 ]"
                 type="button"
                 :data-cy="`background-selector-${backgroundLayer?.id || 'void'}`"
-                @click="onSelectBackground(backgroundLayer)"
+                @click="onSelectBackground(backgroundLayer?.id || null)"
             >
                 <span class="bg-selector-squared-wheel-button-image-cropper">
                     <img

--- a/src/modules/map/components/footer/backgroundSelector/BackgroundSelectorWheelRounded.vue
+++ b/src/modules/map/components/footer/backgroundSelector/BackgroundSelectorWheelRounded.vue
@@ -1,5 +1,4 @@
 <script setup>
-import AbstractLayer from '@/api/layers/AbstractLayer.class'
 import useBackgroundSelector from '@/modules/map/components/footer/backgroundSelector/useBackgroundSelector'
 import useBackgroundLayerProps from '@/modules/map/components/footer/backgroundSelector/useBackgroundSelectorProps'
 
@@ -7,7 +6,7 @@ const { backgroundLayers, currentBackgroundLayer } = defineProps(useBackgroundLa
 
 const emit = defineEmits({
     selectBackground: (backgroundLayer) => {
-        return backgroundLayer === null || backgroundLayer instanceof AbstractLayer
+        return backgroundLayer === null || typeof backgroundLayer === 'string'
     },
 })
 
@@ -28,7 +27,7 @@ const { show, animate, getImageForBackgroundLayer, toggleShowSelector, onSelectB
                 ]"
                 type="button"
                 :data-cy="`background-selector-${backgroundLayer?.id || 'void'}`"
-                @click="onSelectBackground(backgroundLayer)"
+                @click="onSelectBackground(backgroundLayer?.id || null)"
             >
                 <span class="bg-selector-rounded-wheel-button-image-cropper">
                     <img

--- a/src/modules/map/components/openlayers/OpenLayersBackgroundLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersBackgroundLayer.vue
@@ -6,7 +6,7 @@ import { useLayerZIndexCalculation } from '@/modules/map/components/common/z-ind
 import OpenLayersInternalLayer from '@/modules/map/components/openlayers/OpenLayersInternalLayer.vue'
 
 const store = useStore()
-const currentBackgroundLayer = computed(() => store.state.layers.currentBackgroundLayer)
+const currentBackgroundLayer = computed(() => store.getters.currentBackgroundLayer)
 
 const { getZIndexForLayer } = useLayerZIndexCalculation()
 </script>

--- a/src/modules/map/components/openlayers/debug/OpenLayersLayerExtents.vue
+++ b/src/modules/map/components/openlayers/debug/OpenLayersLayerExtents.vue
@@ -24,8 +24,8 @@ const store = useStore()
 const currentProjection = computed(() => store.state.position.projection)
 const allLayers = computed(() => {
     const layers = []
-    if (store.state.layers.currentBackgroundLayer) {
-        layers.push(store.state.layers.currentBackgroundLayer)
+    if (store.getters.currentBackgroundLayer) {
+        layers.push(store.getters.currentBackgroundLayer)
     }
     layers.push(...store.getters.visibleLayers)
     return layers

--- a/src/modules/map/components/openlayers/utils/usePrint.composable.js
+++ b/src/modules/map/components/openlayers/utils/usePrint.composable.js
@@ -61,7 +61,7 @@ export function usePrint(map) {
                 layout: store.state.print.selectedLayout,
                 scale: store.state.print.selectedScale,
                 attributions: store.getters.visibleLayers
-                    .concat([store.state.layers.currentBackgroundLayer])
+                    .concat([store.getters.currentBackgroundLayer])
                     .filter((layer) => !!layer)
                     .map((layer) => layer.attributions)
                     .flat()

--- a/src/router/storeSync/storeSync.config.js
+++ b/src/router/storeSync/storeSync.config.js
@@ -69,13 +69,14 @@ const storeSyncConfig = [
         urlParamName: 'bgLayer',
         mutationsToWatch: ['setBackground'],
         dispatchName: 'setBackground',
+        dispatchValueName: 'bgLayerId',
         extractValueFromStore: (store) => {
-            const backgroundLayer = store.state.layers.currentBackgroundLayer
+            const backgroundLayer = store.state.layers.currentBackgroundLayerId
             // if background layer is null (no background) we write 'void' in the URL
             if (backgroundLayer === null) {
                 return 'void'
             }
-            return backgroundLayer.id
+            return backgroundLayer
         },
         keepInUrlWhenDefault: true,
         valueType: String,

--- a/src/store/modules/__tests__/layers.store.spec.js
+++ b/src/store/modules/__tests__/layers.store.spec.js
@@ -45,36 +45,39 @@ const secondLayer = new GeoAdminWMSLayer({
 
 const resetStore = () => {
     store.dispatch('clearLayers', dispatcher)
-    store.dispatch('setBackground', { bgLayer: null, ...dispatcher })
+    store.dispatch('setBackground', { bgLayerId: null, ...dispatcher })
     store.dispatch('setLayerConfig', { config: [], ...dispatcher })
 }
 
 describe('Background layer is correctly set', () => {
-    const getBackgroundLayer = () => store.state.layers.currentBackgroundLayer
+    const getBackgroundLayer = () => store.getters.currentBackgroundLayer
+    const getBackgroundLayerId = () => store.state.layers.currentBackgroundLayerId
 
     beforeEach(() => {
         resetStore()
     })
 
     it('does not have a background selected by default', () => {
+        expect(getBackgroundLayerId()).to.be.null
         expect(getBackgroundLayer()).to.be.null
     })
     it('does not select a background if the one given is not present in the config', () => {
-        store.dispatch('setBackground', { bgLayer: bgLayer.id, ...dispatcher })
+        store.dispatch('setBackground', { bgLayerId: bgLayer.id })
+        expect(getBackgroundLayerId()).to.be.null
         expect(getBackgroundLayer()).to.be.null
     })
     it('does select the background if it is present in the config', () => {
         store.dispatch('setLayerConfig', { config: [bgLayer], ...dispatcher })
-        store.dispatch('setBackground', { bgLayer: bgLayer.id, ...dispatcher })
+        store.dispatch('setBackground', { bgLayerId: bgLayer.id })
+        expect(getBackgroundLayerId()).to.be.a('string')
         expect(getBackgroundLayer()).to.be.an.instanceof(AbstractLayer)
+        expect(getBackgroundLayerId()).to.eq(bgLayer.id)
         expect(getBackgroundLayer().id).to.eq(bgLayer.id)
     })
     it('does not permit to select a background that has not the flag isBackground set to true', () => {
         store.dispatch('setLayerConfig', { config: [firstLayer], ...dispatcher })
-        store.dispatch('setBackground', {
-            bgLayer: firstLayer.id,
-            ...dispatcher,
-        })
+        store.dispatch('setBackground', { bgLayerId: firstLayer.id })
+        expect(getBackgroundLayerId()).to.be.null
         expect(getBackgroundLayer()).to.be.null
     })
 })

--- a/src/store/modules/cesium.store.js
+++ b/src/store/modules/cesium.store.js
@@ -62,9 +62,9 @@ export default {
         isViewerReady: false,
     },
     getters: {
-        backgroundLayersFor3D(state, _, rootState) {
+        backgroundLayersFor3D(state, getters, rootState) {
             const bgLayers = []
-            const backgroundLayer = rootState.layers.currentBackgroundLayer
+            const backgroundLayer = getters.currentBackgroundLayer
             if (backgroundLayer) {
                 if (backgroundLayer.idIn3d) {
                     bgLayers.push(

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -33,11 +33,11 @@ const cloneActiveLayerConfig = (getters, layer) => {
 
 const state = {
     /**
-     * Current background layer
+     * Current background layer ID
      *
-     * @type AbstractLayer
+     * @type string
      */
-    currentBackgroundLayer: null,
+    currentBackgroundLayerId: null,
     /**
      * Currently active layers (that have been selected by the user from the search bar or the layer
      * tree)
@@ -81,6 +81,14 @@ const state = {
 }
 
 const getters = {
+    /**
+     * Return the current background layer from the list of layers via ID
+     *
+     * @returns {AbstractLayer} The current background layer
+     */
+    currentBackgroundLayer: (state, getters) => {
+        return getters.getLayerConfigById(state.currentBackgroundLayerId)
+    },
     /**
      * Filter all the active layers and gives only those who are visible on the map.
      *
@@ -250,22 +258,16 @@ const actions = {
      * Will set the background to the given layer (or layer ID), but only if this layer's
      * configuration states that this layer can be a background layer (isBackground flag)
      *
-     * @param {String | AbstractLayer} bgLayer Either the background layer id or an AbstractLayer
-     *   object
+     * @param {String | null} bgLayerId The background layer id object
      * @param {string} dispatcher Action dispatcher name
      */
-    setBackground({ commit, getters }, { bgLayer, dispatcher }) {
-        const layerIdOrObject = bgLayer
-        let futureBackground
-        if (typeof layerIdOrObject === 'string') {
-            futureBackground = getters.getLayerConfigById(layerIdOrObject)
-        } else if (layerIdOrObject instanceof AbstractLayer) {
-            futureBackground = getters.getLayerConfigById(layerIdOrObject.id)
+    setBackground({ commit, getters }, { bgLayerId }) {
+        if (bgLayerId === null) {
+            // setting it to no background
+            commit('setBackground', { bgLayerId: null })
         }
-        if (futureBackground?.isBackground) {
-            commit('setBackground', { bgLayer: futureBackground, dispatcher })
-        } else {
-            commit('setBackground', { bgLayer: null, dispatcher })
+        if (getters.getLayerConfigById(bgLayerId)?.isBackground) {
+            commit('setBackground', { bgLayerId: bgLayerId })
         }
     },
 
@@ -781,8 +783,8 @@ const actions = {
 }
 
 const mutations = {
-    setBackground(state, { bgLayer }) {
-        state.currentBackgroundLayer = bgLayer
+    setBackground(state, { bgLayerId }) {
+        state.currentBackgroundLayerId = bgLayerId
     },
     setLayerConfig(state, { config }) {
         state.config = config

--- a/src/store/plugins/topic-change-management.plugin.js
+++ b/src/store/plugins/topic-change-management.plugin.js
@@ -56,12 +56,12 @@ const topicChangeManagementPlugin = (store) => {
             ) {
                 if (currentTopic.defaultBackgroundLayer) {
                     store.dispatch('setBackground', {
-                        bgLayer: currentTopic.defaultBackgroundLayer.id,
+                        bgLayerId: currentTopic.defaultBackgroundLayer.id,
                         ...dispatcher,
                     })
                 } else {
                     store.dispatch('setBackground', {
-                        bgLayer: null,
+                        bgLayerId: null,
                         ...dispatcher,
                     })
                 }

--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -188,9 +188,7 @@ export function getBackgroundLayerFromLegacyUrlParams(layersConfig, legacyUrlPar
         if (bgLayerId === 'voidLayer') {
             return null
         }
-        if (bgLayerId) {
-            return layersConfig.find((layer) => layer.id === bgLayerId)
-        }
+        return bgLayerId
     }
     return undefined
 }

--- a/tests/cypress/tests-e2e/footer.cy.js
+++ b/tests/cypress/tests-e2e/footer.cy.js
@@ -28,7 +28,7 @@ describe('Testing the footer content / tools', () => {
     it('has a functional background wheel', () => {
         function testBackgroundWheel() {
             // first, checking that the current bgLayer is the void layer
-            cy.readStoreValue('state.layers.currentBackgroundLayer').should('be.null')
+            cy.readStoreValue('getters.currentBackgroundLayer').should('be.null')
 
             // opening the background wheel
             cy.get('[data-cy="background-selector-open-wheel-button"]').click()
@@ -42,7 +42,7 @@ describe('Testing the footer content / tools', () => {
                         // checking that clicking on the wheel buttons changes the bgLayer of the app accordingly
                         cy.waitUntilState(
                             (state) =>
-                                state.layers.currentBackgroundLayer?.id === bgLayer.serverLayerName
+                                state.layers.currentBackgroundLayerId === bgLayer.serverLayerName
                         )
                         // reopening the BG wheel
                         cy.get('[data-cy="background-selector-open-wheel-button"]').click()
@@ -51,7 +51,7 @@ describe('Testing the footer content / tools', () => {
 
             // reverting to void layer
             cy.get('[data-cy="background-selector-void"]').click()
-            cy.readStoreValue('state.layers.currentBackgroundLayer').should('be.null')
+            cy.readStoreValue('getters.currentBackgroundLayer').should('be.null')
         }
 
         cy.goToMapView({

--- a/tests/cypress/tests-e2e/layers.cy.js
+++ b/tests/cypress/tests-e2e/layers.cy.js
@@ -651,7 +651,7 @@ describe('Test of layer handling', () => {
             cy.fixture('topics.fixture').then((topicFixtures) => {
                 const [defaultTopic] = topicFixtures.topics
                 cy.goToMapView()
-                cy.readStoreValue('state.layers.currentBackgroundLayer').then((bgLayer) => {
+                cy.readStoreValue('getters.currentBackgroundLayer').then((bgLayer) => {
                     expect(bgLayer).to.not.be.null
                     expect(bgLayer.id).to.eq(defaultTopic.defaultBackground)
                 })
@@ -663,7 +663,7 @@ describe('Test of layer handling', () => {
                 cy.goToMapView({
                     layers: 'test.timeenabled.wmts.layer',
                 })
-                cy.readStoreValue('state.layers.currentBackgroundLayer').then((bgLayer) => {
+                cy.readStoreValue('getters.currentBackgroundLayer').then((bgLayer) => {
                     expect(bgLayer).to.not.be.null
                     expect(bgLayer.id).to.eq(defaultTopic.defaultBackground)
                 })
@@ -679,7 +679,7 @@ describe('Test of layer handling', () => {
             cy.goToMapView({
                 bgLayer: 'test.background.layer2',
             })
-            cy.readStoreValue('state.layers.currentBackgroundLayer').then((bgLayer) => {
+            cy.readStoreValue('getters.currentBackgroundLayer').then((bgLayer) => {
                 expect(bgLayer).to.not.be.null
                 expect(bgLayer.id).to.eq('test.background.layer2')
             })

--- a/tests/cypress/tests-e2e/topics.cy.js
+++ b/tests/cypress/tests-e2e/topics.cy.js
@@ -72,7 +72,7 @@ describe('Topics', () => {
                 expect(layers.length).to.eq(0)
             })
             // we expect background layer to have switched to the one of the topic
-            cy.readStoreValue('state.layers.currentBackgroundLayer').should((bgLayer) => {
+            cy.readStoreValue('getters.currentBackgroundLayer').should((bgLayer) => {
                 expect(bgLayer).to.not.be.null
                 expect(bgLayer.id).to.eq(topicStandard.defaultBackground)
             })
@@ -134,7 +134,7 @@ describe('Topics', () => {
                     expect(activeLayer.opacity).to.eq(expectedOpacity[layerIdThatMustBeActive])
                 })
             })
-            cy.readStoreValue('state.layers.currentBackgroundLayer').should('be.null') // void layer
+            cy.readStoreValue('getters.currentBackgroundLayer').should('be.null') // void layer
         })
 
         //---------------------------------------------------------------------


### PR DESCRIPTION
(the reason I am doing this was because I fixed something small when nobody else was around, this is like the extension of that)
Some notes on the fix: the backgroundLayer was copied inside the store. When one changes the language, the attributions would therefore not be updated. One solution would be to listen to language changes and trigger the update (see first commit), but IMO this would diffuse the responsibility of the data further. So I changed the store a bit so the currentLayer comes through a getter, streamlining the data flow.


[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-912-swisstopo-source/index.html)