### PR TITLE
PB-977: Don't use service-proxy for internal domain and for GPX that support CORS - #patch

### DIFF
--- a/src/api/file-proxy.api.js
+++ b/src/api/file-proxy.api.js
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { isString } from 'lodash'
 
 import { getServiceProxyBaseUrl } from '@/config/baseUrl.config'
@@ -56,41 +55,4 @@ export function proxifyUrl(url) {
         throw new Error(`Malformed URL: ${url}, can't proxify`)
     }
     return `${getServiceProxyBaseUrl()}${fileAsPath}`
-}
-
-/**
- * Get a file through our service-proxy backend, taking care of CORS headers in the process.
- *
- * That means that a file for which there is no defined CORS header will still be accessible through
- * this function (i.e. Dropbox/name your cloud share links)
- *
- * @param {String} fileUrl
- * @param {Object} [options]
- * @param {Number} [options.timeout] How long should the call wait before timing out
- * @returns {Promise<AxiosResponse>} A promise which resolve to the proxy response
- */
-export default function getFileThroughProxy(fileUrl, options = {}) {
-    const { timeout = null } = options
-    return new Promise((resolve, reject) => {
-        try {
-            axios({
-                method: 'get',
-                url: proxifyUrl(fileUrl),
-                timeout,
-            })
-                .then((response) => {
-                    resolve(response)
-                })
-                .catch((error) => {
-                    log.error(
-                        'Error while accessing file URL through service-proxy',
-                        fileUrl,
-                        error
-                    )
-                    reject(error)
-                })
-        } catch (error) {
-            reject(error)
-        }
-    })
 }

--- a/src/config/baseUrl.config.js
+++ b/src/config/baseUrl.config.js
@@ -206,3 +206,6 @@ export function get3dTilesBaseUrl() {
 export function getVectorTilesBaseUrl() {
     return getBaseUrl('vectorTiles')
 }
+
+export const internalDomainRegex =
+    import.meta.env.VITE_APP_INTERNAL_DOMAIN_REGEX ?? /^https:\/\/[^/]*(bgdi|admin)\.ch/

--- a/src/modules/menu/components/advancedTools/ImportFile/ImportFileOnlineTab.vue
+++ b/src/modules/menu/components/advancedTools/ImportFile/ImportFileOnlineTab.vue
@@ -1,9 +1,9 @@
 <script setup>
-import axios, { AxiosError } from 'axios'
+import { AxiosError } from 'axios'
 import { computed, onMounted, ref, toRefs, watch } from 'vue'
 import { useStore } from 'vuex'
 
-import getFileThroughProxy from '@/api/file-proxy.api'
+import { getFileFromUrl } from '@/api/files.api'
 import ImportFileButtons from '@/modules/menu/components/advancedTools/ImportFile/ImportFileButtons.vue'
 import { handleFileContent } from '@/modules/menu/components/advancedTools/ImportFile/utils'
 import TextInput from '@/utils/components/TextInput.vue'
@@ -79,20 +79,9 @@ async function loadFile() {
         return
     }
     loading.value = true
-    let response
 
     try {
-        // catching locally the first error, so that we may decide to use service-proxy if the error was network related
-        try {
-            response = await axios.get(fileUrl.value, { timeout: REQUEST_TIMEOUT })
-        } catch (error) {
-            if (error instanceof AxiosError) {
-                log.debug('Failed to retrieve file directly, trying to go through service-proxy')
-                response = await getFileThroughProxy(fileUrl.value, { timeout: REQUEST_TIMEOUT })
-            } else {
-                throw error
-            }
-        }
+        const response = await getFileFromUrl(fileUrl.value, { timeout: REQUEST_TIMEOUT })
         if (response.status !== 200) {
             throw new Error(`Failed to fetch ${fileUrl.value}; status_code=${response.status}`)
         }

--- a/src/store/plugins/load-gpx-data.plugin.js
+++ b/src/store/plugins/load-gpx-data.plugin.js
@@ -3,10 +3,9 @@
  * it here
  */
 
-import axios from 'axios'
 import GPX from 'ol/format/GPX'
 
-import { proxifyUrl } from '@/api/file-proxy.api'
+import { getFileFromUrl } from '@/api/files.api'
 import GPXLayer from '@/api/layers/GPXLayer.class'
 import log from '@/utils/logging'
 
@@ -20,7 +19,7 @@ const dispatcher = { dispatcher: 'load-gpx-data.plugin' }
 async function loadGpx(store, gpxLayer) {
     log.debug(`Loading data for added GPX layer`, gpxLayer)
     try {
-        const response = await axios.get(proxifyUrl(gpxLayer.gpxFileUrl))
+        const response = await getFileFromUrl(gpxLayer.gpxFileUrl)
         const gpxContent = response.data
         const gpxParser = new GPX()
         const metadata = gpxParser.readMetadata(gpxContent)

--- a/src/utils/kmlUtils.js
+++ b/src/utils/kmlUtils.js
@@ -454,7 +454,7 @@ export function getEditableFeatureFromKmlFeature(kmlFeature, kmlLayer, available
 const nonGeoadminIconUrls = new Set()
 export function iconUrlProxyFy(url, corsIssueCallback = null) {
     // We only proxyfy URL that are not from our backend.
-    if (!/^(https:\/\/[^/]*(bgdi\.ch|geo\.admin\.ch)|http:\/\/localhost)/.test(url)) {
+    if (!/^(https:\/\/[^/]*(bgdi\.ch|geo\.admin\.ch)|https?:\/\/localhost)/.test(url)) {
         const proxyUrl = proxifyUrl(url)
         // Only perform the CORS check if we have a callback and it has not yet been done
         if (!nonGeoadminIconUrls.has(url) && corsIssueCallback) {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,5 +1,6 @@
 import { LineString, Point, Polygon } from 'ol/geom'
 
+import { internalDomainRegex } from '@/config/baseUrl.config'
 import { toLv95 } from '@/utils/coordinates/coordinateUtils'
 import log from '@/utils/logging'
 import { format } from '@/utils/numberUtils'
@@ -248,4 +249,14 @@ export function isValidEmail(email) {
 export function humanFileSize(size) {
     const i = size == 0 ? 0 : Math.floor(Math.log(size) / Math.log(1024))
     return (size / Math.pow(1024, i)).toFixed(2) * 1 + ' ' + ['B', 'kB', 'MB', 'GB', 'TB'][i]
+}
+
+/**
+ * Check if the given url is an internal URL (from bgdi.ch or admin.ch subdomain)
+ *
+ * @param {string} url
+ * @returns {boolean} Returns true if the url is part of an internal server
+ */
+export function isInternalUrl(url) {
+    return internalDomainRegex.test(url)
 }


### PR DESCRIPTION
GPX file used always the service-proxy even if the server supported CORS. Also
on the service-proxy we could see that some requests were made over service-proxy
for internal server like public.geo.admin.ch. This was due to the fact that if
for any reason the initial request failed (network failure) we fallback to the
service proxy. Now in that case we don't fallback anymore.

NOTE unfortunately there is no way for a web application to check for CORS support
see https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors

[Test link](https://sys-map.int.bgdi.ch/preview/bug-pb-977-proxy/index.html)