### PR TITLE
PB-984: add error feedback for all URL parameters

### DIFF
--- a/src/api/errorQueues.api.js
+++ b/src/api/errorQueues.api.js
@@ -15,9 +15,9 @@ export function getStandardErrorMessage(query, urlParamName) {
  * @param {Boolean} is_valid Is the value valid or not
  * @returns
  */
-export function getStandardValidationResponse(query, is_valid, urlParamName) {
+export function getStandardValidationResponse(query, isValid, urlParamName) {
     return {
-        valid: is_valid,
-        errors: is_valid ? null : getStandardErrorMessage(query, urlParamName),
+        valid: isValid,
+        errors: isValid ? null : getStandardErrorMessage(query, urlParamName),
     }
 }

--- a/src/api/errorQueues.api.js
+++ b/src/api/errorQueues.api.js
@@ -1,7 +1,10 @@
 import ErrorMessage from '@/utils/ErrorMessage.class'
 
-export function getStandardErrorMessage(query) {
-    return new ErrorMessage('url_parameter_error', { param: this.urlParamName, value: query })
+export function getStandardErrorMessage(query, urlParamName) {
+    return new ErrorMessage('url_parameter_error', {
+        param: urlParamName,
+        value: query,
+    })
 }
 
 /**
@@ -12,9 +15,11 @@ export function getStandardErrorMessage(query) {
  * @param {Boolean} is_valid Is the value valid or not
  * @returns
  */
-export function getStandardValidationResponse(query, is_valid) {
+export function getStandardValidationResponse(query, is_valid, urlParamName) {
+    console.warn('inGETSTANDARD')
+    console.warn(is_valid)
     return {
         valid: is_valid,
-        errors: is_valid ? null : this.getStandardErrorMessage(query),
+        errors: is_valid ? null : getStandardErrorMessage(query, urlParamName),
     }
 }

--- a/src/api/errorQueues.api.js
+++ b/src/api/errorQueues.api.js
@@ -16,8 +16,6 @@ export function getStandardErrorMessage(query, urlParamName) {
  * @returns
  */
 export function getStandardValidationResponse(query, is_valid, urlParamName) {
-    console.warn('inGETSTANDARD')
-    console.warn(is_valid)
     return {
         valid: is_valid,
         errors: is_valid ? null : getStandardErrorMessage(query, urlParamName),

--- a/src/api/errorQueues.api.js
+++ b/src/api/errorQueues.api.js
@@ -1,0 +1,20 @@
+import ErrorMessage from '@/utils/ErrorMessage.class'
+
+export function getStandardErrorMessage(query) {
+    return new ErrorMessage('url_parameter_error', { param: this.urlParamName, value: query })
+}
+
+/**
+ * Return the standard feedback for most parameters given in the URL: if the query is validated, it
+ * can proceed and be set in the store.
+ *
+ * @param {any} query The value of the URL parameter given
+ * @param {Boolean} is_valid Is the value valid or not
+ * @returns
+ */
+export function getStandardValidationResponse(query, is_valid) {
+    return {
+        valid: is_valid,
+        errors: is_valid ? null : this.getStandardErrorMessage(query),
+    }
+}

--- a/src/api/errorQueues.api.js
+++ b/src/api/errorQueues.api.js
@@ -12,7 +12,7 @@ export function getStandardErrorMessage(query, urlParamName) {
  * can proceed and be set in the store.
  *
  * @param {any} query The value of the URL parameter given
- * @param {Boolean} is_valid Is the value valid or not
+ * @param {Boolean} isValid Is the value valid or not
  * @returns
  */
 export function getStandardValidationResponse(query, isValid, urlParamName) {

--- a/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
@@ -87,7 +87,7 @@ function iconUrlProxy(url) {
     return iconUrlProxyFy(
         url,
         (url) => {
-            store.dispatch('addWarning', {
+            store.dispatch('addWarnings', {
                 warning: new WarningMessage('kml_icon_url_cors_issue', {
                     layerName: layerName.value,
                     url: url,
@@ -96,7 +96,7 @@ function iconUrlProxy(url) {
             })
         },
         (url) => {
-            store.dispatch('addWarning', {
+            store.dispatch('addWarnings', {
                 warning: new WarningMessage('kml_icon_url_scheme_http', {
                     layerName: layerName.value,
                     url: url,

--- a/src/modules/map/components/openlayers/utils/useMapInteractions.composable.js
+++ b/src/modules/map/components/openlayers/utils/useMapInteractions.composable.js
@@ -278,7 +278,7 @@ export default function useMapInteractions(map) {
                 errorKey = 'invalid_import_file_error'
                 log.error(`Failed to load file`, error)
             }
-            store.dispatch('addError', { error: new ErrorMessage(errorKey, null), ...dispatcher })
+            store.dispatch('addErrors', { error: new ErrorMessage(errorKey, null), ...dispatcher })
         }
     }
 

--- a/src/router/storeSync/CameraParamConfig.class.js
+++ b/src/router/storeSync/CameraParamConfig.class.js
@@ -30,14 +30,6 @@ export function readCameraFromUrlParam(urlParamValue) {
     return null
 }
 
-function acceptedValues(store, query) {
-    return (
-        query &&
-        query.split(',').length === 6 &&
-        query.split(',').filter((value) => value === '' || !isNaN(value)).length === 6
-    )
-}
-
 function dispatchCameraFromUrlIntoStore(to, store, urlParamValue) {
     const promisesForAllDispatch = []
     const camera = readCameraFromUrlParam(urlParamValue)
@@ -80,7 +72,10 @@ export default class CameraParamConfig extends AbstractParamConfig {
             extractValueFromStore: generateCameraUrlParamFromStoreValues,
             keepInUrlWhenDefault: false,
             valueType: String,
-            acceptedValues: acceptedValues,
+            acceptedValues: (store, query) =>
+                query &&
+                query.split(',').length === 6 &&
+                query.split(',').filter((value) => value === '' || !isNaN(value)).length === 6,
         })
     }
 }

--- a/src/router/storeSync/CameraParamConfig.class.js
+++ b/src/router/storeSync/CameraParamConfig.class.js
@@ -1,3 +1,4 @@
+import { getStandardValidationResponse } from '@/api/errorQueues.api'
 import AbstractParamConfig, {
     STORE_DISPATCHER_ROUTER_PLUGIN,
 } from '@/router/storeSync/abstractParamConfig.class'
@@ -73,7 +74,7 @@ export default class CameraParamConfig extends AbstractParamConfig {
             keepInUrlWhenDefault: false,
             valueType: String,
             validateUrlInput: (store, query) =>
-                this.getStandardValidationResponse(
+                getStandardValidationResponse(
                     query,
                     query &&
                         query.split(',').length === 6 &&

--- a/src/router/storeSync/CameraParamConfig.class.js
+++ b/src/router/storeSync/CameraParamConfig.class.js
@@ -30,6 +30,14 @@ export function readCameraFromUrlParam(urlParamValue) {
     return null
 }
 
+function acceptedValues(store, query) {
+    return (
+        query &&
+        query.split(',').length === 6 &&
+        query.split(',').filter((value) => value === '' || !isNaN(value)).length === 6
+    )
+}
+
 function dispatchCameraFromUrlIntoStore(to, store, urlParamValue) {
     const promisesForAllDispatch = []
     const camera = readCameraFromUrlParam(urlParamValue)
@@ -72,6 +80,7 @@ export default class CameraParamConfig extends AbstractParamConfig {
             extractValueFromStore: generateCameraUrlParamFromStoreValues,
             keepInUrlWhenDefault: false,
             valueType: String,
+            acceptedValues: acceptedValues,
         })
     }
 }

--- a/src/router/storeSync/CameraParamConfig.class.js
+++ b/src/router/storeSync/CameraParamConfig.class.js
@@ -79,7 +79,8 @@ export default class CameraParamConfig extends AbstractParamConfig {
                     query &&
                         query.split(',').length === 6 &&
                         query.split(',').filter((value) => value === '' || !isNaN(value)).length ===
-                            6
+                            6,
+                    this.urlParamName
                 ),
         })
     }

--- a/src/router/storeSync/CameraParamConfig.class.js
+++ b/src/router/storeSync/CameraParamConfig.class.js
@@ -78,8 +78,7 @@ export default class CameraParamConfig extends AbstractParamConfig {
                     query,
                     query &&
                         query.split(',').length === 6 &&
-                        query.split(',').filter((value) => value === '' || !isNaN(value)).length ===
-                            6,
+                        query.split(',').every((value) => value === '' || !isNaN(value)),
                     this.urlParamName
                 ),
         })

--- a/src/router/storeSync/CameraParamConfig.class.js
+++ b/src/router/storeSync/CameraParamConfig.class.js
@@ -72,10 +72,14 @@ export default class CameraParamConfig extends AbstractParamConfig {
             extractValueFromStore: generateCameraUrlParamFromStoreValues,
             keepInUrlWhenDefault: false,
             valueType: String,
-            acceptedValues: (store, query) =>
-                query &&
-                query.split(',').length === 6 &&
-                query.split(',').filter((value) => value === '' || !isNaN(value)).length === 6,
+            validateUrlInput: (store, query) =>
+                this.getStandardValidationResponse(
+                    query,
+                    query &&
+                        query.split(',').length === 6 &&
+                        query.split(',').filter((value) => value === '' || !isNaN(value)).length ===
+                            6
+                ),
         })
     }
 }

--- a/src/router/storeSync/CompareSliderParamConfig.class.js
+++ b/src/router/storeSync/CompareSliderParamConfig.class.js
@@ -1,3 +1,4 @@
+import { getStandardValidationResponse } from '@/api/errorQueues.api'
 import AbstractParamConfig, {
     STORE_DISPATCHER_ROUTER_PLUGIN,
 } from '@/router/storeSync/abstractParamConfig.class'
@@ -47,7 +48,7 @@ export default class CompareSliderParamConfig extends AbstractParamConfig {
             valueType: Number,
             defaultValue: null,
             validateUrlInput: (store, query) =>
-                this.getStandardValidationResponse(
+                getStandardValidationResponse(
                     query,
                     query && Number(query) <= 1.0 && Number(query) >= 0.0
                 ),

--- a/src/router/storeSync/CompareSliderParamConfig.class.js
+++ b/src/router/storeSync/CompareSliderParamConfig.class.js
@@ -50,7 +50,8 @@ export default class CompareSliderParamConfig extends AbstractParamConfig {
             validateUrlInput: (store, query) =>
                 getStandardValidationResponse(
                     query,
-                    query && Number(query) <= 1.0 && Number(query) >= 0.0
+                    query && Number(query) <= 1.0 && Number(query) >= 0.0,
+                    this.urlParamName
                 ),
         })
     }

--- a/src/router/storeSync/CompareSliderParamConfig.class.js
+++ b/src/router/storeSync/CompareSliderParamConfig.class.js
@@ -46,7 +46,11 @@ export default class CompareSliderParamConfig extends AbstractParamConfig {
             keepInUrlWhenDefault: false,
             valueType: Number,
             defaultValue: null,
-            acceptedValues: (store, query) => query && Number(query) <= 1.0 && Number(query) >= 0.0,
+            validateUrlInput: (store, query) =>
+                this.getStandardValidationResponse(
+                    query,
+                    query && Number(query) <= 1.0 && Number(query) >= 0.0
+                ),
         })
     }
 }

--- a/src/router/storeSync/CompareSliderParamConfig.class.js
+++ b/src/router/storeSync/CompareSliderParamConfig.class.js
@@ -46,6 +46,7 @@ export default class CompareSliderParamConfig extends AbstractParamConfig {
             keepInUrlWhenDefault: false,
             valueType: Number,
             defaultValue: null,
+            acceptedValues: (store, query) => query && Number(query) <= 1.0 && Number(query) >= 0.0,
         })
     }
 }

--- a/src/router/storeSync/CrossHairParamConfig.class.js
+++ b/src/router/storeSync/CrossHairParamConfig.class.js
@@ -78,6 +78,14 @@ function generateCrossHairUrlParamFromStoreValues(store) {
     return null
 }
 
+/**
+ * @param {Object} store
+ * @param {String} query The crossHair parameter can have multiple values, either one identifier for
+ *   the crossHair itself, or one identifier with two coordinates in a coma separated string, or a
+ *   blank identifier with coordinates. For example, crossHair=marker , crossHair=marker,x,y and
+ *   crossHair=,x,y are all valid values.
+ * @returns
+ */
 function validateUrlInput(store, query) {
     if (query) {
         const parts = query.split(',')

--- a/src/router/storeSync/CrossHairParamConfig.class.js
+++ b/src/router/storeSync/CrossHairParamConfig.class.js
@@ -89,6 +89,7 @@ function acceptedValues(store, query) {
             (Object.values(CrossHairs).includes(crossHair) || crossHair === '')
         )
     }
+    return false
 }
 
 /**

--- a/src/router/storeSync/CrossHairParamConfig.class.js
+++ b/src/router/storeSync/CrossHairParamConfig.class.js
@@ -77,19 +77,19 @@ function generateCrossHairUrlParamFromStoreValues(store) {
     return null
 }
 
-function acceptedValues(store, query) {
+function validateUrlInput(store, query) {
     if (query) {
         const parts = query.split(',')
         let crossHair = parts[0]
         let crossHairPosition = [parseFloat(parts[1]), parseFloat(parts[2])]
-
-        return (
-            (typeof query === 'string' || query instanceof String) &&
-            (crossHair || crossHairPosition) &&
-            (Object.values(CrossHairs).includes(crossHair) || crossHair === '')
+        return this.getStandardValidationResponse(
+            query,
+            (crossHair ||
+                crossHairPosition.filter((coordinate) => !isNaN(coordinate)).length === 2) &&
+                (Object.values(CrossHairs).includes(crossHair) || crossHair === '')
         )
     }
-    return false
+    return this.getStandardValidationResponse(query, false)
 }
 
 /**
@@ -109,7 +109,7 @@ export default class CrossHairParamConfig extends AbstractParamConfig {
             keepInUrlWhenDefault: false,
             valueType: String,
             defaultValue: null,
-            acceptedValues: acceptedValues, // TODO : implement this to have a common behavior amongst all params
+            validateUrlInput: validateUrlInput,
         })
     }
 }

--- a/src/router/storeSync/CrossHairParamConfig.class.js
+++ b/src/router/storeSync/CrossHairParamConfig.class.js
@@ -2,7 +2,6 @@ import AbstractParamConfig, {
     STORE_DISPATCHER_ROUTER_PLUGIN,
 } from '@/router/storeSync/abstractParamConfig.class'
 import { CrossHairs } from '@/store/modules/position.store'
-import ErrorMessage from '@/utils/ErrorMessage.class'
 import { round } from '@/utils/numberUtils'
 
 /**
@@ -21,10 +20,6 @@ import { round } from '@/utils/numberUtils'
 
 function dispatchCrossHairFromUrlIntoStore(to, store, urlParamValue) {
     const promisesForAllDispatch = []
-    const error = new ErrorMessage('url_parameter_error', {
-        param: 'crosshair',
-        value: urlParamValue,
-    })
 
     if (typeof urlParamValue !== 'string' && !(urlParamValue instanceof String)) {
         promisesForAllDispatch.push(
@@ -32,10 +27,6 @@ function dispatchCrossHairFromUrlIntoStore(to, store, urlParamValue) {
                 crossHair: null,
                 dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
             })
-        )
-
-        promisesForAllDispatch.push(
-            store.dispatch('addError', { error, dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN })
         )
     } else {
         const parts = urlParamValue.split(',')
@@ -55,19 +46,6 @@ function dispatchCrossHairFromUrlIntoStore(to, store, urlParamValue) {
                     dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
                 })
             )
-            if (urlParamValue !== undefined) {
-                /**
-                 * There are situations where the function is called without any parameter, and it
-                 * makes some tests crash because the error message is over some necessary buttons.
-                 * We consider that if the parameter is undefined, it's a choice made by the user.
-                 */
-                promisesForAllDispatch.push(
-                    store.dispatch('addError', {
-                        error,
-                        dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
-                    })
-                )
-            }
         } else {
             if (crossHair === '') {
                 crossHair = CrossHairs.marker
@@ -99,6 +77,20 @@ function generateCrossHairUrlParamFromStoreValues(store) {
     return null
 }
 
+function acceptedValues(store, query) {
+    if (query) {
+        const parts = query.split(',')
+        let crossHair = parts[0]
+        let crossHairPosition = [parseFloat(parts[1]), parseFloat(parts[2])]
+
+        return (
+            (typeof query === 'string' || query instanceof String) &&
+            (crossHair || crossHairPosition) &&
+            (Object.values(CrossHairs).includes(crossHair) || crossHair === '')
+        )
+    }
+}
+
 /**
  * Concat the crosshair type with its position, if the crosshair's position is not the same as the
  * current center of the map.
@@ -116,6 +108,7 @@ export default class CrossHairParamConfig extends AbstractParamConfig {
             keepInUrlWhenDefault: false,
             valueType: String,
             defaultValue: null,
+            acceptedValues: acceptedValues, // TODO : implement this to have a common behavior amongst all params
         })
     }
 }

--- a/src/router/storeSync/CrossHairParamConfig.class.js
+++ b/src/router/storeSync/CrossHairParamConfig.class.js
@@ -87,10 +87,11 @@ function validateUrlInput(store, query) {
             query,
             (crossHair ||
                 crossHairPosition.filter((coordinate) => !isNaN(coordinate)).length === 2) &&
-                (Object.values(CrossHairs).includes(crossHair) || crossHair === '')
+                (Object.values(CrossHairs).includes(crossHair) || crossHair === ''),
+            this.urlParamName
         )
     }
-    return getStandardValidationResponse(query, false)
+    return getStandardValidationResponse(query, false, this.urlParamName)
 }
 
 /**

--- a/src/router/storeSync/CrossHairParamConfig.class.js
+++ b/src/router/storeSync/CrossHairParamConfig.class.js
@@ -1,3 +1,4 @@
+import { getStandardValidationResponse } from '@/api/errorQueues.api'
 import AbstractParamConfig, {
     STORE_DISPATCHER_ROUTER_PLUGIN,
 } from '@/router/storeSync/abstractParamConfig.class'
@@ -82,14 +83,14 @@ function validateUrlInput(store, query) {
         const parts = query.split(',')
         let crossHair = parts[0]
         let crossHairPosition = [parseFloat(parts[1]), parseFloat(parts[2])]
-        return this.getStandardValidationResponse(
+        return getStandardValidationResponse(
             query,
             (crossHair ||
                 crossHairPosition.filter((coordinate) => !isNaN(coordinate)).length === 2) &&
                 (Object.values(CrossHairs).includes(crossHair) || crossHair === '')
         )
     }
-    return this.getStandardValidationResponse(query, false)
+    return getStandardValidationResponse(query, false)
 }
 
 /**

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -284,7 +284,7 @@ function validateUrlInput(store, query) {
                 ? null
                 : valid
                   ? faulty_layers
-                  : getStandardValidationResponse(query, valid),
+                  : getStandardValidationResponse(query, valid, this.urlParamName),
     }
 }
 

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -260,29 +260,35 @@ function generateLayerUrlParamFromStoreValues(store) {
 // which layer won't render. It's basic, which means it will only tells the user when he gives a non
 // external layer that doesn't exist, or when he forgets the scheme for its external layer.
 function validateUrlInput(store, query) {
+    if (query === '') {
+        return {
+            valid: true,
+            errors: null,
+        }
+    }
     const parsed = parseLayersParam(query)
     const url_matcher = /https?:\/\//
-    const faulty_layers = []
+    const faultyLayers = []
     parsed
         .filter((layer) => !store.getters.getLayerConfigById(layer.id))
         .forEach((layer) => {
             if (!layer.baseUrl) {
-                faulty_layers.push(new ErrorMessage('url_layer_error', { layer: layer.id }))
+                faultyLayers.push(new ErrorMessage('url_layer_error', { layer: layer.id }))
             } else if (!layer.baseUrl?.match(url_matcher)?.length > 0) {
-                faulty_layers.push(
+                faultyLayers.push(
                     new ErrorMessage('url_external_layer_no_scheme_error', {
                         layer: `${layer.type}|${layer.baseUrl}`,
                     })
                 )
             }
         })
-    const valid = faulty_layers.length < parsed.length
+    const valid = faultyLayers.length < parsed.length
     if (!valid) {
         return getStandardValidationResponse(query, valid, this.urlParamName)
     }
     return {
         valid,
-        errors: faulty_layers.length === 0 ? null : faulty_layers,
+        errors: faultyLayers.length === 0 ? null : faultyLayers,
     }
 }
 

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -1,3 +1,4 @@
+import { getStandardValidationResponse } from '@/api/errorQueues.api'
 import getFeature from '@/api/features/features.api'
 import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
@@ -283,7 +284,7 @@ function validateUrlInput(store, query) {
                 ? null
                 : valid
                   ? faulty_layers
-                  : this.getStandardValidationResponse(query, valid),
+                  : getStandardValidationResponse(query, valid),
     }
 }
 

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -271,7 +271,7 @@ function acceptedValues(store, query) {
                 value += `,${layer.visible ? '' : 'f'},${layer.opacity ?? 1}`
             }
             store.dispatch('addError', {
-                error: new ErrorMessage('url_layer_error', { param: 'layers', value: value }),
+                error: new ErrorMessage('url_layer_error', { layer: value }),
                 dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
             })
         })

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -277,14 +277,12 @@ function validateUrlInput(store, query) {
             }
         })
     const valid = faulty_layers.length < parsed.length
+    if (!valid) {
+        return getStandardValidationResponse(query, valid, this.urlParamName)
+    }
     return {
         valid,
-        errors:
-            faulty_layers.length === 0
-                ? null
-                : valid
-                  ? faulty_layers
-                  : getStandardValidationResponse(query, valid, this.urlParamName),
+        errors: faulty_layers.length === 0 ? null : faulty_layers,
     }
 }
 

--- a/src/router/storeSync/PositionParamConfig.class.js
+++ b/src/router/storeSync/PositionParamConfig.class.js
@@ -32,15 +32,15 @@ function generateCenterUrlParamFromStoreValues(store) {
     return null
 }
 
-function acceptedValues(store, query) {
+function validateUrlInput(store, query) {
     if (query) {
-        let center = query.split(',')
-        return (
-            center.length === 2 &&
-            store.state.position.projection.isInBounds(query.split(',')[0], query.split(',')[1])
+        const center = query.split(',')
+        return this.getStandardValidationResponse(
+            query,
+            center.length === 2 && store.state.position.projection.isInBounds(center[0], center[1])
         )
     }
-    return false
+    return this.getStandardValidationResponse(query, false)
 }
 
 /**
@@ -56,7 +56,7 @@ export default class PositionParamConfig extends AbstractParamConfig {
             extractValueFromStore: generateCenterUrlParamFromStoreValues,
             keepInUrlWhenDefault: true,
             valueType: String,
-            acceptedValues: acceptedValues,
+            validateUrlInput: validateUrlInput,
         })
     }
 }

--- a/src/router/storeSync/PositionParamConfig.class.js
+++ b/src/router/storeSync/PositionParamConfig.class.js
@@ -1,3 +1,4 @@
+import { getStandardValidationResponse } from '@/api/errorQueues.api'
 import AbstractParamConfig, {
     STORE_DISPATCHER_ROUTER_PLUGIN,
 } from '@/router/storeSync/abstractParamConfig.class'
@@ -35,12 +36,12 @@ function generateCenterUrlParamFromStoreValues(store) {
 function validateUrlInput(store, query) {
     if (query) {
         const center = query.split(',')
-        return this.getStandardValidationResponse(
+        return getStandardValidationResponse(
             query,
             center.length === 2 && store.state.position.projection.isInBounds(center[0], center[1])
         )
     }
-    return this.getStandardValidationResponse(query, false)
+    return getStandardValidationResponse(query, false)
 }
 
 /**

--- a/src/router/storeSync/PositionParamConfig.class.js
+++ b/src/router/storeSync/PositionParamConfig.class.js
@@ -32,6 +32,17 @@ function generateCenterUrlParamFromStoreValues(store) {
     return null
 }
 
+function acceptedValues(store, query) {
+    if (query) {
+        let center = query.split(',')
+        return (
+            center.length === 2 &&
+            store.state.position.projection.isInBounds(query.split(',')[0], query.split(',')[1])
+        )
+    }
+    return false
+}
+
 /**
  * Describe the position (center) of the map in the URL. It will make sure that the URL values are
  * read as floating numbers.
@@ -45,6 +56,7 @@ export default class PositionParamConfig extends AbstractParamConfig {
             extractValueFromStore: generateCenterUrlParamFromStoreValues,
             keepInUrlWhenDefault: true,
             valueType: String,
+            acceptedValues: acceptedValues,
         })
     }
 }

--- a/src/router/storeSync/PositionParamConfig.class.js
+++ b/src/router/storeSync/PositionParamConfig.class.js
@@ -38,10 +38,11 @@ function validateUrlInput(store, query) {
         const center = query.split(',')
         return getStandardValidationResponse(
             query,
-            center.length === 2 && store.state.position.projection.isInBounds(center[0], center[1])
+            center.length === 2 && store.state.position.projection.isInBounds(center[0], center[1]),
+            this.urlParamName
         )
     }
-    return getStandardValidationResponse(query, false)
+    return getStandardValidationResponse(query, false, this.urlParamName)
 }
 
 /**

--- a/src/router/storeSync/SearchParamConfig.class.js
+++ b/src/router/storeSync/SearchParamConfig.class.js
@@ -28,6 +28,7 @@ export default class SearchParamConfig extends AbstractParamConfig {
             keepInUrlWhenDefault: false,
             valueType: String,
             defaultValue: '',
+            acceptedValues: null,
         })
     }
 }

--- a/src/router/storeSync/SearchParamConfig.class.js
+++ b/src/router/storeSync/SearchParamConfig.class.js
@@ -28,7 +28,7 @@ export default class SearchParamConfig extends AbstractParamConfig {
             keepInUrlWhenDefault: false,
             valueType: String,
             defaultValue: '',
-            acceptedValues: null,
+            validateUrlInput: null,
         })
     }
 }

--- a/src/router/storeSync/SimpleUrlParamConfig.class.js
+++ b/src/router/storeSync/SimpleUrlParamConfig.class.js
@@ -33,7 +33,7 @@ export default class SimpleUrlParamConfig extends AbstractParamConfig {
         keepInUrlWhenDefault = false,
         valueType = String,
         defaultValue = null,
-        acceptedValues = null,
+        validateUrlInput = null,
     } = {}) {
         super({
             urlParamName,
@@ -47,7 +47,7 @@ export default class SimpleUrlParamConfig extends AbstractParamConfig {
             keepInUrlWhenDefault,
             valueType,
             defaultValue,
-            acceptedValues,
+            validateUrlInput,
         })
     }
 }

--- a/src/router/storeSync/SimpleUrlParamConfig.class.js
+++ b/src/router/storeSync/SimpleUrlParamConfig.class.js
@@ -33,6 +33,7 @@ export default class SimpleUrlParamConfig extends AbstractParamConfig {
         keepInUrlWhenDefault = false,
         valueType = String,
         defaultValue = null,
+        acceptedValues = null,
     } = {}) {
         super({
             urlParamName,
@@ -46,6 +47,7 @@ export default class SimpleUrlParamConfig extends AbstractParamConfig {
             keepInUrlWhenDefault,
             valueType,
             defaultValue,
+            acceptedValues,
         })
     }
 }

--- a/src/router/storeSync/TimeSliderParamConfig.class.js
+++ b/src/router/storeSync/TimeSliderParamConfig.class.js
@@ -2,6 +2,7 @@ import { OLDEST_YEAR, YOUNGEST_YEAR } from '@/config/time.config'
 import AbstractParamConfig, {
     STORE_DISPATCHER_ROUTER_PLUGIN,
 } from '@/router/storeSync/abstractParamConfig.class'
+import ErrorMessage from '@/utils/ErrorMessage.class'
 
 function dispatchTimeSliderFromUrlParam(to, store, urlParamValue) {
     const promisesForAllDispatch = []
@@ -35,6 +36,31 @@ function generateTimeSliderUrlParamFromStore(store) {
     return store.state.ui.isTimeSliderActive ? store.state.layers.previewYear : null
 }
 
+function acceptedValues(store, query) {
+    if (
+        query &&
+        !isNaN(query) &&
+        Number.isInteger(query) &&
+        OLDEST_YEAR <= query &&
+        YOUNGEST_YEAR >= query &&
+        store.getters.visibleLayers.filter((layer) => layer.hasMultipleTimestamps).length === 0
+    ) {
+        // we add a small error here to tell the user that every parameter is in order
+        // for the time slider, but that there are no layers that supports it.
+        store.dispatch('addError', {
+            error: new ErrorMessage('time_slider_no_active_time_layer', {}),
+            dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
+        })
+    }
+    return (
+        query &&
+        !isNaN(query) &&
+        Number.isInteger(query) &&
+        OLDEST_YEAR <= query &&
+        YOUNGEST_YEAR >= query
+    )
+}
+
 /**
  * When the timeSlider parameter is set in the URL, if the year is a valid year, it will set the
  * timeSlider to active to the correct year. The parameter only appears if the time Slider is
@@ -50,6 +76,7 @@ export default class TimeSliderParamConfig extends AbstractParamConfig {
             keepInUrlWhenDefault: false,
             valueType: Number,
             defaultValue: null,
+            acceptedValues: acceptedValues,
         })
     }
 }

--- a/src/router/storeSync/TimeSliderParamConfig.class.js
+++ b/src/router/storeSync/TimeSliderParamConfig.class.js
@@ -40,7 +40,10 @@ function generateTimeSliderUrlParamFromStore(store) {
 function validateUrlInput(store, query) {
     const validationObject = getStandardValidationResponse(
         query,
-        !isNaN(query) && Number.isInteger(query) && OLDEST_YEAR <= query && YOUNGEST_YEAR >= query,
+        !isNaN(query) &&
+            Number.isInteger(Number(query)) &&
+            OLDEST_YEAR <= query &&
+            YOUNGEST_YEAR >= query,
         this.urlParamName
     )
 

--- a/src/router/storeSync/TimeSliderParamConfig.class.js
+++ b/src/router/storeSync/TimeSliderParamConfig.class.js
@@ -48,7 +48,7 @@ function acceptedValues(store, query) {
         // we add a small error here to tell the user that every parameter is in order
         // for the time slider, but that there are no layers that supports it.
         store.dispatch('addError', {
-            error: new ErrorMessage('time_slider_no_active_time_layer', {}),
+            error: new ErrorMessage('time_slider_no_time_layer_active_url_error', {}),
             dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
         })
     }

--- a/src/router/storeSync/TimeSliderParamConfig.class.js
+++ b/src/router/storeSync/TimeSliderParamConfig.class.js
@@ -1,8 +1,8 @@
+import { getStandardValidationResponse } from '@/api/errorQueues.api'
 import { OLDEST_YEAR, YOUNGEST_YEAR } from '@/config/time.config'
 import AbstractParamConfig, {
     STORE_DISPATCHER_ROUTER_PLUGIN,
 } from '@/router/storeSync/abstractParamConfig.class'
-import ErrorMessage from '@/utils/ErrorMessage.class'
 import WarningMessage from '@/utils/WarningMessage.class'
 
 function dispatchTimeSliderFromUrlParam(to, store, urlParamValue) {
@@ -38,7 +38,7 @@ function generateTimeSliderUrlParamFromStore(store) {
 }
 
 function validateUrlInput(store, query) {
-    const validationObject = this.getStandardValidationResponse(
+    const validationObject = getStandardValidationResponse(
         query,
         !isNaN(query) && Number.isInteger(query) && OLDEST_YEAR <= query && YOUNGEST_YEAR >= query
     )

--- a/src/router/storeSync/TimeSliderParamConfig.class.js
+++ b/src/router/storeSync/TimeSliderParamConfig.class.js
@@ -40,7 +40,8 @@ function generateTimeSliderUrlParamFromStore(store) {
 function validateUrlInput(store, query) {
     const validationObject = getStandardValidationResponse(
         query,
-        !isNaN(query) && Number.isInteger(query) && OLDEST_YEAR <= query && YOUNGEST_YEAR >= query
+        !isNaN(query) && Number.isInteger(query) && OLDEST_YEAR <= query && YOUNGEST_YEAR >= query,
+        this.urlParamName
     )
 
     if (store.getters.visibleLayers.filter((layer) => layer.hasMultipleTimestamps).length === 0) {

--- a/src/router/storeSync/ZoomParamConfig.class.js
+++ b/src/router/storeSync/ZoomParamConfig.class.js
@@ -1,3 +1,4 @@
+import { getStandardValidationResponse } from '@/api/errorQueues.api'
 import AbstractParamConfig, {
     STORE_DISPATCHER_ROUTER_PLUGIN,
 } from '@/router/storeSync/abstractParamConfig.class'
@@ -41,10 +42,7 @@ export default class ZoomParamConfig extends AbstractParamConfig {
             keepInUrlWhenDefault: true,
             valueType: Number,
             validateUrlInput: (store, query) =>
-                this.getStandardValidationResponse(
-                    query,
-                    query && !isNaN(query) && Number(query) >= 0
-                ),
+                getStandardValidationResponse(query, query && !isNaN(query) && Number(query) >= 0),
         })
     }
 }

--- a/src/router/storeSync/ZoomParamConfig.class.js
+++ b/src/router/storeSync/ZoomParamConfig.class.js
@@ -40,6 +40,7 @@ export default class ZoomParamConfig extends AbstractParamConfig {
             extractValueFromStore: generateZoomUrlParamFromStoreValues,
             keepInUrlWhenDefault: true,
             valueType: Number,
+            acceptedValues: (store, query) => query && !isNaN(query) && Number(query) >= 0,
         })
     }
 }

--- a/src/router/storeSync/ZoomParamConfig.class.js
+++ b/src/router/storeSync/ZoomParamConfig.class.js
@@ -42,7 +42,11 @@ export default class ZoomParamConfig extends AbstractParamConfig {
             keepInUrlWhenDefault: true,
             valueType: Number,
             validateUrlInput: (store, query) =>
-                getStandardValidationResponse(query, query && !isNaN(query) && Number(query) >= 0),
+                getStandardValidationResponse(
+                    query,
+                    query && !isNaN(query) && Number(query) >= 0,
+                    this.urlParamName
+                ),
         })
     }
 }

--- a/src/router/storeSync/ZoomParamConfig.class.js
+++ b/src/router/storeSync/ZoomParamConfig.class.js
@@ -40,7 +40,11 @@ export default class ZoomParamConfig extends AbstractParamConfig {
             extractValueFromStore: generateZoomUrlParamFromStoreValues,
             keepInUrlWhenDefault: true,
             valueType: Number,
-            acceptedValues: (store, query) => query && !isNaN(query) && Number(query) >= 0,
+            validateUrlInput: (store, query) =>
+                this.getStandardValidationResponse(
+                    query,
+                    query && !isNaN(query) && Number(query) >= 0
+                ),
         })
     }
 }

--- a/src/router/storeSync/abstractParamConfig.class.js
+++ b/src/router/storeSync/abstractParamConfig.class.js
@@ -66,7 +66,7 @@ export default class AbstractParamConfig {
             return undefined
         }
 
-        if (!(this.urlParamName in query)) {
+        if (!(this.urlParamName in query) || query[this.urlParamName] === undefined) {
             if (!this.keepInUrlWhenDefault) {
                 return this.defaultValue
             } else {
@@ -79,7 +79,6 @@ export default class AbstractParamConfig {
             let inputValidation = this.validateUrlInput
                 ? this.validateUrlInput(store, queryValue)
                 : { valid: true }
-            console.error(inputValidation)
 
             // if there are no errors, we want to avoid dispatching and commiting, as it is costly
             if (inputValidation.errors) {
@@ -116,7 +115,6 @@ export default class AbstractParamConfig {
         } else if (queryValue === null || queryValue === undefined) {
             return this.defaultValue
         }
-        console.error('let us continue')
         return this.valueType(queryValue)
     }
 

--- a/src/router/storeSync/abstractParamConfig.class.js
+++ b/src/router/storeSync/abstractParamConfig.class.js
@@ -158,7 +158,11 @@ export default class AbstractParamConfig {
     populateStoreWithQueryValue(to, store, query) {
         return new Promise((resolve, reject) => {
             if (store && this.setValuesInStore) {
-                if (this.acceptedValues && !this.acceptedValues(store, query)) {
+                if (
+                    this.acceptedValues &&
+                    to.query[this.urlParamName] &&
+                    !this.acceptedValues(store, query)
+                ) {
                     store.dispatch('addError', {
                         error: new ErrorMessage('url_parameter_error', {
                             param: this.urlParamName,
@@ -166,15 +170,14 @@ export default class AbstractParamConfig {
                         }),
                         dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
                     })
-                } else {
-                    const promiseSetValuesInStore = this.setValuesInStore(to, store, query)
-                    if (promiseSetValuesInStore) {
-                        promiseSetValuesInStore.then(() => {
-                            resolve()
-                        })
-                    } else {
+                }
+                const promiseSetValuesInStore = this.setValuesInStore(to, store, query)
+                if (promiseSetValuesInStore) {
+                    promiseSetValuesInStore.then(() => {
                         resolve()
-                    }
+                    })
+                } else {
+                    resolve()
                 }
             } else {
                 reject('Query, store or setter functions is not set')

--- a/src/router/storeSync/abstractParamConfig.class.js
+++ b/src/router/storeSync/abstractParamConfig.class.js
@@ -159,6 +159,9 @@ export default class AbstractParamConfig {
      * @returns
      */
     getStandardValidationResponse(query, is_valid) {
+        console.error('ENTRY IN STANDARD VALIDATION RESPONSE')
+        console.error(query)
+        console.error(is_valid)
         return {
             valid: is_valid,
             errors: is_valid ? null : this.getStandardErrorMessage(query),

--- a/src/router/storeSync/abstractParamConfig.class.js
+++ b/src/router/storeSync/abstractParamConfig.class.js
@@ -146,27 +146,6 @@ export default class AbstractParamConfig {
         }
     }
 
-    getStandardErrorMessage(query) {
-        return new ErrorMessage('url_parameter_error', { param: this.urlParamName, value: query })
-    }
-
-    /**
-     * Return the standard feedback for most parameters given in the URL: if the query is validated,
-     * it can proceed and be set in the store.
-     *
-     * @param {any} query The value of the URL parameter given
-     * @param {Boolean} is_valid Is the value valid or not
-     * @returns
-     */
-    getStandardValidationResponse(query, is_valid) {
-        console.error('ENTRY IN STANDARD VALIDATION RESPONSE')
-        console.error(query)
-        console.error(is_valid)
-        return {
-            valid: is_valid,
-            errors: is_valid ? null : this.getStandardErrorMessage(query),
-        }
-    }
     /**
      * Sets the store values according to the URL. Returns a promise that will resolve when the
      * store is up-to-date.
@@ -178,6 +157,8 @@ export default class AbstractParamConfig {
      */
     populateStoreWithQueryValue(to, store, query) {
         return new Promise((resolve, reject) => {
+            console.error('HELLO')
+            console.error(query)
             if (store && this.setValuesInStore) {
                 // when removing a parameter from the URL, this sends a query to populate the store with
                 // the query value, with the param being absent from the query. In this case, we don't
@@ -186,9 +167,12 @@ export default class AbstractParamConfig {
                     to.query[this.urlParamName] && this.validateUrlInput
                         ? this.validateUrlInput(store, query)
                         : { valid: true }
+                console.error(inputValidation)
 
                 // if there are no errors, we want to avoid dispatching and commiting, as it is costly
                 if (inputValidation.errors) {
+                    console.warn('ENTRY HERE')
+                    console.warn(inputValidation.errors)
                     store.dispatch('addErrors', {
                         errors: inputValidation.errors,
                         dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,

--- a/src/router/storeSync/layersParamParser.js
+++ b/src/router/storeSync/layersParamParser.js
@@ -50,12 +50,14 @@ export function decodeUrlLayerId(urlLayerId) {
         // KML/GPX do not have layer IDs, so we use their baseUrl as "ID"
         const decodedLayerId = layerId ? decodeExternalLayerParam(layerId) : decodedBaseUrl
         return {
+            isExternal: true,
             id: decodedLayerId,
             type: layerType,
             baseUrl: decodedBaseUrl,
         }
     }
     return {
+        isExternal: false,
         id: urlLayerId,
     }
 }

--- a/src/router/storeSync/layersParamParser.js
+++ b/src/router/storeSync/layersParamParser.js
@@ -50,14 +50,12 @@ export function decodeUrlLayerId(urlLayerId) {
         // KML/GPX do not have layer IDs, so we use their baseUrl as "ID"
         const decodedLayerId = layerId ? decodeExternalLayerParam(layerId) : decodedBaseUrl
         return {
-            isExternal: true,
             id: decodedLayerId,
             type: layerType,
             baseUrl: decodedBaseUrl,
         }
     }
     return {
-        isExternal: false,
         id: urlLayerId,
     }
 }

--- a/src/router/storeSync/storeSync.config.js
+++ b/src/router/storeSync/storeSync.config.js
@@ -1,4 +1,5 @@
 import { DEFAULT_PROJECTION } from '@/config/map.config'
+import { SUPPORTED_LANG } from '@/modules/i18n'
 import createBaseUrlOverrideParamConfig from '@/router/storeSync/BaseUrlOverrideParamConfig.class.js'
 import CameraParamConfig from '@/router/storeSync/CameraParamConfig.class'
 import CompareSliderParamConfig from '@/router/storeSync/CompareSliderParamConfig.class'
@@ -9,6 +10,7 @@ import SearchParamConfig from '@/router/storeSync/SearchParamConfig.class'
 import SimpleUrlParamConfig from '@/router/storeSync/SimpleUrlParamConfig.class'
 import ZoomParamConfig from '@/router/storeSync/ZoomParamConfig.class'
 import { FeatureInfoPositions } from '@/store/modules/ui.store.js'
+import allCoordinateSystems from '@/utils/coordinates/coordinateSystems'
 
 import TimeSliderParamConfig from './TimeSliderParamConfig.class'
 
@@ -26,6 +28,7 @@ const storeSyncConfig = [
         extractValueFromStore: (store) => store.state.i18n.lang,
         keepInUrlWhenDefault: true,
         valueType: String,
+        acceptedValues: (store, query) => SUPPORTED_LANG.includes(query),
     }),
     new SimpleUrlParamConfig({
         urlParamName: 'sr',
@@ -38,6 +41,8 @@ const storeSyncConfig = [
         // Unit tests somehow come to this line without having set DEFAULT_PROJECTION correctly.
         // So as defensive measure for this, we set a "just in case" default hard-coded value.
         defaultValue: DEFAULT_PROJECTION?.epsgNumber ?? 2056,
+        acceptedValues: (store, query) =>
+            allCoordinateSystems.map((cs) => cs.epsgNumber).includes(query),
     }),
     // Position must be processed after the projection param,
     // otherwise the position might be wrongly reprojected at app startup when SR is not equal
@@ -80,6 +85,8 @@ const storeSyncConfig = [
         },
         keepInUrlWhenDefault: true,
         valueType: String,
+        acceptedValues: (store, query) =>
+            store.layers.backgroundLayers.map((layer) => layer.id).includes(query),
     }),
     new SimpleUrlParamConfig({
         urlParamName: 'topic',
@@ -90,6 +97,8 @@ const storeSyncConfig = [
         keepInUrlWhenDefault: true,
         valueType: String,
         defaultValue: null,
+        acceptedValues: (store, query) =>
+            store.state.topics.config.map((topic) => topic.id).includes(query),
     }),
     new SearchParamConfig(),
     new CrossHairParamConfig(),
@@ -104,6 +113,7 @@ const storeSyncConfig = [
         keepInUrlWhenDefault: false,
         valueType: String,
         defaultValue: FeatureInfoPositions.NONE,
+        acceptedValues: (store, query) => Object.values(FeatureInfoPositions).includes(query),
     }),
     new SimpleUrlParamConfig({
         urlParamName: 'catalogNodes',
@@ -118,6 +128,7 @@ const storeSyncConfig = [
         keepInUrlWhenDefault: false,
         valueType: String,
         defaultValue: '',
+        acceptedValues: null,
     }),
     new TimeSliderParamConfig(),
     createBaseUrlOverrideParamConfig({ urlParamName: 'wms_url', baseUrlPropertyName: 'wms' }),

--- a/src/router/storeSync/storeSync.config.js
+++ b/src/router/storeSync/storeSync.config.js
@@ -29,7 +29,8 @@ const storeSyncConfig = [
         extractValueFromStore: (store) => store.state.i18n.lang,
         keepInUrlWhenDefault: true,
         valueType: String,
-        acceptedValues: (store, query) => SUPPORTED_LANG.includes(query),
+        validateUrlInput: (store, query) =>
+            this.getStandardValidationResponse(query, SUPPORTED_LANG.includes(query)),
     }),
     new SimpleUrlParamConfig({
         urlParamName: 'sr',
@@ -42,8 +43,11 @@ const storeSyncConfig = [
         // Unit tests somehow come to this line without having set DEFAULT_PROJECTION correctly.
         // So as defensive measure for this, we set a "just in case" default hard-coded value.
         defaultValue: DEFAULT_PROJECTION?.epsgNumber ?? 2056,
-        acceptedValues: (store, query) =>
-            allCoordinateSystems.map((cs) => cs.epsgNumber).includes(query),
+        validateUrlInput: (store, query) =>
+            this.getStandardValidationResponse(
+                query,
+                allCoordinateSystems.map((cs) => cs.epsgNumber).includes(query)
+            ),
     }),
     // Position must be processed after the projection param,
     // otherwise the position might be wrongly reprojected at app startup when SR is not equal
@@ -86,13 +90,14 @@ const storeSyncConfig = [
         },
         keepInUrlWhenDefault: true,
         valueType: String,
-        acceptedValues: (store, query) => {
+        validateUrlInput: (store, query) =>
             // in cypress, the backgroundLayers is undefined, so we skip this check
-            if (IS_TESTING_WITH_CYPRESS) {
-                return true
-            }
-            return store.state.layers.backgroundLayers?.map((layer) => layer.id).includes(query)
-        },
+
+            this.getStandardValidationResponse(
+                query,
+                IS_TESTING_WITH_CYPRESS ||
+                    store.state.layers.backgroundLayers?.map((layer) => layer.id).includes(query)
+            ),
     }),
     new SimpleUrlParamConfig({
         urlParamName: 'topic',
@@ -103,8 +108,11 @@ const storeSyncConfig = [
         keepInUrlWhenDefault: true,
         valueType: String,
         defaultValue: null,
-        acceptedValues: (store, query) =>
-            store.state.topics.config.map((topic) => topic.id).includes(query),
+        validateUrlInput: (store, query) =>
+            this.getStandardValidationResponse(
+                query,
+                store.state.topics.config.map((topic) => topic.id).includes(query)
+            ),
     }),
     new SearchParamConfig(),
     new CrossHairParamConfig(),
@@ -119,7 +127,11 @@ const storeSyncConfig = [
         keepInUrlWhenDefault: false,
         valueType: String,
         defaultValue: FeatureInfoPositions.NONE,
-        acceptedValues: (store, query) => Object.values(FeatureInfoPositions).includes(query),
+        validateUrlInput: (store, query) =>
+            this.getStandardValidationResponse(
+                query,
+                Object.values(FeatureInfoPositions).includes(query)
+            ),
     }),
     new SimpleUrlParamConfig({
         urlParamName: 'catalogNodes',
@@ -134,7 +146,7 @@ const storeSyncConfig = [
         keepInUrlWhenDefault: false,
         valueType: String,
         defaultValue: '',
-        acceptedValues: null,
+        validateUrlInput: null,
     }),
     new TimeSliderParamConfig(),
     createBaseUrlOverrideParamConfig({ urlParamName: 'wms_url', baseUrlPropertyName: 'wms' }),

--- a/src/router/storeSync/storeSync.config.js
+++ b/src/router/storeSync/storeSync.config.js
@@ -1,4 +1,5 @@
 import { DEFAULT_PROJECTION } from '@/config/map.config'
+import { IS_TESTING_WITH_CYPRESS } from '@/config/staging.config'
 import { SUPPORTED_LANG } from '@/modules/i18n'
 import createBaseUrlOverrideParamConfig from '@/router/storeSync/BaseUrlOverrideParamConfig.class.js'
 import CameraParamConfig from '@/router/storeSync/CameraParamConfig.class'
@@ -85,8 +86,13 @@ const storeSyncConfig = [
         },
         keepInUrlWhenDefault: true,
         valueType: String,
-        acceptedValues: (store, query) =>
-            store.layers.backgroundLayers.map((layer) => layer.id).includes(query),
+        acceptedValues: (store, query) => {
+            // in cypress, the backgroundLayers is undefined, so we skip this check
+            if (IS_TESTING_WITH_CYPRESS) {
+                return true
+            }
+            return store.state.layers.backgroundLayers?.map((layer) => layer.id).includes(query)
+        },
     }),
     new SimpleUrlParamConfig({
         urlParamName: 'topic',

--- a/src/router/storeSync/storeSync.config.js
+++ b/src/router/storeSync/storeSync.config.js
@@ -84,6 +84,7 @@ const storeSyncConfig = [
         dispatchValueName: 'bgLayerId',
         extractValueFromStore: (store) => {
             const backgroundLayer = store.state.layers.currentBackgroundLayerId
+
             // if background layer is null (no background) we write 'void' in the URL
             if (backgroundLayer === null) {
                 return 'void'
@@ -93,12 +94,12 @@ const storeSyncConfig = [
         keepInUrlWhenDefault: true,
         valueType: String,
         validateUrlInput: (store, query) =>
-            // in cypress, the backgroundLayers is undefined, so we skip this check
-
             getStandardValidationResponse(
                 query,
+                // in cypress, the backgroundLayers is undefined, so we skip this check
                 IS_TESTING_WITH_CYPRESS ||
-                    store.state.layers.backgroundLayers?.map((layer) => layer.id).includes(query)
+                    store.getters.backgroundLayers?.map((layer) => layer.id).includes(query),
+                'bgLayer'
             ),
     }),
     new SimpleUrlParamConfig({

--- a/src/router/storeSync/storeSync.config.js
+++ b/src/router/storeSync/storeSync.config.js
@@ -47,7 +47,7 @@ const storeSyncConfig = [
         validateUrlInput: (store, query) =>
             getStandardValidationResponse(
                 query,
-                allCoordinateSystems.map((cs) => cs.epsgNumber).includes(query),
+                allCoordinateSystems.map((cs) => cs.epsgNumber).includes(Number(query)),
                 'sr'
             ),
     }),
@@ -133,7 +133,13 @@ const storeSyncConfig = [
         validateUrlInput: (store, query) =>
             getStandardValidationResponse(
                 query,
-                Object.values(FeatureInfoPositions).includes(query),
+                Object.values(FeatureInfoPositions).filter((featureInfoPosition) => {
+                    return (
+                        featureInfoPosition.localeCompare(query, undefined, {
+                            sensitivity: 'accent',
+                        }) === 0
+                    )
+                }).length === 1,
                 'featureInfo'
             ),
     }),

--- a/src/router/storeSync/storeSync.config.js
+++ b/src/router/storeSync/storeSync.config.js
@@ -31,7 +31,7 @@ const storeSyncConfig = [
         keepInUrlWhenDefault: true,
         valueType: String,
         validateUrlInput: (store, query) =>
-            getStandardValidationResponse(query, SUPPORTED_LANG.includes(query)),
+            getStandardValidationResponse(query, SUPPORTED_LANG.includes(query), 'lang'),
     }),
     new SimpleUrlParamConfig({
         urlParamName: 'sr',
@@ -47,7 +47,8 @@ const storeSyncConfig = [
         validateUrlInput: (store, query) =>
             getStandardValidationResponse(
                 query,
-                allCoordinateSystems.map((cs) => cs.epsgNumber).includes(query)
+                allCoordinateSystems.map((cs) => cs.epsgNumber).includes(query),
+                'sr'
             ),
     }),
     // Position must be processed after the projection param,
@@ -112,7 +113,8 @@ const storeSyncConfig = [
         validateUrlInput: (store, query) =>
             getStandardValidationResponse(
                 query,
-                store.state.topics.config.map((topic) => topic.id).includes(query)
+                store.state.topics.config.map((topic) => topic.id).includes(query),
+                'topic'
             ),
     }),
     new SearchParamConfig(),
@@ -131,7 +133,8 @@ const storeSyncConfig = [
         validateUrlInput: (store, query) =>
             getStandardValidationResponse(
                 query,
-                Object.values(FeatureInfoPositions).includes(query)
+                Object.values(FeatureInfoPositions).includes(query),
+                'featureInfo'
             ),
     }),
     new SimpleUrlParamConfig({

--- a/src/router/storeSync/storeSync.config.js
+++ b/src/router/storeSync/storeSync.config.js
@@ -1,3 +1,4 @@
+import { getStandardValidationResponse } from '@/api/errorQueues.api'
 import { DEFAULT_PROJECTION } from '@/config/map.config'
 import { IS_TESTING_WITH_CYPRESS } from '@/config/staging.config'
 import { SUPPORTED_LANG } from '@/modules/i18n'
@@ -30,7 +31,7 @@ const storeSyncConfig = [
         keepInUrlWhenDefault: true,
         valueType: String,
         validateUrlInput: (store, query) =>
-            this.getStandardValidationResponse(query, SUPPORTED_LANG.includes(query)),
+            getStandardValidationResponse(query, SUPPORTED_LANG.includes(query)),
     }),
     new SimpleUrlParamConfig({
         urlParamName: 'sr',
@@ -44,7 +45,7 @@ const storeSyncConfig = [
         // So as defensive measure for this, we set a "just in case" default hard-coded value.
         defaultValue: DEFAULT_PROJECTION?.epsgNumber ?? 2056,
         validateUrlInput: (store, query) =>
-            this.getStandardValidationResponse(
+            getStandardValidationResponse(
                 query,
                 allCoordinateSystems.map((cs) => cs.epsgNumber).includes(query)
             ),
@@ -93,7 +94,7 @@ const storeSyncConfig = [
         validateUrlInput: (store, query) =>
             // in cypress, the backgroundLayers is undefined, so we skip this check
 
-            this.getStandardValidationResponse(
+            getStandardValidationResponse(
                 query,
                 IS_TESTING_WITH_CYPRESS ||
                     store.state.layers.backgroundLayers?.map((layer) => layer.id).includes(query)
@@ -109,7 +110,7 @@ const storeSyncConfig = [
         valueType: String,
         defaultValue: null,
         validateUrlInput: (store, query) =>
-            this.getStandardValidationResponse(
+            getStandardValidationResponse(
                 query,
                 store.state.topics.config.map((topic) => topic.id).includes(query)
             ),
@@ -128,7 +129,7 @@ const storeSyncConfig = [
         valueType: String,
         defaultValue: FeatureInfoPositions.NONE,
         validateUrlInput: (store, query) =>
-            this.getStandardValidationResponse(
+            getStandardValidationResponse(
                 query,
                 Object.values(FeatureInfoPositions).includes(query)
             ),

--- a/src/router/storeSync/storeSync.routerPlugin.js
+++ b/src/router/storeSync/storeSync.routerPlugin.js
@@ -117,7 +117,7 @@ function urlQueryWatcher(store, to, from) {
     const newQuery = { ...to.query }
     // if this module did not trigger the route change, we need to check if a store change is needed
     storeSyncConfig.forEach((paramConfig) => {
-        const queryValue = paramConfig.readValueFromQuery(to.query)
+        const queryValue = paramConfig.readValueFromQuery(to.query, store)
         const storeValue = paramConfig.readValueFromStore(store)
 
         const setValueInStore = async (paramConfig, store, value) => {

--- a/src/router/storeSync/storeSync.routerPlugin.js
+++ b/src/router/storeSync/storeSync.routerPlugin.js
@@ -125,7 +125,8 @@ function urlQueryWatcher(store, to, from) {
         }
 
         if (
-            queryValue &&
+            // when the query value is an empty string, queryValue is false.
+            (queryValue || queryValue === '') &&
             queryValue !== storeValue &&
             // if the query is undefined and the store is null, we also don't dispatch it, as we want
             // to avoid changing the store value for no reason.

--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -396,7 +396,7 @@ export default {
             ) {
                 commit('addErrors', { errors, dispatcher })
             } else if (errors instanceof ErrorMessage) {
-                if (state.errors.has(errors)) {
+                if (!state.errors.has(errors)) {
                     commit('addError', {
                         error: errors,
                         dispatcher,

--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -389,14 +389,23 @@ export default {
         setShowDisclaimer({ commit }, { showDisclaimer, dispatcher }) {
             commit('setShowDisclaimer', { showDisclaimer, dispatcher })
         },
-        addError({ commit, state }, { error, dispatcher }) {
-            if (!(error instanceof ErrorMessage)) {
+        addErrors({ commit, state }, { errors, dispatcher }) {
+            if (
+                errors instanceof Array &&
+                errors.filter((error) => error instanceof ErrorMessage).length === errors.length
+            ) {
+                commit('addErrors', { errors, dispatcher })
+            } else if (errors instanceof ErrorMessage) {
+                if (state.errors.has(errors)) {
+                    commit('addError', {
+                        error: errors,
+                        dispatcher,
+                    })
+                }
+            } else {
                 throw new Error(
-                    `Error ${error} dispatched by ${dispatcher} is not of type ErrorMessage`
+                    `Error ${errors} dispatched by ${dispatcher} is not of type ErrorMessage, or not an Array of ErrorMessages`
                 )
-            }
-            if (!state.errors.has(error)) {
-                commit('addError', { error, dispatcher })
             }
         },
 
@@ -410,14 +419,21 @@ export default {
                 commit('removeError', { error, dispatcher })
             }
         },
-        addWarning({ commit, state }, { warning, dispatcher }) {
-            if (!(warning instanceof WarningMessage)) {
+        addWarnings({ commit, state }, { warnings, dispatcher }) {
+            if (
+                warnings instanceof Array &&
+                warnings.filter((warning) => warning instanceof WarningMessage).length ===
+                    warnings.length
+            ) {
+                commit('addWarnings', { warnings, dispatcher })
+            } else if (warnings instanceof WarningMessage) {
+                if (!state.warnings.has(warnings)) {
+                    commit('addWarning', { warning: warnings, dispatcher })
+                }
+            } else {
                 throw new Error(
-                    `Warning ${warning} dispatched by ${dispatcher} is not of type WarningMessage`
+                    `Warning ${warnings} dispatched by ${dispatcher} is not of type WarningMessage, or not an Array of WarningMessages`
                 )
-            }
-            if (!state.warnings.has(warning)) {
-                commit('addWarning', { warning, dispatcher })
             }
         },
         removeWarning({ commit, state }, { warning, dispatcher }) {
@@ -493,8 +509,14 @@ export default {
         },
         setShowDisclaimer: (state, { showDisclaimer }) => (state.showDisclaimer = showDisclaimer),
         addError: (state, { error }) => state.errors.add(error),
+        addErrors: (state, { errors }) => {
+            errors.forEach((error) => state.errors.add(error))
+        },
         removeError: (state, { error }) => state.errors.delete(error),
         addWarning: (state, { warning }) => state.warnings.add(warning),
+        addWarnings: (state, { warnings }) => {
+            warnings.forEach((warning) => state.warnings.add(warning))
+        },
         removeWarning: (state, { warning }) => state.warnings.delete(warning),
         setShowDragAndDropOverlay: (state, { showDragAndDropOverlay }) =>
             (state.showDragAndDropOverlay = showDragAndDropOverlay),

--- a/src/store/plugins/geolocation-management.plugin.js
+++ b/src/store/plugins/geolocation-management.plugin.js
@@ -25,7 +25,7 @@ function setCenterIfInBounds(store, center) {
         }
     } else {
         log.warn(`current geolocation is out of bounds: ${JSON.stringify(center)}`)
-        store.dispatch('addError', {
+        store.dispatch('addErrors', {
             error: new ErrorMessage('geoloc_out_of_bounds', null),
             ...dispatcher,
         })
@@ -88,14 +88,14 @@ const handlePositionError = (error, store, state, options = {}) => {
                 denied: true,
                 ...dispatcher,
             })
-            store.dispatch('addError', {
+            store.dispatch('addErrors', {
                 error: new ErrorMessage('geoloc_permission_denied', null),
                 ...dispatcher,
             })
             break
         case error.TIMEOUT:
             store.dispatch('setGeolocation', { active: false, ...dispatcher })
-            store.dispatch('addError', {
+            store.dispatch('addErrors', {
                 error: new ErrorMessage('geoloc_time_out', null),
                 ...dispatcher,
             })
@@ -116,7 +116,7 @@ const handlePositionError = (error, store, state, options = {}) => {
                         activeGeolocation(store, state, { useInitial: false })
                     }
                 } else {
-                    store.dispatch('addError', {
+                    store.dispatch('addErrors', {
                         error: new ErrorMessage('geoloc_unknown', null),
                         ...dispatcher,
                     })

--- a/src/utils/coordinates/coordinateSystems.js
+++ b/src/utils/coordinates/coordinateSystems.js
@@ -13,7 +13,7 @@ export const WGS84 = new WGS84CoordinateSystem()
 export const WEBMERCATOR = new WebMercatorCoordinateSystem()
 
 /** Representation of many (available in this app) projection systems */
-const allCoordinateSystems = [LV95, LV03, WGS84, WEBMERCATOR]
+export const allCoordinateSystems = [LV95, LV03, WGS84, WEBMERCATOR]
 setupProj4(allCoordinateSystems)
 
 // register any custom projection in OpenLayers


### PR DESCRIPTION
Issue : when modifying the URL directly, users received no feedback about what they did wrong when making mistakes, especially on a productive environment where most logs are deactivated.
Fix : we now give a feedback for every parameter that is wrongfully filled. We also added some extra cases for the layers, where we want to give a feedback on each individual layer, and for the time slider when everything is in order, but there are no layers supporting it.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-984-error-feedback-for-all-url-parameters/index.html)