### PR TITLE
PB-1006: Fixed CORS issue with admin.ch hosts

### DIFF
--- a/src/config/baseUrl.config.js
+++ b/src/config/baseUrl.config.js
@@ -208,4 +208,4 @@ export function getVectorTilesBaseUrl() {
 }
 
 export const internalDomainRegex =
-    import.meta.env.VITE_APP_INTERNAL_DOMAIN_REGEX ?? /^https:\/\/[^/]*(bgdi|admin)\.ch/
+    import.meta.env.VITE_APP_INTERNAL_DOMAIN_REGEX ?? /^https:\/\/[^/]*(bgdi|geo\.admin)\.ch/


### PR DESCRIPTION
Some admin.ch hosts like uvek-gis.admin.ch don't support yet CORS, therefore
they still need to go through proxy.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-1006-kml-admin.ch/index.html)