### PR TITLE
PB-896 : show un-simplified GPX track

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
                 "@turf/helpers": "^7.1.0",
                 "@turf/nearest-point": "^7.1.0",
                 "@turf/point-to-line-distance": "^7.1.0",
+                "@turf/simplify": "^7.1.0",
                 "animate.css": "^4.1.1",
                 "axios": "^1.7.5",
                 "bootstrap": "^5.3.3",
@@ -1768,6 +1769,20 @@
                 "url": "https://opencollective.com/turf"
             }
         },
+        "node_modules/@turf/clean-coords": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-7.1.0.tgz",
+            "integrity": "sha512-q1U8UbRVL5cRdwOlNjD8mad8pWjFGe0s4ihg1pSiVNq7i47WASJ3k20yZiUFvuAkyNjV0rZ/A7Jd7WzjcierFg==",
+            "dependencies": {
+                "@turf/helpers": "^7.1.0",
+                "@turf/invariant": "^7.1.0",
+                "@types/geojson": "^7946.0.10",
+                "tslib": "^2.6.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/turf"
+            }
+        },
         "node_modules/@turf/clone": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.1.0.tgz",
@@ -1926,6 +1941,22 @@
             "dependencies": {
                 "@turf/helpers": "^7.1.0",
                 "@turf/invariant": "^7.1.0",
+                "@types/geojson": "^7946.0.10",
+                "tslib": "^2.6.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/turf"
+            }
+        },
+        "node_modules/@turf/simplify": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-7.1.0.tgz",
+            "integrity": "sha512-JypymaoiSiFzGHwEoUkK0OPW1KQSnH3hEsEW3UIRS+apzltJ4HdFovYjsfqQgGZJZ+NJ9+dv7h8pgGLYuqcBUQ==",
+            "dependencies": {
+                "@turf/clean-coords": "^7.1.0",
+                "@turf/clone": "^7.1.0",
+                "@turf/helpers": "^7.1.0",
+                "@turf/meta": "^7.1.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.6.2"
             },

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "@turf/helpers": "^7.1.0",
         "@turf/nearest-point": "^7.1.0",
         "@turf/point-to-line-distance": "^7.1.0",
+        "@turf/simplify": "^7.1.0",
         "animate.css": "^4.1.1",
         "axios": "^1.7.5",
         "bootstrap": "^5.3.3",

--- a/src/modules/infobox/components/ShowGeometryProfileButton.vue
+++ b/src/modules/infobox/components/ShowGeometryProfileButton.vue
@@ -4,7 +4,9 @@ import { toRefs } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 
+import LayerFeature from '@/api/features/LayerFeature.class'
 import SelectableFeature from '@/api/features/SelectableFeature.class'
+import LayerTypes from '@/api/layers/LayerTypes.enum'
 
 const dispatcher = { dispatcher: 'ShowGeometryProfileButton.vue' }
 
@@ -20,7 +22,17 @@ const i18n = useI18n()
 const store = useStore()
 
 function showProfile() {
-    store.dispatch('setProfileFeature', { feature: feature.value, ...dispatcher })
+    let simplifyGeometry = false
+    if (feature.value instanceof LayerFeature) {
+        // PB-800 : to avoid a coastline paradox we simplify the geometry of GPXs
+        // as they might be coming directly from a GPS device (meaning polluted with GPS uncertainty/error)
+        simplifyGeometry = feature.value.layer.type === LayerTypes.GPX
+    }
+    store.dispatch('setProfileFeature', {
+        feature: feature.value,
+        simplifyGeometry,
+        ...dispatcher,
+    })
 }
 </script>
 

--- a/src/utils/gpxUtils.js
+++ b/src/utils/gpxUtils.js
@@ -3,7 +3,6 @@ import bbox from '@turf/bbox'
 import { isEmpty as isExtentEmpty } from 'ol/extent'
 import GPX from 'ol/format/GPX'
 
-import { GPX_GEOMETRY_SIMPLIFICATION_TOLERANCE } from '@/config/map.config'
 import CoordinateSystem from '@/utils/coordinates/CoordinateSystem.class'
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
 import { gpxStyles } from '@/utils/styleUtils'
@@ -46,8 +45,6 @@ export function parseGpx(gpxData, projection) {
     })
     features.forEach((feature) => {
         const geom = feature.getGeometry()
-        // PB-800 : to avoid a coastline paradox we simplify the geometry of GPXs
-        feature.setGeometry(geom.simplify(GPX_GEOMETRY_SIMPLIFICATION_TOLERANCE))
         feature.setStyle(gpxStyles[geom.getType()])
     })
     return features


### PR DESCRIPTION
but still simplify the track before sending it to the profile backend.
This should reduce the coastal paradox we had before when sending raw GPX track, while keeping user "happy" as they will se their raw track on the map

Using TurfJS to do the simplification, as it is also using a Ramer-Douglas-Peucker algorithm (same as OpenLayers) and it would be more difficult / add more complexity to the code to reparse all features as OL features there.

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-896-gpx-simplify-only-profile/index.html)