### PR TITLE
PB-1017: un-proxy external graphics in print specs

### DIFF
--- a/src/api/file-proxy.api.js
+++ b/src/api/file-proxy.api.js
@@ -56,3 +56,15 @@ export function proxifyUrl(url) {
     }
     return `${getServiceProxyBaseUrl()}${fileAsPath}`
 }
+
+export function unProxifyUrl(proxified_url) {
+    if (
+        (typeof proxified_url === 'string' || proxified_url instanceof String) &&
+        proxified_url.startsWith(getServiceProxyBaseUrl())
+    ) {
+        let url = proxified_url.replace(getServiceProxyBaseUrl(), '')
+        return `${url.split('/')[0]}://${decodeURIComponent(url.split('/')[1])}`
+    }
+
+    return proxified_url
+}

--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -8,6 +8,7 @@ import {
 import axios from 'axios'
 import { Circle } from 'ol/style'
 
+import { unProxifyUrl } from '@/api/file-proxy.api'
 import {
     getApi3BaseUrl,
     getViewerDedicatedServicesBaseUrl,
@@ -116,6 +117,9 @@ class GeoAdminCustomizer extends BaseCustomizer {
         if (symbolizer.externalGraphic) {
             size = image.getSize()
             anchor = image.getAnchor()
+            // service print can't handle a proxied url, so we ensure we're
+            // giving the original url for the print job.
+            symbolizer.externalGraphic = unProxifyUrl(symbolizer.externalGraphic)
         } else if (image instanceof Circle) {
             const radius = image.getRadius()
             const width = adjustWidth(2 * radius, this.printResolution)


### PR DESCRIPTION
Issue : Service print can't use service-proxy like the mapviewer, so when external graphics are proxied in the mapviewer to go around CORS issues, those same graphics can't be rendered in print jobs

Fix : we un-proxy the 'externalGraphics' attribute of styles in the print spec, so the original URL is sent to service print.

[Test link](https://sys-map.dev.bgdi.ch/preview/bugfix-pb-1017-unproxify-print-jobs/index.html)