### PR TITLE
PB-364: Add parser for OGC WMS XML response for GetFeatureInfo.

### DIFF
--- a/src/api/features/features.api.js
+++ b/src/api/features/features.api.js
@@ -24,6 +24,7 @@ const GET_FEATURE_INFO_FAKE_VIEWPORT_SIZE = 100
 
 const APPLICATION_JSON_TYPE = 'application/json'
 const APPLICATION_GML_3_TYPE = 'application/vnd.ogc.gml'
+const APPLICATION_OGC_WMS_XML_TYPE = 'application/vnd.ogc.wms_xml'
 const PLAIN_TEXT_TYPE = 'text/plain'
 
 /**
@@ -281,6 +282,50 @@ async function identifyOnExternalLayer(config) {
     }
 }
 
+// Parse OGC WMS XML response to GeoJSON
+function parseOGCWMSFeatureInfoResponse(response) {
+    const parser = new DOMParser()
+    const xmlDoc = parser.parseFromString(response, 'text/xml')
+
+    // Check for parsing errors
+    const parserError = xmlDoc.getElementsByTagName('parsererror')
+    if (parserError.length > 0) {
+        console.error('Error parsing OGC WMS XML response')
+        return null
+    }
+
+    const features = []
+    const fieldElements = xmlDoc.getElementsByTagName('FIELDS')
+
+    for (let i = 0; i < fieldElements.length; i++) {
+        const fieldElement = fieldElements[i]
+        const properties = {}
+
+        // Extract attributes from the FIELDS element
+        for (let j = 0; j < fieldElement.attributes.length; j++) {
+            const attribute = fieldElement.attributes[j]
+            properties[attribute.name] = attribute.value
+        }
+
+        // Create a GeoJSON feature
+        const feature = {
+            type: 'Feature',
+            geometry: null, // Assuming geometry is not provided in the response
+            properties: properties,
+        }
+
+        features.push(feature)
+    }
+
+    // Create a GeoJSON FeatureCollection
+    const geojson = {
+        type: 'FeatureCollection',
+        features: features,
+    }
+
+    return geojson
+}
+
 /**
  * Runs a getFeatureInfo request on the backend of an external WMS layer.
  *
@@ -336,6 +381,8 @@ async function identifyOnExternalWmsLayer(config) {
         // if JSON isn't supported, we check if GML3 is supported
         if (layer.getFeatureInfoCapability.formats?.includes(APPLICATION_GML_3_TYPE)) {
             outputFormat = APPLICATION_GML_3_TYPE
+        } else if (layer.getFeatureInfoCapability.formats?.includes(APPLICATION_OGC_WMS_XML_TYPE)) {
+            outputFormat = APPLICATION_OGC_WMS_XML_TYPE
         } else {
             // if neither JSON nor GML3 are supported, we will ask for plain text
             outputFormat = PLAIN_TEXT_TYPE
@@ -406,6 +453,9 @@ async function identifyOnExternalWmsLayer(config) {
             case APPLICATION_JSON_TYPE:
                 // nothing to do other than extracting the data
                 features = getFeatureInfoResponse.data.features
+                break
+            case APPLICATION_OGC_WMS_XML_TYPE:
+                features = parseOGCWMSFeatureInfoResponse(getFeatureInfoResponse.data)?.features
                 break
             case PLAIN_TEXT_TYPE:
                 // TODO : implement plain text parsing


### PR DESCRIPTION
Originally, the ticket is about parsing plain text response from GetFeatureInfo request. Unfortunately, there is no standard on how to do it. For example these two requests have completely different format if we request as plain/text:

- [Semicolon separated](https://public.geo.lu.ch/ogd/services/managed/GRZGEMLU_DS_V1_MP/MapServer/WMSServer?&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetFeatureInfo&LAYERS=0&CRS=EPSG:2056&BBOX=2619150,1195166,2668924,1245527&WIDTH=100&HEIGHT=100&QUERY_LAYERS=0&INFO_FORMAT=text%2Fplain&FEATURE_COUNT=10&LANG=en&TOLERANCE=10&BUFFER=10&FI_POINT_TOLERANCE=10&FI_LINE_TOLERANCE=10&FI_POLYGON_TOLERANCE=10&I=50&J=50)

```
@Gemeinden Kanton Luzern OBJECTID;BFS-Gemeindenummer;Shape; 2;1121;Polygon; 9;1128;Polygon; 18;1151;Polygon; 74;1086;Polygon; 
```
- [Dash section separated](https://wms.geo.ag.ch/public/ows?SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetFeatureInfo&LAYERS=ch_ag_geo_alg_amphibienzugst_02&CRS=EPSG:2056&BBOX=2653268,1261956,2673113,1282169&WIDTH=100&HEIGHT=100&QUERY_LAYERS=ch_ag_geo_alg_amphibienzugst_02&FEATURE_COUNT=10&LANG=en&TOLERANCE=10&BUFFER=10&FI_POINT_TOLERANCE=10&FI_LINE_TOLERANCE=10&FI_POLYGON_TOLERANCE=10&I=50&J=50&INFO_FORMAT=text/plain)
```
Results for FeatureType 'http://public_20221118_113413:ch_ag_geo_alg_amphibienzugst_02':
--------------------------------------------
amzg_id = 53
gebietnr = 52.0
strecke = Rietheim - Koblenz
esta = 4316
groesse = gross
laenge = 1000
kreising = IV
strassennr = K131
strasse = 1
bahn = 1
tieresamme = 1.0
tafelstell = 0.0
shape = [GEOMETRY (Point) with 1 points]
--------------------------------------------
--------------------------------------------
amzg_id = 54
gebietnr = 53.0
strecke = Rietheim - Zurzach
esta = 4316
groesse = gross
laenge = 400
kreising = IV
strassennr = K131
strasse = 1
bahn = 1
tieresamme = 0.0
tafelstell = 0.0
shape = [GEOMETRY (Point) with 1 points]
--------------------------------------------
--------------------------------------------
amzg_id = 84
gebietnr = 83.0
strecke = Zurzach - Rekingen
esta = 4323
groesse = gross
laenge = 700
kreising = IV
strassennr =  
strasse = 0
bahn = 1
tieresamme = 0.0
tafelstell = 0.0
shape = [GEOMETRY (Point) with 1 points]
--------------------------------------------
```


In this case, I tried to parse other possible format available in the problematic WMS in the ticket, which is a `application/vnd.ogc.wms_xml`. I checked in other WMS in the ticket also have this output format and works well.


## Result

[Test link with sample data](https://sys-s.dev.bgdi.ch/8xpgv21wc7tp)

![image](https://github.com/user-attachments/assets/f7701026-1442-4bc6-88f1-1fb763a32844)
![image](https://github.com/user-attachments/assets/4d4d56e9-6ae4-46e6-b9ff-6d4d614df6f3)


[Test link](https://sys-map.dev.bgdi.ch/preview/pb-364-plain-text-parsing/index.html)