### PR TITLE
PB-960: handle long press events error on some mobiles

### DIFF
--- a/src/modules/map/components/openlayers/utils/useMapInteractions.composable.js
+++ b/src/modules/map/components/openlayers/utils/useMapInteractions.composable.js
@@ -184,6 +184,7 @@ export default function useMapInteractions(map) {
 
     function onMapRightClick(event) {
         clearTimeout(longClickTimeout)
+        longClickTriggered = event.updateLongClickTriggered ?? false
         store.dispatch('click', {
             clickInfo: new ClickInfo({
                 coordinate: event.coordinate,
@@ -212,7 +213,6 @@ export default function useMapInteractions(map) {
             // LocationPopup by touching the same-ish spot for 500ms
             longClickTimeout = setTimeout(() => {
                 if (!mapHasMoved) {
-                    longClickTriggered = true
                     // we are outside of OL event handling, on the HTML element, so we do not receive map pixel and coordinate automatically
                     const pixel = map.getEventPixel(event)
                     const coordinate = map.getCoordinateFromPixel(pixel)
@@ -220,6 +220,7 @@ export default function useMapInteractions(map) {
                         ...event,
                         pixel,
                         coordinate,
+                        updateLongClickTriggered: true,
                     })
                 }
                 mapHasMoved = false


### PR DESCRIPTION
Issue : on some phones, a long press event would also fire a single press event afterwards, causing the application to open both a location popup and an infobox.
Cause : setting the longClickTriggered boolean was not registered while in the longClickTimeout function, most likely due to a scoping issue.

Fix : we set the longClickTriggered boolean in the 'onMapRightClick' event instead. We also added a small parameter in the function to tell if we need to set up the flag or not, as desktop users won't need this.

[Test link](https://sys-map.dev.bgdi.ch/preview/bugfix-pb-960-handle-longpress-event-conflict/index.html)