### PR TITLE
PB-1003: no more long mouse left clicks

### DIFF
--- a/src/modules/map/components/openlayers/utils/useMapInteractions.composable.js
+++ b/src/modules/map/components/openlayers/utils/useMapInteractions.composable.js
@@ -212,7 +212,8 @@ export default function useMapInteractions(map) {
             // triggering a long click on the same spot after 500ms, so that mobile cas have access to the
             // LocationPopup by touching the same-ish spot for 500ms
             longClickTimeout = setTimeout(() => {
-                if (!mapHasMoved) {
+                // we need to ensure long mouse clicks don't trigger this.
+                if (!mapHasMoved && event.originalEvent.pointerType === 'touch') {
                     // we are outside of OL event handling, on the HTML element, so we do not receive map pixel and coordinate automatically
                     const pixel = map.getEventPixel(event)
                     const coordinate = map.getCoordinateFromPixel(pixel)

--- a/src/modules/map/components/openlayers/utils/useMapInteractions.composable.js
+++ b/src/modules/map/components/openlayers/utils/useMapInteractions.composable.js
@@ -20,6 +20,11 @@ import log from '@/utils/logging'
 const dispatcher = {
     dispatcher: 'useMapInteractions.composable',
 }
+const longPressEvents = [
+    'touch',
+    'pen',
+    '', // This is necessary for IoS support
+]
 
 export default function useMapInteractions(map) {
     const store = useStore()
@@ -184,7 +189,7 @@ export default function useMapInteractions(map) {
 
     function onMapRightClick(event) {
         clearTimeout(longClickTimeout)
-        longClickTriggered = event.updateLongClickTriggered ?? false
+        longClickTriggered = event.updateLongClickTriggered ?? event.type === 'contextmenu'
         store.dispatch('click', {
             clickInfo: new ClickInfo({
                 coordinate: event.coordinate,
@@ -213,7 +218,11 @@ export default function useMapInteractions(map) {
             // LocationPopup by touching the same-ish spot for 500ms
             longClickTimeout = setTimeout(() => {
                 // we need to ensure long mouse clicks don't trigger this.
-                if (!mapHasMoved && event.originalEvent.pointerType === 'touch') {
+                if (
+                    !mapHasMoved &&
+                    (longPressEvents.includes(event.originalEvent?.pointerType) ||
+                        longPressEvents.includes(event.pointerType))
+                ) {
                     // we are outside of OL event handling, on the HTML element, so we do not receive map pixel and coordinate automatically
                     const pixel = map.getEventPixel(event)
                     const coordinate = map.getCoordinateFromPixel(pixel)


### PR DESCRIPTION
 Issue : pressing the left mouse button for a long period of time would cause the location popup to appear

 Cause : in openlayers, the singleClick event represents both mouse left clicks and mobiles touchdown events

 Fix : We check the pointer type of the original event, ensuring we only handle the cases where this was triggered on a mobile.

[Test link](https://sys-map.dev.bgdi.ch/preview/bugfix-pb-1003-stop-long-left-click-interaction/index.html)