### PR TITLE
PB-827: Add warning when using http resources

### DIFF
--- a/src/modules/i18n/locales/de.json
+++ b/src/modules/i18n/locales/de.json
@@ -327,6 +327,7 @@
     "kml": "KML",
     "kml_gpx_file_empty": "Die KML/GPX-Datei ist leer",
     "kml_icon_url_cors_issue": "Die KML-Datei „{layerName}“ enthält Symbol(e) mit der URL {url}, die keine CORS-Unterstützung bietet! Bitte wenden Sie sich an den Administrator dieser URL, um die Unterstützung für CORS hinzuzufügen.",
+    "kml_icon_url_scheme_http": "Die KML\" {layerName}\" enthält Symbole mit der {url}-URL in http. Ab dem 31. Januar 2025 wird die Unterstützung für diese Ressourcen eingestellt und nur https-Ressourcen werden unterstützt. Weitere Informationen finden Sie unter https://www.geo.admin.ch/de/informationen-ssl-zertifikate-http-protokoll",
     "kml_no_text_elements": "Information: Die Labels werden nicht gespeichert",
     "kml_style_default": "Standard",
     "kml_style_geoadmin": "GeoAdmin",

--- a/src/modules/i18n/locales/en.json
+++ b/src/modules/i18n/locales/en.json
@@ -327,6 +327,7 @@
     "kml": "KML",
     "kml_gpx_file_empty": "KML/GPX file is empty",
     "kml_icon_url_cors_issue": "The KML \"{layerName}\" contains icon(s) with URL {url} that doesn't support CORS! Please contact the administrator of this URL to add support for CORS.",
+    "kml_icon_url_scheme_http": "The {layerName} KML contains icons with the URL {url} in http. As of January 31, 2025, support for these resources will be discontinued, and only https resources will be supported. For more information, see https://www.geo.admin.ch/en/important-imformation-ssl-certificates-http-protocols",
     "kml_no_text_elements": "Information: The labels won't be saved",
     "kml_style_default": "default",
     "kml_style_geoadmin": "GeoAdmin",

--- a/src/modules/i18n/locales/fr.json
+++ b/src/modules/i18n/locales/fr.json
@@ -327,6 +327,7 @@
     "kml": "KML",
     "kml_gpx_file_empty": "Le fichier KML/GPX est vide",
     "kml_icon_url_cors_issue": "Le KML « {layerName} » contient des icônes avec l'URL {url} qui ne supporte pas CORS ! Veuillez contacter l'administrateur de cette URL pour avoir du support de CORS.",
+    "kml_icon_url_scheme_http": "Le KML « {layerName} » contient des icônes avec l'URL {url} en http. A compter du 31 janvier 2025, le support pour ces ressources sera arrêté, et seules les ressources en https seront supportées. Pour plus d'informations, consultez https://www.geo.admin.ch/fr/informations-importantes-certification-ssl-protocole-http",
     "kml_no_text_elements": "Information: Les étiquettes ne seront pas sauvées",
     "kml_style_default": "défaut",
     "kml_style_geoadmin": "GeoAdmin",

--- a/src/modules/i18n/locales/it.json
+++ b/src/modules/i18n/locales/it.json
@@ -327,6 +327,7 @@
     "kml": "KML",
     "kml_gpx_file_empty": "Il file KML/GPX è vuoto",
     "kml_icon_url_cors_issue": "Il KML “{layerName}” contiene icone con l'URL {url} che non supporta CORS! Contattare l'amministratore di questo URL per aggiungere il supporto per CORS.",
+    "kml_icon_url_scheme_http": "Il KML {layerName} contiene icone con l'URL {url} in http. A partire dal 31 gennaio 2025, il supporto per queste risorse sarà terminato e saranno supportate solo le risorse https. Per maggiori informazioni, vedere https://www.geo.admin.ch/it/informazioni-importanti-crtificati-ssl-protocollo-http",
     "kml_no_text_elements": "Informazione: le etichette non saranno salvate",
     "kml_style_default": "predefinito",
     "kml_style_geoadmin": "GeoAdmin",

--- a/src/modules/i18n/locales/rm.json
+++ b/src/modules/i18n/locales/rm.json
@@ -325,6 +325,7 @@
     "kml": "KML",
     "kml_gpx_file_empty": "La datoteca KML/GPX è vegnida empruva",
     "kml_icon_url_cors_issue": "Il KML \"{layerName}\" cuntegna icona(s) cun URL {url} che na po nagin sustegnair CORS! As drizzai p.pl. a l'administratura da quella URL per agiuntar il sustegn dal CORS.",
+    "kml_icon_url_scheme_http": "Il MPML \" {layerName}\" cuntegna iconas cun il URL {url} en il program da http. A partir dals 31 da schaner 2025 vegn il sustegn per questas resursas franà, i vegn rapportà mo pli da las resursas da https. Ulteriuras infurmaziuns sin https://www.geo.admin.ch/de/informationen-ssl-zertifikate-http-protokoll",
     "kml_no_text_elements": " Infurmaziun: ils labels na vegnan betg memorisads",
     "kml_style_default": "Standard",
     "kml_style_geoadmin": "GeoAdmin",

--- a/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
@@ -84,15 +84,27 @@ onUnmounted(() => {
 })
 
 function iconUrlProxy(url) {
-    return iconUrlProxyFy(url, (url) => {
-        store.dispatch('addWarning', {
-            warning: new WarningMessage('kml_icon_url_cors_issue', {
-                layerName: layerName.value,
-                url: url,
-            }),
-            dispatcher: 'kmlUtils.js',
-        })
-    })
+    return iconUrlProxyFy(
+        url,
+        (url) => {
+            store.dispatch('addWarning', {
+                warning: new WarningMessage('kml_icon_url_cors_issue', {
+                    layerName: layerName.value,
+                    url: url,
+                }),
+                dispatcher: 'kmlUtils.js',
+            })
+        },
+        (url) => {
+            store.dispatch('addWarning', {
+                warning: new WarningMessage('kml_icon_url_scheme_http', {
+                    layerName: layerName.value,
+                    url: url,
+                }),
+                dispatcher: 'kmlUtils.js',
+            })
+        }
+    )
 }
 
 function createSourceForProjection() {

--- a/src/utils/kmlUtils.js
+++ b/src/utils/kmlUtils.js
@@ -453,9 +453,13 @@ export function getEditableFeatureFromKmlFeature(kmlFeature, kmlLayer, available
 }
 
 const nonGeoadminIconUrls = new Set()
-export function iconUrlProxyFy(url, corsIssueCallback = null) {
+export function iconUrlProxyFy(url, corsIssueCallback = null, httpIssueCallBack = null) {
     // We only proxyfy URL that are not from our backend.
     if (!/^(https:\/\/[^/]*(bgdi\.ch|geo\.admin\.ch)|https?:\/\/localhost)/.test(url)) {
+        if (url.startsWith('http:') && httpIssueCallBack) {
+            log.warn(`KML Icon url ${url} has an http scheme`)
+            httpIssueCallBack(url)
+        }
         const proxyUrl = proxifyUrl(url)
         // Only perform the CORS check if we have a callback and it has not yet been done
         if (!nonGeoadminIconUrls.has(url) && corsIssueCallback) {


### PR DESCRIPTION
Issue : Supporting http resources with the mapviewer is being rolled out by late January at the latest. We need to inform people still using them to make the change

Fix : We add a feedback warning specifically saying that there are resources in http, and that the user should change that.

still a draft for now : I need to add the links and ensure translation is correct

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-827-add-warning-http/index.html)