### PR TITLE
PB-984: quick fix for local layers

### DIFF
--- a/src/modules/i18n/locales/de.json
+++ b/src/modules/i18n/locales/de.json
@@ -648,7 +648,7 @@
     "upload_failed": "Fehler beim Hochladen!",
     "upload_succeeded": "Upload OK!",
     "uploading_file": "Laden...",
-    "url_external_layer_no_scheme_error": "Die externe Ebene '{layer}' hat kein gültiges Schema und wird ignoriert.",
+    "url_external_layer_no_scheme_warning": "Sie haben neu geladen, während eine lokale Ebene importiert wurde, oder eine Verknüpfung mit einer lokalen Ebene erhalten, die nicht geladen wurde. Wenn Sie die Datei mit der {layer}-Ebene haben, importieren Sie sie bitte erneut.",
     "url_image": "Foto  URL",
     "url_layer_error": "Die Karte „{layer}“ konnte nicht angezeigt werden. Bitte überprüfen Sie, ob Sie keine Tippfehler gemacht haben",
     "url_link": "Webseite URL",

--- a/src/modules/i18n/locales/en.json
+++ b/src/modules/i18n/locales/en.json
@@ -648,7 +648,7 @@
     "upload_failed": "Upload error!",
     "upload_succeeded": "Upload OK!",
     "uploading_file": "Loading file...",
-    "url_external_layer_no_scheme_error": "The external layer '{layer}' has no valid scheme and will be ignored.",
+    "url_external_layer_no_scheme_warning": "You have reloaded while a local layer was imported, or received a link containing a local layer, which has not been loaded. If you have the file containing the {layer} layer, please re-import it.",
     "url_image": "Photo URL",
     "url_layer_error": "The map '{layer}' could not be displayed. Please check that you have not made any typos",
     "url_link": "Website URL",

--- a/src/modules/i18n/locales/fr.json
+++ b/src/modules/i18n/locales/fr.json
@@ -648,7 +648,7 @@
     "upload_failed": "Erreur d'enregistrement!",
     "upload_succeeded": "Chargement OK!",
     "uploading_file": "Chargement du fichier...",
-    "url_external_layer_no_scheme_error": "La couche externe « {layer} » n'a pas de schéma valide et sera ignorée.",
+    "url_external_layer_no_scheme_warning": "Vous avez rechargé alors qu'une couche locale était importée, ou reçu un lien contenant une couche locale, qui n'a donc pas été chargée. Si vous disposez du fichier contenant la couche {layer}, veuillez le réimporter.",
     "url_image": "Lien de la photo",
     "url_layer_error": "La carte '{layer}' n'a pas pu être affichée. Veuillez vérifier que vous n'avez pas fait de fautes de frappe",
     "url_link": "Lien du site web",

--- a/src/modules/i18n/locales/it.json
+++ b/src/modules/i18n/locales/it.json
@@ -648,7 +648,7 @@
     "upload_failed": "Caricamento fallito!",
     "upload_succeeded": "Caricamento OK!",
     "uploading_file": "Caricamento del file...",
-    "url_external_layer_no_scheme_error": "Il livello esterno '{layer}' non ha uno schema valido e viene ignorato.",
+    "url_external_layer_no_scheme_warning": "Si è ricaricato durante l'importazione di un livello locale, o si è ricevuto un link contenente un livello locale, che non è stato caricato. Se si dispone del file contenente il livello {layer}, si prega di reimportarlo.",
     "url_image": "Link della foto",
     "url_layer_error": "Impossibile visualizzare la mappa '{layer}'. Controlla di non aver commesso errori di battitura",
     "url_link": "Link del sito web",

--- a/src/modules/i18n/locales/rm.json
+++ b/src/modules/i18n/locales/rm.json
@@ -646,7 +646,7 @@
     "upload_failed": "Errur da chargiar",
     "upload_succeeded": "Chargiar reussì",
     "uploading_file": "La datoteca vegn chargiada",
-    "url_external_layer_no_scheme_error": "La stresa exteriura '{layer}' n'ha betg ina regulaziun valaivla e vegn ignorada.",
+    "url_external_layer_no_scheme_warning": "Vus avais chargià u survegnì in link cun ina stresa indigena u avais survegnì ina colliaziun cun ina stresa indigena che n'è pia betg vegnida chargiada. Sche Vus possedais la datoteca cun la stresa layererbock, avais Vus per plaschair importar quella puspè.",
     "url_image": "Link a la fotografia",
     "url_layer_error": "la carta ­\"layerÏ\" n'ha però betg pudì vegnir mussada. Controllai per plaschair che Vus n'avais betg fatg in sbagl da contestaziun",
     "url_link": "Link a la pagina d’internet",

--- a/src/router/storeSync/LayerParamConfig.class.js
+++ b/src/router/storeSync/LayerParamConfig.class.js
@@ -19,6 +19,7 @@ import { flattenExtent } from '@/utils/coordinates/coordinateUtils.js'
 import ErrorMessage from '@/utils/ErrorMessage.class'
 import { getExtentOfGeometries } from '@/utils/geoJsonUtils'
 import log from '@/utils/logging'
+import WarningMessage from '@/utils/WarningMessage.class'
 
 /**
  * Parse layers such as described in
@@ -269,14 +270,15 @@ function validateUrlInput(store, query) {
     const parsed = parseLayersParam(query)
     const url_matcher = /https?:\/\//
     const faultyLayers = []
+    const localLayers = []
     parsed
         .filter((layer) => !store.getters.getLayerConfigById(layer.id))
         .forEach((layer) => {
             if (!layer.baseUrl) {
                 faultyLayers.push(new ErrorMessage('url_layer_error', { layer: layer.id }))
             } else if (!layer.baseUrl?.match(url_matcher)?.length > 0) {
-                faultyLayers.push(
-                    new ErrorMessage('url_external_layer_no_scheme_error', {
+                localLayers.push(
+                    new WarningMessage('url_external_layer_no_scheme_warning', {
                         layer: `${layer.type}|${layer.baseUrl}`,
                     })
                 )
@@ -289,6 +291,7 @@ function validateUrlInput(store, query) {
     return {
         valid,
         errors: faultyLayers.length === 0 ? null : faultyLayers,
+        warnings: localLayers.length === 0 ? null : localLayers,
     }
 }
 

--- a/src/router/storeSync/abstractParamConfig.class.js
+++ b/src/router/storeSync/abstractParamConfig.class.js
@@ -75,7 +75,9 @@ export default class AbstractParamConfig {
         }
 
         const queryValue = query[this.urlParamName]
-        if (store) {
+        // we don't need to validate again if the content of the store is the same as the query
+        // we need the store check to avoid self recursion
+        if (store && this.valuesAreDifferentBetweenQueryAndStore(query, store)) {
             let inputValidation = this.validateUrlInput
                 ? this.validateUrlInput(store, queryValue)
                 : { valid: true }


### PR DESCRIPTION
Issue: when reloading the page, local layers trigger the error feedback, telling them they made a mistake, when technically they did not do anything wrong.

Fix : we assume local layers errors are due to actualisations / links sharing, and that we should warn the users they're trying to get a local file through the URL, which doesn't work, and gives them a feedback about it in the form of a warning.


[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-984-removing-external-layer-check/index.html)