### PR TITLE
Enforced triple eq in condition statements

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -30,6 +30,7 @@ module.exports = {
         'simple-import-sort/imports': 'error',
         'simple-import-sort/exports': 'error',
         'mocha/no-exclusive-tests': 'error', // Do not allow it.only() tests
+        eqeqeq: ['error', 'always'],
     },
     globals: {
         VITE_ENVIRONMENT: true,

--- a/src/modules/drawing/lib/modifyInteraction.js
+++ b/src/modules/drawing/lib/modifyInteraction.js
@@ -928,14 +928,14 @@ class Modify extends PointerInteraction {
     let handled;
     if (
       !mapBrowserEvent.map.getView().getInteracting() &&
-      mapBrowserEvent.type == MapBrowserEventType.POINTERMOVE &&
+      mapBrowserEvent.type === MapBrowserEventType.POINTERMOVE &&
       !this.handlingDownUpSequence
     ) {
       this.handlePointerMove_(mapBrowserEvent);
     }
     if (this.vertexFeature_ && this.deleteCondition_(mapBrowserEvent)) {
       if (
-        mapBrowserEvent.type != MapBrowserEventType.SINGLECLICK ||
+        mapBrowserEvent.type !== MapBrowserEventType.SINGLECLICK ||
         !this.ignoreNextSingleClick_
       ) {
         handled = this.removePoint();
@@ -944,7 +944,7 @@ class Modify extends PointerInteraction {
       }
     }
 
-    if (mapBrowserEvent.type == MapBrowserEventType.SINGLECLICK) {
+    if (mapBrowserEvent.type === MapBrowserEventType.SINGLECLICK) {
       this.ignoreNextSingleClick_ = false;
     }
 
@@ -1501,7 +1501,7 @@ class Modify extends PointerInteraction {
   removePoint() {
     if (
       this.lastPointerEvent_ &&
-      this.lastPointerEvent_.type != MapBrowserEventType.POINTERDRAG
+      this.lastPointerEvent_.type !== MapBrowserEventType.POINTERDRAG
     ) {
       const evt = this.lastPointerEvent_;
       this.willModifyFeatures_(evt, this.dragSegments_);
@@ -1553,7 +1553,7 @@ class Modify extends PointerInteraction {
       if (dragSegment[1] === 0) {
         segmentsByFeature[uid].right = segmentData;
         segmentsByFeature[uid].index = segmentData.index;
-      } else if (dragSegment[1] == 1) {
+      } else if (dragSegment[1] === 1) {
         segmentsByFeature[uid].left = segmentData;
         segmentsByFeature[uid].index = segmentData.index + 1;
       }
@@ -1595,7 +1595,7 @@ class Modify extends PointerInteraction {
         case 'Polygon':
           component = component[segmentData.depth[0]];
           if (component.length > 4) {
-            if (index == component.length - 1) {
+            if (index === component.length - 1) {
               index = 0;
             }
             component.splice(index, 1);

--- a/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
+++ b/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
@@ -209,7 +209,7 @@ export default {
             if (description) {
                 let str = ''
                 for (const [key, value] of Object.entries(description)) {
-                    str = str + `<div>${lang == key ? `<strong>${value}</strong>` : value}</div>`
+                    str = str + `<div>${lang === key ? `<strong>${value}</strong>` : value}</div>`
                     if (!SUPPORTED_LANG.includes(key)) {
                         log.error('Language key provided is not supported: ', key)
                     }
@@ -220,7 +220,7 @@ export default {
         },
         onImageLoad() {
             this.loadedImages = this.loadedImages + 1
-            if (this.loadedImages == this.currentIconSet.icons.length) {
+            if (this.loadedImages === this.currentIconSet.icons.length) {
                 this.loadedImages = 0
                 if (this.currentIconSet.hasDescription && this.showAllSymbols) {
                     this.refreshTippyAttachment()

--- a/src/modules/map/components/CompareSlider.vue
+++ b/src/modules/map/components/CompareSlider.vue
@@ -50,7 +50,7 @@ onUnmounted(() => {
 })
 
 function slice() {
-    if (preRenderKey.value != null && postRenderKey.value != null) {
+    if (preRenderKey.value !== null && postRenderKey.value !== null) {
         unByKey(preRenderKey.value)
         unByKey(postRenderKey.value)
         preRenderKey.value = null

--- a/src/modules/map/components/LocationPopup.vue
+++ b/src/modules/map/components/LocationPopup.vue
@@ -126,7 +126,7 @@ function onPositionTabClick() {
     newClickInfo.value = false
 }
 async function onShareTabClick() {
-    if (newClickInfo.value && showEmbedSharing.value == false) {
+    if (newClickInfo.value && showEmbedSharing.value === false) {
         //copyShareLink is called by watcher since new shortlink is computed with a delay
         requestClipboard.value = true
     } else {

--- a/src/modules/map/components/toolbox/TimeSliderDropdownSearchList.vue
+++ b/src/modules/map/components/toolbox/TimeSliderDropdownSearchList.vue
@@ -23,7 +23,7 @@ const searchList = ref(null)
 
 function goToSpecific(value) {
     const key = entries.value.findIndex((entry) => {
-        return entry.url == value
+        return entry.url === value
     })
     if (key >= 0) {
         const elem = searchList.value.querySelector(`[tabindex="${key}"]`)

--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -158,7 +158,7 @@ const handleLegacyParam = (
         // We decode those so that the new query won't encode encoded character
         // for example, we avoid having " " becoming %2520 in the URI
         // But we don't decode the value if it's a layer, as it's already encoded in transformLayerIntoUrlString function
-        newQuery[key] = param == 'layers' ? newValue : decodeURIComponent(newValue)
+        newQuery[key] = param === 'layers' ? newValue : decodeURIComponent(newValue)
         log.info(
             `[Legacy URL] ${param}=${legacyValue} parameter changed to ${key}=${newQuery[key]}`,
             newQuery

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -193,7 +193,7 @@ const getters = {
      * @returns {AbstractLayer | null} Active layer or null if the index is invalid
      */
     getActiveLayerByIndex: (state) => (index) => {
-        if (index < 0 || index == null) {
+        if (index < 0 || index === null) {
             throw new Error(`Failed to get ActiveLayer by index: invalid index ${index}`)
         }
         return state.activeLayers.at(index) ?? null
@@ -362,7 +362,7 @@ const actions = {
                 }
                 return clone
             })
-            .filter((layer) => layer != null)
+            .filter((layer) => layer !== null)
         commit('setLayers', { layers: clones, dispatcher })
     },
 
@@ -377,7 +377,7 @@ const actions = {
     removeLayer({ commit }, { index = null, layerId = null, dispatcher }) {
         if (layerId) {
             commit('removeLayersById', { layerId, dispatcher })
-        } else if (index != null) {
+        } else if (index !== null) {
             commit('removeLayerByIndex', { index, dispatcher })
         } else {
             log.error(

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -193,7 +193,7 @@ const getters = {
      * @returns {AbstractLayer | null} Active layer or null if the index is invalid
      */
     getActiveLayerByIndex: (state) => (index) => {
-        if (index < 0 || index === null) {
+        if (index < 0 || index === undefined || index === null) {
             throw new Error(`Failed to get ActiveLayer by index: invalid index ${index}`)
         }
         return state.activeLayers.at(index) ?? null

--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -455,7 +455,7 @@ export default {
         },
         setShowLoadingBar(state, { requester, loading }) {
             if (loading) {
-                if (state.loadingBarRequesters[requester] == null) {
+                if (state.loadingBarRequesters[requester] === null) {
                     state.loadingBarRequesters[requester] = 0
                 }
                 state.loadingBarRequesters[requester] += 1

--- a/src/utils/click-outside.js
+++ b/src/utils/click-outside.js
@@ -35,7 +35,7 @@ const clickOutside = {
     beforeMount: (el, binding) => {
         el.clickOutsideEvent = (event) => {
             // here I check that click was outside the el and his children
-            if (!(el == event.target || el.contains(event.target))) {
+            if (!(el === event.target || el.contains(event.target))) {
                 // and if it did, call method provided in attribute value
                 if (typeof binding.value === 'function') {
                     binding.value(event)

--- a/src/utils/geoJsonUtils.js
+++ b/src/utils/geoJsonUtils.js
@@ -86,7 +86,7 @@ export function reprojectGeoJsonData(geoJsonData, toProjection, fromProjection =
  */
 export function transformIntoTurfEquivalent(geoJsonData, fromProjection = null) {
     const geometryWGS84 = reprojectGeoJsonData(
-        geoJsonData.type == 'GeometryCollection' ? geoJsonData.geometries[0] : geoJsonData,
+        geoJsonData.type === 'GeometryCollection' ? geoJsonData.geometries[0] : geoJsonData,
         WGS84,
         fromProjection
     )

--- a/src/utils/geodesicManager.js
+++ b/src/utils/geodesicManager.js
@@ -589,7 +589,7 @@ class AutoSplitArray {
         //Push to lineString (border of the shape)
         this.lineStrings[this.lineStrNr].push(coord)
         //Push to polygons (To color the area of the shape)
-        if (this.polygons[polygonId] === null) {
+        if (this.polygons[polygonId] === undefined) {
             this.polygons[polygonId] = []
         }
         this.polygons[polygonId].push(coord)

--- a/src/utils/geodesicManager.js
+++ b/src/utils/geodesicManager.js
@@ -589,7 +589,7 @@ class AutoSplitArray {
         //Push to lineString (border of the shape)
         this.lineStrings[this.lineStrNr].push(coord)
         //Push to polygons (To color the area of the shape)
-        if (this.polygons[polygonId] == null) {
+        if (this.polygons[polygonId] === null) {
             this.polygons[polygonId] = []
         }
         this.polygons[polygonId].push(coord)

--- a/src/utils/url-router.js
+++ b/src/utils/url-router.js
@@ -127,7 +127,7 @@ export function stringifyQuery(query) {
     for (let key in query) {
         const value = query[key]
         key = encodeQueryKey(key)
-        if (value == null) {
+        if (value === null) {
             // only null adds the value
             if (value !== undefined) {
                 search += (search.length ? '&' : '') + key
@@ -145,7 +145,7 @@ export function stringifyQuery(query) {
             if (value !== undefined) {
                 // only append & with non-empty search
                 search += (search.length ? '&' : '') + key
-                if (value != null) {
+                if (value !== null) {
                     search += '=' + value
                 }
             }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -247,7 +247,7 @@ export function isValidEmail(email) {
  * @returns {String} Human readable size
  */
 export function humanFileSize(size) {
-    const i = size == 0 ? 0 : Math.floor(Math.log(size) / Math.log(1024))
+    const i = size === 0 ? 0 : Math.floor(Math.log(size) / Math.log(1024))
     return (size / Math.pow(1024, i)).toFixed(2) * 1 + ' ' + ['B', 'kB', 'MB', 'GB', 'TB'][i]
 }
 

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -835,10 +835,10 @@ Cypress.Commands.add('checkOlLayer', (args = null) => {
             if (!l.id) {
                 throw new Error(`Invalid layer object ${l}: don't have an id`)
             }
-            if (l.visible == undefined) {
+            if (l.visible === undefined) {
                 l.visible = true
             }
-            if (l.opacity == undefined) {
+            if (l.opacity === undefined) {
                 l.opacity = 1
             }
             return l

--- a/tests/cypress/tests-e2e/layers.cy.js
+++ b/tests/cypress/tests-e2e/layers.cy.js
@@ -953,7 +953,7 @@ describe('Test of layer handling', () => {
                     .contains(timestamp.slice(0, 4))
                 cy.readStoreValue('state.layers.activeLayers').should((activeLayers) => {
                     expect(activeLayers).to.be.an('Array').length(visibleLayerIds.length)
-                    const layer = activeLayers.find((l) => l.id == timedLayerId)
+                    const layer = activeLayers.find((l) => l.id === timedLayerId)
                     expect(layer).not.to.be.undefined
                     expect(layer.timeConfig.currentTimestamp).to.eq(timestamp)
                 })


### PR DESCRIPTION
Enable the eslint rule [eqeqeq](https://eslint.org/docs/v8.x/rules/eqeqeq) which enforces the use of triple equals (`===` and `!=`).

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-eqeqeq-rule-in-eslint/index.html)