### PR TITLE
PB-984 : only accept array of warnings/errors when dispatching

### DIFF
--- a/src/api/errorQueues.api.js
+++ b/src/api/errorQueues.api.js
@@ -18,6 +18,6 @@ export function getStandardErrorMessage(query, urlParamName) {
 export function getStandardValidationResponse(query, isValid, urlParamName) {
     return {
         valid: isValid,
-        errors: isValid ? null : getStandardErrorMessage(query, urlParamName),
+        errors: isValid ? null : [getStandardErrorMessage(query, urlParamName)],
     }
 }

--- a/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
@@ -88,19 +88,23 @@ function iconUrlProxy(url) {
         url,
         (url) => {
             store.dispatch('addWarnings', {
-                warning: new WarningMessage('kml_icon_url_cors_issue', {
-                    layerName: layerName.value,
-                    url: url,
-                }),
+                warnings: [
+                    new WarningMessage('kml_icon_url_cors_issue', {
+                        layerName: layerName.value,
+                        url: url,
+                    }),
+                ],
                 dispatcher: 'kmlUtils.js',
             })
         },
         (url) => {
             store.dispatch('addWarnings', {
-                warning: new WarningMessage('kml_icon_url_scheme_http', {
-                    layerName: layerName.value,
-                    url: url,
-                }),
+                warnings: [
+                    new WarningMessage('kml_icon_url_scheme_http', {
+                        layerName: layerName.value,
+                        url: url,
+                    }),
+                ],
                 dispatcher: 'kmlUtils.js',
             })
         }

--- a/src/modules/map/components/openlayers/utils/useMapInteractions.composable.js
+++ b/src/modules/map/components/openlayers/utils/useMapInteractions.composable.js
@@ -278,7 +278,10 @@ export default function useMapInteractions(map) {
                 errorKey = 'invalid_import_file_error'
                 log.error(`Failed to load file`, error)
             }
-            store.dispatch('addErrors', { error: new ErrorMessage(errorKey, null), ...dispatcher })
+            store.dispatch('addErrors', {
+                errors: [new ErrorMessage(errorKey, null)],
+                ...dispatcher,
+            })
         }
     }
 

--- a/src/router/storeSync/abstractParamConfig.class.js
+++ b/src/router/storeSync/abstractParamConfig.class.js
@@ -90,7 +90,7 @@ export default class AbstractParamConfig {
 
             if (inputValidation.warnings) {
                 store.dispatch('addWarnings', {
-                    errors: inputValidation.warnings,
+                    warnings: inputValidation.warnings,
                     dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
                 })
             }

--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -389,19 +389,12 @@ export default {
         setShowDisclaimer({ commit }, { showDisclaimer, dispatcher }) {
             commit('setShowDisclaimer', { showDisclaimer, dispatcher })
         },
-        addErrors({ commit, state }, { errors, dispatcher }) {
+        addErrors({ commit }, { errors, dispatcher }) {
             if (
                 errors instanceof Array &&
                 errors.filter((error) => error instanceof ErrorMessage).length === errors.length
             ) {
                 commit('addErrors', { errors, dispatcher })
-            } else if (errors instanceof ErrorMessage) {
-                if (!state.errors.has(errors)) {
-                    commit('addError', {
-                        error: errors,
-                        dispatcher,
-                    })
-                }
             } else {
                 throw new Error(
                     `Error ${errors} dispatched by ${dispatcher} is not of type ErrorMessage, or not an Array of ErrorMessages`
@@ -419,17 +412,13 @@ export default {
                 commit('removeError', { error, dispatcher })
             }
         },
-        addWarnings({ commit, state }, { warnings, dispatcher }) {
+        addWarnings({ commit }, { warnings, dispatcher }) {
             if (
                 warnings instanceof Array &&
                 warnings.filter((warning) => warning instanceof WarningMessage).length ===
                     warnings.length
             ) {
                 commit('addWarnings', { warnings, dispatcher })
-            } else if (warnings instanceof WarningMessage) {
-                if (!state.warnings.has(warnings)) {
-                    commit('addWarning', { warning: warnings, dispatcher })
-                }
             } else {
                 throw new Error(
                     `Warning ${warnings} dispatched by ${dispatcher} is not of type WarningMessage, or not an Array of WarningMessages`
@@ -508,12 +497,10 @@ export default {
             state.featureInfoPosition = position
         },
         setShowDisclaimer: (state, { showDisclaimer }) => (state.showDisclaimer = showDisclaimer),
-        addError: (state, { error }) => state.errors.add(error),
         addErrors: (state, { errors }) => {
             errors.forEach((error) => state.errors.add(error))
         },
         removeError: (state, { error }) => state.errors.delete(error),
-        addWarning: (state, { warning }) => state.warnings.add(warning),
         addWarnings: (state, { warnings }) => {
             warnings.forEach((warning) => state.warnings.add(warning))
         },

--- a/src/store/plugins/geolocation-management.plugin.js
+++ b/src/store/plugins/geolocation-management.plugin.js
@@ -26,7 +26,7 @@ function setCenterIfInBounds(store, center) {
     } else {
         log.warn(`current geolocation is out of bounds: ${JSON.stringify(center)}`)
         store.dispatch('addErrors', {
-            error: new ErrorMessage('geoloc_out_of_bounds', null),
+            errors: [new ErrorMessage('geoloc_out_of_bounds', null)],
             ...dispatcher,
         })
     }
@@ -89,14 +89,14 @@ const handlePositionError = (error, store, state, options = {}) => {
                 ...dispatcher,
             })
             store.dispatch('addErrors', {
-                error: new ErrorMessage('geoloc_permission_denied', null),
+                errors: [new ErrorMessage('geoloc_permission_denied', null)],
                 ...dispatcher,
             })
             break
         case error.TIMEOUT:
             store.dispatch('setGeolocation', { active: false, ...dispatcher })
             store.dispatch('addErrors', {
-                error: new ErrorMessage('geoloc_time_out', null),
+                errors: [new ErrorMessage('geoloc_time_out', null)],
                 ...dispatcher,
             })
             break
@@ -117,7 +117,7 @@ const handlePositionError = (error, store, state, options = {}) => {
                     }
                 } else {
                     store.dispatch('addErrors', {
-                        error: new ErrorMessage('geoloc_unknown', null),
+                        errors: [new ErrorMessage('geoloc_unknown', null)],
                         ...dispatcher,
                     })
                     if (reactivate) {


### PR DESCRIPTION
It was confusing to be able to send a single error/warning while having to use the name in plural when dispatching. Only accepting array of both now (and fixing some places where it was wrongly dispatched before)

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-984-couple-fixes-with-warnings/index.html)