### PR TITLE
PB-984: avoid duplicate errors

### DIFF
--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -389,12 +389,21 @@ export default {
         setShowDisclaimer({ commit }, { showDisclaimer, dispatcher }) {
             commit('setShowDisclaimer', { showDisclaimer, dispatcher })
         },
-        addErrors({ commit }, { errors, dispatcher }) {
+        addErrors({ commit, state }, { errors, dispatcher }) {
             if (
                 errors instanceof Array &&
                 errors.filter((error) => error instanceof ErrorMessage).length === errors.length
             ) {
-                commit('addErrors', { errors, dispatcher })
+                errors = errors.filter(
+                    (error) =>
+                        // we only add the errors that are not existing within the store
+                        [...state.errors].filter((otherError) => {
+                            error.isEquals(otherError)
+                        }).length === 0
+                )
+                if (errors.length > 0) {
+                    commit('addErrors', { errors, dispatcher })
+                }
             } else {
                 throw new Error(
                     `Error ${errors} dispatched by ${dispatcher} is not of type ErrorMessage, or not an Array of ErrorMessages`
@@ -412,13 +421,22 @@ export default {
                 commit('removeError', { error, dispatcher })
             }
         },
-        addWarnings({ commit }, { warnings, dispatcher }) {
+        addWarnings({ commit, state }, { warnings, dispatcher }) {
             if (
                 warnings instanceof Array &&
                 warnings.filter((warning) => warning instanceof WarningMessage).length ===
                     warnings.length
             ) {
-                commit('addWarnings', { warnings, dispatcher })
+                warnings = warnings.filter(
+                    (warning) =>
+                        // we only add the warnings that are not existing within the store
+                        [...state.warnings].filter((otherWarning) => {
+                            warning.isEquals(otherWarning)
+                        }).length === 0
+                )
+                if (warnings.length > 0) {
+                    commit('addWarnings', { warnings, dispatcher })
+                }
             } else {
                 throw new Error(
                     `Warning ${warnings} dispatched by ${dispatcher} is not of type WarningMessage, or not an Array of WarningMessages`

--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -390,15 +390,13 @@ export default {
             commit('setShowDisclaimer', { showDisclaimer, dispatcher })
         },
         addErrors({ commit, state }, { errors, dispatcher }) {
-            if (
-                errors instanceof Array &&
-                errors.filter((error) => error instanceof ErrorMessage).length === errors.length
-            ) {
-                errors = errors.filter((error) =>
-                    // we only add the errors that are not existing within the store
-                    [...state.errors].some((otherError) => {
-                        error.isEquals(otherError)
-                    })
+            if (errors instanceof Array && errors.every((error) => error instanceof ErrorMessage)) {
+                errors = errors.filter(
+                    (error) =>
+                        // we only add the errors that are not existing within the store
+                        ![...state.errors].some((otherError) => {
+                            error.isEquals(otherError)
+                        })
                 )
                 if (errors.length > 0) {
                     commit('addErrors', { errors, dispatcher })
@@ -423,14 +421,14 @@ export default {
         addWarnings({ commit, state }, { warnings, dispatcher }) {
             if (
                 warnings instanceof Array &&
-                warnings.filter((warning) => warning instanceof WarningMessage).length ===
-                    warnings.length
+                warnings.every((warning) => warning instanceof WarningMessage)
             ) {
-                warnings = warnings.filter((warning) =>
-                    // we only add the warnings that are not existing within the store
-                    [...state.warnings].some((otherWarning) => {
-                        warning.isEquals(otherWarning)
-                    })
+                warnings = warnings.filter(
+                    (warning) =>
+                        // we only add the warnings that are not existing within the store
+                        ![...state.warnings].some((otherWarning) => {
+                            warning.isEquals(otherWarning)
+                        })
                 )
                 if (warnings.length > 0) {
                     commit('addWarnings', { warnings, dispatcher })

--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -394,12 +394,11 @@ export default {
                 errors instanceof Array &&
                 errors.filter((error) => error instanceof ErrorMessage).length === errors.length
             ) {
-                errors = errors.filter(
-                    (error) =>
-                        // we only add the errors that are not existing within the store
-                        [...state.errors].filter((otherError) => {
-                            error.isEquals(otherError)
-                        }).length === 0
+                errors = errors.filter((error) =>
+                    // we only add the errors that are not existing within the store
+                    [...state.errors].some((otherError) => {
+                        error.isEquals(otherError)
+                    })
                 )
                 if (errors.length > 0) {
                     commit('addErrors', { errors, dispatcher })
@@ -427,12 +426,11 @@ export default {
                 warnings.filter((warning) => warning instanceof WarningMessage).length ===
                     warnings.length
             ) {
-                warnings = warnings.filter(
-                    (warning) =>
-                        // we only add the warnings that are not existing within the store
-                        [...state.warnings].filter((otherWarning) => {
-                            warning.isEquals(otherWarning)
-                        }).length === 0
+                warnings = warnings.filter((warning) =>
+                    // we only add the warnings that are not existing within the store
+                    [...state.warnings].some((otherWarning) => {
+                        warning.isEquals(otherWarning)
+                    })
                 )
                 if (warnings.length > 0) {
                     commit('addWarnings', { warnings, dispatcher })

--- a/src/utils/ErrorMessage.class.js
+++ b/src/utils/ErrorMessage.class.js
@@ -13,11 +13,8 @@ export default class ErrorMessage {
         return (
             object instanceof ErrorMessage &&
             object.msg === this.msg &&
-            Object.keys(this.params).every(
-                (key) =>
-                    Object.keys(object.params).includes(key) &&
-                    this.params[key] === object.params[key]
-            )
+            Object.keys(this.params).length === Object.keys(object.params).length &&
+            Object.keys(this.params).every((key) => this.params[key] === object.params[key])
         )
     }
 }

--- a/src/utils/ErrorMessage.class.js
+++ b/src/utils/ErrorMessage.class.js
@@ -8,4 +8,12 @@ export default class ErrorMessage {
         this.msg = msg
         this.params = params
     }
+
+    isEquals(object) {
+        return (
+            object instanceof ErrorMessage &&
+            object.msg === this.msg &&
+            object.params === this.params
+        )
+    }
 }

--- a/src/utils/ErrorMessage.class.js
+++ b/src/utils/ErrorMessage.class.js
@@ -6,14 +6,18 @@ export default class ErrorMessage {
      */
     constructor(msg, params = null) {
         this.msg = msg
-        this.params = params
+        this.params = params ?? {}
     }
 
     isEquals(object) {
         return (
             object instanceof ErrorMessage &&
             object.msg === this.msg &&
-            object.params === this.params
+            Object.keys(this.params).every(
+                (key) =>
+                    Object.keys(object.params).includes(key) &&
+                    this.params[key] === object.params[key]
+            )
         )
     }
 }

--- a/src/utils/WarningMessage.class.js
+++ b/src/utils/WarningMessage.class.js
@@ -6,14 +6,18 @@ export default class WarningMessage {
      */
     constructor(msg, params = null) {
         this.msg = msg
-        this.params = params
+        this.params = params ?? {}
     }
 
     isEquals(object) {
         return (
             object instanceof WarningMessage &&
             object.msg === this.msg &&
-            object.params === this.params
+            Object.keys(this.params).every(
+                (key) =>
+                    Object.keys(object.params).includes(key) &&
+                    this.params[key] === object.params[key]
+            )
         )
     }
 }

--- a/src/utils/WarningMessage.class.js
+++ b/src/utils/WarningMessage.class.js
@@ -8,4 +8,12 @@ export default class WarningMessage {
         this.msg = msg
         this.params = params
     }
+
+    isEquals(object) {
+        return (
+            object instanceof WarningMessage &&
+            object.msg === this.msg &&
+            object.params === this.params
+        )
+    }
 }

--- a/src/utils/WarningMessage.class.js
+++ b/src/utils/WarningMessage.class.js
@@ -13,11 +13,8 @@ export default class WarningMessage {
         return (
             object instanceof WarningMessage &&
             object.msg === this.msg &&
-            Object.keys(this.params).every(
-                (key) =>
-                    Object.keys(object.params).includes(key) &&
-                    this.params[key] === object.params[key]
-            )
+            Object.keys(this.params).length === Object.keys(object.params).length &&
+            Object.keys(this.params).every((key) => this.params[key] === object.params[key])
         )
     }
 }


### PR DESCRIPTION
Issue : sometimes, errors and warning might get added multiple times, and as they are new object instances, the set had issue ensuring unicity

Fix : we filter the errors and warnings received, ensuring we only add messages with a different message AND different parameters.

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-984-ensure-unicity/index.html)