### PR TITLE
PB-1041: Fix Conflict Layer Name/ID 

### DIFF
--- a/src/modules/map/components/cesium/CesiumWMTSLayer.vue
+++ b/src/modules/map/components/cesium/CesiumWMTSLayer.vue
@@ -76,6 +76,8 @@ export default {
                 )
                 this.addLayerErrorKey({
                     layerId: this.wmtsLayerConfig.id,
+                    isExternal: this.wmtsLayerConfig.isExternal,
+                    baseUrl: this.wmtsLayerConfig.baseUrl,
                     errorKey: threeDErrorKey,
                     ...dispatcher,
                 })
@@ -121,6 +123,8 @@ export default {
         if (this.wmtsLayerConfig.hasErrorKey(threeDErrorKey)) {
             this.removeLayerErrorKey({
                 layerId: this.wmtsLayerConfig.id,
+                isExternal: this.wmtsLayerConfig.isExternal,
+                baseUrl: this.wmtsLayerConfig.baseUrl,
                 errorKey: threeDErrorKey,
                 ...dispatcher,
             })

--- a/src/modules/map/components/footer/MapFooterAttributionList.vue
+++ b/src/modules/map/components/footer/MapFooterAttributionList.vue
@@ -66,7 +66,11 @@ export default {
                                 id: attribution.name.replace(/[._]/g, '-'),
                                 name: attribution.name,
                                 url: attribution.url,
-                                hasDataDisclaimer: this.hasDataDisclaimer(layer.id),
+                                hasDataDisclaimer: this.hasDataDisclaimer(
+                                    layer.id,
+                                    layer.isExternal,
+                                    layer.baseUrl
+                                ),
                                 isExternalDataLocal: this.isLocalFile(layer),
                             }
                         })

--- a/src/modules/menu/components/LayerCatalogueItem.vue
+++ b/src/modules/menu/components/LayerCatalogueItem.vue
@@ -66,7 +66,6 @@ const showItem = computed(() => {
     }
     return true
 })
-const activeLayers = computed(() => store.state.layers.activeLayers)
 
 const hasChildren = computed(() => item.value?.layers?.length > 0)
 const hasDescription = computed(() => canBeAddedToTheMap.value && item.value?.hasDescription)

--- a/src/modules/menu/components/LayerCatalogueItem.vue
+++ b/src/modules/menu/components/LayerCatalogueItem.vue
@@ -149,6 +149,8 @@ function addRemoveLayer() {
     if (layers.length > 0) {
         store.dispatch('removeLayer', {
             layerId: item.value.id,
+            isExternal: item.value.isExternal,
+            baseUrl: item.value.baseUrl,
             ...dispatcher,
         })
     } else if (item.value.isExternal) {

--- a/src/modules/menu/components/LayerCatalogueItem.vue
+++ b/src/modules/menu/components/LayerCatalogueItem.vue
@@ -94,9 +94,14 @@ const canBeAddedToTheMap = computed(() => {
     // only groups of layers from our backends can't be added to the map
     return item.value && !(item.value instanceof GeoAdminGroupOfLayers)
 })
-const isPresentInActiveLayers = computed(() =>
-    activeLayers.value.find((layer) => layer.id === item.value.id)
-)
+const isPresentInActiveLayers = computed(() => {
+    const layers = store.getters.getActiveLayersById(
+        item.value.id,
+        item.value.isExternal,
+        item.value.baseUrl
+    )
+    return layers.length > 0
+})
 
 // When search text is entered, update the children collapsing if needed.
 watch(hasChildrenMatchSearch, (newValue) => {
@@ -137,7 +142,11 @@ function startLayerPreview() {
 
 function addRemoveLayer() {
     // if this is a group of a layer then simply add it to the map
-    const layers = store.getters.getActiveLayersById(item.value.id)
+    const layers = store.getters.getActiveLayersById(
+        item.value.id,
+        item.value.isExternal,
+        item.value.baseUrl
+    )
     if (layers.length > 0) {
         store.dispatch('removeLayer', {
             layerId: item.value.id,

--- a/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
+++ b/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
@@ -65,7 +65,9 @@ const layerDownButton = ref(null)
 const transparencySlider = ref(null)
 const id = computed(() => layer.value.id)
 const isLocalFile = computed(() => store.getters.isLocalFile(layer.value))
-const hasDataDisclaimer = computed(() => store.getters.hasDataDisclaimer(id.value))
+const hasDataDisclaimer = computed(() =>
+    store.getters.hasDataDisclaimer(id.value, layer.value.isExternal, layer.value.baseUrl)
+)
 const attributionName = computed(() =>
     layer.value.attributions.map((attribution) => attribution.name).join(', ')
 )

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -397,9 +397,9 @@ const actions = {
         { index = null, layerId = null, isExternal = null, baseUrl = null, dispatcher }
     ) {
         if (layerId) {
-            commit('removeLayersById', { layerId, dispatcher })
-        } else if (index !== null) {
             commit('removeLayersById', { layerId, isExternal, baseUrl, dispatcher })
+        } else if (index !== null) {
+            commit('removeLayerByIndex', { index, dispatcher })
         } else {
             log.error(
                 `Failed to remove layer: invalid parameter: ${index}, ${layerId}, ${dispatcher}`

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -232,14 +232,14 @@ const getters = {
         (state, getters) =>
         (layerId, isExternal = null, baseUrl = null) => {
             const layer = getters.getActiveLayersById(layerId, isExternal, baseUrl)[0]
-            console.log(
-                'hasDataDisclaimer',
-                layerId,
-                isExternal,
-                baseUrl,
-                layer,
-                layer?.isExternal || (layer?.type === LayerTypes.KML && !layer?.adminId)
-            )
+            // console.log(
+            //     'hasDataDisclaimer',
+            //     layerId,
+            //     isExternal,
+            //     baseUrl,
+            //     layer,
+            //     layer?.isExternal || (layer?.type === LayerTypes.KML && !layer?.adminId)
+            // )
             return layer?.isExternal || (layer?.type === LayerTypes.KML && !layer?.adminId)
         },
 
@@ -345,7 +345,7 @@ const actions = {
         // creating a clone of the config, so that we do not modify the initial config of the app
         // (it is possible to add one layer many times, so we want to always have the correct
         // default values when we add it, not the settings from the layer already added)
-        console.log('addLayer', layer, layerId, layerConfig, dispatcher)
+        // console.log('addLayer', layer, layerId, layerConfig, dispatcher)
         let clone = null
         if (layer) {
             clone = layer.clone()

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -868,8 +868,8 @@ const mutations = {
         })
     },
     removeLayersById(state, { layerId, isExternal = null, baseUrl = null }) {
-        state.activeLayers = state.activeLayers.filter((layer) =>
-            matchTwoLayers(layerId, isExternal, baseUrl, layer)
+        state.activeLayers = state.activeLayers.filter(
+            (layer) => !matchTwoLayers(layerId, isExternal, baseUrl, layer)
         )
     },
     removeLayerByIndex(state, { index }) {

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -196,20 +196,27 @@ const getters = {
         },
 
     /**
-     * Retrieves layer(s) by ID.
+     * Retrieves layer(s) by ID, isExternal, and baseUrl properties.
      *
      * Search in active layer and in preview layer
      *
      * @param {string} layerId ID of the layer(s) to retrieve
+     * @param {boolean | null} isExternal If the layer must be external, not, or both (null)
+     * @param {string | null} baseUrl Base URL of the layer(s) to retrieve. If null, accept all
+     *   baseUrl
      * @returns {[AbstractLayer]} All active layers matching the ID
      */
-    getLayersById: (state) => (layerId) => {
-        const layers = state.activeLayers.filter((layer) => layer.id === layerId)
-        if (state.previewLayer?.id === layerId) {
-            layers.push(state.previewLayer)
-        }
-        return layers
-    },
+    getLayersById:
+        (state) =>
+        (layerId, isExternal = null, baseUrl = null) => {
+            const layers = state.activeLayers.filter((layer) =>
+                matchTwoLayers(layerId, isExternal, baseUrl, layer)
+            )
+            if (matchTwoLayers(layerId, isExternal, baseUrl, state.previewLayer)) {
+                layers.push(state.previewLayer)
+            }
+            return layers
+        },
 
     /**
      * Retrieves active layer by index
@@ -641,14 +648,17 @@ const actions = {
     /**
      * Add a layer error translation key.
      *
-     * NOTE: This set the error key to all layers matching the ID.
+     * NOTE: This set the error key to all layers matching the ID, isExternal, and baseUrl
+     * properties.
      *
      * @param {string} layerId Layer ID of the layer to set the error
+     * @param {boolean | null} isExternal If the layer must be external, not, or both (null)
+     * @param {string | null} baseUrl Base URL of the layer(s). If null, accept all
      * @param {string} errorKey Error translation key to add
      * @param {string} dispatcher Action dispatcher name
      */
-    addLayerErrorKey({ commit, getters }, { layerId, errorKey, dispatcher }) {
-        const layers = getters.getLayersById(layerId)
+    addLayerErrorKey({ commit, getters }, { layerId, isExternal, baseUrl, errorKey, dispatcher }) {
+        const layers = getters.getLayersById(layerId, isExternal, baseUrl)
         if (layers.length === 0) {
             throw new Error(
                 `Failed to add layer error key "${layerId}", layer not found in active layers`
@@ -668,14 +678,20 @@ const actions = {
     /**
      * Remove a layer error translation key.
      *
-     * NOTE: This set the error key to all layers matching the ID.
+     * NOTE: This set the error key to all layers matching the ID, isExternal, and baseUrl
+     * properties.
      *
      * @param {string} layerId Layer ID of the layer to set the error
+     * @param {boolean | null} isExternal If the layer must be external, not, or both (null)
+     * @param {string | null} baseUrl Base URL of the layer(s). If null, accept all
      * @param {string} errorKey Error translation key to remove
      * @param {string} dispatcher Action dispatcher name
      */
-    removeLayerErrorKey({ commit, getters }, { layerId, errorKey, dispatcher }) {
-        const layers = getters.getLayersById(layerId)
+    removeLayerErrorKey(
+        { commit, getters },
+        { layerId, isExternal, baseUrl, errorKey, dispatcher }
+    ) {
+        const layers = getters.getLayersById(layerId, isExternal, baseUrl)
         if (layers.length === 0) {
             throw new Error(
                 `Failed to remove layer error key "${layerId}", layer not found in active layers`

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -352,7 +352,6 @@ const actions = {
             clone = getters.getLayerConfigById(layerId)?.clone() ?? null
         }
         if (clone) {
-            console.log('addLayer', clone)
             commit('addLayer', { layer: clone, dispatcher })
         } else {
             log.error('no layer found for payload:', layer, layerId, layerConfig, dispatcher)
@@ -393,11 +392,14 @@ const actions = {
      * @param {number} index Index of the layer to remove
      * @param {string} dispatcher Action dispatcher name
      */
-    removeLayer({ commit }, { index = null, layerId = null, dispatcher }) {
+    removeLayer(
+        { commit },
+        { index = null, layerId = null, isExternal = null, baseUrl = null, dispatcher }
+    ) {
         if (layerId) {
             commit('removeLayersById', { layerId, dispatcher })
         } else if (index !== null) {
-            commit('removeLayerByIndex', { index, dispatcher })
+            commit('removeLayersById', { layerId, isExternal, baseUrl, dispatcher })
         } else {
             log.error(
                 `Failed to remove layer: invalid parameter: ${index}, ${layerId}, ${dispatcher}`
@@ -840,8 +842,13 @@ const mutations = {
             )
         })
     },
-    removeLayersById(state, { layerId }) {
-        state.activeLayers = state.activeLayers.filter((layer) => layer.id !== layerId)
+    removeLayersById(state, { layerId, isExternal = null, baseUrl = null }) {
+        state.activeLayers = state.activeLayers.filter((layer) => {
+            const matchesLayerId = layer.id === layerId
+            const matchesIsExternal = isExternal === null || layer.isExternal === isExternal
+            const matchesBaseUrl = baseUrl === null || layer.baseUrl === baseUrl
+            return !(matchesLayerId && matchesIsExternal && matchesBaseUrl)
+        })
     },
     removeLayerByIndex(state, { index }) {
         state.activeLayers.splice(index, 1)

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -228,10 +228,20 @@ const getters = {
      * @param {string} layerId Layer ID of the layer to check for data disclaimer
      * @returns {Boolean}
      */
-    hasDataDisclaimer: (state) => (layerId) => {
-        const layer = state.activeLayers.find((layer) => layer.id === layerId)
-        return layer?.isExternal || (layer?.type === LayerTypes.KML && !layer?.adminId)
-    },
+    hasDataDisclaimer:
+        (state, getters) =>
+        (layerId, isExternal = null, baseUrl = null) => {
+            const layer = getters.getActiveLayersById(layerId, isExternal, baseUrl)[0]
+            console.log(
+                'hasDataDisclaimer',
+                layerId,
+                isExternal,
+                baseUrl,
+                layer,
+                layer?.isExternal || (layer?.type === LayerTypes.KML && !layer?.adminId)
+            )
+            return layer?.isExternal || (layer?.type === LayerTypes.KML && !layer?.adminId)
+        },
 
     /**
      * Returns true if the layer comes from a third party (external layer or KML layer) which has

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -165,10 +165,21 @@ const getters = {
      * Retrieves active layer(s) by ID
      *
      * @param {string} layerId ID of the layer(s) to retrieve
+     * @param {string} isExternal If the layer must be external, not, or both
+     * @param {string} baseUrl Base URL of the layer(s) to retrieve
      * @returns {[AbstractLayer]} All active layers matching the ID
      */
-    getActiveLayersById: (state) => (layerId) =>
-        state.activeLayers.filter((layer) => layer.id === layerId),
+    getActiveLayersById:
+        (state) =>
+        (layerId, isExternal = null, baseUrl = null) => {
+            console.log('getActiveLayersById', layerId, isExternal, baseUrl)
+            return state.activeLayers.filter((layer) => {
+                const matchesLayerId = layer.id === layerId
+                const matchesIsExternal = isExternal === null || layer.isExternal === isExternal
+                const matchesBaseUrl = baseUrl === null || layer.baseUrl === baseUrl
+                return matchesLayerId && matchesIsExternal && matchesBaseUrl
+            })
+        },
 
     /**
      * Retrieves layer(s) by ID.
@@ -324,6 +335,7 @@ const actions = {
         // creating a clone of the config, so that we do not modify the initial config of the app
         // (it is possible to add one layer many times, so we want to always have the correct
         // default values when we add it, not the settings from the layer already added)
+        console.log('addLayer', layer, layerId, layerConfig, dispatcher)
         let clone = null
         if (layer) {
             clone = layer.clone()
@@ -334,6 +346,7 @@ const actions = {
             clone = getters.getLayerConfigById(layerId)?.clone() ?? null
         }
         if (clone) {
+            console.log('addLayer', clone)
             commit('addLayer', { layer: clone, dispatcher })
         } else {
             log.error('no layer found for payload:', layer, layerId, layerConfig, dispatcher)

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -15,6 +15,9 @@ import log from '@/utils/logging'
  * @returns {boolean}
  */
 function matchTwoLayers(layerId, isExternal = null, baseUrl = null, layerToMatch) {
+    if (layerToMatch === null) {
+        return false
+    }
     const matchesLayerId = layerToMatch.id === layerId
     const matchesIsExternal = isExternal === null || layerToMatch.isExternal === isExternal
     const matchesBaseUrl = baseUrl === null || layerToMatch.baseUrl === baseUrl

--- a/src/store/modules/search.store.js
+++ b/src/store/modules/search.store.js
@@ -150,7 +150,7 @@ const actions = {
         const dispatcherSelectResultEntry = `${dispatcher}/search.store/selectResultEntry`
         switch (entry.resultType) {
             case SearchResultTypes.LAYER:
-                if (getters.getActiveLayersById(entry.layerId).length === 0) {
+                if (getters.getActiveLayersById(entry.layerId, false).length === 0) {
                     dispatch('addLayer', {
                         layerConfig: { id: entry.layerId, visible: true },
                         dispatcher: dispatcherSelectResultEntry,

--- a/src/store/plugins/external-layers.plugin.js
+++ b/src/store/plugins/external-layers.plugin.js
@@ -113,6 +113,8 @@ async function updateExternalLayer(store, capabilities, layer, projection) {
         log.error(`Failed to update external layer ${layer.id}: `, error)
         store.dispatch('addLayerErrorKey', {
             layerId: layer.id,
+            isExternal: layer.isExternal,
+            baseUrl: layer.baseUrl,
             errorKey: error.key ? error.key : 'error',
             ...dispatcher,
         })

--- a/src/store/plugins/load-gpx-data.plugin.js
+++ b/src/store/plugins/load-gpx-data.plugin.js
@@ -33,6 +33,8 @@ async function loadGpx(store, gpxLayer) {
         log.error(`Error while fetching GPX data for layer ${gpxLayer?.id}`)
         store.dispatch('addLayerErrorKey', {
             layerId: gpxLayer.id,
+            isExternal: gpxLayer.isExternal,
+            baseUrl: gpxLayer.baseUrl,
             errorKey: `loading_error_network_failure`,
             ...dispatcher,
         })

--- a/src/store/plugins/load-kml-data.plugin.js
+++ b/src/store/plugins/load-kml-data.plugin.js
@@ -59,6 +59,8 @@ async function loadData(store, kmlLayer) {
         log.error(`Error while fetching KML data for layer ${kmlLayer?.id}: ${error}`)
         store.dispatch('addLayerErrorKey', {
             layerId: kmlLayer.id,
+            isExternal: kmlLayer.isExternal,
+            baseUrl: kmlLayer.baseUrl,
             errorKey: `loading_error_network_failure`,
             ...dispatcher,
         })


### PR DESCRIPTION
I also ended up refactoring on how we retrieve a layer. LayerID is not enough since it's possible to have two layers with same layerID but different baseURL.

I am thinking also about same layerID, same baseURL, but different type of layer (e.t. WMTS vs WMS). But perhaps it's even more corner case, that can be addressed later.

![Peek 2024-10-14 14-40 - layer name conflict](https://github.com/user-attachments/assets/deb115e9-2be8-4ddf-9d74-81568124d410)


[Test link](https://sys-map.dev.bgdi.ch/preview/pb-1041-conflict-layer-name/index.html)