### PR TITLE
PB-768: swisssearch now centers when it's given coordinates in the URL

### DIFF
--- a/src/router/storeSync/PositionParamConfig.class.js
+++ b/src/router/storeSync/PositionParamConfig.class.js
@@ -16,7 +16,11 @@ export function readCenterFromUrlParam(urlParamValue) {
 function dispatchCenterFromUrlIntoStore(to, store, urlParamValue) {
     const promisesForAllDispatch = []
     const center = readCenterFromUrlParam(urlParamValue)
-    if (center) {
+
+    // Quick explanation here: we use the 'center' parameter to center when
+    // - there is no swisssearch parameter (as it takes priority) or
+    // - there is a swisssearch parameter and a crosshair (it happens when we share positions)
+    if (center && (!to.query.swisssearch || to.query.crosshair)) {
         promisesForAllDispatch.push(
             store.dispatch('setCenter', { center, dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN })
         )

--- a/src/router/storeSync/storeSync.config.js
+++ b/src/router/storeSync/storeSync.config.js
@@ -51,6 +51,8 @@ const storeSyncConfig = [
                 'sr'
             ),
     }),
+    //
+    new SearchParamConfig(),
     // Position must be processed after the projection param,
     // otherwise the position might be wrongly reprojected at app startup when SR is not equal
     // to the default projection EPSG number
@@ -118,7 +120,6 @@ const storeSyncConfig = [
                 'topic'
             ),
     }),
-    new SearchParamConfig(),
     new CrossHairParamConfig(),
     new CompareSliderParamConfig(),
     new LayerParamConfig(),

--- a/src/router/storeSync/storeSync.config.js
+++ b/src/router/storeSync/storeSync.config.js
@@ -51,7 +51,11 @@ const storeSyncConfig = [
                 'sr'
             ),
     }),
-    //
+    // Search should be positioned before position,
+    // this will avoid an issue where when the position is not present in the query,
+    // it would populate the query with the store value, which could be different from the
+    // one we wanted with the Search param. Upon making a second pass through the storeSync router,
+    // the center would be set again to the initial store value
     new SearchParamConfig(),
     // Position must be processed after the projection param,
     // otherwise the position might be wrongly reprojected at app startup when SR is not equal


### PR DESCRIPTION
- Issue : Swisssearch coordinates in the query were not centering the map on the coordinates.
- Cause : We sometimes end up going twice through the storesync, which meant that, since the store was setting the center default param, and it differed from the query, the center param was overwritten by the default value.
- Fix : To counter this, we set the center through the search before the center parameter itself, preventing him to try to set its default value. We also stop the center from populating the store when there is a swisssearch parameter and no crosshair

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-768-swisssearch-center-in-legacy/index.html)