### PR TITLE
PB-1066: Fix error window geolocation can not be closed

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -78,8 +78,7 @@ function refreshPageTitle() {
             v-if="error"
             title="error"
             :count="errorCount"
-            @close="store.dispatch('removeError', { error, ...dispatcher })"
-            @close-all="store.dispatch('removeSimilarError', { error, ...dispatcher })"
+            @close="store.dispatch('removeSimilarError', { error, ...dispatcher })"
         >
             <div>
                 {{ i18n.t(error.msg, error.params) }}

--- a/src/App.vue
+++ b/src/App.vue
@@ -27,6 +27,15 @@ const error = computed(() => {
     }
     return null
 })
+const errorCount = computed(() => {
+    let count = 0
+    store.state.ui.errors.forEach((e) => {
+        if (error.value.equals(e)) {
+            count++
+        }
+    })
+    return count
+})
 const warning = computed(() => {
     if (store.state.ui.warnings.size > 0) {
         return store.state.ui.warnings.values().next().value
@@ -68,6 +77,7 @@ function refreshPageTitle() {
         <ErrorWindow
             v-if="error"
             title="error"
+            :count="errorCount"
             @close="store.dispatch('removeError', { error, ...dispatcher })"
         >
             <div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -79,6 +79,7 @@ function refreshPageTitle() {
             title="error"
             :count="errorCount"
             @close="store.dispatch('removeError', { error, ...dispatcher })"
+            @close-all="store.dispatch('removeSimilarError', { error, ...dispatcher })"
         >
             <div>
                 {{ i18n.t(error.msg, error.params) }}

--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -412,6 +412,19 @@ export default {
                 commit('removeError', { error, dispatcher })
             }
         },
+
+        removeSimilarError({ commit, state }, { error, dispatcher }) {
+            if (!(error instanceof ErrorMessage)) {
+                throw new Error(
+                    `Error ${error} dispatched by ${dispatcher} is not of type ErrorMessage`
+                )
+            }
+            state.errors.forEach((existingError) => {
+                if (existingError.equals(error)) {
+                    commit('removeError', { error: existingError, dispatcher })
+                }
+            })
+        },
         addWarnings({ commit }, { warnings, dispatcher }) {
             if (
                 warnings instanceof Array &&

--- a/src/utils/ErrorMessage.class.js
+++ b/src/utils/ErrorMessage.class.js
@@ -8,4 +8,18 @@ export default class ErrorMessage {
         this.msg = msg
         this.params = params
     }
+    /**
+     * Checks if two ErrorMessage instances are equal
+     *
+     * @param {ErrorMessage} other The other ErrorMessage instance to compare with
+     * @returns {boolean} True if equal, otherwise false
+     */
+    equals(other) {
+        if (!(other instanceof ErrorMessage)) {
+            return false
+        }
+        return (
+            this.msg === other.msg && JSON.stringify(this.params) === JSON.stringify(other.params)
+        )
+    }
 }

--- a/src/utils/components/ErrorWindow.vue
+++ b/src/utils/components/ErrorWindow.vue
@@ -30,7 +30,7 @@ const hasDevSiteWarning = computed(() => store.getters.hasDevSiteWarning)
 
 const i18n = useI18n()
 
-const emit = defineEmits(['close'])
+const emit = defineEmits(['close', 'close-all'])
 </script>
 
 <template>
@@ -58,6 +58,7 @@ const emit = defineEmits(['close'])
                 class="btn btn-light btn-sm btn-outline-danger"
                 data-cy="error-window-close"
                 @click.stop="emit('close')"
+                @contextmenu.prevent="emit('close-all')"
             >
                 <FontAwesomeIcon icon="times" />
             </button>

--- a/src/utils/components/ErrorWindow.vue
+++ b/src/utils/components/ErrorWindow.vue
@@ -30,7 +30,7 @@ const hasDevSiteWarning = computed(() => store.getters.hasDevSiteWarning)
 
 const i18n = useI18n()
 
-const emit = defineEmits(['close', 'close-all'])
+const emit = defineEmits(['close'])
 </script>
 
 <template>
@@ -58,7 +58,6 @@ const emit = defineEmits(['close', 'close-all'])
                 class="btn btn-light btn-sm btn-outline-danger"
                 data-cy="error-window-close"
                 @click.stop="emit('close')"
-                @contextmenu.prevent="emit('close-all')"
             >
                 <FontAwesomeIcon icon="times" />
             </button>

--- a/src/utils/components/ErrorWindow.vue
+++ b/src/utils/components/ErrorWindow.vue
@@ -16,6 +16,10 @@ const props = defineProps({
         type: Boolean,
         default: false,
     },
+    count: {
+        type: Number,
+        default: 1,
+    },
 })
 const { title, hide } = toRefs(props)
 
@@ -40,7 +44,9 @@ const emit = defineEmits(['close'])
             class="card-header d-flex align-items-center justify-content-sm-end"
             data-cy="window-header"
         >
-            <span v-if="title" class="me-auto text-truncate">{{ i18n.t(title) }}</span>
+            <span v-if="title" class="me-auto text-truncate">
+                {{ i18n.t(title) }} <span v-if="count > 1">({{ count }})</span>
+            </span>
             <span v-else class="me-auto" />
             <button
                 class="btn btn-light btn-sm btn-outline-danger me-2"


### PR DESCRIPTION
Original issue is caused by multtiple tries of geolocation, but keep getting failed result. It will show many `Error Window` with the same value, so when you close only 1 or 2, it seems the error window is still there.

I am fixing this by adding the number of similar error in the error window title. When you click the close button, it will remove the similar error altogether.

![image](https://github.com/user-attachments/assets/da3a7f21-8b66-4471-bc2d-4d7b3a4e0ed7)


It can be discussed though. Another alternatives:

1. Put another button to close all the similar error window. So we have two button, one will close one error and one will close all similar error. Drawback: it might be confusing and polluting the UI.
2. Add another action to close all the window, for example right-click. It will need a tooltip for it
3. Remove the count in the error window altogether. We will always close all similar error window. It might be a good solution, but it failed to show that the application requesting the geolocation several times