### PR TITLE
PB-1116 : move drawing name to store

### DIFF
--- a/src/api/layers/KMLLayer.class.js
+++ b/src/api/layers/KMLLayer.class.js
@@ -81,6 +81,12 @@ export default class KMLLayer extends AbstractLayer {
         this.kmlMetadata = kmlMetadata
         if (kmlData) {
             this.name = parseKmlName(kmlData)
+            if (!this.name || this.name === '') {
+                this.name = isLocalFile
+                    ? kmlFileUrl
+                    : // only keeping what is after the last slash
+                      kmlFileUrl.split('/').pop()
+            }
             this.isLoading = false
         } else {
             this.isLoading = true

--- a/src/modules/drawing/DrawingModule.vue
+++ b/src/modules/drawing/DrawingModule.vue
@@ -2,6 +2,7 @@
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
 import { computed, inject, onBeforeUnmount, onMounted, provide, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 
 import { IS_TESTING_WITH_CYPRESS } from '@/config/staging.config'
@@ -22,6 +23,7 @@ const olMap = inject('olMap')
 const drawingInteractions = ref(null)
 const isNewDrawing = ref(true)
 
+const i18n = useI18n()
 const store = useStore()
 const availableIconSets = computed(() => store.state.drawing.iconSets)
 const projection = computed(() => store.state.position.projection)
@@ -130,6 +132,11 @@ onMounted(() => {
     if (hasKml.value) {
         isNewDrawing.value = false
         addKmlToDrawing()
+    } else {
+        store.dispatch('setDrawingName', {
+            name: i18n.t('draw_layer_label'),
+            ...dispatcher,
+        })
     }
     olMap.addLayer(drawingLayer)
 

--- a/src/store/modules/drawing.store.js
+++ b/src/store/modules/drawing.store.js
@@ -63,6 +63,12 @@ export default {
          * @type {String | null}
          */
         temporaryKmlId: null,
+        /**
+         * The name of the drawing, or null if no drawing is currently edited.
+         *
+         * @type {String | null}
+         */
+        name: null,
     },
     getters: {
         isDrawingEmpty(state) {
@@ -118,6 +124,9 @@ export default {
                 dispatcher,
             })
         },
+        setDrawingName({ commit }, { name, dispatcher }) {
+            commit('setDrawingName', { name, dispatcher })
+        },
     },
     mutations: {
         setDrawingMode: (state, { mode }) => (state.mode = mode),
@@ -131,6 +140,9 @@ export default {
             state.drawingOverlay.title = title
             state.online = online
             state.temporaryKmlId = kmlId
+        },
+        setDrawingName(state, { name }) {
+            state.name = name
         },
     },
 }


### PR DESCRIPTION
there was some bugs by keeping it only in the toolbox. For instance deleting the drawing and adding new features would not give a correct drawing name.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-1116-drawing-name-fix/index.html)