### PR TITLE
PB-1120: Remove error key when the extent is valid.

### DIFF
--- a/src/api/layers/AbstractLayer.class.js
+++ b/src/api/layers/AbstractLayer.class.js
@@ -156,7 +156,13 @@ export default class AbstractLayer {
 
     /** @param {ErrorMessage} errorMessage */
     removeErrorMessage(errorMessage) {
-        this.errorMessages.delete(errorMessage)
+        // We need to find the error message that equals to remove it
+        for (let msg of this.errorMessages) {
+            if (msg.isEquals(errorMessage)) {
+                this.errorMessages.delete(msg)
+                break
+            }
+        }
         this.hasError = !!this.errorMessages.size
     }
 

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -771,8 +771,7 @@ const actions = {
                 }
                 clone.isLoading = false
                 // Reset the error keys for the layer as the data is now loaded
-                clone.removeErrorKey('kml_gpx_file_empty')
-                clone.removeErrorKey('imported_file_out_of_bounds')
+                clone.clearErrorMessages()
 
                 if (!extent) {
                     clone.addErrorMessage(new ErrorMessage('kml_gpx_file_empty'))

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -770,6 +770,9 @@ const actions = {
                     extent = getGpxExtent(data)
                 }
                 clone.isLoading = false
+                // Reset the error keys for the layer as the data is now loaded
+                clone.removeErrorKey('kml_gpx_file_empty')
+                clone.removeErrorKey('imported_file_out_of_bounds')
 
                 if (!extent) {
                     clone.addErrorMessage(new ErrorMessage('kml_gpx_file_empty'))

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -770,11 +770,15 @@ const actions = {
                     extent = getGpxExtent(data)
                 }
                 clone.isLoading = false
-                // Reset the error keys for the layer as the data is now loaded
-                clone.clearErrorMessages()
+
+                // Always clean up the error messages before doing the check
+                const emptyFileErrorMessage = new ErrorMessage('kml_gpx_file_empty')
+                const outOfBoundsErrorMessage = new ErrorMessage('imported_file_out_of_bounds')
+                clone.removeErrorMessage(emptyFileErrorMessage)
+                clone.removeErrorMessage(outOfBoundsErrorMessage)
 
                 if (!extent) {
-                    clone.addErrorMessage(new ErrorMessage('kml_gpx_file_empty'))
+                    clone.addErrorMessage(emptyFileErrorMessage)
                 } else if (
                     !getExtentIntersectionWithCurrentProjection(
                         extent,
@@ -782,7 +786,7 @@ const actions = {
                         rootState.position.projection
                     )
                 ) {
-                    clone.addErrorMessage(new ErrorMessage('imported_file_out_of_bounds'))
+                    clone.addErrorMessage(outOfBoundsErrorMessage)
                 }
             }
             if (metadata) {


### PR DESCRIPTION


[Test link](https://sys-map.dev.bgdi.ch/preview/pb-1120-layer-error-are-not-emptied/index.html)