### PR TITLE
PB-598: Hide zoom buttons on mobile.

### DIFF
--- a/src/modules/map/components/toolbox/MapToolbox.vue
+++ b/src/modules/map/components/toolbox/MapToolbox.vue
@@ -49,7 +49,7 @@ const isDrawingMode = computed(() => store.state.drawing.drawingOverlay.show)
     >
         <FullScreenButton v-if="fullScreenButton" />
         <GeolocButton v-if="geolocButton" :compass-button="compassButton" />
-        <ZoomButtons />
+        <ZoomButtons class="hide-on-mobile" />
         <Toggle3dButton v-if="toggle3dButton" />
         <slot />
     </div>
@@ -85,6 +85,12 @@ const isDrawingMode = computed(() => store.state.drawing.drawingOverlay.show)
         &.dev-disclaimer-present.drawing-mode {
             top: $header-height;
         }
+    }
+}
+
+.hide-on-mobile {
+    @include respond-below(phone) {
+        display: none;
     }
 }
 </style>

--- a/tests/cypress/tests-e2e/embed.cy.js
+++ b/tests/cypress/tests-e2e/embed.cy.js
@@ -11,8 +11,6 @@ describe('Testing the embed view', () => {
         cy.get('[data-cy="mouse-position-select"]').should('not.exist')
         cy.get('[data-cy="mouse-position"]').should('not.exist')
 
-        cy.get('[data-cy="zoom-in"]').should('be.visible')
-        cy.get('[data-cy="zoom-out"]').should('be.visible')
         cy.get('[data-cy="3d-button"]').should('be.visible')
 
         cy.get('[data-cy="geolocation-button"]').should('not.exist')
@@ -104,8 +102,6 @@ describe('Testing the embed view', () => {
         cy.get('[data-cy="mouse-position-select"]').should('not.exist')
         cy.get('[data-cy="mouse-position"]').should('not.exist')
 
-        cy.get('[data-cy="zoom-in"]').should('be.visible')
-        cy.get('[data-cy="zoom-out"]').should('be.visible')
         cy.get('[data-cy="3d-button"]').should('be.visible')
 
         cy.get('[data-cy="geolocation-button"]').should('not.exist')

--- a/tests/cypress/tests-e2e/footer.cy.js
+++ b/tests/cypress/tests-e2e/footer.cy.js
@@ -13,16 +13,14 @@ describe('Testing the footer content / tools', () => {
         // which mean a higher resolution as the acceptable threshold for scale line to be visible.
         cy.get('[data-cy="scaleline"]').should('not.be.visible')
 
-        // triple zoom, the scale line should appear (zoom level 10)
-        cy.get('[data-cy="zoom-in"]').click()
-        cy.get('[data-cy="zoom-in"]').click()
-        cy.get('[data-cy="zoom-in"]').click()
+        // zoom by mouse wheel, the scale line should appear (zoom level 10)
+        cy.get('[data-cy="map"]').trigger('wheel', { deltaY: -5000 })
+        cy.get('[data-cy="map"]').trigger('wheel', { deltaY: -5000 })
         cy.get('[data-cy="scaleline"]').should('be.visible')
 
         // it should disappear again if we zoom out again
-        cy.get('[data-cy="zoom-out"]').click()
-        cy.get('[data-cy="zoom-out"]').click()
-        cy.get('[data-cy="zoom-out"]').click()
+        cy.get('[data-cy="map"]').trigger('wheel', { deltaY: 5000 })
+        cy.get('[data-cy="map"]').trigger('wheel', { deltaY: 5000 })
         cy.get('[data-cy="scaleline"]').should('not.be.visible')
     })
     it('has a functional background wheel', () => {

--- a/tests/cypress/tests-e2e/footer.cy.js
+++ b/tests/cypress/tests-e2e/footer.cy.js
@@ -5,6 +5,7 @@ import { WEBMERCATOR } from '@/utils/coordinates/coordinateSystems'
 
 describe('Testing the footer content / tools', () => {
     it('shows/hide the scale line depending on the map resolution, while in Mercator', () => {
+        cy.viewport(1920, 1080)
         cy.goToMapView({
             sr: WEBMERCATOR.epsgNumber,
         })
@@ -13,14 +14,16 @@ describe('Testing the footer content / tools', () => {
         // which mean a higher resolution as the acceptable threshold for scale line to be visible.
         cy.get('[data-cy="scaleline"]').should('not.be.visible')
 
-        // zoom by mouse wheel, the scale line should appear (zoom level 10)
-        cy.get('[data-cy="map"]').trigger('wheel', { deltaY: -5000 })
-        cy.get('[data-cy="map"]').trigger('wheel', { deltaY: -5000 })
+        // triple zoom, the scale line should appear (zoom level 10)
+        cy.get('[data-cy="zoom-in"]').click()
+        cy.get('[data-cy="zoom-in"]').click()
+        cy.get('[data-cy="zoom-in"]').click()
         cy.get('[data-cy="scaleline"]').should('be.visible')
 
         // it should disappear again if we zoom out again
-        cy.get('[data-cy="map"]').trigger('wheel', { deltaY: 5000 })
-        cy.get('[data-cy="map"]').trigger('wheel', { deltaY: 5000 })
+        cy.get('[data-cy="zoom-out"]').click()
+        cy.get('[data-cy="zoom-out"]').click()
+        cy.get('[data-cy="zoom-out"]').click()
         cy.get('[data-cy="scaleline"]').should('not.be.visible')
     })
     it('has a functional background wheel', () => {

--- a/tests/cypress/tests-e2e/shareShortLink.cy.js
+++ b/tests/cypress/tests-e2e/shareShortLink.cy.js
@@ -38,10 +38,8 @@ describe('Testing the share menu', () => {
             cy.get('[data-cy="menu-share-section"]').click()
             // a short link should be generated as it is our first time opening this section
             cy.wait('@shortLink')
-            // We close the menu to still be able too click on the zoom button
-            cy.get('[data-cy="menu-button"]').click()
-            // zoom in the map in order to change the URL
-            cy.get('[data-cy="zoom-in"]').click()
+            // change the language in order to change the URL
+            cy.clickOnLanguage('fr')
             // checking that the shortLink value doesn't exist anymore
             cy.readStoreValue('state.share.shortLink').should('eq', null)
             // opening the general menu again


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e1ca3f97-eccf-4ed2-8d9c-487c4454978e)

![image](https://github.com/user-attachments/assets/de50eaca-69bc-434b-b211-7b842c5515ee)


[Test link](https://sys-map.dev.bgdi.ch/preview/pb-598-hide-zoom-buttons/index.html)