### PR TITLE
PB-995: revert Cesium to 1.119 and fix Cesium CSS import warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,8 @@
         "": {
             "name": "web-mapviewer",
             "dependencies": {
+                "@cesium/engine": "11.1.0",
+                "@cesium/widgets": "9.0.1",
                 "@fortawesome/fontawesome-svg-core": "^6.6.0",
                 "@fortawesome/free-brands-svg-icons": "^6.6.0",
                 "@fortawesome/free-regular-svg-icons": "^6.6.0",
@@ -34,7 +36,7 @@
                 "animate.css": "^4.1.1",
                 "axios": "^1.7.7",
                 "bootstrap": "^5.3.3",
-                "cesium": "^1.122.0",
+                "cesium": "1.119.0",
                 "chart.js": "^4.4.4",
                 "chartjs-plugin-zoom": "^2.0.1",
                 "dompurify": "^3.1.7",
@@ -197,16 +199,76 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@cesium/widgets": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@cesium/widgets/-/widgets-8.1.0.tgz",
-            "integrity": "sha512-WD5eokNfSQmB3oqe97KmdmDefwzooHaMWBm9kE/Af9edyD2j3eQVTrbNhiJ06UIyEjd01U1af2iDOawI9adAgA==",
+        "node_modules/@cesium/engine/node_modules/quickselect": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+            "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+        },
+        "node_modules/@cesium/engine/node_modules/rbush": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+            "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
             "dependencies": {
-                "@cesium/engine": "^11.1.0",
+                "quickselect": "^2.0.0"
+            }
+        },
+        "node_modules/@cesium/widgets": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/@cesium/widgets/-/widgets-9.0.1.tgz",
+            "integrity": "sha512-qSm5c97zsGk1IWJKkPhsPNLWTcBqn9RdtumTm5dJCCtpOtJw05H/Uywr5Jz93H7QXs9ClygxLwe5nshNaa+6ig==",
+            "dependencies": {
+                "@cesium/engine": "^12.0.1",
                 "nosleep.js": "^0.12.0"
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@cesium/widgets/node_modules/@cesium/engine": {
+            "version": "12.0.1",
+            "resolved": "https://registry.npmjs.org/@cesium/engine/-/engine-12.0.1.tgz",
+            "integrity": "sha512-ou/Vu/tthTHDa2GbCrPiVWgue9AhPevWRk8hOQiEmwd1gy8aQCeMfCAfN3DXfBu7uj4wcw0+AeM7ObQgfVjjdg==",
+            "dependencies": {
+                "@tweenjs/tween.js": "^25.0.0",
+                "@zip.js/zip.js": "^2.7.34",
+                "autolinker": "^4.0.0",
+                "bitmap-sdf": "^1.0.3",
+                "dompurify": "^3.0.2",
+                "draco3d": "^1.5.1",
+                "earcut": "^3.0.0",
+                "grapheme-splitter": "^1.0.4",
+                "jsep": "^1.3.8",
+                "kdbush": "^4.0.1",
+                "ktx-parse": "^0.7.0",
+                "lerc": "^2.0.0",
+                "mersenne-twister": "^1.1.0",
+                "meshoptimizer": "^0.22.0",
+                "pako": "^2.0.4",
+                "protobufjs": "^7.1.0",
+                "rbush": "3.0.1",
+                "topojson-client": "^3.1.0",
+                "urijs": "^1.19.7"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@cesium/widgets/node_modules/meshoptimizer": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+            "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg=="
+        },
+        "node_modules/@cesium/widgets/node_modules/quickselect": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+            "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+        },
+        "node_modules/@cesium/widgets/node_modules/rbush": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+            "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+            "dependencies": {
+                "quickselect": "^2.0.0"
             }
         },
         "node_modules/@colors/colors": {
@@ -2675,9 +2737,9 @@
             }
         },
         "node_modules/@zip.js/zip.js": {
-            "version": "2.7.52",
-            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.52.tgz",
-            "integrity": "sha512-+5g7FQswvrCHwYKNMd/KFxZSObctLSsQOgqBSi0LzwHo3li9Eh1w5cF5ndjQw9Zbr3ajVnd2+XyiX85gAetx1Q==",
+            "version": "2.7.53",
+            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.53.tgz",
+            "integrity": "sha512-G6Bl5wN9EXXVaTUIox71vIX5Z454zEBe+akKpV4m1tUboIctT5h7ID3QXCJd/Lfy2rSvmkTmZIucf1jGRR4f5A==",
             "engines": {
                 "bun": ">=0.7.0",
                 "deno": ">=1.0.0",
@@ -3240,20 +3302,66 @@
             "dev": true
         },
         "node_modules/cesium": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/cesium/-/cesium-1.122.0.tgz",
-            "integrity": "sha512-zHxF4QMVE9/ukhxvV/UULzytZp5uz0JVjegc+qxfhHtvN3crFbpL6/8frkVrcQ0GTjH6/LT1AcMERj/bNdVYng==",
+            "version": "1.119.0",
+            "resolved": "https://registry.npmjs.org/cesium/-/cesium-1.119.0.tgz",
+            "integrity": "sha512-ifapkGusMJ2YhpyjAXGNiiZXFZ+QLzWro1OyBsqJjSGOK95Aab9dOBw0aPDXdzlaN7hxUFViN5+b2nN75fC9QA==",
             "workspaces": [
                 "packages/engine",
                 "packages/widgets"
             ],
             "dependencies": {
-                "@cesium/engine": "^11.1.0",
-                "@cesium/widgets": "^8.1.0"
+                "@cesium/engine": "^10.0.0",
+                "@cesium/widgets": "^7.0.0"
             },
             "engines": {
                 "node": ">=18.18.0"
             }
+        },
+        "node_modules/cesium/node_modules/@cesium/engine": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/@cesium/engine/-/engine-10.1.0.tgz",
+            "integrity": "sha512-xwdJEhGYgf6481vhrb80N5DgQZMwWvn08TWE6NXEgOhkZ7WnTCykYoCDNBMj9WQBqTfREk7/e+/RI4Gx2/TlUA==",
+            "dependencies": {
+                "@tweenjs/tween.js": "^23.1.1",
+                "@zip.js/zip.js": "^2.7.34",
+                "autolinker": "^4.0.0",
+                "bitmap-sdf": "^1.0.3",
+                "dompurify": "^3.0.2",
+                "draco3d": "^1.5.1",
+                "earcut": "^3.0.0",
+                "grapheme-splitter": "^1.0.4",
+                "jsep": "^1.3.8",
+                "kdbush": "^4.0.1",
+                "ktx-parse": "^0.7.0",
+                "lerc": "^2.0.0",
+                "mersenne-twister": "^1.1.0",
+                "meshoptimizer": "^0.21.0",
+                "pako": "^2.0.4",
+                "protobufjs": "^7.1.0",
+                "rbush": "^4.0.0",
+                "topojson-client": "^3.1.0",
+                "urijs": "^1.19.7"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/cesium/node_modules/@cesium/widgets": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@cesium/widgets/-/widgets-7.1.0.tgz",
+            "integrity": "sha512-SZCtaByBrBTssyUpg0Nir34B4wvvu8bKOMOOevv0AzYxfMeYRBX8CH/Ck/5fUJcTcsVmcYHVOqBF339wwKtcag==",
+            "dependencies": {
+                "@cesium/engine": "^10.1.0",
+                "nosleep.js": "^0.12.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/cesium/node_modules/@tweenjs/tween.js": {
+            "version": "23.1.3",
+            "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+            "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="
         },
         "node_modules/chai": {
             "version": "5.1.1",
@@ -6090,9 +6198,9 @@
             }
         },
         "node_modules/jsep": {
-            "version": "1.3.9",
-            "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.9.tgz",
-            "integrity": "sha512-i1rBX5N7VPl0eYb6+mHNp52sEuaS2Wi8CDYx1X5sn9naevL78+265XJqy1qENEk7mRKwS06NHpUqiBwR7qeodw==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+            "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
             "engines": {
                 "node": ">= 10.16.0"
             }
@@ -7584,14 +7692,6 @@
                 "pbf": "bin/pbf"
             }
         },
-        "node_modules/ol/node_modules/rbush": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
-            "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
-            "dependencies": {
-                "quickselect": "^3.0.0"
-            }
-        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8196,17 +8296,12 @@
             }
         },
         "node_modules/rbush": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
-            "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+            "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
             "dependencies": {
-                "quickselect": "^2.0.0"
+                "quickselect": "^3.0.0"
             }
-        },
-        "node_modules/rbush/node_modules/quickselect": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-            "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
         },
         "node_modules/readable-stream": {
             "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "animate.css": "^4.1.1",
         "axios": "^1.7.7",
         "bootstrap": "^5.3.3",
-        "cesium": "^1.122.0",
+        "cesium": "1.119.0",
         "chart.js": "^4.4.4",
         "chartjs-plugin-zoom": "^2.0.1",
         "dompurify": "^3.1.7",

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -7,7 +7,7 @@
 // properly therefore it is imported here in the un-scoped app styling.
 @import '@/scss/tippy-theme';
 
-@import 'node_modules/cesium/Build/Cesium/Widgets/widgets.css';
+@import 'node_modules/cesium/Build/Cesium/Widgets/widgets';
 
 body {
     // disabling double tap = zoom the UI on iOS


### PR DESCRIPTION
there's a problem with our label layer and version 1.120 and further (flickering black frame when zooming/panning, there's an issue on the Cesium tracker for that here : https://github.com/CesiumGS/cesium/issues/12231 )

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-995-fix-css-import/index.html)