### PR TITLE
PB-1121: compare slider support for COGtiffs

### DIFF
--- a/src/modules/map/components/CompareSlider.vue
+++ b/src/modules/map/components/CompareSlider.vue
@@ -34,15 +34,12 @@ watch(storeCompareRatio, (newValue) => {
 
 watch(visibleLayerOnTop, (newLayerOnTop, oldLayerOnTop) => {
     unRegisterRenderingEvents(oldLayerOnTop.id)
-    olMap.renderSync()
     registerRenderingEvents(newLayerOnTop.id)
-    olMap.renderSync()
 })
 
 onMounted(() => {
     compareRatio.value = storeCompareRatio.value
     registerRenderingEvents(visibleLayerOnTop.value.id)
-    //register event
     olMap.render()
 })
 
@@ -55,6 +52,9 @@ onBeforeUnmount(() => {
 
 function registerRenderingEvents(layerId) {
     const layer = getLayerFromMapById(layerId)
+    // When loading a layer for the first time, we might need to clean the
+    // context to ensure it is also cut correctly upon activating the compare slider
+    // or loading a new COG layer on top.
     layer?.once('prerender', (event) => {
         if (shouldUseWebGlContext.value) {
             event.context.clear(event.context.COLOR_BUFFER_BIT)
@@ -93,6 +93,9 @@ function onPreRender(event) {
         if (compareRatio.value < 1.0 && compareRatio.value > 0.0) {
             width = Math.round(width * compareRatio.value)
         }
+        // We need to clear the color of the context. If we don't, the slider
+        // will leave the right side of the slider drawn on startup or when
+        // moving the slider.
         context.clear(context.COLOR_BUFFER_BIT)
 
         context.scissor(bottomLeft[0], bottomLeft[1], width, height)

--- a/src/modules/map/components/openlayers/OpenLayersCOGTiffLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersCOGTiffLayer.vue
@@ -41,6 +41,10 @@ const layer = new WebGLTileLayer({
     source: createLayerSource(),
     opacity: opacity.value,
 })
+// we need to set the id, otherwise it would be undefined and we could not work with the layer with some tools
+if (!layer.get('id')) {
+    layer.set('id', source.value.url)
+}
 useAddLayerToMap(layer, olMap, zIndex)
 
 watch(opacity, (newOpacity) => layer.setOpacity(newOpacity))

--- a/src/modules/map/components/openlayers/OpenLayersCOGTiffLayer.vue
+++ b/src/modules/map/components/openlayers/OpenLayersCOGTiffLayer.vue
@@ -40,11 +40,9 @@ const opacity = computed(() => parentLayerOpacity.value ?? geotiffConfig.value.o
 const layer = new WebGLTileLayer({
     source: createLayerSource(),
     opacity: opacity.value,
+    id: source.value.url,
 })
-// we need to set the id, otherwise it would be undefined and we could not work with the layer with some tools
-if (!layer.get('id')) {
-    layer.set('id', source.value.url)
-}
+
 useAddLayerToMap(layer, olMap, zIndex)
 
 watch(opacity, (newOpacity) => layer.setOpacity(newOpacity))

--- a/src/modules/menu/components/advancedTools/ImportFile/useImportFile.composable.js
+++ b/src/modules/menu/components/advancedTools/ImportFile/useImportFile.composable.js
@@ -52,11 +52,6 @@ export default function useImportFile() {
                 requester: source.name ?? source,
                 ...dispatcher,
             })
-            // When importing file, the compare slider sometimes doesn't update
-            // correctly, as it checks for the changes in the layers config before
-            // the map is registered in the openlayers Map itself. So we need to send a flag to tell
-            // the compare slider to update itself.
-            store.dispatch('forceCompareSliderUpdate', { shouldUpdate: true, ...dispatcher })
         }
     }
 

--- a/src/modules/menu/components/advancedTools/ImportFile/useImportFile.composable.js
+++ b/src/modules/menu/components/advancedTools/ImportFile/useImportFile.composable.js
@@ -52,6 +52,11 @@ export default function useImportFile() {
                 requester: source.name ?? source,
                 ...dispatcher,
             })
+            // When importing file, the compare slider sometimes doesn't update
+            // correctly, as it checks for the changes in the layers config before
+            // the map is registered in the openlayers Map itself. So we need to send a flag to tell
+            // the compare slider to update itself.
+            store.dispatch('forceCompareSliderUpdate', { shouldUpdate: true, ...dispatcher })
         }
     }
 

--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -141,10 +141,18 @@ export default {
          */
         isCompareSliderActive: false,
         /**
+         * Flag telling if we need to enforce a compare slider update, as sometimes the order in
+         * which some events occur won't let the compare slider update correctly
+         *
+         * @type Boolean
+         */
+        isCompareSliderInNeedOfAForcedUpdate: false,
+        /**
          * Flag telling if the time slider is currently active or not
          *
          * @type Boolean
          */
+
         isTimeSliderActive: false,
 
         /**
@@ -358,6 +366,11 @@ export default {
         setCompareSliderActive({ commit }, args) {
             commit('setCompareSliderActive', args)
         },
+        forceCompareSliderUpdate({ commit, state }, args) {
+            commit('forceCompareSliderUpdate', {
+                shouldUpdate: state.isCompareSliderActive && args?.shouldUpdate,
+            })
+        },
         setFeatureInfoPosition({ commit, state }, { position, dispatcher }) {
             let featurePosition = FeatureInfoPositions[position?.toUpperCase()]
             if (!featurePosition) {
@@ -500,6 +513,9 @@ export default {
         },
         setCompareSliderActive(state, { compareSliderActive }) {
             state.isCompareSliderActive = compareSliderActive
+        },
+        forceCompareSliderUpdate(state, { shouldUpdate }) {
+            state.isCompareSliderInNeedOfAForcedUpdate = !!shouldUpdate
         },
         setTimeSliderActive(state, { timeSliderActive }) {
             state.isTimeSliderActive = timeSliderActive

--- a/src/store/modules/ui.store.js
+++ b/src/store/modules/ui.store.js
@@ -139,14 +139,8 @@ export default {
          *
          * @type Boolean
          */
+
         isCompareSliderActive: false,
-        /**
-         * Flag telling if we need to enforce a compare slider update, as sometimes the order in
-         * which some events occur won't let the compare slider update correctly
-         *
-         * @type Boolean
-         */
-        isCompareSliderInNeedOfAForcedUpdate: false,
         /**
          * Flag telling if the time slider is currently active or not
          *
@@ -366,11 +360,6 @@ export default {
         setCompareSliderActive({ commit }, args) {
             commit('setCompareSliderActive', args)
         },
-        forceCompareSliderUpdate({ commit, state }, args) {
-            commit('forceCompareSliderUpdate', {
-                shouldUpdate: state.isCompareSliderActive && args?.shouldUpdate,
-            })
-        },
         setFeatureInfoPosition({ commit, state }, { position, dispatcher }) {
             let featurePosition = FeatureInfoPositions[position?.toUpperCase()]
             if (!featurePosition) {
@@ -513,9 +502,6 @@ export default {
         },
         setCompareSliderActive(state, { compareSliderActive }) {
             state.isCompareSliderActive = compareSliderActive
-        },
-        forceCompareSliderUpdate(state, { shouldUpdate }) {
-            state.isCompareSliderInNeedOfAForcedUpdate = !!shouldUpdate
         },
         setTimeSliderActive(state, { timeSliderActive }) {
             state.isTimeSliderActive = timeSliderActive


### PR DESCRIPTION
Issue : COGTiffs are rendered as a webGL layer, which has a different graphical context than other OpenLayers layers. This causes the compare slider to not work on them.

Fix : when we deal with a COGtiff layer, we instead use the webgl context tools to make the slice.

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1121-support-compare-slider-for-cogtiffs/index.html)