### PR TITLE
PB-1140: add a minimal scale for print specs

### DIFF
--- a/src/api/__tests__/print.api.spec.js
+++ b/src/api/__tests__/print.api.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { describe, it } from 'vitest'
 
-import { PrintLayout, PrintLayoutAttribute } from '@/api/print.api.js'
+import { MIN_PRINT_SCALE_SIZE, PrintLayout, PrintLayoutAttribute } from '@/api/print.api.js'
 import { PRINT_DPI_COMPENSATION } from '@/config/print.config'
 import { adjustWidth } from '@/utils/styleUtils'
 
@@ -78,6 +78,11 @@ describe('Print API unit tests', () => {
             expect(adjustWidth(100, 254)).to.be.closeTo(
                 (100 * PRINT_DPI_COMPENSATION) / 254,
                 1 / 254
+            )
+            // we check that the minimum print scale size is correctly enforced
+            expect(adjustWidth(MIN_PRINT_SCALE_SIZE / 1000, 254)).to.be.closeTo(
+                MIN_PRINT_SCALE_SIZE,
+                MIN_PRINT_SCALE_SIZE / 2
             )
         })
     })

--- a/src/api/__tests__/print.api.spec.js
+++ b/src/api/__tests__/print.api.spec.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai'
 import { describe, it } from 'vitest'
 
-import { MIN_PRINT_SCALE_SIZE, PrintLayout, PrintLayoutAttribute } from '@/api/print.api.js'
-import { PRINT_DPI_COMPENSATION } from '@/config/print.config'
+import { PrintLayout, PrintLayoutAttribute } from '@/api/print.api.js'
+import { MIN_PRINT_SCALE_SIZE, PRINT_DPI_COMPENSATION } from '@/config/print.config'
 import { adjustWidth } from '@/utils/styleUtils'
 
 describe('Print API unit tests', () => {

--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -20,7 +20,6 @@ import { adjustWidth } from '@/utils/styleUtils'
 
 const PRINTING_DEFAULT_POLL_INTERVAL = 2000 // interval between each polling of the printing job status (ms)
 const PRINTING_DEFAULT_POLL_TIMEOUT = 600000 // ms (10 minutes)
-export const MIN_PRINT_SCALE_SIZE = 0.0001 // when the scale is too low, the print backend can't read the exponent. So when there is a non 0 scale, we set its minimum to 0.0001
 const SERVICE_PRINT_URL = `${getViewerDedicatedServicesBaseUrl()}print3/print/mapviewer`
 const MAX_PRINT_SPEC_SIZE = 1 * 1024 * 1024 // 1MB in bytes (should be in sync with the backend)
 

--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -20,7 +20,7 @@ import { adjustWidth } from '@/utils/styleUtils'
 
 const PRINTING_DEFAULT_POLL_INTERVAL = 2000 // interval between each polling of the printing job status (ms)
 const PRINTING_DEFAULT_POLL_TIMEOUT = 600000 // ms (10 minutes)
-
+export const MIN_PRINT_SCALE_SIZE = 0.0001 // when the scale is too low, the print backend can't read the exponent. So when there is a non 0 scale, we set its minimum to 0.0001
 const SERVICE_PRINT_URL = `${getViewerDedicatedServicesBaseUrl()}print3/print/mapviewer`
 const MAX_PRINT_SPEC_SIZE = 1 * 1024 * 1024 // 1MB in bytes (should be in sync with the backend)
 

--- a/src/config/print.config.js
+++ b/src/config/print.config.js
@@ -1,3 +1,7 @@
 // In the old mapviewer, a magic number (90) was set to make some compensation between the print and the viewer,
 // to keep the scale between the two services. In the current implementation, 144 seems to be giving the best results.
 export const PRINT_DPI_COMPENSATION = 144
+
+// when the scale is too low, the print backend can't read the exponent.
+//So when there is a non 0 scale, we set its minimum to 0.0001
+export const MIN_PRINT_SCALE_SIZE = 0.0001

--- a/src/utils/styleUtils.js
+++ b/src/utils/styleUtils.js
@@ -3,6 +3,7 @@ import CircleStyle from 'ol/style/Circle.js'
 
 import { PRINT_DPI_COMPENSATION } from '@/config/print.config'
 import variables from '@/scss/variables-admin.module.scss'
+import { MIN_PRINT_SCALE_SIZE } from '@/api/print.api'
 
 const { red, mocassin, mocassinToRed1, mocassinToRed2, malibu, black, white } = variables
 
@@ -159,9 +160,9 @@ export const highlightPointStyle = new Style({
 // Change a width according to the change of DPI (from the old geoadmin)
 // Originally introduced here https://github.com/geoadmin/mf-geoadmin3/pull/3280
 export function adjustWidth(width, dpi) {
-    if (!width || isNaN(width) || !dpi || isNaN(dpi) || dpi <= 0) {
+    if (!width || isNaN(width) || width <= 0 || !dpi || isNaN(dpi) || dpi <= 0) {
         return 0
     }
 
-    return (width * PRINT_DPI_COMPENSATION) / dpi
+    return Math.max((width * PRINT_DPI_COMPENSATION) / dpi, MIN_PRINT_SCALE_SIZE)
 }

--- a/src/utils/styleUtils.js
+++ b/src/utils/styleUtils.js
@@ -1,9 +1,9 @@
 import { Circle, Fill, Stroke, Style } from 'ol/style'
 import CircleStyle from 'ol/style/Circle.js'
 
+import { MIN_PRINT_SCALE_SIZE } from '@/api/print.api'
 import { PRINT_DPI_COMPENSATION } from '@/config/print.config'
 import variables from '@/scss/variables-admin.module.scss'
-import { MIN_PRINT_SCALE_SIZE } from '@/api/print.api'
 
 const { red, mocassin, mocassinToRed1, mocassinToRed2, malibu, black, white } = variables
 
@@ -160,7 +160,7 @@ export const highlightPointStyle = new Style({
 // Change a width according to the change of DPI (from the old geoadmin)
 // Originally introduced here https://github.com/geoadmin/mf-geoadmin3/pull/3280
 export function adjustWidth(width, dpi) {
-    if (!width || isNaN(width) || width <= 0 || !dpi || isNaN(dpi) || dpi <= 0) {
+    if (!width || isNaN(width) || width <= 0.0 || !dpi || isNaN(dpi) || dpi <= 0) {
         return 0
     }
 

--- a/src/utils/styleUtils.js
+++ b/src/utils/styleUtils.js
@@ -1,8 +1,7 @@
 import { Circle, Fill, Stroke, Style } from 'ol/style'
 import CircleStyle from 'ol/style/Circle.js'
 
-import { MIN_PRINT_SCALE_SIZE } from '@/api/print.api'
-import { PRINT_DPI_COMPENSATION } from '@/config/print.config'
+import { MIN_PRINT_SCALE_SIZE, PRINT_DPI_COMPENSATION } from '@/config/print.config'
 import variables from '@/scss/variables-admin.module.scss'
 
 const { red, mocassin, mocassinToRed1, mocassinToRed2, malibu, black, white } = variables


### PR DESCRIPTION
Issue : When sending a print spec, if the scale was too small, it would be sent to the backend in a scientific notation (for example : '1.00045e-11px'), which couldn't be interpreted by the backend.

Fix : We set a new minimal scale value to ensure we always send readable specs, which is enforced as long as the scale is greater than 0.

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1140-minimal-scale-for-printing/index.html)