### PR TITLE
PB-1028 : fix COG loading after rebase error

### DIFF
--- a/src/api/file-proxy.api.js
+++ b/src/api/file-proxy.api.js
@@ -74,7 +74,7 @@ export function unProxifyUrl(proxifiedUrl) {
  * @param {String} fileUrl
  * @returns {Promise<ArrayBuffer>}
  */
-export async function getContentThroughServiceProxy(fileUrl) {
+export async function getFileContentThroughServiceProxy(fileUrl) {
     const proxifyGetResponse = await axios.get(proxifyUrl(fileUrl), {
         responseType: 'arraybuffer',
     })

--- a/src/modules/menu/components/advancedTools/ImportFile/parser/GPXParser.class.js
+++ b/src/modules/menu/components/advancedTools/ImportFile/parser/GPXParser.class.js
@@ -28,6 +28,7 @@ export default class GPXParser extends FileParser {
             fileExtensions: ['.gpx'],
             fileContentTypes: ['application/gpx+xml', 'application/xml', 'text/xml'],
             validateFileContent: isGpx,
+            allowServiceProxy: true,
         })
     }
 
@@ -49,7 +50,7 @@ export default class GPXParser extends FileParser {
             throw new OutOfBoundsError(`GPX is out of bounds of current projection: ${extent}`)
         }
         return new GPXLayer({
-            gpxFileUrl: fileSource,
+            gpxFileUrl: this.isLocalFile(fileSource) ? fileSource.name : fileSource,
             visible: true,
             opacity: 1.0,
             gpxData: gpxAsText,

--- a/src/modules/menu/components/advancedTools/ImportFile/parser/KMLParser.class.js
+++ b/src/modules/menu/components/advancedTools/ImportFile/parser/KMLParser.class.js
@@ -30,12 +30,13 @@ export class KMLParser extends FileParser {
                 'text/xml',
             ],
             validateFileContent: isKml,
+            allowServiceProxy: true,
         })
     }
 
     /**
      * @param {ArrayBuffer} fileContent
-     * @param fileSource
+     * @param {String | File} fileSource
      * @param currentProjection
      * @param {Map<string, ArrayBuffer>} [linkFiles] Used in the context of a KMZ to carry the
      *   embedded files with the layer
@@ -59,7 +60,7 @@ export class KMLParser extends FileParser {
             throw new OutOfBoundsError(`KML is out of bounds of current projection: ${extent}`)
         }
         return new KMLLayer({
-            kmlFileUrl: fileSource,
+            kmlFileUrl: this.isLocalFile(fileSource) ? fileSource.name : fileSource,
             visible: true,
             opacity: 1.0,
             adminId: null,

--- a/src/modules/menu/components/advancedTools/ImportFile/parser/KMZParser.class.js
+++ b/src/modules/menu/components/advancedTools/ImportFile/parser/KMZParser.class.js
@@ -36,12 +36,15 @@ export default class KMZParser extends FileParser {
 
     /**
      * @param {ArrayBuffer} data
-     * @param {String} fileSource
+     * @param {String | File} fileSource
      * @param {CoordinateSystem} currentProjection
      * @returns {Promise<KMLLayer>}
      */
     async parseFileContent(data, fileSource, currentProjection) {
-        const kmz = await unzipKmz(data, fileSource)
+        const kmz = await unzipKmz(
+            data,
+            this.isLocalFile(fileSource) ? fileSource.name : fileSource
+        )
         return kmlParser.parseFileContent(kmz.kml, kmz.name, currentProjection, kmz.files)
     }
 }

--- a/src/modules/menu/components/advancedTools/ImportFile/parser/index.js
+++ b/src/modules/menu/components/advancedTools/ImportFile/parser/index.js
@@ -1,5 +1,5 @@
-import { getContentThroughServiceProxy } from '@/api/file-proxy.api'
-import { getFileFromUrl, getFileMimeType } from '@/api/files.api'
+import { getFileContentThroughServiceProxy } from '@/api/file-proxy.api'
+import { checkOnlineFileCompliance, getFileContentFromUrl } from '@/api/files.api'
 import AbstractLayer from '@/api/layers/AbstractLayer.class'
 import { CloudOptimizedGeoTIFFParser } from '@/modules/menu/components/advancedTools/ImportFile/parser/CloudOptimizedGeoTIFFParser.class'
 import GPXParser from '@/modules/menu/components/advancedTools/ImportFile/parser/GPXParser.class'
@@ -19,8 +19,7 @@ const allParsers = [
  * @param {File | String} config.fileSource
  * @param {CoordinateSystem} config.currentProjection
  * @param {Object} [options]
- * @param {Boolean} [options.allowServiceProxy=false] Default is `false`
- * @param {String} [options.mimeType]
+ * @param {OnlineFileCompliance} [options.fileCompliance]
  * @param {ArrayBuffer} [options.loadedContent]
  * @returns {Promise<AbstractLayer>}
  */
@@ -44,124 +43,76 @@ async function parseAll(config, options) {
 }
 
 /**
- * Will (attempt to) load the MIME type of the file (through a HEAD request) and then decide if it
- * requires service-proxy to get the content (HEAD request failed) or if the content should be
- * loaded with a simple GET request.
- *
- * If nothing could get loaded (HTTP 4xx or 5xx for both request) it will return `null` for both
- * mimeType and loadedContent (no error will be thrown)
- *
- * @param {String} fileUrl
- * @param {Object} [options]
- * @param {Boolean} [options.allowServiceProxy=false] Flag telling the function if it can use
- *   service-proxy in case a HEAD feature failed (potential CORS issue) on the file URL. Only use it
- *   for file format that are meant for non-technical users (KML/GPX,etc...). Default is `false`
- * @returns {Promise<{ mimeType: [String, null]; loadedContent: [null, ArrayBuffer] }>}
- */
-export async function getOnlineFileContent(fileUrl, options) {
-    const { allowServiceProxy = false } = options
-    let mimeType = null
-    let loadedContent = null
-    try {
-        mimeType = await getFileMimeType(fileUrl)
-        log.debug('[FileParser] got MIME type', mimeType, 'for file', fileUrl)
-    } catch (error) {
-        log.debug(
-            '[FileParser][getOnlineFileContent] could not have a HEAD response on',
-            fileUrl,
-            'this file might require service-proxy',
-            error
-        )
-    }
-    if (!mimeType && allowServiceProxy) {
-        try {
-            loadedContent = await getContentThroughServiceProxy(fileUrl)
-        } catch (error) {
-            log.error(
-                '[FileParser][getOnlineFileContent] could not get content of file',
-                fileUrl,
-                'through service-proxy',
-                error
-            )
-        }
-    }
-    if (!loadedContent) {
-        try {
-            const fileContentRequest = await getFileFromUrl(fileUrl, {
-                responseType: 'arraybuffer',
-            })
-            loadedContent = fileContentRequest.data
-        } catch (error) {
-            log.error(
-                '[FileParser][getOnlineFileContent] could not get content for file',
-                fileUrl,
-                error
-            )
-        }
-    }
-    return {
-        loadedContent,
-        mimeType,
-    }
-}
-
-/**
  * @param {File | String} fileSource
  * @param {CoordinateSystem} currentProjection Can be used to check bounds of parsed file against
  *   the current projection (and raise OutOfBoundError in case no mutual data is available)
- * @param {Object} [options]
- * @param {Number} [options.timeout] The timeout length (in milliseconds) to use when requesting
- *   online file
  * @returns {Promise<AbstractLayer>}
  */
-export async function parseLayerFromFile(fileSource, currentProjection, options = {}) {
-    const isLocalFile = fileSource instanceof File
-    if (!isLocalFile) {
-        // first pass without using service-proxy
-        const { mimeType, loadedContent } = await getOnlineFileContent(fileSource, {
-            allowServiceProxy: false,
+export async function parseLayerFromFile(fileSource, currentProjection) {
+    // if local file, just parse it
+    if (fileSource instanceof File) {
+        return await parseAll({
+            fileSource,
+            currentProjection,
         })
-        const resultsWithoutServiceProxy = await parseAll(
+    }
+
+    // online file, we start by getting its MIME type and other compliance information (CORS, HTTPS)
+    const fileComplianceCheck = await checkOnlineFileCompliance(fileSource)
+    log.debug(
+        '[FileParser][parseLayerFromFile] file',
+        fileSource,
+        'has compliance',
+        fileComplianceCheck
+    )
+    const { mimeType, supportsCORS, supportsHTTPS } = fileComplianceCheck
+
+    if (mimeType) {
+        // trying to find a matching parser only based on MIME type. This is required for COG, as we
+        // can't be loading the entire COG data to check against our parsers (some COG can weight in the To)
+        const parserMatchingMIME = allParsers.find((parser) =>
+            parser.fileContentTypes.includes(mimeType)
+        )
+        if (parserMatchingMIME) {
+            log.debug(
+                '[FileParser][parseLayerFromFile] parser found for MIME type',
+                mimeType,
+                parserMatchingMIME
+            )
+            return parserMatchingMIME.parseUrl(fileSource, currentProjection, {
+                fileCompliance: fileComplianceCheck,
+            })
+        }
+    }
+
+    // no MIME type match, getting file content and trying to find a parser that can handle it
+    try {
+        log.debug(
+            '[FileParser][parseLayerFromFile] no MIME type match, loading file content for',
+            fileSource
+        )
+        let loadedContent = null
+        if (supportsCORS && supportsHTTPS) {
+            loadedContent = await getFileContentFromUrl(fileSource)
+        } else {
+            loadedContent = await getFileContentThroughServiceProxy(fileSource)
+        }
+        return await parseAll(
             {
                 fileSource,
                 currentProjection,
             },
             {
-                ...options,
-                mimeType,
+                fileCompliance: fileComplianceCheck,
                 loadedContent,
-                allowServiceProxy: false,
             }
         )
-        if (resultsWithoutServiceProxy) {
-            return resultsWithoutServiceProxy
-        }
-        // getting content through service-proxy and running another pass of parsing
-        try {
-            const proxyfiedContent = await getContentThroughServiceProxy(fileSource)
-            return await parseAll(
-                {
-                    fileSource,
-                    currentProjection,
-                },
-                {
-                    ...options,
-                    mimeType,
-                    loadedContent: proxyfiedContent,
-                    allowServiceProxy: false,
-                }
-            )
-        } catch (error) {
-            log.error(
-                '[FileParser][parseLayerFromFile] could not get content through service-proxy for file',
-                fileSource,
-                error
-            )
-            throw error
-        }
+    } catch (error) {
+        log.error(
+            '[FileParser][parseLayerFromFile] could not get content for file',
+            fileSource,
+            error
+        )
+        throw error
     }
-    return await parseAll({
-        fileSource,
-        currentProjection,
-    })
 }

--- a/src/store/plugins/load-cog-extent.plugin.js
+++ b/src/store/plugins/load-cog-extent.plugin.js
@@ -6,15 +6,10 @@ import { CloudOptimizedGeoTIFFParser } from '@/modules/menu/components/advancedT
 const cogParser = new CloudOptimizedGeoTIFFParser()
 
 async function loadExtentAndUpdateLayer(store, layer) {
-    const layerWithExtent = await cogParser.parse(
-        {
-            fileSource: layer.fileSource,
-            currentProjection: toValue(store.state.position.projection),
-        },
-        {
-            allowServiceProxy: false,
-        }
-    )
+    const layerWithExtent = await cogParser.parse({
+        fileSource: layer.fileSource,
+        currentProjection: toValue(store.state.position.projection),
+    })
     store.dispatch('updateLayer', {
         layerId: layer.id,
         values: {

--- a/src/store/plugins/load-gpx-data.plugin.js
+++ b/src/store/plugins/load-gpx-data.plugin.js
@@ -20,15 +20,10 @@ const gpxParser = new GPXParser()
 async function loadGpx(store, gpxLayer) {
     log.debug(`Loading data for added GPX layer`, gpxLayer)
     try {
-        const updatedLayer = await gpxParser.parse(
-            {
-                fileSource: gpxLayer.gpxFileUrl,
-                currentProjection: store.state.position.projection,
-            },
-            {
-                allowServiceProxy: true,
-            }
-        )
+        const updatedLayer = await gpxParser.parse({
+            fileSource: gpxLayer.gpxFileUrl,
+            currentProjection: store.state.position.projection,
+        })
         store.dispatch('updateLayer', {
             layerId: updatedLayer.id,
             values: updatedLayer,

--- a/tests/cypress/tests-e2e/print.cy.js
+++ b/tests/cypress/tests-e2e/print.cy.js
@@ -31,10 +31,6 @@ describe('Testing print', () => {
         }).as('printRequest')
     }
 
-    function interceptKml(fixture) {
-        cy.intercept('GET', '**/**.kml', { fixture }).as('kmlRequest')
-    }
-
     function interceptPrintStatus() {
         cy.intercept('GET', '**/status/**', (req) => {
             req.reply({
@@ -179,7 +175,11 @@ describe('Testing print', () => {
             interceptPrintRequest()
             interceptPrintStatus()
             interceptDownloadReport()
-            interceptKml(kmlFixture)
+
+            cy.intercept('HEAD', '**/**.kml', {
+                headers: { 'Content-Type': 'application/vnd.google-earth.kml+xml' },
+            }).as('kmlHeadRequest')
+            cy.intercept('GET', '**/**.kml', { fixture: kmlFixture }).as('kmlGetRequest')
 
             cy.goToMapView(
                 {
@@ -188,7 +188,7 @@ describe('Testing print', () => {
                 },
                 true
             )
-            cy.wait('@kmlRequest')
+            cy.wait(['@kmlHeadRequest', '@kmlGetRequest'])
             cy.readStoreValue('state.layers.activeLayers').should('have.length', 1)
 
             cy.openMenuIfMobile()


### PR DESCRIPTION
While working on the latest PR for PB-1028 I made some rebase mistake and didn't detect them before merging.

COG files were loaded entirely once again... So here's the fix, with some additional benefits.

I tried to simplify the FileAPI functions, the ones that load files (either through a simple GET or through service-proxy) It wasn't possible, with the addition of COG to the mix, to keep FileParser to decide to load content on its own, so I created a function that get the MIME type (and other relevant info on the file) so that each time we need to load a file, we can decide which way (of loading) we want to go (proxy or not proxy)

I will add a new E2E test for COG in the next PR

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-1028-adapt-cog-loading/index.html)