### PR TITLE
PB-1221 : partially out of bound KML was ignored entirely

### DIFF
--- a/tests/cypress/tests-e2e/importToolFile.cy.js
+++ b/tests/cypress/tests-e2e/importToolFile.cy.js
@@ -224,7 +224,7 @@ describe('The Import File Tool', () => {
         )
         const expectedLayerId = 'external-kml-file.kml'
         const expectedOnlineLayerId = 'https://example.com/second-valid-kml-file.kml'
-        const acceptedDelta = 0.1
+        const acceptedDelta = 0.2
         const checkLocation = (expected, result) => {
             expect(result).to.be.an('Array')
             expect(result.length).to.eq(2)
@@ -821,7 +821,7 @@ describe('The Import File Tool', () => {
         cy.closeMenuIfMobile()
 
         cy.get('[data-cy="window-close"]').click()
-        cy.get('[data-cy="ol-map"]').click(150, 250)
+        cy.get('[data-cy="ol-map"]').click(170, 250)
 
         cy.log('Check that the error is displayed in the profile popup')
         cy.get('[data-cy="show-profile"]').click()


### PR DESCRIPTION
The KML extent detection was not performing as expected with KML that had only one dimension out of LV95 bounds.

To counteract that, I've reverted the logic in the extent calculation, transforming LV95 bounds into WGS84 to do the matching instead of transforming a potentially big WGS84 extent to LV95 (lead to big math error...)

[Test link with sample file](https://sys-s.dev.bgdi.ch/5tsm1i0pza4b)
[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-1221-kml-extent-false-positive/index.html)