### PR TITLE
PB-1211 : do not add ; if layer with feature selection is alone

### DIFF
--- a/src/utils/legacyLayerParamUtils.js
+++ b/src/utils/legacyLayerParamUtils.js
@@ -243,7 +243,10 @@ export function handleLegacyFeaturePreSelectionParam(params, store, newQuery) {
                     // if there are no layers parameters at all, we need to create one
                     newQuery.layers = ''
                 }
-                newQuery.layers += `;${layerId}@features=${featuresIds.split(',').join(':')}`
+                if (newQuery.layers.length > 0) {
+                    newQuery.layers += ';'
+                }
+                newQuery.layers += `${layerId}@features=${featuresIds.split(',').join(':')}`
             }
         })
 }


### PR DESCRIPTION
When opening the app with a layerId=featureId URL param, the ; was still added to the layers URL param after processing the feature pre-selection. This means the layers URL param was malformed and an error showed up.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-1211-more-link-issue/index.html)