### PR TITLE
PB-1222 : fix mishandling of feature ID that are "number-like"

### DIFF
--- a/src/router/storeSync/TimeSliderParamConfig.class.js
+++ b/src/router/storeSync/TimeSliderParamConfig.class.js
@@ -48,9 +48,11 @@ function validateUrlInput(store, query) {
     )
 
     if (store.getters.visibleLayers.filter((layer) => layer.hasMultipleTimestamps).length === 0) {
-        validationObject['warnings'] = new WarningMessage(
-            'time_slider_no_time_layer_active_url_warning',
-            {}
+        if (!validationObject.warnings) {
+            validationObject.warnings = []
+        }
+        validationObject.warnings.push(
+            new WarningMessage('time_slider_no_time_layer_active_url_warning', {})
         )
     }
     return validationObject

--- a/src/router/storeSync/__tests__/layersParamParser.spec.js
+++ b/src/router/storeSync/__tests__/layersParamParser.spec.js
@@ -127,6 +127,22 @@ describe('Testing layersParamParser', () => {
                 )
             })
         })
+        it('parses correctly a pre-selected feature on a layer', () => {
+            const layerId = 'fake-layer-id'
+            const featureId = '1234.050' // some of our IDs end with 0, we have to make sure they are treated as string and not numbers
+            const result = parseLayersParam(`${layerId}@features=${featureId}`)
+            checkParsedLayer(result[0], layerId, true, undefined, {
+                features: featureId,
+            })
+        })
+        it('parses correctly multiple pre-selected features on a single layer', () => {
+            const layerId = 'fake-layer-id'
+            const featureIds = ['1234.560', 'iAmSomeId']
+            const result = parseLayersParam(`${layerId}@features=${featureIds.join(':')}`)
+            checkParsedLayer(result[0], layerId, true, undefined, {
+                features: featureIds.join(':'),
+            })
+        })
 
         describe('Visibility/Opacity parsing', () => {
             it('Parses correctly the visible when specified', () => {

--- a/src/router/storeSync/layersParamParser.js
+++ b/src/router/storeSync/layersParamParser.js
@@ -115,6 +115,10 @@ export function parseLayersParam(queryValue) {
                     let parsedValue
                     if (value === 'true' || value === 'false') {
                         parsedValue = 'true' === value
+                    } else if (key === 'features') {
+                        // some IDs are "numbers", such as 1314.070, but we NEED the trailing zero
+                        // (they shouldn't be parsed as numbers)
+                        parsedValue = value
                     } else if (isNumber(value)) {
                         parsedValue = Number(value)
                     } else if (key === 'year' && value.toLowerCase() === 'none') {


### PR DESCRIPTION
some feature IDs ends with something like "1314.070" and the layer parsing code was transforming them into number, removing the trailing zero from the ID.

This broke many "Link to object" link generated by the backend.

Also fixing an issue with the time slider warning not being wrapped in an array, and generating a crash when its value was not set to something valid

[Test link with "Link to object" params](https://sys-map.dev.bgdi.ch/preview/fix-pb-1222-broken-link-to-object/index.html?ch.vbs.schiessanzeigen=1314.070&time=None&lang=de&topic=ech)
[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1222-broken-link-to-object/index.html)