### PR TITLE
PB-995 : Cesium WMTS as composable

### DIFF
--- a/src/api/layers/ExternalWMTSLayer.class.js
+++ b/src/api/layers/ExternalWMTSLayer.class.js
@@ -92,7 +92,8 @@ export default class ExternalWMTSLayer extends ExternalLayer {
      *   Default is `REST`
      * @param {String | null} [externalWmtsData.urlTemplate=''] WMTS Get Tile url template for REST
      *   encoding. Default is `''`
-     * @param {String} [externalWmtsData.style='default'] WMTS layer style. Default is `'default'`
+     * @param {String} [externalWmtsData.style=null] WMTS layer style. If no style is given here,
+     *   and no style is found in the options, the 'default' style will be used. Default is `null`
      * @param {[TileMatrixSet]} [externalWmtsData.tileMatrixSets=[]] WMTS tile matrix sets
      *   identifiers. Default is `[]`
      * @param {[WMTSDimension]} [externalWmtsData.dimensions=[]] WMTS tile dimensions. Default is
@@ -123,7 +124,7 @@ export default class ExternalWMTSLayer extends ExternalLayer {
             options = null,
             getTileEncoding = WMTSEncodingTypes.REST,
             urlTemplate = '',
-            style = 'default',
+            style = null,
             tileMatrixSets = [],
             dimensions = [],
             timeConfig = null,
@@ -149,7 +150,13 @@ export default class ExternalWMTSLayer extends ExternalLayer {
         this.options = options
         this.getTileEncoding = getTileEncoding
         this.urlTemplate = urlTemplate
-        this.style = style
+        if (style) {
+            this.style = style
+        } else if (options?.style) {
+            this.style = options.style
+        } else {
+            this.style = 'default'
+        }
         this.tileMatrixSets = tileMatrixSets
         this.dimensions = dimensions
     }

--- a/src/modules/map/components/cesium/CesiumInternalLayer.vue
+++ b/src/modules/map/components/cesium/CesiumInternalLayer.vue
@@ -3,14 +3,13 @@
     <CesiumWMTSLayer
         v-if="layerConfig.type === LayerTypes.WMTS"
         :wmts-layer-config="layerConfig"
-        :projection="projection"
         :parent-layer-opacity="parentLayerOpacity"
         :z-index="zIndex"
-        :is-time-slider-active="isTimeSliderActive"
     />
     <CesiumWMSLayer
         v-if="layerConfig.type === LayerTypes.WMS"
         :wms-layer-config="layerConfig"
+        :parent-layer-opacity="parentLayerOpacity"
         :projection="projection"
         :z-index="zIndex"
         :is-time-slider-active="isTimeSliderActive"

--- a/src/modules/map/components/cesium/CesiumVisibleLayers.vue
+++ b/src/modules/map/components/cesium/CesiumVisibleLayers.vue
@@ -21,9 +21,14 @@ const backgroundLayersFor3D = computed(() => store.getters.backgroundLayersFor3D
 const visibleImageryLayers = computed(() =>
     visibleLayers.value.filter(isImageryLayer).map((imageryLayer) => {
         if (imageryLayer.idIn3d) {
-            return (
-                layersConfig.value.find((layer) => layer.id === imageryLayer.idIn3d) ?? imageryLayer
-            )
+            // in order to have the correct opacity, we need to clone the 3D config and give it the 2D opacity
+            // (we can't just modify the 3D config without cloning it, as it comes directly from the store)
+            let configIn3d = layersConfig.value.find((layer) => layer.id === imageryLayer.idIn3d)
+            if (configIn3d) {
+                configIn3d = configIn3d.clone()
+                configIn3d.opacity = imageryLayer.opacity
+                return configIn3d
+            }
         }
         return imageryLayer
     })

--- a/src/modules/map/components/cesium/CesiumWMTSLayer.vue
+++ b/src/modules/map/components/cesium/CesiumWMTSLayer.vue
@@ -1,169 +1,125 @@
-<template>
-    <slot />
-</template>
-
-<script>
-import {
-    ImageryLayer,
-    Rectangle,
-    UrlTemplateImageryProvider,
-    WebMapTileServiceImageryProvider,
-} from 'cesium'
-import { isEqual } from 'lodash'
-import { mapActions } from 'vuex'
+<script setup>
+import { Rectangle, UrlTemplateImageryProvider, WebMapTileServiceImageryProvider } from 'cesium'
+import { computed, inject, onBeforeUnmount, toRef, toRefs, watch } from 'vue'
+import { useStore } from 'vuex'
 
 import ExternalWMTSLayer, { WMTSEncodingTypes } from '@/api/layers/ExternalWMTSLayer.class'
 import GeoAdminWMTSLayer from '@/api/layers/GeoAdminWMTSLayer.class'
 import { DEFAULT_PROJECTION } from '@/config/map.config'
-import CoordinateSystem from '@/utils/coordinates/CoordinateSystem.class'
+import useAddImageryLayer from '@/modules/map/components/cesium/utils/useAddImageryLayer.composable'
 import { WGS84 } from '@/utils/coordinates/coordinateSystems'
 import ErrorMessage from '@/utils/ErrorMessage.class'
-import { getTimestampFromConfig, getWmtsXyzUrl } from '@/utils/layerUtils'
+import { getWmtsXyzUrl } from '@/utils/layerUtils'
 import log from '@/utils/logging'
-
-import addImageryLayerMixins from './utils/addImageryLayer-mixins'
 
 const dispatcher = { dispatcher: 'CesiumWMTSLayer.vue' }
 
 const MAXIMUM_LEVEL_OF_DETAILS = 18
+const unsupportedProjectionError = new ErrorMessage('3d_unsupported_projection')
 
-const threeDError = new ErrorMessage('3d_unsupported_projection')
+const props = defineProps({
+    wmtsLayerConfig: {
+        type: [GeoAdminWMTSLayer, ExternalWMTSLayer],
+        required: true,
+    },
+    zIndex: {
+        type: Number,
+        default: -1,
+    },
+    parentLayerOpacity: {
+        type: Number,
+        default: null,
+    },
+})
 
-export default {
-    mixins: [addImageryLayerMixins],
-    props: {
-        wmtsLayerConfig: {
-            type: [GeoAdminWMTSLayer, ExternalWMTSLayer],
-            required: true,
-        },
-        projection: {
-            type: CoordinateSystem,
-            required: true,
-        },
-        zIndex: {
-            type: Number,
-            default: -1,
-        },
-        isTimeSliderActive: {
-            type: Boolean,
-            default: false,
-        },
-        parentLayerOpacity: {
-            type: Number,
-            default: null,
-        },
-    },
-    computed: {
-        layerId() {
-            return this.wmtsLayerConfig.id
-        },
-        opacity() {
-            return this.parentLayerOpacity ?? this.wmtsLayerConfig.opacity ?? 1.0
-        },
-        url() {
-            return getWmtsXyzUrl(this.wmtsLayerConfig, this.projection, {
-                addTimestamp: true,
-            })
-        },
-        tileMatrixSet() {
-            const set =
-                this.wmtsLayerConfig.tileMatrixSets.find(
-                    (set) => set.projection.epsg === this.projection.epsg
-                ) ?? null
-            if (!set) {
-                log.error(
-                    `External layer ${this.wmtsLayerConfig.id} does not support ${this.projection.epsg}`
-                )
-                this.addLayerError({
-                    layerId: this.wmtsLayerConfig.id,
-                    isExternal: this.wmtsLayerConfig.isExternal,
-                    baseUrl: this.wmtsLayerConfig.baseUrl,
-                    error: threeDError,
-                    ...dispatcher,
-                })
-            }
-            return set
-        },
-        tileMatrixSetId() {
-            return this.tileMatrixSet?.id ?? ''
-        },
-        dimensions() {
-            const dimensions = {}
-            this.wmtsLayerConfig.dimensions?.reduce((acc, dimension) => {
-                if (dimension.current) {
-                    acc[dimension.id] = 'current'
-                } else {
-                    acc[dimension.id] = dimension.values[0]
-                }
-            }, dimensions)
-            if (this.wmtsLayerConfig.hasMultipleTimestamps) {
-                // if we have a time config use it as dimension
-                const timestamp = getTimestampFromConfig(this.wmtsLayerConfig)
-                // overwrite any Time, TIME or time dimension
-                const timeDimension = Object.entries(dimensions).find(
-                    (e) => e[0].toLowerCase() === 'time'
-                )
-                if (timeDimension) {
-                    dimensions[timeDimension[0]] = timestamp
-                }
-            }
+const { wmtsLayerConfig, zIndex, parentLayerOpacity } = toRefs(props)
 
-            return dimensions
-        },
-    },
-    watch: {
-        dimensions(newDimension, oldDimension) {
-            if (!isEqual(newDimension, oldDimension)) {
-                log.debug(`layer dimension have been updated`, oldDimension, newDimension)
-                this.updateLayer()
-            }
-        },
-    },
-    unmounted() {
-        if (this.wmtsLayerConfig.containErrorMessage(threeDError)) {
-            this.removeLayerError({
-                layerId: this.wmtsLayerConfig.id,
-                isExternal: this.wmtsLayerConfig.isExternal,
-                baseUrl: this.wmtsLayerConfig.baseUrl,
-                error: threeDError,
-                ...dispatcher,
-            })
-        }
-    },
-    methods: {
-        ...mapActions(['addLayerError', 'removeLayerError']),
-        createImagery(url) {
-            const options = {
-                alpha: this.opacity,
-            }
-            if (this.wmtsLayerConfig instanceof ExternalWMTSLayer && this.tileMatrixSetId) {
-                return new ImageryLayer(
-                    new WebMapTileServiceImageryProvider({
-                        url:
-                            this.wmtsLayerConfig.getTileEncoding === WMTSEncodingTypes.KVP
-                                ? this.wmtsLayerConfig.baseUrl
-                                : this.wmtsLayerConfig.urlTemplate,
-                        layer: this.wmtsLayerConfig.id,
-                        style: this.wmtsLayerConfig.style,
-                        tileMatrixSetID: this.tileMatrixSetId,
-                        dimensions: this.dimensions,
-                    }),
-                    options
-                )
-            } else if (this.wmtsLayerConfig instanceof GeoAdminWMTSLayer) {
-                return new ImageryLayer(
-                    new UrlTemplateImageryProvider({
-                        rectangle: Rectangle.fromDegrees(
-                            ...DEFAULT_PROJECTION.getBoundsAs(WGS84).flatten
-                        ),
-                        maximumLevel: MAXIMUM_LEVEL_OF_DETAILS,
-                        url: url,
-                    }),
-                    options
-                )
-            }
-            return null
-        },
-    },
+const getViewer = inject('getViewer')
+
+const store = useStore()
+const projection = computed(() => store.state.position.projection)
+const opacity = computed(() => parentLayerOpacity.value ?? wmtsLayerConfig.value.opacity ?? 1.0)
+const currentYear = computed(() => wmtsLayerConfig.value.timeConfig?.currentYear)
+
+const url = computed(() =>
+    getWmtsXyzUrl(wmtsLayerConfig.value, projection.value, {
+        addTimestamp: true,
+    })
+)
+const tileMatrixSet = computed(() => {
+    if (!wmtsLayerConfig.value.tileMatrixSets) {
+        return null
+    }
+    if (
+        !wmtsLayerConfig.value.tileMatrixSets.some(
+            (set) => set.projection.epsg === projection.value.epsg
+        )
+    ) {
+        log.error(
+            `External layer ${wmtsLayerConfig.value.id} does not support ${projection.value.epsg}`
+        )
+        store.dispatch('addLayerError', {
+            layerId: wmtsLayerConfig.value.id,
+            isExternal: wmtsLayerConfig.value.isExternal,
+            baseUrl: wmtsLayerConfig.value.baseUrl,
+            error: unsupportedProjectionError,
+            ...dispatcher,
+        })
+    }
+    return wmtsLayerConfig.value.tileMatrixSets
+})
+const tileMatrixSetId = computed(() => tileMatrixSet.value?.id ?? projection.value.epsg)
+const tileMatrixLabels = computed(() => wmtsLayerConfig.value?.options?.tileGrid?.getMatrixIds())
+
+watch(currentYear, () => {
+    refreshLayer()
+})
+
+onBeforeUnmount(() => {
+    if (wmtsLayerConfig.value.containErrorMessage(unsupportedProjectionError)) {
+        store.dispatch('removeLayerError', {
+            layerId: wmtsLayerConfig.value.id,
+            isExternal: wmtsLayerConfig.value.isExternal,
+            baseUrl: wmtsLayerConfig.value.baseUrl,
+            error: unsupportedProjectionError,
+            ...dispatcher,
+        })
+    }
+})
+
+function createProvider() {
+    let provider
+    if (wmtsLayerConfig.value instanceof ExternalWMTSLayer && tileMatrixSetId.value) {
+        provider = new WebMapTileServiceImageryProvider({
+            url:
+                wmtsLayerConfig.value.getTileEncoding === WMTSEncodingTypes.KVP
+                    ? wmtsLayerConfig.value.baseUrl
+                    : wmtsLayerConfig.value.urlTemplate,
+            layer: wmtsLayerConfig.value.id,
+            style: wmtsLayerConfig.value.style,
+            tileMatrixSetID: tileMatrixSetId.value,
+            tileMatrixLabels: tileMatrixLabels.value,
+        })
+    } else if (wmtsLayerConfig.value instanceof GeoAdminWMTSLayer) {
+        provider = new UrlTemplateImageryProvider({
+            rectangle: Rectangle.fromDegrees(...DEFAULT_PROJECTION.getBoundsAs(WGS84).flatten),
+            maximumLevel: MAXIMUM_LEVEL_OF_DETAILS,
+            url: url.value,
+        })
+    } else {
+        log.error('Unknown WMTS layer type', wmtsLayerConfig.value, 'could not create 3D layer')
+    }
+    return provider
 }
+
+const { refreshLayer } = useAddImageryLayer(
+    getViewer(),
+    createProvider,
+    toRef(zIndex),
+    toRef(opacity)
+)
 </script>
+
+<template>
+    <slot />
+</template>

--- a/src/modules/map/components/cesium/utils/useAddImageryLayer.composable.js
+++ b/src/modules/map/components/cesium/utils/useAddImageryLayer.composable.js
@@ -1,0 +1,74 @@
+import { onBeforeUnmount, onMounted, toValue, watch } from 'vue'
+
+/**
+ * Will create a Cesium layer with the provider coming from `createProvider` function call and add
+ * it to the cesiumViewer.
+ *
+ * If opacity or zIndex changes, it will alter the corresponding Cesium layer accordingly.
+ *
+ * Will remove the layer when unmounted.
+ *
+ * In case the provider needs to be changed (edited), call the exposed function `refreshLayer` so
+ * that the layer will be removed and re-added with a new call to `createProvider` function.
+ *
+ * @param {Viewer} cesiumViewer
+ * @param {Function<ImageryProvider>} createProvider
+ * @param {Ref<Number>} zIndex
+ * @param {Ref<Number>} opacity
+ * @returns {{ layer: ImageryLayer; refreshLayer: Function }}
+ */
+export default function useAddImageryLayer(cesiumViewer, createProvider, zIndex, opacity) {
+    let layer
+
+    function refreshLayer() {
+        if (layer) {
+            cesiumViewer.scene.imageryLayers.remove(layer)
+        }
+        const provider = createProvider()
+        if (provider) {
+            layer = cesiumViewer.scene.imageryLayers.addImageryProvider(
+                createProvider(),
+                toValue(zIndex)
+            )
+        }
+    }
+
+    onMounted(() => {
+        refreshLayer()
+        if (layer) {
+            layer.alpha = toValue(opacity)
+        }
+    })
+
+    onBeforeUnmount(() => {
+        if (layer) {
+            layer.show = false
+            cesiumViewer.scene.imageryLayers.remove(layer)
+            cesiumViewer.scene.requestRender()
+        }
+    })
+
+    watch(opacity, () => {
+        if (layer) {
+            layer.alpha = toValue(opacity)
+            cesiumViewer.scene.requestRender()
+        }
+    })
+    watch(zIndex, () => {
+        if (layer) {
+            const index = cesiumViewer.scene.imageryLayers.indexOf(layer)
+            const indexDiff = Math.abs(toValue(zIndex) - index)
+            for (let i = indexDiff; i !== 0; i--) {
+                if (index > zIndex) {
+                    cesiumViewer.scene.imageryLayers.lower(layer)
+                } else {
+                    cesiumViewer.scene.imageryLayers.raise(layer)
+                }
+            }
+        }
+    })
+
+    return {
+        refreshLayer,
+    }
+}

--- a/src/store/plugins/sync-camera-lonlatzoom.js
+++ b/src/store/plugins/sync-camera-lonlatzoom.js
@@ -21,7 +21,7 @@ export default function syncCameraLonLatZoom(store) {
             log.debug(`[${self}] ignore mutation triggered by this plugin`, mutation)
             return
         }
-        if (mutation.type === 'setCameraPosition') {
+        if (mutation.type === 'setCameraPosition' && state.position.camera) {
             const lon = state.position.camera.x
             const lat = state.position.camera.y
             const height = state.position.camera.z

--- a/tests/cypress/fixtures/layers.fixture.json
+++ b/tests/cypress/fixtures/layers.fixture.json
@@ -92,6 +92,26 @@
         "hasLegend": true,
         "label": "WMS test layer 4",
         "type": "wms",
+        "serverLayerName": "test-4.wms.layer",
+        "config3d": "test-4.wms.layer-3d"
+    },
+    "test-4.wms.layer-3d": {
+        "opacity": 0.75,
+        "wmsLayers": "test-4.wms.layer_internal1,test-4.wms.layer_internal2",
+        "attribution": "attribution.test-4.wms.layer-3d",
+        "background": false,
+        "searchable": false,
+        "format": "png",
+        "topics": "ech,test-topic-standard",
+        "wmsUrl": "https://wms.geo.admin.ch",
+        "tooltip": true,
+        "timeEnabled": false,
+        "singleTile": false,
+        "highlightable": true,
+        "chargeable": false,
+        "hasLegend": true,
+        "label": "WMS test layer 4 for 3D",
+        "type": "wms",
         "serverLayerName": "test-4.wms.layer"
     },
     "test.wmts.layer": {
@@ -168,7 +188,37 @@
         "hasLegend": true,
         "label": "Time enabled WMTS test layer",
         "type": "wmts",
-        "serverLayerName": "test.timeenabled.wmts.layer"
+        "serverLayerName": "test.timeenabled.wmts.layer",
+        "config3d": "test.timeenabled.wmts.layer.2_3d"
+    },
+    "test.timeenabled.wmts.layer.2_3d": {
+        "opacity": 0.7,
+        "attribution": "attribution.timeenabled.wmts.layer",
+        "background": false,
+        "searchable": true,
+        "format": "png",
+        "queryableAttributes": ["id", "name"],
+        "topics": "ech,test-topic-standard",
+        "attributionUrl": "THIS_IS_NOT_A_VALID_URL",
+        "tooltip": true,
+        "highlightable": true,
+        "chargeable": false,
+        "timeEnabled": true,
+        "timestamps": [
+            "20230101",
+            "20210101",
+            "20190101",
+            "20170101",
+            "20150101",
+            "20130101",
+            "20110101",
+            "20090101"
+        ],
+        "timeBehaviour": "20110101",
+        "hasLegend": true,
+        "label": "Time enabled WMTS test layer specific for 3D",
+        "type": "wmts",
+        "serverLayerName": "test.timeenabled.wmts.layer_3d"
     },
     "test.timeenabled.wmts.layer.3": {
         "opacity": 0.7,
@@ -237,7 +287,7 @@
         ],
         "label": "Background test layer",
         "type": "wmts",
-        "serverLayerName": "test.background.layer"
+        "serverLayerName": "test.background.layer_3d"
     },
     "test.background.layer2": {
         "attribution": "attribution.test.wmts.layer",


### PR DESCRIPTION
transform the Cesium WMTS component to composition API

Adding a composable that can be used for WMS layers when we want to move them to composition API too.

Issues fixed by this commit :
- opacity when a layer as a specific config for 3D (like SWISSIMAGE) by giving the 3D config the same opacity as the 2D equivalent. The opacity of the 3D config was used, but the UI is editing the opacity of the 2D layer.
- error that popped up in the console when switching from 3D to 2D, the camera position is set to null by the unmounted CesiumMap hook and then the sync camera plugin uses the camera value without checking its validity. Adding a little check to remove the error
- External WMTS style wasn't properly applied to the 3D viewer, a good example is to load swissdatacube WMTS with layer diff_all_CH, as its default style isn't named "default" but something else

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-995-cesium-wmts-composable/index.html)