### PR TITLE
PB-1259: allow bgLayer modification through URL

### DIFF
--- a/src/router/storeSync/storeSync.config.js
+++ b/src/router/storeSync/storeSync.config.js
@@ -106,6 +106,7 @@ const storeSyncConfig = [
                 query,
                 // in cypress, the backgroundLayers is undefined, so we skip this check
                 IS_TESTING_WITH_CYPRESS ||
+                    query === 'void' ||
                     store.getters.backgroundLayers?.map((layer) => layer.id).includes(query),
                 'bgLayer'
             ),

--- a/src/store/modules/layers.store.js
+++ b/src/store/modules/layers.store.js
@@ -311,7 +311,7 @@ const actions = {
      * @param {string} dispatcher Action dispatcher name
      */
     setBackground({ commit, getters }, { bgLayerId }) {
-        if (bgLayerId === null) {
+        if (bgLayerId === null || bgLayerId === 'void') {
             // setting it to no background
             commit('setBackground', { bgLayerId: null })
         }


### PR DESCRIPTION
Issue: when the application was already loaded, it was no longer possible to set the background layer to the void layer.

Cause: the url parser validation checked for the 'void' string which is not in the background layers, and the setter only accepted null as a valid option.

Fix : we allowed the 'void' string value in both cases

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1259-change-bglayer-through-url/index.html)