### PR TITLE
PB-1260: handle legacy value 'voidLayer'

### DIFF
--- a/src/router/legacyPermalinkManagement.routerPlugin.js
+++ b/src/router/legacyPermalinkManagement.routerPlugin.js
@@ -145,6 +145,9 @@ const handleLegacyParam = (
             newValue =
                 legacyValue === 'true' ? FeatureInfoPositions.DEFAULT : FeatureInfoPositions.NONE
             break
+        case 'bgLayer':
+            newValue = legacyValue === 'voidLayer' ? 'void' : legacyValue
+            break
         // if no special work to do, we just copy past legacy params to the new viewer
         default:
             // NOTE: legacyValue is parsed using URLSearchParams which don't make any difference


### PR DESCRIPTION
Issue: In the old mapviewer, it was possible to have the bgLayer parameter to equals 'voidLayer', which is equivalent to the current 'void' parameter. However, it caused issues where it displayed errors and refused to show the correct "layer".

Cause: we did not handle the parameter at all in the legacy parser.

Fix: when bgLayer is set to 'voidLayer' while navigating a legacy route, we handle it correctly and transform it to 'void'

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1260-voidlayer-full-support/index.html)