### PR TITLE
PB-1176: Fix cesium static assets location

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -35,6 +35,7 @@ module.exports = {
     globals: {
         VITE_ENVIRONMENT: true,
         __APP_VERSION__: true,
+        __CESIUM_STATIC_PATH__: true,
         defineModel: 'readonly',
     },
     overrides: [

--- a/src/config/map.config.js
+++ b/src/config/map.config.js
@@ -77,3 +77,10 @@ export const DEFAULT_FEATURE_COUNT_RECTANGLE_SELECTION = 50
  * @type {Number}
  */
 export const GPX_GEOMETRY_SIMPLIFICATION_TOLERANCE = 12.5 // meters
+
+/**
+ * Path to the cesium static assets
+ *
+ * @type {string}
+ */
+export const CESIUM_STATIC_PATH = __CESIUM_STATIC_PATH__

--- a/src/modules/map/components/cesium/CesiumMap.vue
+++ b/src/modules/map/components/cesium/CesiumMap.vue
@@ -74,7 +74,7 @@ import GeoAdminGeoJsonLayer from '@/api/layers/GeoAdminGeoJsonLayer.class'
 import GPXLayer from '@/api/layers/GPXLayer.class'
 import KMLLayer from '@/api/layers/KMLLayer.class'
 import { get3dTilesBaseUrl, getWmsBaseUrl, getWmtsBaseUrl } from '@/config/baseUrl.config'
-import { DEFAULT_PROJECTION } from '@/config/map.config'
+import { CESIUM_STATIC_PATH, DEFAULT_PROJECTION } from '@/config/map.config'
 import { IS_TESTING_WITH_CYPRESS } from '@/config/staging.config'
 import FeatureEdit from '@/modules/infobox/components/FeatureEdit.vue'
 import FeatureList from '@/modules/infobox/components/FeatureList.vue'
@@ -207,7 +207,7 @@ export default {
     beforeCreate() {
         // Global variable required for Cesium and point to the URL where four static directories (see vite.config) are served
         // https://cesium.com/learn/cesiumjs-learn/cesiumjs-quickstart/#install-with-npm
-        window['CESIUM_BASE_URL'] = '.'
+        window['CESIUM_BASE_URL'] = CESIUM_STATIC_PATH
 
         // required for ol-cesium
         window['Cesium'] = cesium

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -20,7 +20,7 @@ if (!appVersion) {
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const cesiumSource = `${__dirname}/node_modules/cesium/Source`
-const cesiumWorkers = '../Build/Cesium/Workers'
+const cesiumStaticDir = `./${appVersion}/cesium/`
 
 /**
  * We use manual chunks to reduce the size of the final index.js file to improve startup
@@ -78,20 +78,20 @@ export default defineConfig(({ mode }) => {
             viteStaticCopy({
                 targets: [
                     {
-                        src: normalizePath(`${cesiumSource}/${cesiumWorkers}`),
-                        dest: `./`,
+                        src: normalizePath(`${cesiumSource}/../Build/Cesium/Workers`),
+                        dest: cesiumStaticDir,
                     },
                     {
                         src: normalizePath(`${cesiumSource}/Assets/`),
-                        dest: `./`,
+                        dest: cesiumStaticDir,
                     },
                     {
                         src: normalizePath(`${cesiumSource}/Widgets/`),
-                        dest: `./`,
+                        dest: cesiumStaticDir,
                     },
                     {
                         src: normalizePath(`${cesiumSource}/ThirdParty/`),
-                        dest: `./`,
+                        dest: cesiumStaticDir,
                     },
                 ],
             }),
@@ -106,6 +106,7 @@ export default defineConfig(({ mode }) => {
         define: {
             __APP_VERSION__: JSON.stringify(appVersion),
             VITE_ENVIRONMENT: JSON.stringify(mode),
+            __CESIUM_STATIC_PATH__: JSON.stringify(cesiumStaticDir),
         },
         test: {
             include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],


### PR DESCRIPTION
During the build the cesium static assets were put into the root of the application.
This was an issue for our deployment strategy were we have all assets in a
versioned folder and were we first deploy the versioned folder before deploying
the entry point index.html that point to the versioned folder. This allow for
a pseudo atomic deployment.

So now all the cesium static assets have been placed into VERSION/cesium/ path.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-1176-cesium-build/index.html)