### PR TITLE
PB-1146: Zoom in on geolocation first activation

### DIFF
--- a/src/store/plugins/geolocation-management.plugin.js
+++ b/src/store/plugins/geolocation-management.plugin.js
@@ -22,6 +22,14 @@ function setCenterIfInBounds(store, center) {
                 center: center,
                 ...dispatcher,
             })
+
+            if (firstTimeActivatingGeolocation) {
+                firstTimeActivatingGeolocation = !firstTimeActivatingGeolocation
+                store.dispatch('setZoom', {
+                    zoom: store.state.position.projection.get1_25000ZoomLevel(),
+                    ...dispatcher,
+                })
+            }
         }
     } else {
         log.warn(`current geolocation is out of bounds: ${JSON.stringify(center)}`)


### PR DESCRIPTION
Issue : When activating geolocation for the first time, we do not zoom on the location

Fix : We use the already existing boolean to check if we're on the geolocation first activation. If that's the case, we now zoom at zoom level 8

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1146-zoom-on-location-geolocation/index.html)