### PR TITLE
PB-1278: Fix Icon with offset (pin) changes positon

### DIFF
--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -136,7 +136,7 @@ class GeoAdminCustomizer extends BaseCustomizer {
             // don't ask why it works, but that's the best I could do.
             // Note(IS): I'm not sure if this is the best way to handle the Y offset. Need to be tested of different case.
             // Per issue 1278, it's correct. But Martin did it differently, but all test is pass.
-            symbolizer.graphicYOffset = symbolizer.graphicYOffset ? symbolizer.graphicYOffset : 0
+            symbolizer.graphicYOffset = symbolizer.graphicYOffset ?? 0
         }
         if (size) {
             symbolizer.graphicWidth = adjustWidth(size[0] * scale, this.printResolution)

--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -134,7 +134,7 @@ class GeoAdminCustomizer extends BaseCustomizer {
                   )
                 : 0
             // don't ask why it works, but that's the best I could do.
-            symbolizer.graphicYOffset = Math.round(symbolizer.graphicYOffset) ?? 0
+            symbolizer.gaphicYOffset = Math.round(1000 * symbolizer.gaphicYOffset ?? 0) / 1000
         }
         if (size) {
             symbolizer.graphicWidth = adjustWidth(size[0] * scale, this.printResolution)

--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -134,10 +134,9 @@ class GeoAdminCustomizer extends BaseCustomizer {
                   )
                 : 0
             // don't ask why it works, but that's the best I could do.
-
-            symbolizer.graphicYOffset = symbolizer.graphicYOffset
-                ? (symbolizer.graphicYOffset = adjustWidth(-size[1], this.printResolution))
-                : 0
+            // Note(IS): I'm not sure if this is the best way to handle the Y offset. Need to be tested of different case.
+            // Per issue 1278, it's correct. But Martin did it differently, but all test is pass.
+            symbolizer.graphicYOffset = symbolizer.graphicYOffset ? symbolizer.graphicYOffset : 0
         }
         if (size) {
             symbolizer.graphicWidth = adjustWidth(size[0] * scale, this.printResolution)

--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -134,9 +134,7 @@ class GeoAdminCustomizer extends BaseCustomizer {
                   )
                 : 0
             // don't ask why it works, but that's the best I could do.
-            // Note(IS): I'm not sure if this is the best way to handle the Y offset. Need to be tested of different case.
-            // Per issue 1278, it's correct. But Martin did it differently, but all test is pass.
-            symbolizer.graphicYOffset = symbolizer.graphicYOffset ?? 0
+            symbolizer.graphicYOffset = Math.round(symbolizer.graphicYOffset) ?? 0
         }
         if (size) {
             symbolizer.graphicWidth = adjustWidth(size[0] * scale, this.printResolution)

--- a/src/utils/styleUtils.js
+++ b/src/utils/styleUtils.js
@@ -164,6 +164,8 @@ export function adjustWidth(width, dpi) {
     if (!width || isNaN(width) || !dpi || isNaN(dpi) || dpi <= 0) {
         return 0
     }
-
+    if (width <= 0) {
+        return -adjustWidth(-width, dpi)
+    }
     return Math.max((width * PRINT_DPI_COMPENSATION) / dpi, MIN_PRINT_SCALE_SIZE)
 }

--- a/src/utils/styleUtils.js
+++ b/src/utils/styleUtils.js
@@ -161,7 +161,7 @@ export const highlightPointStyle = new Style({
 // Change a width according to the change of DPI (from the old geoadmin)
 // Originally introduced here https://github.com/geoadmin/mf-geoadmin3/pull/3280
 export function adjustWidth(width, dpi) {
-    if (!width || isNaN(width) || width <= 0.0 || !dpi || isNaN(dpi) || dpi <= 0) {
+    if (!width || isNaN(width) || !dpi || isNaN(dpi) || dpi <= 0) {
         return 0
     }
 


### PR DESCRIPTION
Need to be reviewd by @ltkum as this revert his change in https://github.com/geoadmin/web-mapviewer/pull/1015

[Test link](https://sys-map.dev.bgdi.ch/preview/pb-1278-icon-offset/index.html)

Sample on 1:500 and 1:5000. Looks good
![image](https://github.com/user-attachments/assets/dee84ef9-ba56-49b2-87f0-8ab2e34b678c)


[Test link](https://sys-map.dev.bgdi.ch/preview/pb-1278-icon-offset/index.html)