### PR TITLE
PB-1310: 3D navigation compass was not showing

### DIFF
--- a/src/modules/map/components/cesium/CesiumMap.vue
+++ b/src/modules/map/components/cesium/CesiumMap.vue
@@ -125,11 +125,6 @@ async function createViewer() {
 
     viewerCreated.value = true
 
-    if (compassElement.value) {
-        compassElement.value.scene = viewer.scene
-        compassElement.value.clock = viewer.clock
-    }
-
     if (IS_TESTING_WITH_CYPRESS) {
         window.cesiumViewer = viewer
         // reduce screen space error to downgrade visual quality but speed up tests
@@ -140,6 +135,11 @@ async function createViewer() {
         isViewerReady: true,
         ...dispatcher,
     })
+
+    if (compassElement.value) {
+        compassElement.value.scene = viewer.scene
+        compassElement.value.clock = viewer.clock
+    }
     log.info('[Cesium] CesiumMap component mounted and ready')
 }
 


### PR DESCRIPTION
Issue: The compass in the 3d viewer was hidden

Cause: We checked before there was an instance of the component if we could add the scene and the clock to the compass element, meaning it would create an empty compass.

Fix: We wait for the map to be ready before adding the compass

[Test link](https://sys-map.dev.bgdi.ch/preview/hotfix-compass-not-showing/index.html)