### PR TITLE
PB-1031: Add a github link to the version

### DIFF
--- a/src/config/staging.config.js
+++ b/src/config/staging.config.js
@@ -24,6 +24,13 @@ export const IS_TESTING_WITH_CYPRESS = typeof window !== 'undefined' ? !!window.
 export const APP_VERSION = __APP_VERSION__
 
 /**
+ * The Github Repository.
+ *
+ * @type {String}
+ */
+
+export const GITHUB_REPOSITORY = 'https://github.com/geoadmin/web-mapviewer'
+/**
  * Display a big development banner on all but these hosts.
  *
  * @type {String[]}

--- a/src/setup-fontawesome.js
+++ b/src/setup-fontawesome.js
@@ -1,5 +1,11 @@
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { faFacebook, faLinkedin, faWhatsapp, faXTwitter } from '@fortawesome/free-brands-svg-icons'
+import {
+    faFacebook,
+    faGithub,
+    faLinkedin,
+    faWhatsapp,
+    faXTwitter,
+} from '@fortawesome/free-brands-svg-icons'
 import {
     faCheckSquare,
     faCircle as faRegularCircle,
@@ -172,5 +178,6 @@ library.add(
     faFacebook,
     faWhatsapp,
     faXTwitter,
-    faLinkedin
+    faLinkedin,
+    faGithub
 )

--- a/src/utils/components/AppVersion.vue
+++ b/src/utils/components/AppVersion.vue
@@ -3,15 +3,26 @@ import { computed, ref } from 'vue'
 import { useStore } from 'vuex'
 
 import { APP_VERSION } from '@/config/staging.config'
+import { GITHUB_REPOSITORY } from '@/config/staging.config'
 
 const store = useStore()
 const appVersion = ref(APP_VERSION)
 
 const isProd = computed(() => store.getters.isProductionSite)
+
+function openGithubLink() {
+    window.open(GITHUB_REPOSITORY, '_blank')
+}
 </script>
 
 <template>
-    <div class="app-version" :class="{ 'app-version-prod': isProd }" data-cy="app-version">
+    <div
+        class="app-version"
+        :class="{ 'app-version-prod': isProd }"
+        data-cy="app-version"
+        @click="openGithubLink"
+    >
+        <font-awesome-icon :icon="['fab', 'github']" />
         {{ appVersion }}
     </div>
 </template>
@@ -21,6 +32,7 @@ const isProd = computed(() => store.getters.isProductionSite)
 
 .app-version {
     color: $gray-800;
+    cursor: pointer;
 }
 
 .app-version-prod {


### PR DESCRIPTION
Issue : We want to allow people to be able to reach the github repository of the mapviewer

Fix : We add a small github icon next to the version, and allow people to click on the version or the icon to open the github repository in a new tab.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-1031-add-github-link/index.html)