### PR TITLE
PB-995 : add import KML in 3D test through the import popup

### DIFF
--- a/packages/mapviewer/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
+++ b/packages/mapviewer/src/modules/menu/components/advancedTools/MenuAdvancedToolsList.vue
@@ -81,6 +81,7 @@ function onToggleImportFile() {
                 movable
                 initial-position="top-left"
                 wide
+                data-cy="import-window"
                 @close="onToggleImportFile"
             >
                 <ImportFile />


### PR DESCRIPTION
we only tested pre-loading KMLs through the URL param in 3d/layers.cy.js, so here's a test that import a KML through the Advanced Tool menu section

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-995-add-import-kml-3d-test/index.html)