### PR TITLE
Enforce ESLint no-console rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -27,6 +27,7 @@ module.exports = {
                 destructuredArrayIgnorePattern: '^_',
             },
         ],
+        'no-console': 'error',
         'simple-import-sort/imports': 'error',
         'simple-import-sort/exports': 'error',
         'mocha/no-exclusive-tests': 'error', // Do not allow it.only() tests
@@ -43,6 +44,13 @@ module.exports = {
             files: ['tests/**/*.{js,ts,jsx,tsx}', 'src/**/__test__/**/*.spec.js'],
             rules: {
                 'no-prototype-builtins': 'off',
+                'no-console': 'off',
+            },
+        },
+        {
+            files: ['scripts/**'],
+            rules: {
+                'no-console': 'off',
             },
         },
         {

--- a/src/api/features/features.api.js
+++ b/src/api/features/features.api.js
@@ -288,7 +288,7 @@ function parseOGCWMSFeatureInfoResponse(response) {
     // Check for parsing errors
     const parserError = xmlDoc.getElementsByTagName('parsererror')
     if (parserError.length > 0) {
-        console.error('Error parsing OGC WMS XML response')
+        log.error('Error parsing OGC WMS XML response')
         return null
     }
 

--- a/src/modules/map/components/cesium/utils/highlightUtils.js
+++ b/src/modules/map/components/cesium/utils/highlightUtils.js
@@ -2,6 +2,7 @@ import { Cartesian3, Color, Entity, HeightReference } from 'cesium'
 import proj4 from 'proj4'
 
 import { WEBMERCATOR, WGS84 } from '@/utils/coordinates/coordinateSystems'
+import log from '@/utils/logging'
 
 let highlightedEntities = []
 const highlightFill = Color.fromCssColorString('rgba(255, 255, 0, 0.75)')
@@ -25,7 +26,7 @@ export function highlightSelectedArea(viewer, geometry) {
             highlightPoint(viewer, coordinates)
             break
         default:
-            console.error(`Geometry "${geometry.type}" not handled`)
+            log.error(`Geometry "${geometry.type}" not handled`)
     }
     viewer.scene.requestRender()
 }

--- a/src/store/modules/drawing.store.js
+++ b/src/store/modules/drawing.store.js
@@ -117,17 +117,8 @@ export default {
             return state.featureIds.length === 0
         },
 
-        showNotSharedDrawingWarning(state) {
-            console.log(
-                'showNotSharedDrawingWarning',
-                !state.isVisitWithAdminId,
-                !state.isDrawingEditShared,
-                state.isDrawingModified
-            )
-            return (
-                !state.isVisitWithAdminId && !state.isDrawingEditShared && state.isDrawingModified
-            )
-        },
+        showNotSharedDrawingWarning: (state) =>
+            !state.isVisitWithAdminId && !state.isDrawingEditShared && state.isDrawingModified,
     },
     actions: {
         setDrawingMode({ commit }, { mode, dispatcher }) {

--- a/vite-plugins/vite-plugin-generate-build-info.js
+++ b/vite-plugins/vite-plugin-generate-build-info.js
@@ -95,6 +95,7 @@ export default function generateBuildInfo(staging, version) {
                         2
                     ),
                 })
+                // eslint-disable-next-line no-console
                 console.log(`Created ${version}/info.json`)
             },
         },


### PR DESCRIPTION
there are from time to time console.log (or console.error) that slips through our review process. To counter that I've activated the ESLint no-console rule on all non-test, non-script files.

[Test link](https://sys-map.dev.bgdi.ch/preview/enforce-no-console/index.html)