### PR TITLE
PB 1358: fix issue with printing imported KMLS

### DIFF
--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -136,7 +136,7 @@ class GeoAdminCustomizer extends BaseCustomizer {
                   )
                 : 0
             // don't ask why it works, but that's the best I could do.
-            symbolizer.gaphicYOffset = Math.round(1000 * symbolizer.gaphicYOffset ?? 0) / 1000
+            symbolizer.graphicYOffset = Math.round(1000 * symbolizer.graphicYOffset ?? 0) / 1000
         }
         if (size) {
             symbolizer.graphicWidth = adjustWidth(size[0] * scale, this.printResolution)

--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -67,6 +67,8 @@ class GeoAdminCustomizer extends BaseCustomizer {
         if (symbolizer.strokeWidth) {
             symbolizer.strokeWidth = adjustWidth(symbolizer.strokeWidth, this.printResolution)
         }
+        symbolizer.graphicXOffset = symbolizer.graphicXOffset ?? 0
+        symbolizer.graphicYOffset = symbolizer.graphicYOffset ?? 0
     }
 
     /**


### PR DESCRIPTION
Issue : when trying to print imported kmls, we sometimes ran into an issue where there was no offset, and the printing service was not able to interpret a field not being present

Fix : We now add a little line to ensure offsets exists in line when printing

[Test link](https://sys-map.dev.bgdi.ch/preview/bugfix-pb-1358-cant-print-kmls/index.html)