### PR TITLE
PB 1358: Allow printing measures again

### DIFF
--- a/src/api/print.api.js
+++ b/src/api/print.api.js
@@ -135,8 +135,8 @@ class GeoAdminCustomizer extends BaseCustomizer {
                       this.printResolution
                   )
                 : 0
-            // don't ask why it works, but that's the best I could do.
-            symbolizer.graphicYOffset = Math.round(1000 * symbolizer.graphicYOffset ?? 0) / 1000
+            // if there is no graphicYOffset, we can't print points
+            symbolizer.graphicYOffset = Math.round(1000 * (symbolizer.graphicYOffset ?? 0)) / 1000
         }
         if (size) {
             symbolizer.graphicWidth = adjustWidth(size[0] * scale, this.printResolution)


### PR DESCRIPTION
Issue : Measures could not be printed anymore
Cause : With the implementation, we had set the graphicYoffset to NaN instead of 0 when there is no offset, meaning the print service could not interpret it
Fix : We ensure the graphicYoffset is set to 0 if non existent.

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1358-fix-printing-for-measures/index.html)