### PR TITLE
PB-1031: redirect github link to release page

### DIFF
--- a/src/config/staging.config.js
+++ b/src/config/staging.config.js
@@ -29,7 +29,7 @@ export const APP_VERSION = __APP_VERSION__
  * @type {String}
  */
 
-export const GITHUB_REPOSITORY = 'https://github.com/geoadmin/web-mapviewer/releases/tag/'
+export const GITHUB_REPOSITORY = 'https://github.com/geoadmin/web-mapviewer'
 /**
  * Display a big development banner on all but these hosts.
  *

--- a/src/config/staging.config.js
+++ b/src/config/staging.config.js
@@ -29,7 +29,7 @@ export const APP_VERSION = __APP_VERSION__
  * @type {String}
  */
 
-export const GITHUB_REPOSITORY = 'https://github.com/geoadmin/web-mapviewer'
+export const GITHUB_REPOSITORY = 'https://github.com/geoadmin/web-mapviewer/releases/tag/'
 /**
  * Display a big development banner on all but these hosts.
  *

--- a/src/utils/components/AppVersion.vue
+++ b/src/utils/components/AppVersion.vue
@@ -11,7 +11,7 @@ const appVersion = ref(APP_VERSION)
 const isProd = computed(() => store.getters.isProductionSite)
 
 function openGithubLink() {
-    window.open(GITHUB_REPOSITORY, '_blank')
+    window.open(GITHUB_REPOSITORY + APP_VERSION, '_blank')
 }
 </script>
 
@@ -32,6 +32,7 @@ function openGithubLink() {
 
 .app-version {
     color: $gray-800;
+    word-spacing: 3px;
     cursor: pointer;
 }
 

--- a/src/utils/components/AppVersion.vue
+++ b/src/utils/components/AppVersion.vue
@@ -5,25 +5,31 @@ import { useStore } from 'vuex'
 import { APP_VERSION } from '@/config/staging.config'
 import { GITHUB_REPOSITORY } from '@/config/staging.config'
 
+const cleanAppVersionRegex = /v\d+\.\d+\.\d+$/
 const store = useStore()
 const appVersion = ref(APP_VERSION)
 
 const isProd = computed(() => store.getters.isProductionSite)
 
-function openGithubLink() {
-    window.open(GITHUB_REPOSITORY + APP_VERSION, '_blank')
+function openGithubReleaseLink() {
+    const isAppVersionClean = appVersion.value.match(cleanAppVersionRegex)
+    if (!isAppVersionClean) {
+        openGithubRepoLink()
+    } else {
+        window.open(GITHUB_REPOSITORY + `/releases/tag/` + APP_VERSION, '_blank')
+    }
+}
+function openGithubRepoLink() {
+    window.open(GITHUB_REPOSITORY, '_blank')
 }
 </script>
 
 <template>
-    <div
-        class="app-version"
-        :class="{ 'app-version-prod': isProd }"
-        data-cy="app-version"
-        @click="openGithubLink"
-    >
-        <font-awesome-icon :icon="['fab', 'github']" />
-        {{ appVersion }}
+    <div class="app-version" :class="{ 'app-version-prod': isProd }" data-cy="app-version">
+        <span @click="openGithubRepoLink" class="githubIcon"
+            ><font-awesome-icon :icon="['fab', 'github']"
+        /></span>
+        <span class="app-version-link" @click="openGithubReleaseLink"> {{ appVersion }}</span>
     </div>
 </template>
 
@@ -32,11 +38,19 @@ function openGithubLink() {
 
 .app-version {
     color: $gray-800;
-    word-spacing: 3px;
     cursor: pointer;
+}
+
+.app-version-link {
+    margin-left: 3px;
+}
+
+.githubIcon {
+    margin-right: 3px;
 }
 
 .app-version-prod {
     color: $gray-500;
+    cursor: pointer;
 }
 </style>


### PR DESCRIPTION
The github link now leads to the specific release

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-1031-add-github-link-to-release/index.html)