### PR TITLE
PB-1443: re-introduce zoom buttons on mobile

### DIFF
--- a/packages/mapviewer/src/modules/map/components/toolbox/MapToolbox.vue
+++ b/packages/mapviewer/src/modules/map/components/toolbox/MapToolbox.vue
@@ -51,7 +51,7 @@ const isDrawingMode = computed(() => store.state.drawing.drawingOverlay.show)
             v-if="geolocButton"
             :compass-button="compassButton"
         />
-        <ZoomButtons class="hide-on-mobile" />
+        <ZoomButtons />
         <Toggle3dButton v-if="toggle3dButton" />
         <slot />
     </div>


### PR DESCRIPTION
Issue : Some people expressed that removing the zoom buttons on mobile was an issue for them, either regarding the hardware they are using or because of outside issues which stopped them from using the mapviewer correctly.

Fix : We bring the zoom buttons back.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-1444-put-back-the-zoom-buttons-on-mobile/index.html)