### PR TITLE
PB-1208 : Have layer legend behind the menu on mobile

### DIFF
--- a/packages/mapviewer/src/modules/menu/components/LayerDescriptionPopup.vue
+++ b/packages/mapviewer/src/modules/menu/components/LayerDescriptionPopup.vue
@@ -73,18 +73,36 @@ onMounted(async () => {
         initial-position="top-left"
         @close="emit('close', layerId)"
     >
-        <div class="layer-description" data-cy="layer-description-popup">
-            <h4 v-if="!isExternal && !htmlContent" class="mb-0">
-                <font-awesome-icon spin :icon="['fa', 'spinner']" />
+        <div
+            class="layer-description"
+            data-cy="layer-description-popup"
+        >
+            <h4
+                v-if="!isExternal && !htmlContent"
+                class="mb-0"
+            >
+                <font-awesome-icon
+                    spin
+                    :icon="['fa', 'spinner']"
+                />
             </h4>
             <div v-else-if="isExternal">
-                <h6 v-if="body" data-cy="layer-description-popup-description-title">
+                <h6
+                    v-if="body"
+                    data-cy="layer-description-popup-description-title"
+                >
                     {{ t('description') }}
                 </h6>
-                <div v-if="body" data-cy="layer-description-popup-description-body">
+                <div
+                    v-if="body"
+                    data-cy="layer-description-popup-description-body"
+                >
                     {{ body }}
                 </div>
-                <div v-if="legends.length" class="mt-4">
+                <div
+                    v-if="legends.length"
+                    class="mt-4"
+                >
                     <h6 data-cy="layer-description-popup-legends-title">
                         {{ t('legend') }}
                     </h6>
@@ -93,9 +111,19 @@ onMounted(async () => {
                         :key="legend.url"
                         :data-cy="`layer-description-popup-legends-body-${legend.url}`"
                     >
-                        <img v-if="legend.format.startsWith('image/')" :src="legend.url" />
-                        <iframe v-else-if="legend.format === 'text/html'" :src="legend.url" />
-                        <a v-else :href="legend.url" target="_blank">{{ legend.url }}</a>
+                        <img
+                            v-if="legend.format.startsWith('image/')"
+                            :src="legend.url"
+                        >
+                        <iframe
+                            v-else-if="legend.format === 'text/html'"
+                            :src="legend.url"
+                        />
+                        <a
+                            v-else
+                            :href="legend.url"
+                            target="_blank"
+                        >{{ legend.url }}</a>
                     </div>
                 </div>
 
@@ -104,14 +132,22 @@ onMounted(async () => {
                     data-cy="layer-description-popup-attributions"
                 >
                     <span class="me-1">{{ t('copyright_data') }}</span>
-                    <a v-if="attributionUrl" :href="attributionUrl" target="_blank">{{
+                    <a
+                        v-if="attributionUrl"
+                        :href="attributionUrl"
+                        target="_blank"
+                    >{{
                         attributionName
                     }}</a>
                     <span v-else>{{ attributionName }}</span>
                 </div>
             </div>
             <!-- eslint-disable vue/no-v-html-->
-            <div v-else data-cy="layer-description" v-html="htmlContent" />
+            <div
+                v-else
+                data-cy="layer-description"
+                v-html="htmlContent"
+            />
             <!-- eslint-enable vue/no-v-html-->
         </div>
     </SimpleWindow>

--- a/packages/mapviewer/src/modules/menu/components/LayerDescriptionPopup.vue
+++ b/packages/mapviewer/src/modules/menu/components/LayerDescriptionPopup.vue
@@ -66,42 +66,26 @@ onMounted(async () => {
 <template>
     <SimpleWindow
         :title="title"
+        :small="true"
+        :class="{ small }"
         movable
         allow-print
         resizeable
         initial-position="top-left"
         @close="emit('close', layerId)"
     >
-        <div
-            class="layer-description"
-            data-cy="layer-description-popup"
-        >
-            <h4
-                v-if="!isExternal && !htmlContent"
-                class="mb-0"
-            >
-                <font-awesome-icon
-                    spin
-                    :icon="['fa', 'spinner']"
-                />
+        <div class="layer-description" data-cy="layer-description-popup">
+            <h4 v-if="!isExternal && !htmlContent" class="mb-0">
+                <font-awesome-icon spin :icon="['fa', 'spinner']" />
             </h4>
             <div v-else-if="isExternal">
-                <h6
-                    v-if="body"
-                    data-cy="layer-description-popup-description-title"
-                >
+                <h6 v-if="body" data-cy="layer-description-popup-description-title">
                     {{ t('description') }}
                 </h6>
-                <div
-                    v-if="body"
-                    data-cy="layer-description-popup-description-body"
-                >
+                <div v-if="body" data-cy="layer-description-popup-description-body">
                     {{ body }}
                 </div>
-                <div
-                    v-if="legends.length"
-                    class="mt-4"
-                >
+                <div v-if="legends.length" class="mt-4">
                     <h6 data-cy="layer-description-popup-legends-title">
                         {{ t('legend') }}
                     </h6>
@@ -110,19 +94,9 @@ onMounted(async () => {
                         :key="legend.url"
                         :data-cy="`layer-description-popup-legends-body-${legend.url}`"
                     >
-                        <img
-                            v-if="legend.format.startsWith('image/')"
-                            :src="legend.url"
-                        >
-                        <iframe
-                            v-else-if="legend.format === 'text/html'"
-                            :src="legend.url"
-                        />
-                        <a
-                            v-else
-                            :href="legend.url"
-                            target="_blank"
-                        >{{ legend.url }}</a>
+                        <img v-if="legend.format.startsWith('image/')" :src="legend.url" />
+                        <iframe v-else-if="legend.format === 'text/html'" :src="legend.url" />
+                        <a v-else :href="legend.url" target="_blank">{{ legend.url }}</a>
                     </div>
                 </div>
 
@@ -131,22 +105,14 @@ onMounted(async () => {
                     data-cy="layer-description-popup-attributions"
                 >
                     <span class="me-1">{{ t('copyright_data') }}</span>
-                    <a
-                        v-if="attributionUrl"
-                        :href="attributionUrl"
-                        target="_blank"
-                    >{{
+                    <a v-if="attributionUrl" :href="attributionUrl" target="_blank">{{
                         attributionName
                     }}</a>
                     <span v-else>{{ attributionName }}</span>
                 </div>
             </div>
             <!-- eslint-disable vue/no-v-html-->
-            <div
-                v-else
-                data-cy="layer-description"
-                v-html="htmlContent"
-            />
+            <div v-else data-cy="layer-description" v-html="htmlContent" />
             <!-- eslint-enable vue/no-v-html-->
         </div>
     </SimpleWindow>

--- a/packages/mapviewer/src/modules/menu/components/LayerDescriptionPopup.vue
+++ b/packages/mapviewer/src/modules/menu/components/LayerDescriptionPopup.vue
@@ -74,18 +74,36 @@ onMounted(async () => {
         initial-position="top-left"
         @close="emit('close', layerId)"
     >
-        <div class="layer-description" data-cy="layer-description-popup">
-            <h4 v-if="!isExternal && !htmlContent" class="mb-0">
-                <font-awesome-icon spin :icon="['fa', 'spinner']" />
+        <div
+            class="layer-description"
+            data-cy="layer-description-popup"
+        >
+            <h4
+                v-if="!isExternal && !htmlContent"
+                class="mb-0"
+            >
+                <font-awesome-icon
+                    spin
+                    :icon="['fa', 'spinner']"
+                />
             </h4>
             <div v-else-if="isExternal">
-                <h6 v-if="body" data-cy="layer-description-popup-description-title">
+                <h6
+                    v-if="body"
+                    data-cy="layer-description-popup-description-title"
+                >
                     {{ t('description') }}
                 </h6>
-                <div v-if="body" data-cy="layer-description-popup-description-body">
+                <div
+                    v-if="body"
+                    data-cy="layer-description-popup-description-body"
+                >
                     {{ body }}
                 </div>
-                <div v-if="legends.length" class="mt-4">
+                <div
+                    v-if="legends.length"
+                    class="mt-4"
+                >
                     <h6 data-cy="layer-description-popup-legends-title">
                         {{ t('legend') }}
                     </h6>
@@ -94,9 +112,19 @@ onMounted(async () => {
                         :key="legend.url"
                         :data-cy="`layer-description-popup-legends-body-${legend.url}`"
                     >
-                        <img v-if="legend.format.startsWith('image/')" :src="legend.url" />
-                        <iframe v-else-if="legend.format === 'text/html'" :src="legend.url" />
-                        <a v-else :href="legend.url" target="_blank">{{ legend.url }}</a>
+                        <img
+                            v-if="legend.format.startsWith('image/')"
+                            :src="legend.url"
+                        >
+                        <iframe
+                            v-else-if="legend.format === 'text/html'"
+                            :src="legend.url"
+                        />
+                        <a
+                            v-else
+                            :href="legend.url"
+                            target="_blank"
+                        >{{ legend.url }}</a>
                     </div>
                 </div>
 
@@ -105,14 +133,22 @@ onMounted(async () => {
                     data-cy="layer-description-popup-attributions"
                 >
                     <span class="me-1">{{ t('copyright_data') }}</span>
-                    <a v-if="attributionUrl" :href="attributionUrl" target="_blank">{{
+                    <a
+                        v-if="attributionUrl"
+                        :href="attributionUrl"
+                        target="_blank"
+                    >{{
                         attributionName
                     }}</a>
                     <span v-else>{{ attributionName }}</span>
                 </div>
             </div>
             <!-- eslint-disable vue/no-v-html-->
-            <div v-else data-cy="layer-description" v-html="htmlContent" />
+            <div
+                v-else
+                data-cy="layer-description"
+                v-html="htmlContent"
+            />
             <!-- eslint-enable vue/no-v-html-->
         </div>
     </SimpleWindow>

--- a/packages/mapviewer/src/modules/menu/components/LayerDescriptionPopup.vue
+++ b/packages/mapviewer/src/modules/menu/components/LayerDescriptionPopup.vue
@@ -66,44 +66,25 @@ onMounted(async () => {
 <template>
     <SimpleWindow
         :title="title"
-        :small="true"
-        :class="{ small }"
+        small
         movable
         allow-print
         resizeable
         initial-position="top-left"
         @close="emit('close', layerId)"
     >
-        <div
-            class="layer-description"
-            data-cy="layer-description-popup"
-        >
-            <h4
-                v-if="!isExternal && !htmlContent"
-                class="mb-0"
-            >
-                <font-awesome-icon
-                    spin
-                    :icon="['fa', 'spinner']"
-                />
+        <div class="layer-description" data-cy="layer-description-popup">
+            <h4 v-if="!isExternal && !htmlContent" class="mb-0">
+                <font-awesome-icon spin :icon="['fa', 'spinner']" />
             </h4>
             <div v-else-if="isExternal">
-                <h6
-                    v-if="body"
-                    data-cy="layer-description-popup-description-title"
-                >
+                <h6 v-if="body" data-cy="layer-description-popup-description-title">
                     {{ t('description') }}
                 </h6>
-                <div
-                    v-if="body"
-                    data-cy="layer-description-popup-description-body"
-                >
+                <div v-if="body" data-cy="layer-description-popup-description-body">
                     {{ body }}
                 </div>
-                <div
-                    v-if="legends.length"
-                    class="mt-4"
-                >
+                <div v-if="legends.length" class="mt-4">
                     <h6 data-cy="layer-description-popup-legends-title">
                         {{ t('legend') }}
                     </h6>
@@ -112,19 +93,9 @@ onMounted(async () => {
                         :key="legend.url"
                         :data-cy="`layer-description-popup-legends-body-${legend.url}`"
                     >
-                        <img
-                            v-if="legend.format.startsWith('image/')"
-                            :src="legend.url"
-                        >
-                        <iframe
-                            v-else-if="legend.format === 'text/html'"
-                            :src="legend.url"
-                        />
-                        <a
-                            v-else
-                            :href="legend.url"
-                            target="_blank"
-                        >{{ legend.url }}</a>
+                        <img v-if="legend.format.startsWith('image/')" :src="legend.url" />
+                        <iframe v-else-if="legend.format === 'text/html'" :src="legend.url" />
+                        <a v-else :href="legend.url" target="_blank">{{ legend.url }}</a>
                     </div>
                 </div>
 
@@ -133,22 +104,14 @@ onMounted(async () => {
                     data-cy="layer-description-popup-attributions"
                 >
                     <span class="me-1">{{ t('copyright_data') }}</span>
-                    <a
-                        v-if="attributionUrl"
-                        :href="attributionUrl"
-                        target="_blank"
-                    >{{
+                    <a v-if="attributionUrl" :href="attributionUrl" target="_blank">{{
                         attributionName
                     }}</a>
                     <span v-else>{{ attributionName }}</span>
                 </div>
             </div>
             <!-- eslint-disable vue/no-v-html-->
-            <div
-                v-else
-                data-cy="layer-description"
-                v-html="htmlContent"
-            />
+            <div v-else data-cy="layer-description" v-html="htmlContent" />
             <!-- eslint-enable vue/no-v-html-->
         </div>
     </SimpleWindow>

--- a/packages/mapviewer/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
+++ b/packages/mapviewer/src/modules/menu/components/activeLayers/MenuActiveLayersListItem.vue
@@ -152,6 +152,10 @@ function onTransparencyCommit() {
 
 function showLayerDescriptionPopup() {
     emit('showLayerDescriptionPopup', id.value)
+    //close menu on mobile only
+    if (isPhoneMode.value) {
+        store.dispatch('toggleMenu', dispatcher)
+    }
 }
 
 function duplicateLayer() {

--- a/packages/mapviewer/src/utils/components/SimpleWindow.vue
+++ b/packages/mapviewer/src/utils/components/SimpleWindow.vue
@@ -8,8 +8,8 @@ import { useMovableElement } from '@/utils/composables/useMovableElement.composa
 
 const acceptedInitialPositions = ['top-left', 'top-center', 'top-right']
 
-const { title, hide, movable, resizeable, allowPrint, initialPosition, wide, dataCy } = defineProps(
-    {
+const { title, hide, movable, resizeable, allowPrint, initialPosition, wide, small, dataCy } =
+    defineProps({
         title: {
             type: String,
             default: '',
@@ -43,12 +43,15 @@ const { title, hide, movable, resizeable, allowPrint, initialPosition, wide, dat
             type: Boolean,
             default: false,
         },
+        small: {
+            type: Boolean,
+            default: false,
+        },
         dataCy: {
             type: String,
             default: 'simple-window',
         },
-    }
-)
+    })
 
 const store = useStore()
 
@@ -96,6 +99,7 @@ onMounted(() => {
                 {
                     'dev-disclaimer-present': hasDevSiteWarning,
                     wide: wide,
+                    small: small,
                     resizable: resizeable && showBody,
                 },
             ]"
@@ -105,20 +109,11 @@ onMounted(() => {
                 class="card-header d-flex align-items-center justify-content-sm-end"
                 data-cy="window-header"
             >
-                <span
-                    v-if="title"
-                    data-cy="simple-window-title"
-                    class="me-auto text-truncate"
+                <span v-if="title" data-cy="simple-window-title" class="me-auto text-truncate">
+                    {{ t(title) }}</span
                 >
-                    {{ t(title) }}</span>
-                <span
-                    v-else
-                    class="me-auto"
-                />
-                <PrintButton
-                    v-if="allowPrint && showBody"
-                    :content="contentRef"
-                />
+                <span v-else class="me-auto" />
+                <PrintButton v-if="allowPrint && showBody" :content="contentRef" />
                 <button
                     class="btn btn-light btn-sm me-2"
                     data-cy="simple-window-minimize"
@@ -196,12 +191,19 @@ onMounted(() => {
         $top-margin: $header-height;
 
         top: $top-margin;
-        left: 10px;
-        right: 10px;
+        left: 0px;
+        right: 0px;
         transform: unset;
         max-height: calc(100vh - $top-margin);
-        max-width: 75vw;
-        width: 75vw;
+        max-width: 100vw;
+        width: 100vw;
+
+        &.small {
+            left: 10px;
+            right: 10px;
+            max-width: 75vw;
+            width: 75vw;
+        }
 
         &.dev-disclaimer-present {
             top: calc($top-margin + $dev-disclaimer-height);

--- a/packages/mapviewer/src/utils/components/SimpleWindow.vue
+++ b/packages/mapviewer/src/utils/components/SimpleWindow.vue
@@ -105,11 +105,20 @@ onMounted(() => {
                 class="card-header d-flex align-items-center justify-content-sm-end"
                 data-cy="window-header"
             >
-                <span v-if="title" data-cy="simple-window-title" class="me-auto text-truncate">
-                    {{ t(title) }}</span
+                <span
+                    v-if="title"
+                    data-cy="simple-window-title"
+                    class="me-auto text-truncate"
                 >
-                <span v-else class="me-auto" />
-                <PrintButton v-if="allowPrint && showBody" :content="contentRef" />
+                    {{ t(title) }}</span>
+                <span
+                    v-else
+                    class="me-auto"
+                />
+                <PrintButton
+                    v-if="allowPrint && showBody"
+                    :content="contentRef"
+                />
                 <button
                     class="btn btn-light btn-sm me-2"
                     data-cy="simple-window-minimize"

--- a/packages/mapviewer/src/utils/components/SimpleWindow.vue
+++ b/packages/mapviewer/src/utils/components/SimpleWindow.vue
@@ -109,11 +109,20 @@ onMounted(() => {
                 class="card-header d-flex align-items-center justify-content-sm-end"
                 data-cy="window-header"
             >
-                <span v-if="title" data-cy="simple-window-title" class="me-auto text-truncate">
-                    {{ t(title) }}</span
+                <span
+                    v-if="title"
+                    data-cy="simple-window-title"
+                    class="me-auto text-truncate"
                 >
-                <span v-else class="me-auto" />
-                <PrintButton v-if="allowPrint && showBody" :content="contentRef" />
+                    {{ t(title) }}</span>
+                <span
+                    v-else
+                    class="me-auto"
+                />
+                <PrintButton
+                    v-if="allowPrint && showBody"
+                    :content="contentRef"
+                />
                 <button
                     class="btn btn-light btn-sm me-2"
                     data-cy="simple-window-minimize"

--- a/packages/mapviewer/src/utils/components/SimpleWindow.vue
+++ b/packages/mapviewer/src/utils/components/SimpleWindow.vue
@@ -6,7 +6,7 @@ import { useStore } from 'vuex'
 import PrintButton from '@/utils/components/PrintButton.vue'
 import { useMovableElement } from '@/utils/composables/useMovableElement.composable'
 
-const accepetedInitialPositions = ['top-left', 'top-center', 'top-right']
+const acceptedInitialPositions = ['top-left', 'top-center', 'top-right']
 
 const { title, hide, movable, resizeable, allowPrint, initialPosition, wide, dataCy } = defineProps(
     {
@@ -64,7 +64,7 @@ const headerRef = useTemplateRef('headerRef')
 const contentRef = useTemplateRef('contentRef')
 
 const initialPositionClass = computed(() => {
-    if (accepetedInitialPositions.includes(initialPosition)) {
+    if (acceptedInitialPositions.includes(initialPosition)) {
         return initialPosition
     } else {
         return 'top-center'
@@ -105,20 +105,11 @@ onMounted(() => {
                 class="card-header d-flex align-items-center justify-content-sm-end"
                 data-cy="window-header"
             >
-                <span
-                    v-if="title"
-                    data-cy="simple-window-title"
-                    class="me-auto text-truncate"
+                <span v-if="title" data-cy="simple-window-title" class="me-auto text-truncate">
+                    {{ t(title) }}</span
                 >
-                    {{ t(title) }}</span>
-                <span
-                    v-else
-                    class="me-auto"
-                />
-                <PrintButton
-                    v-if="allowPrint && showBody"
-                    :content="contentRef"
-                />
+                <span v-else class="me-auto" />
+                <PrintButton v-if="allowPrint && showBody" :content="contentRef" />
                 <button
                     class="btn btn-light btn-sm me-2"
                     data-cy="simple-window-minimize"
@@ -196,12 +187,12 @@ onMounted(() => {
         $top-margin: $header-height;
 
         top: $top-margin;
-        left: 0px;
-        right: 0px;
+        left: 10px;
+        right: 10px;
         transform: unset;
         max-height: calc(100vh - $top-margin);
-        max-width: 100vw;
-        width: 100vw;
+        max-width: 75vw;
+        width: 75vw;
 
         &.dev-disclaimer-present {
             top: calc($top-margin + $dev-disclaimer-height);

--- a/packages/mapviewer/tests/cypress/tests-e2e/reportProblem.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/reportProblem.cy.js
@@ -250,7 +250,10 @@ describe('Testing the report problem form', () => {
         cy.log(
             'Cancel the report and open the drawing mode to verify that there is no drawing layer after closing it'
         )
+
+        cy.get('[data-cy="report-problem-button"]').scrollIntoView()
         cy.get('[data-cy="report-problem-button"]').should('be.visible').click()
+
         cy.get('[data-cy="report-problem-form"]').as('reportForm').should('be.visible')
         cy.get('[data-cy="report-problem-drawing-button"]')
             .as('reportDrawing')
@@ -268,7 +271,7 @@ describe('Testing the report problem form', () => {
         })
 
         cy.get('[data-cy="drawing-toolbox-close-button"]').should('be.visible').click()
-        cy.get('@reportForm').should('be.visible')
+        cy.get('@reportForm').should('exist')
         cy.get('[data-cy="drawing-header-title"]').should('not.exist')
 
         cy.get('[data-cy="window-close"]').should('be.visible').click()
@@ -281,7 +284,7 @@ describe('Testing the report problem form', () => {
         })
         cy.get('[data-cy="menu-help-section"]:visible').click()
         cy.get('[data-cy="report-problem-button"]').should('be.visible').click()
-        cy.get('@reportForm').should('be.visible')
+        cy.get('@reportForm').should('exist')
         cy.get('[data-cy="report-problem-drawing-button"]').as('reportDrawing').should('be.visible')
 
         cy.log('Redo the drawing in the report problem form')
@@ -377,7 +380,7 @@ describe('Testing the report problem form', () => {
 
         cy.get('[data-cy="drawing-toolbox-close-button"]').should('be.visible').click()
         cy.get('@categoryDropdown').scrollIntoView()
-        cy.get('@reportForm').should('be.visible')
+        cy.get('@reportForm').should('exist')
         cy.get('[data-cy="drawing-header-title"]').should('not.exist')
         cy.get('@textArea').should('have.value', text)
         cy.get('@emailInput').should('have.value', validEmail)

--- a/packages/mapviewer/tests/cypress/tests-e2e/topics.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/topics.cy.js
@@ -270,6 +270,8 @@ describe('Topics', () => {
                 .click()
             cy.wait('@legend')
 
+            cy.get('[data-cy="menu-topic-tree"]').should('not.exist')
+
             const popupSelector = '[data-cy="simple-window"]'
             const popupSelectorHeader = '[data-cy="window-header"]'
             const moveX = 100


### PR DESCRIPTION
The layer legend info window has been smaller on mobile displays, and when displayed, closes the menu so as to not obscure the map behind. 

Here's a preview of the change : 
![image](https://github.com/user-attachments/assets/89968e85-c346-4cba-8286-03632c952b70)


[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-1208-layer-legend-popup/index.html)