### PR TITLE
Bump npm version to 11 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
     "engines": {
         "node": ">=22",
-        "npm": "10.*.*"
+        "npm": "11.*.*"
     },
     "dependencies": {
         "@turf/turf": "^7.2.0",


### PR DESCRIPTION
Updating the NPM version in package.json to 11. This goes in tandem with https://github.com/geoadmin/infra-terraform-bgdi/pull/772.

This is preparatory work for having the possibility to use pnpm alongside npm for a short period of time on the CI. After the pnpm merge, this will probably become irrelevant.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-npm-11/index.html)