### PR TITLE
PB-1209: Fix no feature tooltip when select feature from search.

### DIFF
--- a/packages/mapviewer/src/store/modules/search.store.js
+++ b/packages/mapviewer/src/store/modules/search.store.js
@@ -8,6 +8,7 @@ import LayerTypes from '@/api/layers/LayerTypes.enum'
 import reframe from '@/api/lv03Reframe.api'
 import search, { SearchResultTypes } from '@/api/search.api'
 import { isWhat3WordsString, retrieveWhat3WordsLocation } from '@/api/what3words.api'
+import { FeatureInfoPositions } from '@/store/modules/ui.store'
 import coordinateFromString from '@/utils/coordinates/coordinateExtractors'
 import { flattenExtent, normalizeExtent } from '@/utils/extentUtils'
 import { parseGpx } from '@/utils/gpxUtils'
@@ -250,6 +251,10 @@ const actions = {
                                 features: [feature],
                                 dispatcher,
                             })
+                            dispatch('setFeatureInfoPosition', {
+                                position: FeatureInfoPositions.TOOLTIP,
+                                ...dispatcher,
+                            })
                         })
                     } else {
                         // For imported KML and GPX files
@@ -270,6 +275,10 @@ const actions = {
                         dispatch('setSelectedFeatures', {
                             features: layerFeatures,
                             dispatcher,
+                        })
+                        dispatch('setFeatureInfoPosition', {
+                            position: FeatureInfoPositions.TOOLTIP,
+                            ...dispatcher,
                         })
                     }
                 } catch (error) {

--- a/packages/mapviewer/tests/cypress/tests-e2e/search/search-results.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/search/search-results.cy.js
@@ -57,6 +57,7 @@ describe('Test the search bar result handling', () => {
         expectedCenterEpsg4326
     )
     const expectedLayerId = 'test.wmts.layer'
+    const expectedFeatureId = 5678
     const locationResponse = {
         results: [
             {
@@ -99,11 +100,11 @@ describe('Test the search bar result handling', () => {
     const layerFeatureResponse = {
         results: [
             {
-                id: 5678,
+                id: expectedFeatureId,
                 weight: 4,
                 attrs: {
-                    featureId: 5678,
-                    feature_id: 5678,
+                    featureId: expectedFeatureId,
+                    feature_id: expectedFeatureId,
                     x: expectedCenterDefaultProjection[0],
                     y: expectedCenterDefaultProjection[1],
                     lon: expectedCenterEpsg4326[0],
@@ -416,6 +417,11 @@ describe('Test the search bar result handling', () => {
             expect(x).to.be.closeTo(expectedCenterDefaultProjection[0], 1)
             expect(y).to.be.closeTo(expectedCenterDefaultProjection[1], 1)
         })
+
+        // Check that the infobox for the selected feature is visible
+        cy.get('[data-cy="infobox"]').as('infobox').should('be.visible')
+        cy.get('@infobox').find('[data-cy="feature-item"]').should('have.length', 1)
+        cy.get('@infobox').find('[data-cy="feature-item"]').first().should('contain.text', expectedFeatureId)
 
         cy.log('Checking that the swisssearch url param is not present after reloading the page')
         cy.reload()


### PR DESCRIPTION


[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-1209-select-feature-no-info-from-search/index.html)