### PR TITLE
PB-1004 : only use right click to trigger "delete point" action

### DIFF
--- a/packages/mapviewer/src/modules/drawing/DrawingModule.vue
+++ b/packages/mapviewer/src/modules/drawing/DrawingModule.vue
@@ -65,6 +65,8 @@ const selectedLineFeature = computed(() => {
 const showAddVertexButton = computed(() => {
     return store.state.drawing.editingMode === EditMode.MODIFY && !!selectedLineFeature.value
 })
+const editMode = computed(() => store.state.drawing.editingMode)
+const currentDrawingMode = computed(() => store.state.drawing.mode)
 
 const hasKml = computed(() => {
     if (online.value) {
@@ -225,7 +227,10 @@ function createSourceForProjection() {
     })
 }
 function removeLastPoint() {
-    drawingInteractions.value?.removeLastPoint()
+    // only deleting the last point by right-click when we are drawing a feature (or editing it)
+    if (currentDrawingMode.value !== null || editMode.value === EditMode.EXTEND) {
+        drawingInteractions.value?.removeLastPoint()
+    }
 }
 
 function removeLastPointOnRightClick(_event) {

--- a/packages/mapviewer/src/modules/drawing/components/useModifyInteraction.composable.js
+++ b/packages/mapviewer/src/modules/drawing/components/useModifyInteraction.composable.js
@@ -1,4 +1,4 @@
-import { noModifierKeys } from 'ol/events/condition'
+import { noModifierKeys, primaryAction } from 'ol/events/condition'
 import ModifyInteraction from 'ol/interaction/Modify'
 import { computed, inject, onBeforeUnmount, onMounted, watch } from 'vue'
 import { useStore } from 'vuex'
@@ -34,6 +34,11 @@ export default function useModifyInteraction(features) {
     const modifyInteraction = new ModifyInteraction({
         features,
         style: editingVertexStyleFunction,
+        condition: (event) =>
+            primaryAction(event) ||
+            (event.type === 'pointerdown' &&
+                event.originalEvent.button === 2 &&
+                noModifierKeys(event)), // To delete a point with right click (contextmenu), one has to first select the point and then right click on it, therefore this select vertex condition is needed
         deleteCondition: (event) => event.type === 'contextmenu' && noModifierKeys(event),
         // This seems to be calculated differently than the hitTolerance properties of
         // SelectInteraction and forEachFeatureAtPixel. That's why we have to manually correct the

--- a/packages/mapviewer/src/modules/drawing/components/useModifyInteraction.composable.js
+++ b/packages/mapviewer/src/modules/drawing/components/useModifyInteraction.composable.js
@@ -1,4 +1,4 @@
-import { doubleClick, noModifierKeys, primaryAction } from 'ol/events/condition'
+import { noModifierKeys } from 'ol/events/condition'
 import ModifyInteraction from 'ol/interaction/Modify'
 import { computed, inject, onBeforeUnmount, onMounted, watch } from 'vue'
 import { useStore } from 'vuex'
@@ -27,7 +27,6 @@ export default function useModifyInteraction(features) {
     const reverseLineStringExtension = computed(
         () => store.state.drawing.reverseLineStringExtension
     )
-    const isPhoneMode = computed(() => store.getters.isPhoneMode)
 
     const olMap = inject('olMap')
     const { willModify, debounceSaveDrawing } = useSaveKmlOnChange()
@@ -35,15 +34,7 @@ export default function useModifyInteraction(features) {
     const modifyInteraction = new ModifyInteraction({
         features,
         style: editingVertexStyleFunction,
-        condition: (event) =>
-            primaryAction(event) ||
-            (event.type === 'pointerdown' &&
-                event.originalEvent.button === 2 &&
-                noModifierKeys(event)), // To delete a point with right click (contextmenu) one has to first select the point and then right click on it, therefore this select vertex condition is needed
-        deleteCondition: (event) =>
-            isPhoneMode.value
-                ? doubleClick(event)
-                : event.type === 'contextmenu' && noModifierKeys(event),
+        deleteCondition: (event) => event.type === 'contextmenu' && noModifierKeys(event),
         // This seems to be calculated differently than the hitTolerance properties of
         // SelectInteraction and forEachFeatureAtPixel. That's why we have to manually correct the
         // value here.

--- a/packages/mapviewer/tests/cypress/tests-e2e/drawing.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/drawing.cy.js
@@ -1518,10 +1518,9 @@ describe('Drawing module tests', () => {
             )
             cy.get('[data-cy="profile-graph"]').trigger('mouseleave')
 
-            cy.log('check that profile gets updated when feature is modified by removing a point')
-            // for mobile double click and on desktop right click
-            cy.get('[data-cy="ol-map"]').dblclick(190, 250)
-            cy.wait('@profile')
+            cy.log(
+                'check that profile gets updated when feature is modified by removing a point (by right clicking on it)'
+            )
             cy.get('[data-cy="ol-map"]').rightclick(150, 250)
             cy.wait('@profile')
 

--- a/packages/mapviewer/tests/cypress/tests-e2e/drawing.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/drawing.cy.js
@@ -632,76 +632,86 @@ describe('Drawing module tests', () => {
                 [900, 400],
                 [1000, 400],
             ]
-            lineCoordinates.forEach((coordinate) => {
-                cy.get('[data-cy="ol-map"]').click(...coordinate)
+            lineCoordinates.forEach(([x, y], index) => {
+                cy.get('[data-cy="ol-map"]').click(x, y)
+                if (index === lineCoordinates.length - 1) {
+                    // should create a line by re-clicking the last point
+                    cy.get('[data-cy="ol-map"]').click(x, y)
+                }
             })
-            // should create a line by re-clicking the last point
-            cy.get('[data-cy="ol-map"]').click(...lineCoordinates.at(lineCoordinates.length - 1))
+            cy.wait('@post-kml')
+
             const firstFeatureDescription = 'first feature'
             addDecription(firstFeatureDescription)
 
             checkDrawnFeature(
                 firstFeatureDescription,
-                8,
+                lineCoordinates.length,
                 'LineString',
                 EditableFeatureTypes.LINEPOLYGON
             )
 
-            // Extend from the last node of line
+            cy.log('Extending from the last node of the line')
             cy.get('[data-cy="extend-from-last-node-button"] button').click()
-            cy.get('[data-cy="ol-map"]').click(1100, 450)
-            // finish extending the line by clicking the last point
-            cy.get('[data-cy="ol-map"]').click(1100, 450)
+            cy.get('[data-cy="ol-map"]').click(1050, 420)
+            cy.get('[data-cy="ol-map"]').dblclick(1100, 450)
+            cy.wait('@update-kml')
             checkDrawnFeature(
                 firstFeatureDescription,
-                9,
+                lineCoordinates.length + 2,
                 'LineString',
                 EditableFeatureTypes.LINEPOLYGON
             )
 
-            // Extend from the first node of line
+            cy.log('Extending from the first node of the line')
             cy.get('[data-cy="extend-from-first-node-button"] button').click()
             cy.get('[data-cy="ol-map"]').click(500, 250)
-            cy.get('[data-cy="ol-map"]').click(600, 250)
-            // finish extending the line by clicking the last point
-            cy.get('[data-cy="ol-map"]').click(600, 250)
+            cy.get('[data-cy="ol-map"]').dblclick(600, 250)
+            cy.wait('@update-kml')
             checkDrawnFeature(
                 firstFeatureDescription,
-                11,
+                lineCoordinates.length + 4,
                 'LineString',
                 EditableFeatureTypes.LINEPOLYGON
             )
 
-            // Delete the last node by right click
-            cy.get('[data-cy="ol-map"]').rightclick()
+            cy.log('Deleting a node in the middle by right clicking on it')
+            cy.get('[data-cy="ol-map"]').rightclick(500, 250)
+            cy.wait('@update-kml')
             checkDrawnFeature(
                 firstFeatureDescription,
-                10,
+                lineCoordinates.length + 3,
                 'LineString',
                 EditableFeatureTypes.LINEPOLYGON
             )
 
-            // Delete the last node by clicking the delete button
+            cy.log('Deleting the last node by clicking the delete button')
+            cy.get('[data-cy="extend-from-first-node-button"] button').click()
             cy.get('[data-cy="drawing-delete-last-point-button"]').click()
+            // Click the first node to finish the polygon
+            const firstPoint = lineCoordinates[0]
+            // re-clicking an existing point to finish editing
+            cy.get('[data-cy="ol-map"]').click(firstPoint[0], firstPoint[1])
+            cy.wait('@update-kml')
             checkDrawnFeature(
                 firstFeatureDescription,
-                9,
+                lineCoordinates.length + 2,
                 'LineString',
                 EditableFeatureTypes.LINEPOLYGON
             )
 
-            // Extend to make a polygon
+            cy.log('Extending line into a polygon (closing it)')
             cy.get('[data-cy="extend-from-last-node-button"] button').click()
-            cy.get('[data-cy="ol-map"]').click(750, 350)
-            // Click the first node to finish the polygon
-            cy.get('[data-cy="ol-map"]').click(600, 250)
+            cy.get('[data-cy="ol-map"]').click(firstPoint[0], firstPoint[1])
+            cy.wait('@update-kml')
             checkDrawnFeature(
                 firstFeatureDescription,
-                11,
+                lineCoordinates.length + 3, // closing point counts twice (start and finish of geometry)
                 'Polygon',
                 EditableFeatureTypes.LINEPOLYGON
             )
-            // No extend button for polygon
+
+            cy.log('Checking that no more "extend button" are present with a polygon')
             cy.get('[data-cy="drawing-delete-first-point-button"]').should('not.exist')
             cy.get('[data-cy="drawing-delete-last-point-button"]').should('not.exist')
 
@@ -737,9 +747,7 @@ describe('Drawing module tests', () => {
 
             // Extend from the last node of line
             cy.get('[data-cy="extend-from-last-node-button"] button').click()
-            cy.get('[data-cy="ol-map"]').click(1400, 450)
-            // finish extending the line by clicking the last point
-            cy.get('[data-cy="ol-map"]').click(1400, 450)
+            cy.get('[data-cy="ol-map"]').dblclick(1400, 450)
             checkDrawnFeature(
                 secondFeatureDescription,
                 9,


### PR DESCRIPTION
users on touch devices could trigger a delete by double tapping on the last point they were drawing, which wasn't ideal.

As I've run out of ideas on how to fix this on mobile, I've simply removed the possibility to delete a point on mobile as we lack "gestures" to achieve it.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-1004-revert-use-of-right-click/index.html)