### PR TITLE
Don't render invisible layer catalogue items

### DIFF
--- a/packages/mapviewer/src/modules/menu/components/LayerCatalogueItem.vue
+++ b/packages/mapviewer/src/modules/menu/components/LayerCatalogueItem.vue
@@ -243,7 +243,7 @@ function containsLayer(layers, searchText) {
 
 <template>
     <div
-        v-show="showItem"
+        v-if="showItem"
         class="menu-catalogue-item"
         :class="{ compact: compact }"
         :data-cy="`catalogue-tree-item-${item.id}`"
@@ -315,7 +315,7 @@ function containsLayer(layers, searchText) {
         </div>
         <CollapseTransition :duration="200">
             <ul
-                v-show="showChildren"
+                v-if="showChildren"
                 class="menu-catalogue-item-children"
                 :class="`ps-${2 + depth}`"
             >

--- a/packages/mapviewer/tests/cypress/tests-e2e/importToolMaps.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/importToolMaps.cy.js
@@ -117,7 +117,7 @@ describe('The Import Maps Tool', () => {
             .should('be.visible')
             .find('svg')
             .should('have.class', 'fa-caret-right')
-        cy.get(`[data-cy="catalogue-tree-item-${firstSubItemId}"]`).should('not.be.visible')
+        cy.get(`[data-cy="catalogue-tree-item-${firstSubItemId}"]`).should('not.exist')
         cy.get(`[data-cy="catalogue-collapse-layer-button-${itemId}"]`).should('be.visible').click()
 
         //---------------------------------------------------------------------------------

--- a/packages/mapviewer/tests/cypress/tests-e2e/topics.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/topics.cy.js
@@ -143,8 +143,8 @@ describe('Topics', () => {
 
         // it must not open the first elements of the tree by default
         cy.get('[data-cy="catalogue-tree-item-2"]').should('be.visible')
-        cy.get('[data-cy="catalogue-tree-item-3"]').should('not.be.visible')
-        cy.get('[data-cy="catalogue-tree-item-5"]').should('not.be.visible')
+        cy.get('[data-cy="catalogue-tree-item-3"]').should('not.exist')
+        cy.get('[data-cy="catalogue-tree-item-5"]').should('not.exist')
 
         // shows a topic tree item's children when we click on it
         cy.get('[data-cy="catalogue-tree-item-title-2"]').should('be.visible').click()
@@ -235,7 +235,7 @@ describe('Topics', () => {
         cy.get('[data-cy="menu-topic-tree"]').should('be.visible')
         cy.get('[data-cy="catalogue-tree-item-3"]').should('be.visible')
         cy.get('[data-cy="catalogue-tree-item-5"]').should('be.visible')
-        cy.get('[data-cy="catalogue-tree-item-test.wmts.layer"]').should('not.be.visible')
+        cy.get('[data-cy="catalogue-tree-item-test.wmts.layer"]').should('not.exist')
         cy.get('[data-cy="catalogue-tree-item-test.wms.layer"]').should('be.visible')
         cy.readStoreValue('state.topics.openedTreeThemesIds').should((currentlyOpenedThemesId) => {
             expect(currentlyOpenedThemesId).to.be.an('Array')


### PR DESCRIPTION
Don't render the invisible layer catalogue items. Only render them when the nested navigation is un-collapsed.
This produces quite a performance gain, as many sub-sequent components don't need rendering. This includes `<TextTruncate>`, where each of them creates a ResizeObserver on the DOM. Without this change we have ~1100 resize observers, with the change there are only ~250.

I will investigate those ~250 maybe in another attempt, some of them might be resolved when switching to the new tooltip.

This results in quite the performance gain, mostly noticable in development mode.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-less-text-truncate/index.html)