### PR TITLE
PB-1436 Specify packageManager in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,5 @@
             "sharp"
         ]
     },
-    "packageManager": "pnpm@10.4.1"
+    "packageManager": "pnpm"
 }

--- a/package.json
+++ b/package.json
@@ -67,5 +67,6 @@
             "cypress",
             "sharp"
         ]
-    }
+    },
+    "packageManager": "pnpm@10.4.1"
 }


### PR DESCRIPTION
The build on CI fails because the pnpm command adds the `packageManager` field to package.json, making the working tree dirty. This subsequently prevents the build from succeeding.

As it seems, having this field is actually desirable, thus adding it here.

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-1436-pnpm/index.html)