### PR TITLE
PB-1480: Fix bug with swissearch and crosshair together

### DIFF
--- a/packages/mapviewer/src/router/storeSync/SearchParamConfig.class.js
+++ b/packages/mapviewer/src/router/storeSync/SearchParamConfig.class.js
@@ -1,6 +1,7 @@
 import AbstractParamConfig, {
     STORE_DISPATCHER_ROUTER_PLUGIN,
 } from '@/router/storeSync/abstractParamConfig.class'
+import coordinateFromString from '@/utils/coordinates/coordinateExtractors'
 import { removeQueryParamFromHref } from '@/utils/searchParamUtils'
 
 export const URL_PARAM_NAME_SWISSSEARCH = 'swisssearch'
@@ -15,9 +16,15 @@ export const URL_PARAM_NAME_SWISSSEARCH = 'swisssearch'
 function dispatchSearchFromUrl(to, store, urlParamValue) {
     // avoiding dispatching the search query to the store when there is nothing to set. Not avoiding this makes the CI test very flaky
     if (urlParamValue) {
+        let shouldCenter = !(to.query.crosshair && to.query.center)
+        // When the query is a valid coordinate, we want to center the map
+        const extractedCoordinate = coordinateFromString(to.query[URL_PARAM_NAME_SWISSSEARCH])
+        if (extractedCoordinate) {
+            shouldCenter = true
+        }
         store.dispatch('setSearchQuery', {
             query: urlParamValue,
-            shouldCenter: !(to.query.crosshair && to.query.center),
+            shouldCenter: shouldCenter,
             dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
             originUrlParam: true,
         })

--- a/packages/mapviewer/src/router/storeSync/SearchParamConfig.class.js
+++ b/packages/mapviewer/src/router/storeSync/SearchParamConfig.class.js
@@ -1,7 +1,6 @@
 import AbstractParamConfig, {
     STORE_DISPATCHER_ROUTER_PLUGIN,
 } from '@/router/storeSync/abstractParamConfig.class'
-import coordinateFromString from '@/utils/coordinates/coordinateExtractors'
 import { removeQueryParamFromHref } from '@/utils/searchParamUtils'
 
 export const URL_PARAM_NAME_SWISSSEARCH = 'swisssearch'
@@ -16,15 +15,8 @@ export const URL_PARAM_NAME_SWISSSEARCH = 'swisssearch'
 function dispatchSearchFromUrl(to, store, urlParamValue) {
     // avoiding dispatching the search query to the store when there is nothing to set. Not avoiding this makes the CI test very flaky
     if (urlParamValue) {
-        let shouldCenter = !(to.query.crosshair && to.query.center)
-        // When the query is a valid coordinate, we want to center the map
-        const extractedCoordinate = coordinateFromString(to.query[URL_PARAM_NAME_SWISSSEARCH])
-        if (extractedCoordinate) {
-            shouldCenter = true
-        }
         store.dispatch('setSearchQuery', {
             query: urlParamValue,
-            shouldCenter: shouldCenter,
             dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
             originUrlParam: true,
         })

--- a/packages/mapviewer/src/store/modules/search.store.js
+++ b/packages/mapviewer/src/store/modules/search.store.js
@@ -98,7 +98,7 @@ const actions = {
             // there are situations where we don't want to center on the features or coordinates searched.
             // for example: when we are sharing a position with a search query. In those situation, the
             // 'zoom to extent' should be avoided. We center by default.
-            if (extractedCoordinate  && shouldCenter) {
+            if (extractedCoordinate && shouldCenter) {
                 let coordinates = [...extractedCoordinate.coordinate]
                 if (extractedCoordinate.coordinateSystem !== currentProjection) {
                     // special case for LV03 input, we can't use proj4 to transform them into

--- a/packages/mapviewer/src/store/modules/search.store.js
+++ b/packages/mapviewer/src/store/modules/search.store.js
@@ -77,7 +77,7 @@ const actions = {
     ) => {
         let results = []
         commit('setSearchQuery', { query, dispatcher })
-        console.log('setSearchQuery', query, originUrlParam, shouldCenter, dispatcher)
+        log.debug('setSearchQuery', query, originUrlParam, shouldCenter, dispatcher)
         // only firing search if query is longer than or equal to 2 chars
         if (query.length >= 2) {
             const currentProjection = rootState.position.projection
@@ -100,7 +100,7 @@ const actions = {
             // for example: when we are sharing a position with a search query. In those situation, the
             // 'zoom to extent' should be avoided. We center by default.
             if (extractedCoordinate && shouldCenter) {
-                console.log('valid extractedCoordinate', extractedCoordinate,shouldCenter)
+                log.debug('valid extractedCoordinate', extractedCoordinate,shouldCenter)
                 let coordinates = [...extractedCoordinate.coordinate]
                 if (extractedCoordinate.coordinateSystem !== currentProjection) {
                     // special case for LV03 input, we can't use proj4 to transform them into
@@ -108,14 +108,14 @@ const actions = {
                     // So we pass through a LV95 reframe (done by a backend service that knows all deformations between the two)
                     // and then go to the wanted coordinate system
                     if (extractedCoordinate.coordinateSystem === LV03) {
-                        console.log('extractedCoordinate.coordinateSystem === LV03')
+                        log.debug('extractedCoordinate.coordinateSystem === LV03')
                         coordinates = await reframe({
                             inputProjection: LV03,
                             inputCoordinates: coordinates,
                             outputProjection: currentProjection,
                         })
                     } else {
-                        console.log('extractedCoordinate.coordinateSystem != LV03')
+                        log.debug('extractedCoordinate.coordinateSystem != LV03')
                         coordinates = reprojectAndRound(
                             extractedCoordinate.coordinateSystem,
                             currentProjection,
@@ -166,7 +166,7 @@ const actions = {
                     dispatcher: dispatcherWhat3words,
                 })
             } else {
-                console.log('go to else')
+                log.debug('go to else')
                 try {
                     results = await search({
                         outputProjection: currentProjection,

--- a/packages/mapviewer/src/store/modules/search.store.js
+++ b/packages/mapviewer/src/store/modules/search.store.js
@@ -98,7 +98,7 @@ const actions = {
             // there are situations where we don't want to center on the features or coordinates searched.
             // for example: when we are sharing a position with a search query. In those situation, the
             // 'zoom to extent' should be avoided. We center by default.
-            if (extractedCoordinate && shouldCenter) {
+            if (extractedCoordinate  && shouldCenter) {
                 let coordinates = [...extractedCoordinate.coordinate]
                 if (extractedCoordinate.coordinateSystem !== currentProjection) {
                     // special case for LV03 input, we can't use proj4 to transform them into

--- a/packages/mapviewer/src/store/modules/search.store.js
+++ b/packages/mapviewer/src/store/modules/search.store.js
@@ -77,7 +77,6 @@ const actions = {
     ) => {
         let results = []
         commit('setSearchQuery', { query, dispatcher })
-        log.debug('setSearchQuery', query, originUrlParam, dispatcher)
         // only firing search if query is longer than or equal to 2 chars
         if (query.length >= 2) {
             const currentProjection = rootState.position.projection
@@ -97,7 +96,6 @@ const actions = {
             }
 
             if (extractedCoordinate) {
-                log.debug('valid extractedCoordinate', extractedCoordinate)
                 let coordinates = [...extractedCoordinate.coordinate]
                 if (extractedCoordinate.coordinateSystem !== currentProjection) {
                     // special case for LV03 input, we can't use proj4 to transform them into
@@ -105,14 +103,12 @@ const actions = {
                     // So we pass through a LV95 reframe (done by a backend service that knows all deformations between the two)
                     // and then go to the wanted coordinate system
                     if (extractedCoordinate.coordinateSystem === LV03) {
-                        log.debug('extractedCoordinate.coordinateSystem === LV03')
                         coordinates = await reframe({
                             inputProjection: LV03,
                             inputCoordinates: coordinates,
                             outputProjection: currentProjection,
                         })
                     } else {
-                        log.debug('extractedCoordinate.coordinateSystem != LV03')
                         coordinates = reprojectAndRound(
                             extractedCoordinate.coordinateSystem,
                             currentProjection,
@@ -163,7 +159,6 @@ const actions = {
                     dispatcher: dispatcherWhat3words,
                 })
             } else {
-                log.debug('go to else')
                 try {
                     results = await search({
                         outputProjection: currentProjection,

--- a/packages/mapviewer/src/store/modules/search.store.js
+++ b/packages/mapviewer/src/store/modules/search.store.js
@@ -77,6 +77,7 @@ const actions = {
     ) => {
         let results = []
         commit('setSearchQuery', { query, dispatcher })
+        console.log('setSearchQuery', query, originUrlParam, shouldCenter, dispatcher)
         // only firing search if query is longer than or equal to 2 chars
         if (query.length >= 2) {
             const currentProjection = rootState.position.projection
@@ -99,6 +100,7 @@ const actions = {
             // for example: when we are sharing a position with a search query. In those situation, the
             // 'zoom to extent' should be avoided. We center by default.
             if (extractedCoordinate && shouldCenter) {
+                console.log('valid extractedCoordinate', extractedCoordinate,shouldCenter)
                 let coordinates = [...extractedCoordinate.coordinate]
                 if (extractedCoordinate.coordinateSystem !== currentProjection) {
                     // special case for LV03 input, we can't use proj4 to transform them into
@@ -106,12 +108,14 @@ const actions = {
                     // So we pass through a LV95 reframe (done by a backend service that knows all deformations between the two)
                     // and then go to the wanted coordinate system
                     if (extractedCoordinate.coordinateSystem === LV03) {
+                        console.log('extractedCoordinate.coordinateSystem === LV03')
                         coordinates = await reframe({
                             inputProjection: LV03,
                             inputCoordinates: coordinates,
                             outputProjection: currentProjection,
                         })
                     } else {
+                        console.log('extractedCoordinate.coordinateSystem != LV03')
                         coordinates = reprojectAndRound(
                             extractedCoordinate.coordinateSystem,
                             currentProjection,
@@ -162,6 +166,7 @@ const actions = {
                     dispatcher: dispatcherWhat3words,
                 })
             } else {
+                console.log('go to else')
                 try {
                     results = await search({
                         outputProjection: currentProjection,

--- a/packages/mapviewer/src/store/modules/search.store.js
+++ b/packages/mapviewer/src/store/modules/search.store.js
@@ -73,11 +73,11 @@ const actions = {
      */
     setSearchQuery: async (
         { commit, rootState, dispatch, getters },
-        { query = '', originUrlParam = false, shouldCenter = true, dispatcher }
+        { query = '', originUrlParam = false, dispatcher }
     ) => {
         let results = []
         commit('setSearchQuery', { query, dispatcher })
-        log.debug('setSearchQuery', query, originUrlParam, shouldCenter, dispatcher)
+        log.debug('setSearchQuery', query, originUrlParam, dispatcher)
         // only firing search if query is longer than or equal to 2 chars
         if (query.length >= 2) {
             const currentProjection = rootState.position.projection
@@ -96,11 +96,8 @@ const actions = {
                 }
             }
 
-            // there are situations where we don't want to center on the features or coordinates searched.
-            // for example: when we are sharing a position with a search query. In those situation, the
-            // 'zoom to extent' should be avoided. We center by default.
-            if (extractedCoordinate && shouldCenter) {
-                log.debug('valid extractedCoordinate', extractedCoordinate,shouldCenter)
+            if (extractedCoordinate) {
+                log.debug('valid extractedCoordinate', extractedCoordinate)
                 let coordinates = [...extractedCoordinate.coordinate]
                 if (extractedCoordinate.coordinateSystem !== currentProjection) {
                     // special case for LV03 input, we can't use proj4 to transform them into
@@ -142,7 +139,7 @@ const actions = {
                     })
                 }
                 dispatch('setPinnedLocation', { coordinates, dispatcher: dispatcherCoordinate })
-            } else if (what3wordLocation && shouldCenter) {
+            } else if (what3wordLocation) {
                 const dispatcherWhat3words = `${dispatcher}/search.store/setSearchQuery/what3words`
                 dispatch('setCenter', {
                     center: what3wordLocation,

--- a/packages/mapviewer/src/store/plugins/redo-search-when-needed.plugin.js
+++ b/packages/mapviewer/src/store/plugins/redo-search-when-needed.plugin.js
@@ -1,5 +1,3 @@
-import log from '@geoadmin/log'
-
 import { SET_LANG_MUTATION_KEY } from '@/store/modules/i18n.store'
 
 /**
@@ -21,7 +19,6 @@ const redoSearchWhenNeeded = (store) => {
     store.subscribe((mutation) => {
         if (mutation.type === SET_LANG_MUTATION_KEY) {
             // we redispatch the same query to the search store (the lang will be picked by the search store)
-            log.debug('lang changed, redoing search')
             redoSearch()
         } else if (
             mutation.type === 'setLayers' &&

--- a/packages/mapviewer/src/store/plugins/redo-search-when-needed.plugin.js
+++ b/packages/mapviewer/src/store/plugins/redo-search-when-needed.plugin.js
@@ -1,3 +1,5 @@
+import log from '@geoadmin/log'
+
 import { SET_LANG_MUTATION_KEY } from '@/store/modules/i18n.store'
 import coordinateFromString from '@/utils/coordinates/coordinateExtractors'
 
@@ -27,6 +29,7 @@ const redoSearchWhenNeeded = (store) => {
     store.subscribe((mutation) => {
         if (mutation.type === SET_LANG_MUTATION_KEY) {
             // we redispatch the same query to the search store (the lang will be picked by the search store)
+            log.debug('lang changed, redoing search')
             redoSearch()
         } else if (
             mutation.type === 'setLayers' &&

--- a/packages/mapviewer/src/store/plugins/redo-search-when-needed.plugin.js
+++ b/packages/mapviewer/src/store/plugins/redo-search-when-needed.plugin.js
@@ -1,7 +1,6 @@
 import log from '@geoadmin/log'
 
 import { SET_LANG_MUTATION_KEY } from '@/store/modules/i18n.store'
-import coordinateFromString from '@/utils/coordinates/coordinateExtractors'
 
 /**
  * Redo the search results on lang change if the search query is defined
@@ -11,15 +10,8 @@ import coordinateFromString from '@/utils/coordinates/coordinateExtractors'
 const redoSearchWhenNeeded = (store) => {
     function redoSearch() {
         if (store.state.search.query.length > 2) {
-            let shouldCenter = store.state.position.crossHair === null
-            const extractedCoordinate = coordinateFromString(store.state.search.query)
-            if (extractedCoordinate) {
-                shouldCenter = true
-            }
             store.dispatch('setSearchQuery', {
                 query: store.state.search.query,
-                // we don't center on the search query when redoing a search if there is a crosshair
-                shouldCenter: shouldCenter,
                 originUrlParam: true, // necessary to select the first result if there is only one else it will not be because this redo search is done every time the page loaded
                 dispatcher: 'redoSearchWhenNeeded',
             })

--- a/packages/mapviewer/src/store/plugins/redo-search-when-needed.plugin.js
+++ b/packages/mapviewer/src/store/plugins/redo-search-when-needed.plugin.js
@@ -1,4 +1,5 @@
 import { SET_LANG_MUTATION_KEY } from '@/store/modules/i18n.store'
+import coordinateFromString from '@/utils/coordinates/coordinateExtractors'
 
 /**
  * Redo the search results on lang change if the search query is defined
@@ -8,11 +9,17 @@ import { SET_LANG_MUTATION_KEY } from '@/store/modules/i18n.store'
 const redoSearchWhenNeeded = (store) => {
     function redoSearch() {
         if (store.state.search.query.length > 2) {
+            let shouldCenter = store.state.position.crossHair === null
+            const extractedCoordinate = coordinateFromString(store.state.search.query)
+            if (extractedCoordinate) {
+                shouldCenter = true
+            }
             store.dispatch('setSearchQuery', {
                 query: store.state.search.query,
                 // we don't center on the search query when redoing a search if there is a crosshair
-                shouldCenter: store.state.position.crossHair === null,
+                shouldCenter: shouldCenter,
                 originUrlParam: true, // necessary to select the first result if there is only one else it will not be because this redo search is done every time the page loaded
+                dispatcher: 'redoSearchWhenNeeded',
             })
         }
     }

--- a/packages/mapviewer/tests/cypress/support/commands.js
+++ b/packages/mapviewer/tests/cypress/support/commands.js
@@ -85,7 +85,7 @@ Cypress.Commands.add(
             queryParams.lang = 'en'
         }
         if (
-            !['lat', 'lon', 'x', 'y', 'center', '3d'].some((unwantedKey) =>
+            !['lat', 'lon', 'x', 'y', 'center', '3d', 'swisssearch'].some((unwantedKey) =>
                 Object.keys(queryParams).includes(unwantedKey)
             )
         ) {

--- a/packages/mapviewer/tests/cypress/support/commands.js
+++ b/packages/mapviewer/tests/cypress/support/commands.js
@@ -81,6 +81,10 @@ Cypress.Commands.add(
             }
         }
 
+        if (!('lang' in queryParams)) {
+            queryParams.lang = 'en'
+        }
+
         if (
             !['lat', 'lon', 'x', 'y', 'center', '3d', 'swisssearch'].some((unwantedKey) =>
                 Object.keys(queryParams).includes(unwantedKey)

--- a/packages/mapviewer/tests/cypress/support/commands.js
+++ b/packages/mapviewer/tests/cypress/support/commands.js
@@ -81,9 +81,6 @@ Cypress.Commands.add(
             }
         }
 
-        // if (!('lang' in queryParams)) {
-        //     queryParams.lang = 'en'
-        // }
         if (
             !['lat', 'lon', 'x', 'y', 'center', '3d', 'swisssearch'].some((unwantedKey) =>
                 Object.keys(queryParams).includes(unwantedKey)

--- a/packages/mapviewer/tests/cypress/support/commands.js
+++ b/packages/mapviewer/tests/cypress/support/commands.js
@@ -67,7 +67,7 @@ Cypress.Commands.add(
         queryParams = {},
         withHash = true,
         geolocationMockupOptions = { latitude: 47, longitude: 7, errorCode: null },
-        fixturesAndIntercepts = {}
+        fixturesAndIntercepts = {},
     ) => {
         // Intercepts passed as parameters to "fixturesAndIntercepts" will overwrite the correspondent
         // default intercept.
@@ -81,9 +81,9 @@ Cypress.Commands.add(
             }
         }
 
-        if (!('lang' in queryParams)) {
-            queryParams.lang = 'en'
-        }
+        // if (!('lang' in queryParams)) {
+        //     queryParams.lang = 'en'
+        // }
         if (
             !['lat', 'lon', 'x', 'y', 'center', '3d', 'swisssearch'].some((unwantedKey) =>
                 Object.keys(queryParams).includes(unwantedKey)

--- a/packages/mapviewer/tests/cypress/tests-e2e/search/search-results.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/search/search-results.cy.js
@@ -502,7 +502,7 @@ describe('Test the search bar result handling', () => {
         cy.get('@locationSearchResults').should('not.be.visible')
     })
 
-    it('handle swisssearch and crosshair together correctly', () => {
+    it.only('handle swisssearch and crosshair together correctly', () => {
         const latitude = 46.3163
         const longitude = 7.6347
         const swisssearch = `${latitude},${longitude}`
@@ -515,10 +515,6 @@ describe('Test the search bar result handling', () => {
             longitude,
             latitude,
         ])
-
-        // For some reason, the center is modified when the crosshair is set, but only in the test
-        const newX = 2660013.5
-        const newY = 1185172
 
         // =========================================================================== //
         cy.log('Legacy parser / router (without #map part in the URL)')
@@ -552,17 +548,17 @@ describe('Test the search bar result handling', () => {
         )
         // Check the query and the center of the map
         cy.readStoreValue('state.search.query').should('eq', swisssearch)
-        cy.readStoreValue('state.position.center[0]').should('be.approximately', newX, 0.1)
-        cy.readStoreValue('state.position.center[1]').should('be.approximately', newY, 0.1)
+        cy.readStoreValue('state.position.center[0]').should('be.approximately', x, 0.1)
+        cy.readStoreValue('state.position.center[1]').should('be.approximately', y, 0.1)
         // Check the location of pinnedLocation
-        // cy.readStoreValue('state.map.pinnedLocation[0]').should('be.approximately', x, 0.1)
-        // cy.readStoreValue('state.map.pinnedLocation[1]').should('be.approximately', y, 0.1)
+        cy.readStoreValue('state.map.pinnedLocation[0]').should('be.approximately', x, 0.1)
+        cy.readStoreValue('state.map.pinnedLocation[1]').should('be.approximately', y, 0.1)
         // Check the crosshair position
         cy.readStoreValue('state.position.crossHair').should('eq', CrossHairs.cross)
-        cy.readStoreValue('state.position.crossHairPosition[0]').should('be.approximately', newX, 0.1)
-        cy.readStoreValue('state.position.crossHairPosition[1]').should('be.approximately', newY, 0.1)
+        cy.readStoreValue('state.position.crossHairPosition[0]').should('be.approximately', x, 0.1)
+        cy.readStoreValue('state.position.crossHairPosition[1]').should('be.approximately', y, 0.1)
 
-        // =========================================================================== //
+        // // =========================================================================== //
         cy.log('Current parser / router (with #map part in the URL)')
         // --------------------------------------------------------------------------- //
         cy.log('Swisssearch only')
@@ -595,15 +591,15 @@ describe('Test the search bar result handling', () => {
 
         // Check the query and the center of the map
         cy.readStoreValue('state.search.query').should('eq', swisssearch)
-        cy.readStoreValue('state.position.center[0]').should('be.approximately', newX, 0.1)
-        cy.readStoreValue('state.position.center[1]').should('be.approximately', newY, 0.1)
+        cy.readStoreValue('state.position.center[0]').should('be.approximately', x, 0.1)
+        cy.readStoreValue('state.position.center[1]').should('be.approximately', y, 0.1)
         // Check the location of pinnedLocation
         cy.readStoreValue('state.map.pinnedLocation[0]').should('be.approximately', x, 0.1)
         cy.readStoreValue('state.map.pinnedLocation[1]').should('be.approximately', y, 0.1)
         // Check the crosshair position
         cy.readStoreValue('state.position.crossHair').should('eq', CrossHairs.cross)
-        cy.readStoreValue('state.position.crossHairPosition[0]').should('be.approximately', newX, 0.1)
-        cy.readStoreValue('state.position.crossHairPosition[1]').should('be.approximately', newY, 0.1)
+        cy.readStoreValue('state.position.crossHairPosition[0]').should('be.approximately', x, 0.1)
+        cy.readStoreValue('state.position.crossHairPosition[1]').should('be.approximately', y, 0.1)
 
         // --------------------------------------------------------------------------- //
         cy.log('Swisssearch with crosshair and crosshair location')
@@ -617,8 +613,8 @@ describe('Test the search bar result handling', () => {
 
         // Check the query and the center of the map
         cy.readStoreValue('state.search.query').should('eq', swisssearch)
-        cy.readStoreValue('state.position.center[0]').should('be.approximately', newX, 0.1)
-        cy.readStoreValue('state.position.center[1]').should('be.approximately', newY, 0.1)
+        cy.readStoreValue('state.position.center[0]').should('be.approximately', x, 0.1)
+        cy.readStoreValue('state.position.center[1]').should('be.approximately', y, 0.1)
         // Check the location of pinnedLocation
         cy.readStoreValue('state.map.pinnedLocation[0]').should('be.approximately', x, 0.1)
         cy.readStoreValue('state.map.pinnedLocation[1]').should('be.approximately', y, 0.1)

--- a/packages/mapviewer/tests/cypress/tests-e2e/search/search-results.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/search/search-results.cy.js
@@ -57,8 +57,8 @@ function testQueryPositionCrosshairStore({
     searchQuery,
     expectedCenter,
     expectedPinnedLocation,
-    expectedCrosshair = null,
-    expectedCrosshairPosition = null,
+    expectedCrosshair,
+    expectedCrosshairPosition,
 }) {
     // check the query
     cy.readStoreValue('state.search.query').should('eq', searchQuery)
@@ -71,11 +71,8 @@ function testQueryPositionCrosshairStore({
         checkLocation(expectedPinnedLocation, pinnedLocation)
     )
     // check the crosshair
-    if (expectedCrosshair !== null) {
-        cy.readStoreValue('state.position.crossHair').should('eq', expectedCrosshair)
-    } else {
-        cy.readStoreValue('state.position.crossHair').should('be.null')
-    }
+    cy.readStoreValue('state.position.crossHair').should('eq', expectedCrosshair)
+
     // check the crosshair position
     if (expectedCrosshairPosition !== null) {
         cy.readStoreValue('state.position.crossHairPosition').should((crossHairPosition) =>

--- a/packages/mapviewer/tests/cypress/tests-e2e/search/search-results.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/search/search-results.cy.js
@@ -542,168 +542,104 @@ describe('Test the search bar result handling', () => {
     it('handle swisssearch and crosshair together correctly', () => {
         const latitude = 46.3163
         const longitude = 7.6347
-        const swisssearchCoordinate = `${latitude},${longitude}`
+        const swissSearchString = `${latitude},${longitude}`
 
-        const [x, y] = proj4(WGS84.epsg, DEFAULT_PROJECTION.epsg, [longitude, latitude])
+        const [swissSearchX, swissSearchY] = proj4(WGS84.epsg, DEFAULT_PROJECTION.epsg, [longitude, latitude])
+        const swissSearchXYCoordinates = [swissSearchX, swissSearchY]
 
         // Cross hair position
         const crossHairX = 2660113
         const crossHairY = 1185272
+        const crossHairXYCoordinates = [crossHairX, crossHairY]
 
         // =========================================================================== //
         cy.log('Legacy parser / router (without #map part in the URL)')
         // --------------------------------------------------------------------------- //
-        cy.log('Swisssearch only')
+        cy.log('Swisssearch only -> center to swisssearch coordinates')
         cy.goToMapView(
             {
-                swisssearch: swisssearchCoordinate,
+                swisssearch: swissSearchString,
             },
             false
         )
         testQueryPositionCrosshairStore({
-            searchQuery: swisssearchCoordinate,
-            expectedCenter: [x, y],
-            expectedPinnedLocation: [x, y],
+            searchQuery: swissSearchString,
+            expectedCenter: swissSearchXYCoordinates,
+            expectedPinnedLocation: swissSearchXYCoordinates,
             expectedCrosshair: null,
             expectedCrosshairPosition: null,
         })
 
         // --------------------------------------------------------------------------- //
-        cy.log('Swisssearch with crosshair')
+        cy.log('Swisssearch with crosshair -> center to swisssearch coordinates with crosshair in swisssearch coordinate')
         cy.goToMapView(
             {
-                swisssearch: swisssearchCoordinate,
+                swisssearch: swissSearchString,
                 crosshair: CrossHairs.cross,
             },
             false
         )
         testQueryPositionCrosshairStore({
-            searchQuery: swisssearchCoordinate,
-            expectedCenter: [x, y],
-            expectedPinnedLocation: [x, y],
+            searchQuery: swissSearchString,
+            expectedCenter: swissSearchXYCoordinates,
+            expectedPinnedLocation: swissSearchXYCoordinates,
             expectedCrosshair: CrossHairs.cross,
-            expectedCrosshairPosition: [x, y],
+            expectedCrosshairPosition: swissSearchXYCoordinates,
         })
 
         // =========================================================================== //
         cy.log('Current parser / router (with #map part in the URL)')
 
         // --------------------------------------------------------------------------- //
-        cy.log('Swisssearch only')
+        cy.log('Swisssearch only -> center to swisssearch coordinates')
         cy.goToMapView(
             {
-                swisssearch: swisssearchCoordinate,
+                swisssearch: swissSearchString,
             },
             true
         )
         testQueryPositionCrosshairStore({
-            searchQuery: swisssearchCoordinate,
-            expectedCenter: [x, y],
-            expectedPinnedLocation: [x, y],
+            searchQuery: swissSearchString,
+            expectedCenter: swissSearchXYCoordinates,
+            expectedPinnedLocation: swissSearchXYCoordinates,
             expectedCrosshair: null,
             expectedCrosshairPosition: null,
         })
 
         // --------------------------------------------------------------------------- //
-        cy.log('Swisssearch with crosshair')
+        cy.log('Swisssearch with crosshair -> center to swisssearch coordinates with crosshair in swisssearch coordinate')
         cy.goToMapView(
             {
-                swisssearch: swisssearchCoordinate,
+                swisssearch: swissSearchString,
                 crosshair: CrossHairs.cross,
             },
             true
         )
         testQueryPositionCrosshairStore({
-            searchQuery: swisssearchCoordinate,
-            expectedCenter: [x, y],
-            expectedPinnedLocation: [x, y],
+            searchQuery: swissSearchString,
+            expectedCenter: swissSearchXYCoordinates,
+            expectedPinnedLocation: swissSearchXYCoordinates,
             expectedCrosshair: CrossHairs.cross,
-            expectedCrosshairPosition: [x, y],
+            expectedCrosshairPosition: swissSearchXYCoordinates,
         })
 
         // --------------------------------------------------------------------------- //
-        cy.log('Swisssearch with crosshair and crosshair location')
+        cy.log('Swisssearch with crosshair and crosshair location -> center to swisssearch coordinates with crosshair in crosshair coordinate')
         cy.goToMapView(
             {
-                swisssearch: swisssearchCoordinate,
+                swisssearch: swissSearchString,
                 crosshair: `${CrossHairs.cross},${crossHairX},${crossHairY}`,
             },
             true
         )
         testQueryPositionCrosshairStore({
-            searchQuery: swisssearchCoordinate,
-            expectedCenter: [x, y],
-            expectedPinnedLocation: [x, y],
+            searchQuery: swissSearchString,
+            expectedCenter: swissSearchXYCoordinates,
+            expectedPinnedLocation: swissSearchXYCoordinates,
             expectedCrosshair: CrossHairs.cross,
-            expectedCrosshairPosition: [crossHairX, crossHairY],
+            expectedCrosshairPosition: crossHairXYCoordinates,
         })
 
     })
 
-})
-
-describe('Test the swisssearch that happens to be valid coordinate and valid locations', () => {
-    it.skip('handle swisssearch and crosshair together correctly with a location that is also a valid coordinate', () => {
-        // --------------------------------------------------------------------------- //
-        // This is a location that is a valid coordinate but also will return a location on the search service
-        const latitudeLocation = 46.5057
-        const longitudeLocation = 6.6278
-        const swisssearchCoordinateLocation = `${latitudeLocation},${longitudeLocation}`
-        const [xLocation, yLocation] = proj4(WGS84.epsg, DEFAULT_PROJECTION.epsg, [
-            longitudeLocation,
-            latitudeLocation,
-        ])
-        const response = {
-            results: [
-                {
-                    attrs: {
-                        detail: 'dorfstrasse 46 5057 reitnau 4281 reitnau ch ag',
-                        label: 'Dorfstrasse 46 <b>5057 Reitnau</b>',
-                        lat: 47.247169494628906,
-                        lon: 8.048954963684082,
-                        x: 1233096.375,
-                        y: 2646205.0,
-                    },
-                },
-            ],
-        }
-        cy.mockupBackendResponse(
-            `/rest/services/ech/SearchServer*searchText=${latitudeLocation},${longitudeLocation}*?type=locations*`,
-            response,
-            'search-locations-bug'
-        )
-
-        cy.log('Swisssearch that also valid location with crosshair only')
-        // cy.goToMapView() // go to map view first to load the map, still no idea why
-        cy.goToMapView(
-            {
-                swisssearch: swisssearchCoordinateLocation,
-                crosshair: `${CrossHairs.marker}`,
-                // swisssearch_autoselect: 'true',
-            },
-            true
-        )
-        // Wait for the intercept to be called
-        // Just to make sure the request is done
-        cy.wait('@search-locations-bug').then((interception) => {
-            // Log the intercepted request and response for debugging
-            cy.log('Intercepted Request:', interception.request);
-            cy.log('Intercepted Response:', interception.response);
-
-            // Make assertions on the intercepted request
-            expect(interception.request.url).to.include('searchText=46.5057,6.6278');
-            expect(interception.request.method).to.equal('GET');
-
-            // Make assertions on the intercepted response
-            expect(interception.response.body.results).to.have.length(1);
-            expect(interception.response.body.results[0].attrs.detail).to.equal('dorfstrasse 46 5057 reitnau 4281 reitnau ch ag');
-            testQueryPositionCrosshairStore({
-                searchQuery: swisssearchCoordinateLocation,
-                expectedCenter: [xLocation, yLocation],
-                expectedPinnedLocation: [xLocation, yLocation],
-                expectedCrosshair: CrossHairs.cross,
-                expectedCrosshairPosition: [xLocation, yLocation],
-            })
-        })
-    })
 })


### PR DESCRIPTION
[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-1480-swissearch-crosshair/index.html)

## Bug description

The issue occurs when the swisssearch value is a valid location and also a valid coordinate. An example from the JIRA issue: http://map.geo.admin.ch/?swisssearch=46.5057,6.6278&zoom=8&crosshair=marker. The query is **swisssearch=46.5057,6.6278**. It is a valid coordinate, and when we search the location, it returns a valid object:
```json
{
    "fuzzy": "true",
    "results": [
        {
            "attrs": {
                "detail": "dorfstrasse 46 5057 reitnau 4281 reitnau ch ag",
                "featureId": "3098536_0",
                "geom_quadindex": "021131022303023202112",
                "geom_st_box2d": "BOX(2646205.076 1233096.405,2646205.076 1233096.405)",
                "label": "Dorfstrasse 46 <b>5057 Reitnau</b>",
                "lat": 47.247169494628906,
                "lon": 8.048954963684082,
                "num": 46,
                "objectclass": "",
                "origin": "address",
                "rank": 7,
                "x": 1233096.375,
                "y": 2646205.0,
                "zoomlevel": 10
            },
            "id": 974163,
            "weight": 1546
        }
    ]
}
```

## Fix

It seems we don't keep the swisssearch in the URL anymore when sharing location, so the center should be set to the swisssearch location.

## Result

### Legacy URL Parser

- swisssearch=x,y: https://sys-map.dev.bgdi.ch/preview/bug-pb-1480-swissearch-crosshair/index.html?swisssearch=46.3163,7.6347
- swisssearch=x,y and crosshair: https://sys-map.dev.bgdi.ch/preview/bug-pb-1480-swissearch-crosshair/index.html?swisssearch=46.3163,7.6347&crosshair=cross

**With the buggy coordinate**
- Only swisssearch: https://sys-map.dev.bgdi.ch/preview/bug-pb-1480-swissearch-crosshair/index.html?swisssearch=46.5057,6.6278
- Swisssearch and crosshair: https://sys-map.dev.bgdi.ch/preview/bug-pb-1480-swissearch-crosshair/index.html?swisssearch=46.5057,6.6278&crosshair=cross


### New URL Parser

- swisssearch=x,y: https://sys-map.dev.bgdi.ch/preview/bug-pb-1480-swissearch-crosshair/index.html#/map?swisssearch=46.3163,7.6347
- swisssearch=x,y and crosshair:https://sys-map.dev.bgdi.ch/preview/bug-pb-1480-swissearch-crosshair/index.html#/map?swisssearch=46.3163,7.6347&crosshair=cross
- swisssearch=x,y and crosshair with crosshair position: https://sys-map.dev.bgdi.ch/preview/bug-pb-1480-swissearch-crosshair/index.html#/map?swisssearch=46.3163,7.6347&crosshair=cross,2660113,1185272

**With the buggy coordinate**
- Only swisssearch: https://sys-map.dev.bgdi.ch/preview/bug-pb-1480-swissearch-crosshair/index.html#/map?swisssearch=46.5057,6.6278
- Swisssearch and crosshair: https://sys-map.dev.bgdi.ch/preview/bug-pb-1480-swissearch-crosshair/index.html#/map?swisssearch=46.5057,6.6278&crosshair=cross
- swisssearch and crosshair + location: https://sys-map.dev.bgdi.ch/preview/bug-pb-1480-swissearch-crosshair/index.html#/map?swisssearch=46.5057,6.6278&crosshair=cross,2660113,1185272

### Full list of URL variations

I write all possible combinations of the URL [here](https://docs.google.com/spreadsheets/d/1mH_ZVba6OvOlWPl4REC6pfz447OLYbPwSOw_o4E6iZY/edit?usp=sharing) 

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-1480-swissearch-crosshair/index.html)