### PR TITLE
PB-1435 Fix the german link to the feedback help page anchor

### DIFF
--- a/packages/mapviewer/src/modules/i18n/README.md
+++ b/packages/mapviewer/src/modules/i18n/README.md
@@ -55,7 +55,7 @@ See [i18n guide](https://kazupon.github.io/vue-i18n/guide/formatting.html)
 
 ## update translations
 
-See [the main README.md's section on that](../../../README.md#tooling-for-translation-update)
+See [the main README.md's section on that](../../../../../CONTRIBUTING.md#tooling-for-translation-update)
 
 ## State properties
 

--- a/packages/mapviewer/src/modules/i18n/locales/de.json
+++ b/packages/mapviewer/src/modules/i18n/locales/de.json
@@ -246,7 +246,7 @@
     "feedback_mail": "4. Ihre E-Mail Adresse :",
     "feedback_modify_drawing": "Zeichnung editieren",
     "feedback_more_info_text": "Weitere Informationen zu den Kategorien",
-    "feedback_more_info_url": "https://www.geo.admin.ch/de/kartenviewer-navigation-und-orientierung#Problem-melden#Die-Problem-Melden-Kategorien",
+    "feedback_more_info_url": "https://www.geo.admin.ch/de/kartenviewer-navigation-und-orientierung#Problem-melden",
     "feedback_permalink": "Folgender Link wird übermittelt: ",
     "feedback_placeholder": "Fügen Sie eine .pdf, .zip, .jpg, .jpeg, .kml, .kmz oder .gpx Datei hinzu",
     "feedback_rating_text": "Teilen Sie uns mit, wie Sie sich mit unserem Kartenviewer fühlen",


### PR DESCRIPTION
The anchor in the link to the German version of the help for the feedback form wasn't correct

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1435-feedback-help-link/index.html)