### PR TITLE
PB-1261: add test case for void background

### DIFF
--- a/packages/mapviewer/src/router/storeSync/storeSync.config.js
+++ b/packages/mapviewer/src/router/storeSync/storeSync.config.js
@@ -2,7 +2,6 @@ import { allCoordinateSystems } from '@geoadmin/coordinates'
 
 import { getStandardValidationResponse } from '@/api/errorQueues.api'
 import { DEFAULT_PROJECTION } from '@/config/map.config'
-import { IS_TESTING_WITH_CYPRESS } from '@/config/staging.config'
 import { SUPPORTED_LANG } from '@/modules/i18n'
 import createBaseUrlOverrideParamConfig from '@/router/storeSync/BaseUrlOverrideParamConfig.class.js'
 import CameraParamConfig from '@/router/storeSync/CameraParamConfig.class'
@@ -127,9 +126,7 @@ const storeSyncConfig = [
         validateUrlInput: (store, query) =>
             getStandardValidationResponse(
                 query,
-                // in cypress, the backgroundLayers is undefined, so we skip this check
-                IS_TESTING_WITH_CYPRESS ||
-                    query === 'void' ||
+                query === 'void' ||
                     store.getters.backgroundLayers?.map((layer) => layer.id).includes(query),
                 'bgLayer'
             ),

--- a/packages/mapviewer/tests/cypress/tests-e2e/layers.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/layers.cy.js
@@ -555,6 +555,10 @@ describe('Test of layer handling', () => {
         })
     })
     context('Background layer in URL at app startup', () => {
+        it('sets the background to the void layer if we set the bgLayer parameter to "void"', () => {
+            cy.goToMapView({ bgLayer: 'void' })
+            cy.readStoreValue('getters.currentBackgroundLayer').should('be.null')
+        })
         it('sets the background to the topic default if none is defined in the URL', () => {
             cy.fixture('topics.fixture').then((topicFixtures) => {
                 const [defaultTopic] = topicFixtures.topics


### PR DESCRIPTION
- Removed the cypress bypass in the background layer validation.
	- At one point, cypress was sending an `undefined` parameter rather than nothing, which caused the validation to crash.
	- This is apparently no longer the case, so we can get rid of this exception.
- Added a test to ensure we are having the 'void' layer as a background when requesting the 'void' layer specifically.

remove unused import

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-1261-tests-for-bg-layers/index.html)