### PR TITLE
PB-1530 : fix menu issues on Safari

### DIFF
--- a/packages/mapviewer/src/modules/menu/components/header/ConfederationFullLogo.vue
+++ b/packages/mapviewer/src/modules/menu/components/header/ConfederationFullLogo.vue
@@ -127,7 +127,9 @@ $letterSpacing: calc((78 / 1000) * 1em);
     }
 
     .swiss-flag {
-        height: fit-content;
+        // because Safari doesn't understand fit-content, we need to fix the height to some pixel height
+        // Without that, Safari spreads the flag way down over the menu, and breaks the menu usability
+        height: 36px;
     }
 
     &.dev-site {


### PR DESCRIPTION
The new confederation logo was using some CSS properties that aren't well supported by Safari, and the Swiss flag was stretching way over the logo because of that. When users were clicking on the menu elements, they were in fact clicking on the flag (invisible container) and thus being thrown back to the "home" view.