### PR TITLE
PB-1318 : give a better error message on deleted KMLs

### DIFF
--- a/packages/mapviewer/src/modules/i18n/locales/de.json
+++ b/packages/mapviewer/src/modules/i18n/locales/de.json
@@ -382,6 +382,7 @@
     "linkedin_tooltip": "Teilen Sie diese Karte auf LinkedIn",
     "load_local_file": "Laden...",
     "loading": "Laden",
+    "loading_error_file_deleted": "Die Datei konnte nicht geladen werden, da sie von ihrem Besitzer gelöscht wurde.",
     "loading_error_network_failure": "Laden fehlgeschlagen, auf die Datei kann nicht zugegriffen werden",
     "loading_external_layer": "Laden der externen Layer",
     "loading_file": "Laden...",

--- a/packages/mapviewer/src/modules/i18n/locales/en.json
+++ b/packages/mapviewer/src/modules/i18n/locales/en.json
@@ -382,6 +382,7 @@
     "linkedin_tooltip": "Share this map on LinkedIn",
     "load_local_file": "Load",
     "loading": "Loading",
+    "loading_error_file_deleted": "Failed to load, the file was deleted by its owner",
     "loading_error_network_failure": "Failed to load, file not accessible",
     "loading_external_layer": "Loading external layer",
     "loading_file": "Loading file...",

--- a/packages/mapviewer/src/modules/i18n/locales/fr.json
+++ b/packages/mapviewer/src/modules/i18n/locales/fr.json
@@ -382,6 +382,7 @@
     "linkedin_tooltip": "Partager cette carte sur LinkedIn",
     "load_local_file": "Charger",
     "loading": "Chargement",
+    "loading_error_file_deleted": "Échec du chargement, le fichier a été supprimé par son propriétaire",
     "loading_error_network_failure": "Échec du chargement, fichier non accessible",
     "loading_external_layer": "Chargement de la couche externe",
     "loading_file": "Chargement du fichier...",

--- a/packages/mapviewer/src/modules/i18n/locales/it.json
+++ b/packages/mapviewer/src/modules/i18n/locales/it.json
@@ -382,6 +382,7 @@
     "linkedin_tooltip": "Condivida la carta su LinkedIn",
     "load_local_file": "Caricare",
     "loading": "Caricamento",
+    "loading_error_file_deleted": "Caricamento fallito, il file è stato cancellato dal suo proprietario",
     "loading_error_network_failure": "Impossibile caricare, file non accessibile",
     "loading_external_layer": "Caricamento del livello esterno",
     "loading_file": "Caricamento del file...",

--- a/packages/mapviewer/src/modules/i18n/locales/rm.json
+++ b/packages/mapviewer/src/modules/i18n/locales/rm.json
@@ -380,6 +380,7 @@
     "linkedin_tooltip": "Partais quella charta sin LinkedIn",
     "load_local_file": "Chargiar",
     "loading": "Chargiada",
+    "loading_error_file_deleted": "La datoteca n'ha betg pudì vegnir chargiada, cunquai ch'ella è vegnida stizzada da ses possessur.",
     "loading_error_network_failure": "Na pudì cargar, il file na stat betg accessibel.",
     "loading_external_layer": "Chargiar la strata esterna",
     "loading_file": "La datoteca vegn chargiada",

--- a/packages/mapviewer/src/store/plugins/load-kml-kmz-data.plugin.js
+++ b/packages/mapviewer/src/store/plugins/load-kml-kmz-data.plugin.js
@@ -99,7 +99,7 @@ async function loadData(store, kmlLayer) {
             layerId: kmlLayer.id,
             isExternal: kmlLayer.isExternal,
             baseUrl: kmlLayer.baseUrl,
-            error: new ErrorMessage('loading_error_network_failure'),
+            error: new ErrorMessage(kmlLayer.isExternal ? 'loading_error_network_failure' : 'loading_error_file_deleted'),
             ...dispatcher,
         })
         // stopping there, there won't be anything to do with this file


### PR DESCRIPTION
Trying to better convey why the KML couldn't be loaded, to help reduce questions on our helpdesk team about it.