### PR TITLE
Add vitest workspace configuration to make tests work in vscode

### DIFF
--- a/packages/mapviewer/package.json
+++ b/packages/mapviewer/package.json
@@ -32,8 +32,8 @@
         "test:e2e:desktop": "start-server-and-test preview 8080 'cypress open --e2e --config viewportWidth=1440,viewportHeight=900'",
         "test:e2e:headless": "start-server-and-test dev 8080 'cypress run'",
         "test:e2e:tablet": "start-server-and-test preview 8080 'cypress open --e2e --config viewportWidth=768,viewportHeight=1024'",
-        "test:unit": "pnpm run delete:reports:unit && vitest --run --mode development --environment jsdom",
-        "test:unit:watch": "pnpm run delete:reports:unit && vitest --mode development --environment jsdom",
+        "test:unit": "pnpm run delete:reports:unit && vitest --run --mode development",
+        "test:unit:watch": "pnpm run delete:reports:unit && vitest --mode development",
         "type-check": "vue-tsc -p tsconfig.json",
         "update:translations": "node scripts/generate-i18n-files.js"
     },

--- a/packages/mapviewer/vite.config.mts
+++ b/packages/mapviewer/vite.config.mts
@@ -134,6 +134,7 @@ export default defineConfig(({ mode, disableDevTools = false }) => {
             outputFile: 'tests/results/unit/unit-test-report.xml',
             silent: true,
             setupFiles: ['tests/setup-vitest.ts'],
+            environment: "jsdom"
         },
     }
 })

--- a/vitest.workspace.js
+++ b/vitest.workspace.js
@@ -1,0 +1,9 @@
+import { defineWorkspace } from 'vitest/config'
+
+export default defineWorkspace([
+    './vite.config.shared.js',
+    './packages/geoadmin-numbers/vite.config.js',
+    './packages/geoadmin-coordinates/vite.config.js',
+    './packages/mapviewer/vite.config.mts',
+    './packages/geoadmin-log/vite.config.js',
+])


### PR DESCRIPTION
The vitest plugin in vscode suggested using this vitest.workspace setup. This helps with running the unit tests from inside the editor, hence these changes.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-vitest-workspace/index.html)