### PR TITLE
PB-1448: add  back flaky kml admin test

### DIFF
--- a/packages/mapviewer/tests/cypress/tests-e2e/drawing.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/drawing.cy.js
@@ -1121,8 +1121,7 @@ describe('Drawing module tests', () => {
                 })
             })
         })
-        // way too flaky on the CI for some reason, will be worked on by https://jira.swisstopo.ch/browse/PB-1448
-        it.skip('manages the KML layer correctly if it comes attached with an adminId at startup', () => {
+        it('manages the KML layer correctly if it comes attached with an adminId at startup', () => {
             // Position of the marker defined in service-kml/lonelyMarker.kml
             const markerLatitude = 46.883715999352546
             const markerLongitude = 7.656108679791837


### PR DESCRIPTION
With the work done on PB-1548, we have solved a flakyness in the behavior of the drawing module. Which means the tests did not have any issues, our code had some issues.

We reinstate the tests so we can be warned when something is wrong

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-1448-add-back-kml-admin-test/index.html)