### PR TITLE
PB-1493 : Add iframe parameter to scroll / zoom with CTRL

### DIFF
--- a/packages/mapviewer/src/modules/i18n/locales/de.json
+++ b/packages/mapviewer/src/modules/i18n/locales/de.json
@@ -640,6 +640,8 @@
     "time_slider_legend_tooltip_partial_data": "Teilweise Daten",
     "time_slider_no_time_layer_active_url_warning": "Es ist nicht möglich, einen Zeitschieberegler hinzuzufügen, wenn keine aktiven Zeitkarten vorhanden sind",
     "title": "Titel",
+    "toggle_zooming_mode" : "Zoom nur mit der Ctrl/Cmd-Taste zulassen",
+    "toggle_zooming_mode_tooltip" : "Wenn Sie hier klicken, kann der Zoom Ihres iFrames nur durch Gedrückthalten der Ctrl/Cmd erfolgen.",
     "tooltip": "Tooltip",
     "topic_are_tooltip": "Bundesamt für Raumentwicklung",
     "topic_astra_tooltip": "Bundesamt für Strassen",
@@ -734,5 +736,6 @@
     "woodland": "Wald",
     "yellow": "Gelb",
     "zoom_in": "Vergrössere Kartenausschnitt",
-    "zoom_out": "Verkleinere Kartenausschnitt"
+    "zoom_out": "Verkleinere Kartenausschnitt",
+    "zooming_mode_warning" : "Zum Zoomen der Karte Strg/Cmd gedrückt halten"
 }

--- a/packages/mapviewer/src/modules/i18n/locales/en.json
+++ b/packages/mapviewer/src/modules/i18n/locales/en.json
@@ -640,6 +640,8 @@
     "time_slider_legend_tooltip_partial_data": "Partial data",
     "time_slider_no_time_layer_active_url_warning": "It is not possible to add a time slider, when there is no active time map available",
     "title": "Title",
+    "toggle_zooming_mode" : "Enable zooming only with Ctrl/Cmd key",
+    "toggle_zooming_mode_tooltip" : "By klicking this button, your iFrame's zooming will only be possible by keeping the Ctrl/Cmd button pressed.",
     "tooltip": "Tooltip",
     "topic_are_tooltip": "Federal Office for Spatial Development ",
     "topic_astra_tooltip": "Federal roads office",
@@ -734,5 +736,6 @@
     "woodland": "Forest",
     "yellow": "yellow",
     "zoom_in": "Zoom in",
-    "zoom_out": "Zoom out"
+    "zoom_out": "Zoom out",
+    "zooming_mode_warning" : "Hold Ctrl/Cmd while scrolling to zoom the map"
 }

--- a/packages/mapviewer/src/modules/i18n/locales/fr.json
+++ b/packages/mapviewer/src/modules/i18n/locales/fr.json
@@ -640,6 +640,8 @@
     "time_slider_legend_tooltip_partial_data": "Données partielles",
     "time_slider_no_time_layer_active_url_warning": "Il est impossible d'ajouter un curseur temporel lorsqu'il n'y a pas de cartes temporelles actives",
     "title": "Titre",
+    "toggle_zooming_mode" : "Permettre le zoom uniquement avec la touche Ctrl/Cmd",
+    "toggle_zooming_mode_tooltip" : "En cliquant ici, le zoom de votre iFrame ne sera possible qu'en maintenant le bouton Ctrl/Cmd enfoncé.",
     "tooltip": "Tooltip",
     "topic_are_tooltip": "Office fédéral du développement territorial ",
     "topic_astra_tooltip": "Office fédéral des routes",
@@ -734,5 +736,6 @@
     "woodland": "Forêt",
     "yellow": "jaune",
     "zoom_in": "Zoomer plus",
-    "zoom_out": "Zoomer moins"
+    "zoom_out": "Zoomer moins",
+    "zooming_mode_warning" : "Maintenir Ctrl/Cmd pour zoomer sur la carte"
 }

--- a/packages/mapviewer/src/modules/i18n/locales/it.json
+++ b/packages/mapviewer/src/modules/i18n/locales/it.json
@@ -640,6 +640,8 @@
     "time_slider_legend_tooltip_partial_data": "Dati parziali",
     "time_slider_no_time_layer_active_url_warning": "Non è possibile aggiungere un dispositivo di scorrimento temporale quando non sono presenti mappe temporali attive",
     "title": "Titolo",
+    "toggle_zooming_mode" : "Abilitare lo zoom solo con il tasto Ctrl/Cmd",
+    "toggle_zooming_mode_tooltip" : "Facendo clic qui, lo zoom dell'iFrame sarà possibile solo tenendo premuto il pulsante Ctrl/Cmd.",
     "tooltip": "Tooltip",
     "topic_are_tooltip": "Ufficio federale dello sviluppo territoriale ",
     "topic_astra_tooltip": "Ufficio federale delle strade",
@@ -734,5 +736,6 @@
     "woodland": "Foresta",
     "yellow": "giallo",
     "zoom_in": "Zoom in avanti",
-    "zoom_out": "Zoom indietro"
+    "zoom_out": "Zoom indietro",
+    "zooming_mode_warning" : "Mantenere Ctrl/Cmd premuto per zoomare la mappa"
 }

--- a/packages/mapviewer/src/modules/i18n/locales/rm.json
+++ b/packages/mapviewer/src/modules/i18n/locales/rm.json
@@ -638,6 +638,8 @@
     "time_slider_legend_tooltip_partial_data": "Datas parzialas",
     "time_slider_no_time_layer_active_url_warning": "I n'è betg pussaivel d'agiuntar in reglader da temp, sch'i na dat naginas cartas da temp activas",
     "title": "Titel",
+    "toggle_zooming_mode" : "Permetter il zoom exclusivamain cun la tasta da Ctrl/Cmd",
+    "toggle_zooming_mode_tooltip" : "Cun cliccar qua, il zoom da l'iFrame vegn mo ad esser pussaivel cun tegnair en il buttun Ctrl/Cmd.",
     "tooltip": "Tooltip",
     "topic_are_tooltip": "Uffizi federal da planisaziun dal territori",
     "topic_astra_tooltip": "Uffizi federal da vias",
@@ -732,5 +734,6 @@
     "woodland": "Guaud",
     "yellow": "mellen",
     "zoom_in": "Engrondir l'extract da la charta",
-    "zoom_out": "Empitschnir l'extract da la charta"
+    "zoom_out": "Empitschnir l'extract da la charta",
+    "zooming_mode_warning" : "Tegnair Ctrl/Cmd cuntschaint per zoomar la charta"
 }

--- a/packages/mapviewer/src/modules/menu/components/share/MenuShareEmbed.vue
+++ b/packages/mapviewer/src/modules/menu/components/share/MenuShareEmbed.vue
@@ -20,6 +20,7 @@ import { IFRAME_EVENTS } from '@/api/iframePostMessageEvent.api'
 import MenuShareInputCopyButton from '@/modules/menu/components/share/MenuShareInputCopyButton.vue'
 import ModalWithBackdrop from '@/utils/components/ModalWithBackdrop.vue'
 import { transformUrlMapToEmbed } from '@/utils/utils'
+import { insertParameterIntoUrl, removeParamaterFromUrl } from '@/utils/utils'
 
 /**
  * Different pre-defined sizes that an iFrame can take
@@ -52,6 +53,8 @@ const embedInput = useTemplateRef('embedInput')
 const showEmbedSharing = ref(false)
 const showPreviewModal = ref(false)
 const currentPreviewSize = ref(EmbedSizes.SMALL)
+const zoomModeLabel = ref(null)
+const labelWidth = ref(0)
 const customSize = ref({
     width: EmbedSizes.SMALL.width,
     height: EmbedSizes.SMALL.height,
@@ -64,9 +67,14 @@ const route = useRoute()
 const store = useStore()
 
 const embedSource = ref(transformUrlMapToEmbed(window.location.href))
+const noSimpleZoom = ref(false)
 const embedPreviewModalWidth = computed(() => {
-    // Uses the iframe's width as maximal width for the entire modal window
-    const style = { 'max-width': iFrameWidth.value }
+    // Uses the width of the zoomModeLabel to set the width of the modal
+    // to avoid line breaks
+    const style = {
+        'max-width': `${Math.max(labelWidth.value, iFrameWidth.value)}px`,
+        'min-width': `${Math.max(300, labelWidth.value)}px`,
+    }
     if (isPreviewSizeCustom.value) {
         style['min-width'] = '630px'
     }
@@ -123,6 +131,10 @@ function toggleEmbedSharing() {
 function togglePreviewModal() {
     showPreviewModal.value = !showPreviewModal.value
     if (showPreviewModal.value) {
+        if (zoomModeLabel.value) {
+            //margin to display zooming mode label correctly
+            labelWidth.value = zoomModeLabel.value.offsetWidth
+        }
         window.addEventListener('message', onPreviewChange)
     } else {
         window.removeEventListener('message', onPreviewChange)
@@ -155,6 +167,13 @@ watch(
         embedSource.value = transformUrlMapToEmbed(window.location.href)
     }
 )
+
+watch(noSimpleZoom, (value) => {
+    const currentUrl = embedSource.value
+    embedSource.value = value
+        ? insertParameterIntoUrl(currentUrl, 'noSimpleZoom', true)
+        : removeParamaterFromUrl(currentUrl, 'noSimpleZoom')
+})
 </script>
 
 <template>
@@ -292,6 +311,24 @@ watch(
                         </div>
                     </div>
                 </div>
+                <div class="form-check ms-2">
+                    <input
+                        id="toggleZoomModeCheckbox"
+                        v-model="noSimpleZoom"
+                        class="form-check-input"
+                        type="checkbox"
+                        data-cy="menu-share-embed-zoom-toggle"
+                    />
+                    <GeoadminTooltip :tooltip-content="t('toggle_zooming_mode_tooltip')">
+                        <label
+                            ref="zoomModeLabel"
+                            class="form-check-label"
+                            for="toggleZoomModeCheckbox"
+                        >
+                            {{ t('toggle_zooming_mode') }}
+                        </label>
+                    </GeoadminTooltip>
+                </div>
                 <div class="d-flex flex-row mb-2">
                     <MenuShareInputCopyButton
                         class="flex-grow-1"
@@ -309,6 +346,7 @@ watch(
                         :src="embedSource"
                         :style="iFrameStyle"
                         allow="geolocation"
+                        data-cy="menu-share-embed-iframe-preview"
                     />
                 </div>
                 <!-- eslint-disable vue/no-v-html-->

--- a/packages/mapviewer/src/router/storeSync/NoSimpleZoomParamConfig.class.js
+++ b/packages/mapviewer/src/router/storeSync/NoSimpleZoomParamConfig.class.js
@@ -1,0 +1,27 @@
+import AbstractParamConfig, {
+    STORE_DISPATCHER_ROUTER_PLUGIN,
+} from '@/router/storeSync/abstractParamConfig.class'
+
+const URL_PARAM_NAME = 'noSimpleZoom'
+
+export default class NoSimpleZoomParamConfig extends AbstractParamConfig {
+    constructor() {
+        super({
+            urlParamName: URL_PARAM_NAME,
+            mutationsToWatch: ['setNoSimpleZoomEmbed'],
+            setValuesInStore: dispatchNoSimpleZoomFromUrlIntoStore,
+            extractValueFromStore: (store) => store.state.ui.noSimpleZoomEmbed,
+            keepInUrlWhenDefault: false,
+            valueType: Boolean,
+        })
+    }
+}
+
+function dispatchNoSimpleZoomFromUrlIntoStore(to, store, urlParamValue) {
+    if (to.path.toLowerCase().includes('embed')) {
+        store.dispatch('setNoSimpleZoomEmbed', {
+            noSimpleZoomEmbed: urlParamValue,
+            dispatcher: STORE_DISPATCHER_ROUTER_PLUGIN,
+        })
+    }
+}

--- a/packages/mapviewer/src/router/storeSync/storeSync.config.js
+++ b/packages/mapviewer/src/router/storeSync/storeSync.config.js
@@ -8,6 +8,7 @@ import CameraParamConfig from '@/router/storeSync/CameraParamConfig.class'
 import CompareSliderParamConfig from '@/router/storeSync/CompareSliderParamConfig.class'
 import CrossHairParamConfig from '@/router/storeSync/CrossHairParamConfig.class'
 import LayerParamConfig from '@/router/storeSync/LayerParamConfig.class'
+import NoSimpleZoomParamConfig from '@/router/storeSync/NoSimpleZoomParamConfig.class'
 import PositionParamConfig from '@/router/storeSync/PositionParamConfig.class'
 import PrintConfigParamConfig from '@/router/storeSync/PrintConfig.class'
 import SearchAutoSelectConfig from '@/router/storeSync/SearchAutoSelectConfig.class'
@@ -36,6 +37,7 @@ const storeSyncConfig = [
         validateUrlInput: (store, query) =>
             getStandardValidationResponse(query, SUPPORTED_LANG.includes(query), 'lang'),
     }),
+    new NoSimpleZoomParamConfig(),
     new SimpleUrlParamConfig({
         urlParamName: 'sr',
         mutationsToWatch: ['setProjection'],

--- a/packages/mapviewer/src/store/modules/ui.store.js
+++ b/packages/mapviewer/src/store/modules/ui.store.js
@@ -77,6 +77,13 @@ export default {
          */
         embed: false,
         /**
+         * Flag telling if the ctrl key is required to scroll. This is useful when the map is
+         * embedded in an iframe and the parent page needs to scroll.
+         *
+         * @type Boolean
+         */
+        noSimpleZoomEmbed: false,
+        /**
          * Mapping of loading bar requesters. The loading bar on top of the screen is shown as soon
          * as this mapping (object) is not empty. A requester can request several times the loading
          * bar, but then it needs to clear it as many times it has set it.
@@ -227,6 +234,12 @@ export default {
         isDesktopMode(state) {
             return state.mode === UIModes.DESKTOP
         },
+        hasNoSimpleZoomEmbedEnabled(state) {
+            return state.noSimpleZoomEmbed
+        },
+        isEmbed(state) {
+            return state.embed
+        },
         isPhoneSize(state, getters) {
             return getters.isPhoneMode
         },
@@ -313,6 +326,14 @@ export default {
         },
         setEmbed({ commit }, { embed, dispatcher }) {
             commit('setEmbed', { embed: !!embed, dispatcher })
+        },
+        setNoSimpleZoomEmbed({ commit }, { noSimpleZoomEmbed, dispatcher }) {
+            if (typeof noSimpleZoomEmbed === 'boolean') {
+                commit('setNoSimpleZoomEmbed', {
+                    noSimpleZoomEmbed,
+                    dispatcher,
+                })
+            }
         },
         setLoadingBarRequester({ commit }, { requester, dispatcher }) {
             commit('setShowLoadingBar', { requester, loading: true, dispatcher })
@@ -466,6 +487,9 @@ export default {
         },
         setEmbed(state, { embed }) {
             state.embed = embed
+        },
+        setNoSimpleZoomEmbed(state, { noSimpleZoomEmbed }) {
+            state.noSimpleZoomEmbed = noSimpleZoomEmbed
         },
         setShowLoadingBar(state, { requester, loading }) {
             if (loading) {

--- a/packages/mapviewer/src/utils/utils.js
+++ b/packages/mapviewer/src/utils/utils.js
@@ -195,6 +195,51 @@ export function transformUrlMapToEmbed(url) {
 }
 
 /**
+ * Inserts a parameter into the URL hash
+ *
+ * @param {string} url Url to transform
+ * @param {string} paramName Name of the parameter to insert
+ * @param {string} paramValue Value of the parameter to insert
+ * @returns {string} Url transformed
+ */
+
+export function insertParameterIntoUrl(url, paramName, paramValue) {
+    const { urlObj, hash, query } = parseUrlHashQuery(url)
+
+    const params = new URLSearchParams(query)
+    params.set(paramName, paramValue)
+
+    const basePath = hash.split('?')[0]
+    const newQuery = decodeURIComponent(params.toString())
+
+    urlObj.hash = `${basePath}?${newQuery}`
+
+    return urlObj.toString()
+}
+
+/**
+ * Removes a parameter from the URL hash
+ *
+ * @param {string} url
+ * @param {string} paramName
+ * @returns
+ */
+export function removeParamaterFromUrl(url, paramName) {
+    const { urlObj, hash, query } = parseUrlHashQuery(url)
+
+    const params = new URLSearchParams(query)
+    params.delete(paramName)
+
+    const basePath = hash.split('?')[0]
+    const newQuery = decodeURIComponent(params.toString())
+
+    // if the query is empty, we remove it from the hash
+    urlObj.hash = newQuery ? `${basePath}?${newQuery}` : basePath
+
+    return urlObj.toString()
+}
+
+/**
  * Check if the provided string is a valid email address
  *
  * @param {string} email Email address to check

--- a/packages/mapviewer/tests/cypress/tests-e2e/embed.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/embed.cy.js
@@ -204,4 +204,33 @@ describe('Testing the embed view', () => {
                 )
             )
     })
+
+    it('Open in embed mode with ctrl scrolling', () => {
+        cy.goToEmbedView({
+            queryParams: { z: 2, nosimplezoom: true },
+        })
+
+        cy.log('Test that mouse zoom scrolling fails without pressing ctrl')
+
+        cy.get('[data-cy="ol-map"]').trigger('wheel', {
+            deltaY: -100,
+            ctrlKey: false,
+            bubbles: true, // needed to make sure the listener is triggered
+        })
+
+        cy.location('hash').should('contain', 'z=2')
+
+        cy.log('Test that mouse zoom scrolling works with pressing ctrl')
+
+        cy.get('[data-cy="ol-map"]').trigger('wheel', {
+            deltaY: -100,
+            ctrlKey: true,
+            bubbles: true,
+        })
+
+        cy.location('hash').should('satisfy', (hash) => {
+            const match = hash.match(/z=(\d+(?:\.\d+)?)/)
+            return match && parseFloat(match[1]) > 2
+        })
+    })
 })

--- a/packages/mapviewer/tests/cypress/tests-e2e/shareShortLink.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/shareShortLink.cy.js
@@ -195,6 +195,15 @@ describe('Testing the share menu', () => {
                     .should('contain.value', `height: ${height}`)
             }
 
+            // This is needed to perform actions in the iframe (see cypress docs)
+            function getIframeBody() {
+                return cy
+                    .get('[data-cy="menu-share-embed-iframe-preview"]')
+                    .its('0.contentDocument.body')
+                    .should('not.be.empty')
+                    .then(cy.wrap)
+            }
+
             beforeEach(() => {
                 // beforeEach for the whole test is clicking on the menu button once, we must click it another time
                 // otherwise the menu will be closed by the first click
@@ -253,6 +262,42 @@ describe('Testing the share menu', () => {
                     .should('contain.value', '100 %')
                     .should('have.attr', 'readonly')
                 checkIFrameSnippetSize('100%', 300)
+            })
+            it('enables the user to tick the zoom checkbox and require ctrl/cmd to zoom', () => {
+                cy.get('[data-cy="menu-share-embed-preview-button"]').click()
+                cy.get('[data-cy="menu-share-embed-zoom-toggle"]').should('exist')
+                cy.get('[data-cy="menu-share-embed-iframe-size-selector"]').select('Custom size')
+                cy.get('[data-cy="menu-share-embed-iframe-preview"]').should('be.visible')
+
+                cy.get('[data-cy="menu-share-embed-zoom-toggle"]').click()
+
+                cy.get(
+                    '[data-cy="menu-share-embed-iframe-snippet"] [data-cy="menu-share-input-copy-button"]'
+                ).should('contain.value', 'noSimpleZoom')
+
+                cy.log('Test that mouse zoom scrolling fails without pressing ctrl')
+
+                getIframeBody().find('[data-cy="ol-map"]').trigger('wheel', {
+                    deltaY: -100,
+                    ctrlKey: false,
+                    bubbles: true,
+                })
+
+                cy.get(
+                    '[data-cy="menu-share-embed-iframe-snippet"] [data-cy="menu-share-input-copy-button"]'
+                ).should('contain.value', 'z=1')
+
+                cy.log('Test that mouse zoom scrolling works with pressing ctrl')
+
+                getIframeBody().find('[data-cy="ol-map"]').trigger('wheel', {
+                    deltaY: -100,
+                    ctrlKey: true,
+                    bubbles: true,
+                })
+
+                cy.get(
+                    '[data-cy="menu-share-embed-iframe-snippet"] [data-cy="menu-share-input-copy-button"]'
+                ).should('contain.value', 'z=1.333')
             })
         }
     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -734,46 +734,6 @@ importers:
         specifier: 'catalog:'
         version: 17.7.2
 
-  packages/testbed:
-    dependencies:
-      '@geoadmin/tooltip':
-        specifier: 'workspace:'
-        version: link:../geoadmin-tooltip
-      vue:
-        specifier: 'catalog:'
-        version: 3.5.13(typescript@5.8.2)
-    devDependencies:
-      '@tailwindcss/vite':
-        specifier: 'catalog:'
-        version: 4.0.17(vite@6.2.1(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.77.6))
-      '@tsconfig/node22':
-        specifier: 'catalog:'
-        version: 22.0.1
-      '@types/jsdom':
-        specifier: 'catalog:'
-        version: 21.1.7
-      '@vitejs/plugin-vue':
-        specifier: 'catalog:'
-        version: 5.2.1(vite@6.2.1(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.77.6))(vue@3.5.13(typescript@5.8.2))
-      '@vue/tsconfig':
-        specifier: 'catalog:'
-        version: 0.7.0(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2))
-      tailwindcss:
-        specifier: 'catalog:'
-        version: 4.0.17
-      vite:
-        specifier: 'catalog:'
-        version: 6.2.1(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.77.6)
-      vite-plugin-vue-devtools:
-        specifier: 'catalog:'
-        version: 7.7.2(rollup@4.35.0)(vite@6.2.1(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.77.6))(vue@3.5.13(typescript@5.8.2))
-      vitest:
-        specifier: 'catalog:'
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(sass@1.77.6)
-      vue-tsc:
-        specifier: 'catalog:'
-        version: 2.2.8(typescript@5.8.2)
-
 packages:
 
   '@4tw/cypress-drag-drop@2.3.0':


### PR DESCRIPTION
If the nosimplezoom = true parameter is added to an embedded URL, the user needs to press ctrl in order to zoom into the map. Here's a preview of the hint : 
![image](https://github.com/user-attachments/assets/8fede695-9b3c-4d6a-83c1-1f426b318743)

[Test link](https://sys-map.dev.bgdi.ch/preview/task-pb-1493-add-iframe-specific-scroll/index.html)