### PR TITLE
PB-1558: fix printing with geojson layers

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ catalogs:
       specifier: ^0.6.0
       version: 0.6.0
     '@geoblocks/mapfishprint':
-      specifier: ^0.2.19
-      version: 0.2.19
+      specifier: ^0.2.20
+      version: 0.2.20
     '@geoblocks/ol-maplibre-layer':
       specifier: ^1.0.3
       version: 1.0.3
@@ -472,7 +472,7 @@ importers:
         version: 0.6.0(@cesium/engine@15.0.0)
       '@geoblocks/mapfishprint':
         specifier: 'catalog:'
-        version: 0.2.19(ol@10.4.0)
+        version: 0.2.20(ol@10.4.0)
       '@geoblocks/ol-maplibre-layer':
         specifier: 'catalog:'
         version: 1.0.3(maplibre-gl@5.2.0)(ol@10.4.0)
@@ -1148,8 +1148,8 @@ packages:
     peerDependencies:
       '@cesium/engine': '>=10'
 
-  '@geoblocks/mapfishprint@0.2.19':
-    resolution: {integrity: sha512-8hgcjHTz1yJxO5VyzrKsc2+WEXdVT0u6Sge5KclYWI9T88/LsCAI/Ub8cP/zqiNPTot7kUdlTjTRy9L8rQpdbw==}
+  '@geoblocks/mapfishprint@0.2.20':
+    resolution: {integrity: sha512-9Z0IhGhCkWIDH1L/k7q+k6DAODUc2OaX+csIucNeEoW34XydN2QNZtvNRA19/9NhWhdx2dOJSV+N2h7nEbyOFg==}
     peerDependencies:
       ol: 6 || 7 || 8 || 9 || 10
 
@@ -5741,7 +5741,7 @@ snapshots:
       '@cesium/engine': 15.0.0
       lit: 3.2.1
 
-  '@geoblocks/mapfishprint@0.2.19(ol@10.4.0)':
+  '@geoblocks/mapfishprint@0.2.20(ol@10.4.0)':
     dependencies:
       ol: 10.4.0
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ catalog:
     '@fortawesome/free-solid-svg-icons': ^6.7.2
     '@fortawesome/vue-fontawesome': ^3.0.8
     '@geoblocks/cesium-compass': ^0.6.0
-    '@geoblocks/mapfishprint': ^0.2.19
+    '@geoblocks/mapfishprint': ^0.2.20
     '@geoblocks/ol-maplibre-layer': ^1.0.3
     '@ivanv/vue-collapse-transition': ^1.0.2
     '@mapbox/togeojson': ^0.16.2


### PR DESCRIPTION
Issue: When a Geojson layer has a label, it uses a function in mapfish print meant to give the font information to the print server. This function could give null as a result and had no safety around it in case it failed to produce a valid result.

Fix: we did a small PR in mapfishprint which add safeties around the function, meaning that even if the font is not recognised (which would be due to an issue in openlayers, as the regex to check fonts is faulty and can't parse fonts with a number in it), we at least give back basic results.