### PR TITLE
PB-878: limiting the extent of the print

### DIFF
--- a/packages/mapviewer/src/api/__tests__/print.api.spec.js
+++ b/packages/mapviewer/src/api/__tests__/print.api.spec.js
@@ -3,11 +3,6 @@ import { describe, it } from 'vitest'
 
 import { PrintLayout, PrintLayoutAttribute } from '@/api/print.api.js'
 import { MIN_PRINT_SCALE_SIZE, PRINT_DPI_COMPENSATION } from '@/config/print.config'
-// We need to import the router here to avoid error when initializing router plugins, this is
-// needed since some store plugins might require access to router to get the query parameters
-// (e.g. topic management plugin)
-import router from '@/router' // eslint-disable-line no-unused-vars
-import store from '@/store' // eslint-disable-line no-unused-vars
 import { adjustWidth } from '@/utils/styleUtils'
 
 describe('Print API unit tests', () => {

--- a/packages/mapviewer/src/api/__tests__/print.api.spec.js
+++ b/packages/mapviewer/src/api/__tests__/print.api.spec.js
@@ -3,6 +3,11 @@ import { describe, it } from 'vitest'
 
 import { PrintLayout, PrintLayoutAttribute } from '@/api/print.api.js'
 import { MIN_PRINT_SCALE_SIZE, PRINT_DPI_COMPENSATION } from '@/config/print.config'
+// We need to import the router here to avoid error when initializing router plugins, this is
+// needed since some store plugins might require access to router to get the query parameters
+// (e.g. topic management plugin)
+import router from '@/router' // eslint-disable-line no-unused-vars
+import store from '@/store' // eslint-disable-line no-unused-vars
 import { adjustWidth } from '@/utils/styleUtils'
 
 describe('Print API unit tests', () => {

--- a/packages/mapviewer/src/api/print.api.js
+++ b/packages/mapviewer/src/api/print.api.js
@@ -16,7 +16,6 @@ import {
     getWmsBaseUrl,
 } from '@/config/baseUrl.config'
 import i18n from '@/modules/i18n'
-import store from '@/store'
 import { adjustWidth } from '@/utils/styleUtils'
 
 const PRINTING_DEFAULT_POLL_INTERVAL = 2000 // interval between each polling of the printing job status (ms)
@@ -31,7 +30,7 @@ const MAX_PRINT_SPEC_SIZE = 1 * 1024 * 1024 // 1MB in bytes (should be in sync w
  */
 class GeoAdminCustomizer extends BaseCustomizer {
     /**
-     * constructor(layerIDsToExclude, printResolution) {
+     * Constructor(layerIDsToExclude, printResolution) {
      *
      * @param {number[]} printExtent - The extent of the area to be printed. super()
      * @param {string[]} layerIDsToExclude - An array of layer IDs to exclude from the print.
@@ -331,6 +330,7 @@ async function transformOlMapToPrintParams(olMap, config) {
         scale = null,
         layersWithLegends = [],
         lang = null,
+        printExtent = null,
         printGrid = false,
         projection = null,
         excludedLayerIDs = [],
@@ -353,13 +353,16 @@ async function transformOlMapToPrintParams(olMap, config) {
     if (!lang) {
         throw new PrintError('Missing lang')
     }
+    if (!printExtent) {
+        throw new PrintError('Missing print extent')
+    }
     if (printGrid && !projection) {
         throw new PrintError('Missing projection to print the grid')
     }
     if (!dpi) {
         throw new PrintError('Missing DPI for printing')
     }
-    const customizer = new GeoAdminCustomizer(store.state.print.printExtent, excludedLayerIDs, dpi)
+    const customizer = new GeoAdminCustomizer(printExtent, excludedLayerIDs, dpi)
 
     const attributionsOneLine = attributions.length > 0 ? `© ${attributions.join(', ')}` : ''
     try {
@@ -485,6 +488,7 @@ export async function createPrintJob(map, config) {
         layersWithLegends = [],
         lang = null,
         printGrid = false,
+        printExtent = null,
         projection = null,
         excludedLayerIDs = [],
         outputFilename = null,
@@ -500,6 +504,7 @@ export async function createPrintJob(map, config) {
             layersWithLegends,
             lang,
             printGrid,
+            printExtent,
             projection,
             excludedLayerIDs,
             outputFilename,

--- a/packages/mapviewer/src/modules/map/components/openlayers/utils/usePrint.composable.js
+++ b/packages/mapviewer/src/modules/map/components/openlayers/utils/usePrint.composable.js
@@ -80,6 +80,7 @@ export function usePrint(map) {
                     : [],
                 lang: store.state.i18n.lang,
                 printGrid: printGrid,
+                printExtent: store.getters.printExtent,
                 projection: store.state.position.projection,
                 dpi: store.getters.selectedDPI,
             })

--- a/packages/mapviewer/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
+++ b/packages/mapviewer/src/modules/map/components/openlayers/utils/usePrintAreaRenderer.composable.js
@@ -118,6 +118,22 @@ export default function usePrintAreaRenderer(map) {
 
         const printRectangle = calculatePageBoundsPixels(selectedScale.value, printLayoutSize.value)
 
+        const topLeftCoordinate = map.getCoordinateFromPixel([printRectangle[0], printRectangle[1]])
+        const rightBottomCoordinate = map.getCoordinateFromPixel([
+            printRectangle[2],
+            printRectangle[3],
+        ])
+
+        store.commit('setPrintExtent', {
+            printExtent: [
+                topLeftCoordinate[0], // minX
+                rightBottomCoordinate[1], // minY
+                rightBottomCoordinate[0], // maxX
+                topLeftCoordinate[1], // maxY
+            ],
+            dispatcher,
+        })
+
         const minx = printRectangle[0]
         const miny = printRectangle[1]
         const maxx = printRectangle[2]

--- a/packages/mapviewer/src/store/modules/print.store.js
+++ b/packages/mapviewer/src/store/modules/print.store.js
@@ -37,6 +37,9 @@ export default {
             )
             return mapAttributes?.clientInfo?.maxDPI
         },
+        printExtent(state) {
+            return state.printExtent
+        },
     },
     actions: {
         /** @deprecated Should be removed as soon as we've switched to the new print backend */

--- a/packages/mapviewer/src/store/modules/print.store.js
+++ b/packages/mapviewer/src/store/modules/print.store.js
@@ -12,6 +12,7 @@ export default {
         /** @deprecated Should be removed as soon as we've switched to the new print backend */
         selectedScale: null,
         printSectionShown: false,
+        printExtent: [],
         config: {
             dpi: PRINT_DEFAULT_DPI,
             layout: 'A4_L',
@@ -59,6 +60,9 @@ export default {
         setPrintSectionShown({ commit }, { show, dispatcher }) {
             commit('setPrintSectionShown', { show, dispatcher })
         },
+        setPrintExtent({ commit }, { printExtent, dispatcher }) {
+            commit('setPrintExtent', { printExtent, dispatcher })
+        },
         setPrintConfig({ commit }, { config, dispatcher }) {
             commit('setPrintConfig', { config, dispatcher })
         },
@@ -71,6 +75,7 @@ export default {
         /** @deprecated Should be removed as soon as we've switched to the new print backend */
         setSelectedScale: (state, { scale }) => (state.selectedScale = scale),
         setPrintSectionShown: (state, { show }) => (state.printSectionShown = show),
+        setPrintExtent: (state, { printExtent }) => (state.printExtent = printExtent),
         setPrintConfig: (state, { config }) => (state.config = config),
     },
 }


### PR DESCRIPTION
- This is work mostly done by Ismail Sunni, in a new branch now that a lot modularization has been done.
- limit the print specification sent to the print service to the printed extent

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-878-filter-print-extent/index.html)