### PR TITLE
PB-1494: use geoadmin style on legacy links

### DIFF
--- a/packages/mapviewer/src/utils/legacyLayerParamUtils.js
+++ b/packages/mapviewer/src/utils/legacyLayerParamUtils.js
@@ -5,6 +5,7 @@ import ExternalWMSLayer from '@/api/layers/ExternalWMSLayer.class'
 import ExternalWMTSLayer from '@/api/layers/ExternalWMTSLayer.class'
 import GPXLayer from '@/api/layers/GPXLayer.class'
 import KMLLayer from '@/api/layers/KMLLayer.class'
+import KmlStyles from '@/api/layers/KmlStyles.enum'
 import storeSyncConfig from '@/router/storeSync/storeSync.config'
 
 const standardURLParams = storeSyncConfig.map((param) => {
@@ -112,7 +113,7 @@ export function getLayersFromLegacyUrlParams(
         }
         if (layerId.startsWith('KML||')) {
             const [_layerType, url] = layerId.split('||')
-            layer = new KMLLayer({ kmlFileUrl: url, visible: true })
+            layer = new KMLLayer({ kmlFileUrl: url, visible: true, style: KmlStyles.GEOADMIN })
         }
         if (layerId.startsWith('GPX||')) {
             const [_layerType, url] = layerId.split('||')

--- a/packages/mapviewer/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -3,6 +3,7 @@
 import { registerProj4, WGS84 } from '@geoadmin/coordinates'
 import proj4 from 'proj4'
 
+import KmlStyles from '@/api/layers/KmlStyles.enum'
 import { DEFAULT_PROJECTION } from '@/config/map.config'
 import { FeatureInfoPositions } from '@/store/modules/ui.store'
 
@@ -182,6 +183,7 @@ describe('Test on legacy param import', () => {
                 expect(kmlLayer.baseUrl).to.eq(`${kmlServiceBaseUrl}${kmlServiceFilePath}`)
                 expect(kmlLayer.opacity).to.eq(0.6)
                 expect(kmlLayer.visible).to.be.true
+                expect(kmlLayer.style).to.eq(KmlStyles.GEOADMIN)
             })
         })
         it('is able to import an external KML from a legacy adminId query param', () => {


### PR DESCRIPTION
Issue: When parsing a legacy link, KML layers would use the standard style. Those KMLs were most likely designed on the old viewer, where they were rendered with the `geoadmin` style. Users would like their KMLs to still have the same style as they used to.

Fix: When loading a legacy KML layer, we set its style to geoadmin.

Test link with a kml layer : [TEST](https://sys-map.dev.bgdi.ch/preview/fix-pb-1494-use-old-style-on-legacy-links/index.html?layers=KML||https://sys-public.dev.bgdi.ch/api/kml/files/Gz7X_4hAQDyb3_f13UukcA)
same layer on geoadmin : [CURRENT](https://map.geo.admin.ch?layers=KML||https://sys-public.dev.bgdi.ch/api/kml/files/Gz7X_4hAQDyb3_f13UukcA)

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1494-use-old-style-on-legacy-links/index.html)