### PR TITLE
PB-1559: external WMS not displayed switching from 3D to 2D

### DIFF
--- a/packages/geoadmin-coordinates/src/proj/WGS84CoordinateSystem.ts
+++ b/packages/geoadmin-coordinates/src/proj/WGS84CoordinateSystem.ts
@@ -42,10 +42,30 @@ export default class WGS84CoordinateSystem extends StandardCoordinateSystem {
             Math.abs(
                 (PIXEL_LENGTH_IN_KM_AT_ZOOM_ZERO_WITH_256PX_TILES *
                     Math.cos((center[1] * Math.PI) / 180.0)) /
-                    Math.pow(2, zoom)
+                Math.pow(2, zoom)
             ),
             2
         )
+    }
+
+    /**
+     * Ensures an extent is in X,Y order (longitude, latitude).
+     * If coordinates are in Y,X order (latitude, longitude), swaps them.
+     * WGS84 traditionally uses latitude-first (Y,X) axis order [minY, minX, maxY, maxX]
+     * Some WGS84 implementations may use X,Y order therefore we need to check and swap if needed.
+     * 
+     * TODO: This method works for the common coordinates in and around switzerland but will not work for the whole world.
+     *       Therefore a better solution should be implemented if we want to support coordinates and extents of the whole world.
+     * 
+     * @link Problem description https://docs.geotools.org/latest/userguide/library/referencing/order.html
+     * @param extent - Input extent [minX, minY, maxX, maxY] or [minY, minX, maxY, maxX]
+     * @returns Extent guaranteed to be in [minX, minY, maxX, maxY] order
+     */
+    getExtentInOrderXY(extent: [number, number, number, number]): [number, number, number, number] {
+        if (extent[0] > extent[1]) {
+            return [extent[1], extent[0], extent[3], extent[2]]
+        }
+        return extent
     }
 
     /**
@@ -68,8 +88,8 @@ export default class WGS84CoordinateSystem extends StandardCoordinateSystem {
         return Math.abs(
             Math.log2(
                 resolution /
-                    PIXEL_LENGTH_IN_KM_AT_ZOOM_ZERO_WITH_256PX_TILES /
-                    Math.cos((center[1] * Math.PI) / 180.0)
+                PIXEL_LENGTH_IN_KM_AT_ZOOM_ZERO_WITH_256PX_TILES /
+                Math.cos((center[1] * Math.PI) / 180.0)
             )
         )
     }

--- a/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersWMSLayer.vue
+++ b/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersWMSLayer.vue
@@ -108,9 +108,9 @@ watch(projection, () => {
     layer.setSource(createSourceForProjection())
     setExtent()
 })
-watch(wmsUrlParams, () => {
-    layer.getSource().updateParams(wmsUrlParams.value)
-})
+
+watch(wmsUrlParams, layer.getSource().updateParams(wmsUrlParams.value))
+watch(() => wmsLayerConfig.extent, setExtent)
 
 function createSourceForProjection() {
     let source = null

--- a/packages/mapviewer/src/store/index.js
+++ b/packages/mapviewer/src/store/index.js
@@ -27,7 +27,7 @@ import loadGpxDataAndMetadata from '@/store/plugins/load-gpx-data.plugin'
 import loadKmlDataAndMetadata from '@/store/plugins/load-kml-kmz-data.plugin'
 import loadLayersConfigOnLangChange from '@/store/plugins/load-layersconfig-on-lang-change'
 import redoSearchWhenNeeded from '@/store/plugins/redo-search-when-needed.plugin'
-import reprojectSelectedFeaturesOnProjectionChangePlugin from '@/store/plugins/reproject-selected-features-on-projection-change.plugin'
+import reprojectLayersOnProjectionChangePlugin from '@/store/plugins/reproject-layers-on-projection-change.plugin'
 import screenSizeManagementPlugin from '@/store/plugins/screen-size-management.plugin'
 import syncCameraLonLatZoom from '@/store/plugins/sync-camera-lonlatzoom'
 import topicChangeManagementPlugin from '@/store/plugins/topic-change-management.plugin'
@@ -46,7 +46,7 @@ const store = createStore({
         topicChangeManagementPlugin,
         screenSizeManagementPlugin,
         syncCameraLonLatZoom,
-        reprojectSelectedFeaturesOnProjectionChangePlugin,
+        reprojectLayersOnProjectionChangePlugin,
         from2Dto3Dplugin,
         loadExternalLayerAttributes,
         loadGeojsonStyleAndData,

--- a/packages/mapviewer/src/store/modules/layers.store.js
+++ b/packages/mapviewer/src/store/modules/layers.store.js
@@ -738,7 +738,7 @@ const actions = {
      * @param {string} dispatcher Action dispatcher name
      */
     clearLayerErrors({ commit, getters }, { layerId, dispatcher }) {
-        const layers = getters.getLayerById(layerId)
+        const layers = getters.getLayersById(layerId)
         if (layers.length === 0) {
             throw new Error(
                 `Failed to clear layer error keys "${layerId}", layer not found in active layers`

--- a/packages/mapviewer/tests/cypress/tests-e2e/3d/layers.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/3d/layers.cy.js
@@ -1,6 +1,7 @@
 import { WEBMERCATOR, LV95 } from '@geoadmin/coordinates'
 
 import { EditableFeatureTypes } from '@/api/features/EditableFeature.class'
+import { transformLayerIntoUrlString } from '@/router/storeSync/layersParamParser'
 
 function expectLayerCountToBe(viewer, layerCount) {
     const layers = viewer.scene.imageryLayers
@@ -335,6 +336,45 @@ describe('Test of layer handling in 3D', () => {
         cy.get('@highlightedFeatures').should('not.exist')
         cy.readWindowValue('cesiumViewer').then((viewer) => {
             expect(viewer.entities.values.length).to.eq(0)
+        })
+    })
+    it('Verify a layer with EPSG:4326(WEBMERCATOR) bounding box in 2D and 3D', () => {
+        cy.getExternalWmsMockConfig().then((layerObjects) => {
+            const mockExternalWms2 = layerObjects[1]
+            const layers = [layerObjects[1]].map(transformLayerIntoUrlString).join(';')
+            cy.goToMapView({ '3d': true, layers })
+            cy.log('Go to 3D and add a WMS layer')
+            // This layer extent got transformed from EPSG:4326 to EPSG:2056
+            const layerExtentInLV95 = [2485071.58, 1075346.31, 2828515.82, 1299941.79]
+            cy.waitUntilCesiumTilesLoaded()
+            cy.readWindowValue('cesiumViewer').then((viewer) => {
+                expectLayerCountToBe(viewer, 2)
+                const wmsLayer = viewer.scene.imageryLayers.get(1)
+                expect(wmsLayer.show).to.eq(true)
+                expect(wmsLayer.imageryProvider.layers).to.have.string(mockExternalWms2.id)
+            })
+
+            cy.log('Switching to 2D and checking that the layer is still visible')
+            // deactivate 3D
+            cy.get('[data-cy="3d-button"]').should('be.visible').click()
+            cy.readWindowValue('map').then((map) => {
+                const layers = map.getLayers().getArray()
+                expect(layers[1].getProperties().id).to.deep.equal(mockExternalWms2.id)
+                // If the layer is not visible, it is usually because the extent is not correct
+                expect(layers[1].getExtent()).to.deep.equal(layerExtentInLV95)
+            })
+
+            // activate 3D
+            cy.get('[data-cy="3d-button"]').should('be.visible').click()
+            cy.waitUntilCesiumTilesLoaded()
+
+            cy.get('[data-cy="3d-button"]').should('be.visible').click()
+            cy.readWindowValue('map').then((map) => {
+                const layers = map.getLayers().getArray()
+                expect(layers[1].getProperties().id).to.deep.equal(mockExternalWms2.id)
+                // If the layer is not visible, it is usually because the extent is not correct
+                expect(layers[1].getExtent()).to.deep.equal(layerExtentInLV95)
+            })
         })
     })
 })


### PR DESCRIPTION
[Test link with layers of the ticket](https://sys-map.dev.bgdi.ch/preview/fix-pb-1559-external-wms-not-displayed-switching-3d-2d/index.html#/map?lang=de&sr=3857&camera=8.004717,46.7976,397911.2,-90,,&3d&topic=ech&layers=WMS%7Chttps://geo.csd.ch/server/services/DCH000513_01_Planungskooridor_Innertkirchen_Mettlen/MapServer/WMSServer?%7C9,,0.63;WMS%7Chttps://geo.csd.ch/server/services/DCH000513_01_Planungskooridor_Innertkirchen_Mettlen/MapServer/WMSServer?%7C10,,0.65;WMS%7Chttps://geo.csd.ch/server/services/DCH000513_01_Planungskooridor_Innertkirchen_Mettlen/MapServer/WMSServer?%7C11,,0.65;WMS%7Chttps://geo.csd.ch/server/services/DCH000513_01_Planungskooridor_Innertkirchen_Mettlen/MapServer/WMSServer?%7C1;WMS%7Chttps://geo.csd.ch/server/services/DCH000513_01_Planungskooridor_Innertkirchen_Mettlen/MapServer/WMSServer?%7C2;WMS%7Chttps://geo.csd.ch/server/services/DCH000513_01_Planungskooridor_Innertkirchen_Mettlen/MapServer/WMSServer?%7C3;WMS%7Chttps://geo.csd.ch/server/services/DCH000513_01_Planungskooridor_Innertkirchen_Mettlen/MapServer/WMSServer?%7C4&bgLayer=ch.swisstopo.pixelkarte-farbe&catalogNodes=532,533)

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1559-external-wms-not-displayed-switching-3d-2d/index.html)