### PR TITLE
PB-1561: revert CSS changes to generic feature pop up windows

### DIFF
--- a/packages/mapviewer/src/modules/infobox/components/FeatureDetail.vue
+++ b/packages/mapviewer/src/modules/infobox/components/FeatureDetail.vue
@@ -128,16 +128,18 @@ function getIframeHosts(value) {
                     :external-iframe-hosts="externalIframeHosts"
                     :title="key"
                 />
-                <div class="d-flex flex-row justify-content-between">
-                    <div class="fw-bold">{{ t(key) }}</div>
-                    <!-- eslint-disable vue/no-v-html-->
-                    <div
-                        data-cy="feature-detail-description-content"
-                        class="text-end pr-3"
-                        v-html="t(value)"
-                    ></div>
-                    <!-- eslint-enable vue/no-v-html-->
+                <div
+                    v-else
+                    class="fw-bold"
+                >
+                    {{ t(key) }}
                 </div>
+                <!-- eslint-disable vue/no-v-html-->
+                <div
+                    data-cy="feature-detail-description-content"
+                    v-html="t(value)"
+                ></div>
+                <!-- eslint-enable vue/no-v-html-->
             </div>
             <div v-if="sanitizedFeatureDataEntries.length === 0">
                 {{ t('no_more_information') }}

--- a/packages/mapviewer/src/modules/infobox/components/FeatureDetail.vue
+++ b/packages/mapviewer/src/modules/infobox/components/FeatureDetail.vue
@@ -100,18 +100,15 @@ function getIframeHosts(value) {
 
 <template>
     <!-- eslint-disable vue/no-v-html-->
-
     <div
         v-if="hasFeatureStringData && popupDataCanBeTrusted"
         v-html="feature.data"
     />
-
     <div
         v-else-if="hasFeatureStringData"
         v-html="sanitizeHtml(feature.data)"
     />
     <!-- eslint-enable vue/no-v-html-->
-
     <div
         v-else
         class="htmlpopup-container"
@@ -138,7 +135,7 @@ function getIframeHosts(value) {
                 <div
                     data-cy="feature-detail-description-content"
                     v-html="t(value)"
-                ></div>
+                />
                 <!-- eslint-enable vue/no-v-html-->
             </div>
             <div v-if="sanitizedFeatureDataEntries.length === 0">


### PR DESCRIPTION
Issue : we adapted the CSS for the generic pop up which holds the 3d features info for now , but the styling doesn't please our users who are using the drawings.

Fix : We revert the changes and the 3d pop up will be done when we can get it from the backend :)

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-1561-drawing-tooltip-descriptions-readability/index.html)