### PR TITLE
PB-1605 : detect COG projection based on name when no EPSG found

### DIFF
--- a/packages/geoadmin-coordinates/src/proj/CoordinateSystem.ts
+++ b/packages/geoadmin-coordinates/src/proj/CoordinateSystem.ts
@@ -5,6 +5,7 @@ import proj4 from 'proj4'
 import type { SingleCoordinate } from '@/utils'
 
 import CoordinateSystemBounds from '@/proj/CoordinateSystemBounds'
+
 /**
  * These are the zoom levels, for each projection, which give us a 1:25'000 ratio map.
  *
@@ -48,6 +49,11 @@ export interface CoordinateSystemProps {
      * key)
      */
     label: string
+    /**
+     * Name of this projection, if applicable, so that it can be tested against name in fields such
+     * as COG metadata parsing.
+     */
+    technicalName?: string
     /**
      * A string describing how proj4 should handle projection/reprojection of this coordinate
      * system, in regard to WGS84. These matrices can be found on the EPSG website for each
@@ -103,6 +109,11 @@ export default abstract class CoordinateSystem {
      */
     public readonly label: string
     /**
+     * Name of this projection, if applicable, so that it can be tested against name in fields such
+     * as COG metadata parsing.
+     */
+    public readonly technicalName?: string
+    /**
      * A string describing how proj4 should handle projection/reprojection of this coordinate
      * system, in regard to WGS84. These matrices can be found on the EPSG website for each
      * projection in the Export section, inside the PROJ.4 export type (can be directly accessed by
@@ -138,6 +149,7 @@ export default abstract class CoordinateSystem {
             label,
             proj4transformationMatrix,
             bounds,
+            technicalName,
             usesMercatorPyramid = false,
         } = args
         this.epsgNumber = epsgNumber
@@ -150,6 +162,7 @@ export default abstract class CoordinateSystem {
         this.label = label
         this.proj4transformationMatrix = proj4transformationMatrix
         this.bounds = bounds
+        this.technicalName = technicalName
         this.usesMercatorPyramid = usesMercatorPyramid
     }
 

--- a/packages/geoadmin-coordinates/src/proj/LV03CoordinateSystem.ts
+++ b/packages/geoadmin-coordinates/src/proj/LV03CoordinateSystem.ts
@@ -6,6 +6,7 @@ export default class LV03CoordinateSystem extends SwissCoordinateSystem {
         super({
             epsgNumber: 21781,
             label: 'CH1903 / LV03',
+            technicalName: 'LV03',
             // matrix is coming fom https://epsg.io/21781.proj4
             proj4transformationMatrix:
                 '+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs +type=crs',

--- a/packages/geoadmin-coordinates/src/proj/LV95CoordinateSystem.ts
+++ b/packages/geoadmin-coordinates/src/proj/LV95CoordinateSystem.ts
@@ -6,6 +6,7 @@ export default class LV95CoordinateSystem extends SwissCoordinateSystem {
         super({
             epsgNumber: 2056,
             label: 'CH1903+ / LV95',
+            technicalName: 'LV95',
             // matrix is coming fom https://epsg.io/2056.proj4
             proj4transformationMatrix:
                 '+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs +type=crs',

--- a/packages/mapviewer/src/store/index.js
+++ b/packages/mapviewer/src/store/index.js
@@ -21,7 +21,7 @@ import appReadinessPlugin from '@/store/plugins/app-readiness.plugin'
 import clickOnMapManagementPlugin from '@/store/plugins/click-on-map-management.plugin'
 import loadExternalLayerAttributes from '@/store/plugins/external-layers.plugin'
 import geolocationManagementPlugin from '@/store/plugins/geolocation-management.plugin'
-import loadCOGExtent from '@/store/plugins/load-cog-extent.plugin'
+import loadCOGMetadata from '@/store/plugins/load-cog-metadata.plugin'
 import loadGeojsonStyleAndData from '@/store/plugins/load-geojson-style-and-data.plugin'
 import loadGpxDataAndMetadata from '@/store/plugins/load-gpx-data.plugin'
 import loadKmlDataAndMetadata from '@/store/plugins/load-kml-kmz-data.plugin'
@@ -52,7 +52,7 @@ const store = createStore({
         loadGeojsonStyleAndData,
         loadKmlDataAndMetadata,
         loadGpxDataAndMetadata,
-        loadCOGExtent,
+        loadCOGMetadata,
         updateSelectedFeaturesPlugin,
     ],
     modules: {

--- a/packages/mapviewer/src/store/plugins/load-cog-metadata.plugin.js
+++ b/packages/mapviewer/src/store/plugins/load-cog-metadata.plugin.js
@@ -5,7 +5,7 @@ import { CloudOptimizedGeoTIFFParser } from '@/modules/menu/components/advancedT
 
 const cogParser = new CloudOptimizedGeoTIFFParser()
 
-async function loadExtentAndUpdateLayer(store, layer) {
+async function loadCOGMetadataAndUpdateLayer(store, layer) {
     const layerWithExtent = await cogParser.parse({
         fileSource: layer.fileSource,
         currentProjection: toValue(store.state.position.projection),
@@ -14,24 +14,25 @@ async function loadExtentAndUpdateLayer(store, layer) {
         layerId: layer.id,
         values: {
             extent: layerWithExtent.extent,
+            noDataValue: layerWithExtent.noDataValue,
         },
     })
 }
 
 /**
- * COG loaded through a URL param at startup didn't go through the file parser that loads the extent
- * of the COG from the file.
+ * COG loaded through a URL param at startup didn't go through the file parser that loads the
+ * extent, no data value, and other metadata of the COG from the file.
  *
- * This plugin aims to do just that, check if any added COG is missing its extent, and if so run the
- * file parser on it to extract this extent.
+ * This plugin aims to do just that, check if any added COG is missing its metadata, and if so run
+ * the file parser on it to extract this extent.
  *
  * @param {Vuex.Store} store
  */
-export default function loadCOGExtent(store) {
+export default function loadCOGMetadata(store) {
     store.subscribe((mutation) => {
         const addLayerSubscriber = (layer) => {
             if (layer instanceof CloudOptimizedGeoTIFFLayer && !layer.extent) {
-                loadExtentAndUpdateLayer(store, layer)
+                loadCOGMetadataAndUpdateLayer(store, layer)
             }
         }
         if (mutation.type === 'addLayer') {


### PR DESCRIPTION
Some COGs we provide aren't encoded with an EPSG number in the corresponding field, but with a specific number telling us it is a "user defined CRS". In order to be able to detect such COGs, I've added a technical name to both LV95 and LV03, which will be used to detect COGs that are in such format.

[Test link with relevant COG](https://sys-map.dev.bgdi.ch/preview/bug-pb-1605-fix-cog-projection-detection/index.html#/map?layers=COG|https://data.geo.admin.ch/ch.bafu.luftreinhaltung-stickstoffdioxid/luftreinhaltung-stickstoffdioxid_1990/luftreinhaltung-stickstoffdioxid_1990_2056.tif)

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-1605-fix-cog-projection-detection/index.html)