### PR TITLE
PB-1202 : Fix overflow issue in 3D feature tooltip view on Chrome

### DIFF
--- a/packages/mapviewer/src/modules/infobox/components/FeatureList.vue
+++ b/packages/mapviewer/src/modules/infobox/components/FeatureList.vue
@@ -72,11 +72,14 @@ function loadMoreResultForLayer(layerId) {
 <template>
     <div
         ref="featureListContainer"
-        class="clear-no-ios-long-press"
-        :class="['feature-list', isPhoneMode ? 'mobile' : 'desktop']"
+        class="clear-no-ios-long-press feature-list"
+        :class="[isPhoneMode ? 'mobile' : 'desktop']"
         data-cy="highlighted-features"
     >
-        <div class="feature-list-inner">
+        <div
+            class="feature-list-inner"
+            data-cy="feature-list-inner"
+        >
             <!-- Only showing drawing features when outside the drawing module/mode -->
             <FeatureListCategory
                 v-if="!isCurrentlyDrawing && selectedEditableFeatures.length > 0"

--- a/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersHighlightedFeatures.vue
+++ b/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersHighlightedFeatures.vue
@@ -132,6 +132,6 @@ function setBottomPanelFeatureInfoPosition() {
             :read-only="!isCurrentlyDrawing"
             :feature="feature"
         />
-        <FeatureList fluid />
+        <FeatureList />
     </OpenLayersPopover>
 </template>

--- a/packages/mapviewer/tests/cypress/tests-e2e/3d/layers.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/3d/layers.cy.js
@@ -311,7 +311,6 @@ describe('Test of layer handling in 3D', () => {
             .find('[data-cy="feature-item"]')
             .should('have.length', 10)
 
-        
         // deactivate 3D
         cy.get('[data-cy="3d-button"]').should('be.visible').click()
         cy.get('@highlightedFeatures')
@@ -319,17 +318,17 @@ describe('Test of layer handling in 3D', () => {
             .find('[data-cy="feature-item"]')
             .should('have.length', 10)
 
+        cy.log(
+            'Switch to 3D and remove the layer and check that the selected features are not visible anymore'
+        )
 
-        cy.log('Switch to 3D and remove the layer and check that the selected features are not visible anymore')
         // activate 3D
         cy.get('[data-cy="3d-button"]').should('be.visible').click()
         cy.waitUntilCesiumTilesLoaded()
-            
+
         cy.openMenuIfMobile()
 
-        cy.get(
-            `[data-cy^="button-toggle-visibility-layer-${expectedWmsLayerId}-"]`
-        ).click()
+        cy.get(`[data-cy^="button-toggle-visibility-layer-${expectedWmsLayerId}-"]`).click()
 
         cy.closeMenuIfMobile()
         cy.readStoreValue('getters.selectedFeatures').should('have.length', 0)

--- a/packages/mapviewer/tests/cypress/tests-e2e/featureSelection.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/featureSelection.cy.js
@@ -350,7 +350,7 @@ describe('Testing the feature selection', () => {
             cy.get('@highlightedFeatures')
                 .find('[data-cy="feature-item"]')
                 .should('have.length', featureCountWithKml)
-            cy.get('@highlightedFeatures').scrollTo('bottom')
+            cy.get('[data-cy="feature-list-inner"]').scrollTo('bottom')
 
             cy.get('[data-cy="feature-list-load-more"]').as('loadMore').should('be.visible')
             cy.get('@loadMore').click()
@@ -379,7 +379,7 @@ describe('Testing the feature selection', () => {
                 results: [],
             }).as('noMoreResults')
 
-            cy.get('@highlightedFeatures').scrollTo('bottom')
+            cy.get('[data-cy="feature-list-inner"]').scrollTo('bottom')
             cy.get('@loadMore').click()
             cy.wait('@noMoreResults')
 


### PR DESCRIPTION
Issue : An overflow was causing two scroll bars to appear on Chromium browsers when using the 3D view.

Fix : removed the fluid css condition, and added logic to switch max height depending on aspect ratio of viewport.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-1202-double-overflow-3d-tooltip/index.html)