### PR TITLE
Add a build dev watch option to geoadmin packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "scripts": {
         "build-all": "pnpm run -r build",
         "build:dev": "pnpm -r run build:dev",
+        "build:dev:watch": "pnpm -r --parallel --if-present run build:dev:watch --filter=!web-mapviewer",
         "build:int": "pnpm -r run build:int",
         "build:prod": "pnpm -r run build:prod",
         "dev": "pnpm run -r --filter=web-mapviewer dev ",

--- a/packages/geoadmin-coordinates/package.json
+++ b/packages/geoadmin-coordinates/package.json
@@ -16,6 +16,7 @@
     "scripts": {
         "build": "pnpm run type-check && pnpm run generate-types && vite build",
         "build:dev": "pnpm run build -- --mode development",
+        "build:dev:watch": "pnpm run build --watch -- --mode development",
         "build:int": "pnpm run build -- --mode integration",
         "build:prod": "pnpm run build -- --mode production",
         "dev": "vite",

--- a/packages/geoadmin-log/package.json
+++ b/packages/geoadmin-log/package.json
@@ -16,6 +16,7 @@
     "scripts": {
         "build": "pnpm run type-check && pnpm run generate-types && vite build",
         "build:dev": "pnpm run build -- --mode development",
+        "build:dev:watch": "pnpm run build --watch -- --mode development",
         "build:int": "pnpm run build -- --mode integration",
         "build:prod": "pnpm run build -- --mode production",
         "dev": "vite",

--- a/packages/geoadmin-numbers/package.json
+++ b/packages/geoadmin-numbers/package.json
@@ -16,6 +16,7 @@
     "scripts": {
         "build": "pnpm run type-check && pnpm run generate-types && vite build",
         "build:dev": "pnpm run build -- --mode development",
+        "build:dev:watch": "pnpm run build --watch -- --mode development",
         "build:int": "pnpm run build -- --mode integration",
         "build:prod": "pnpm run build -- --mode production",
         "dev": "vite",

--- a/packages/geoadmin-tooltip/package.json
+++ b/packages/geoadmin-tooltip/package.json
@@ -21,6 +21,7 @@
     "scripts": {
         "build": "pnpm run type-check && pnpm run generate-types && vite build",
         "build:dev": "pnpm run build -- --mode development",
+        "build:dev:watch": "pnpm run build --watch -- --mode development",
         "build:int": "pnpm run build -- --mode integration",
         "build:prod": "pnpm run build -- --mode production",
         "dev": "vite",


### PR DESCRIPTION
Running `pnpm run build:dev:watch` permits the user to modify the geodamin package and updating the build so that the changes have direct effect on the running mapviewer.

Note: I observed that the mapviewer updates the open page too fast, which makes it not load correctly and a reload of the page is sometimes needed.

[Test link](https://sys-map.dev.bgdi.ch/preview/add-build-watch-packages/index.html)