### PR TITLE
PB-1602: fix duplicates layer can not be compared

### DIFF
--- a/packages/mapviewer/package.json
+++ b/packages/mapviewer/package.json
@@ -76,6 +76,7 @@
         "proj4": "catalog:",
         "reproject": "catalog:",
         "sortablejs": "catalog:",
+        "uuid": "catalog:",
         "vue": "catalog:",
         "vue-chartjs": "catalog:",
         "vue-i18n": "catalog:",

--- a/packages/mapviewer/src/api/layers/AbstractLayer.class.js
+++ b/packages/mapviewer/src/api/layers/AbstractLayer.class.js
@@ -1,4 +1,5 @@
 import { cloneDeep } from 'lodash'
+import { v4 as uuidv4 } from 'uuid'
 
 import { InvalidLayerDataError } from '@/api/layers/InvalidLayerData.error'
 
@@ -44,6 +45,9 @@ export class LayerAttribution {
  */
 export default class AbstractLayer {
     /**
+     * @param {String} layerData.uuid Unique ID of this layer (UUID v4) to be able to differntiate
+     *   between the same layers (e.g. when a using a layer multiple times in the map to show
+     *   different timestamps)
      * @param {String} layerData.name Name of this layer in the current lang
      * @param {String} layerData.id The unique ID of this layer that will be used in the URL to
      *   identify it (and also in subsequent backend services for GeoAdmin layers)
@@ -84,6 +88,7 @@ export default class AbstractLayer {
             throw new InvalidLayerDataError('Missing layer data', layerData)
         }
         const {
+            uuid = uuidv4(),
             name = null,
             id = null,
             type = null,
@@ -112,6 +117,7 @@ export default class AbstractLayer {
         if (baseUrl === null) {
             throw new InvalidLayerDataError('Missing base URL', layerData)
         }
+        this.uuid = uuid
         this.name = name
         this.id = id
         this.type = type
@@ -238,6 +244,8 @@ export default class AbstractLayer {
     }
 
     clone() {
-        return cloneDeep(this)
+        const cloneLayer = cloneDeep(this)
+        cloneLayer.uuid = uuidv4()
+        return cloneLayer
     }
 }

--- a/packages/mapviewer/src/modules/map/components/cesium/CesiumVisibleLayers.vue
+++ b/packages/mapviewer/src/modules/map/components/cesium/CesiumVisibleLayers.vue
@@ -65,14 +65,14 @@ function isPrimitiveLayer(layer) {
 -->
     <CesiumInternalLayer
         v-for="(layer, index) in visibleImageryLayers"
-        :key="layer.id"
+        :key="layer.id + layer.uuid"
         :layer-config="layer"
         :projection="projection"
         :z-index="index + startingZIndexForImageryLayers"
     />
     <CesiumInternalLayer
         v-for="layer in visiblePrimitiveLayers"
-        :key="layer.id"
+        :key="layer.id + layer.uuid"
         :layer-config="layer"
         :projection="projection"
     />

--- a/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersAccuracyCircle.vue
+++ b/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersAccuracyCircle.vue
@@ -8,6 +8,7 @@ import Feature from 'ol/Feature'
 import { Circle } from 'ol/geom'
 import { Vector as VectorLayer } from 'ol/layer'
 import { Vector as VectorSource } from 'ol/source'
+import { v4 as uuidv4 } from 'uuid'
 import { computed, inject, watch } from 'vue'
 import { useStore } from 'vuex'
 
@@ -33,6 +34,7 @@ const accuracyCircleFeature = new Feature({
 accuracyCircleFeature.setStyle(geolocationAccuracyCircleStyle)
 const layer = new VectorLayer({
     id: `geolocation-accuracy-layer`,
+    uuid: uuidv4(),
     source: new VectorSource({
         features: [accuracyCircleFeature],
     }),

--- a/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersCOGTiffLayer.vue
+++ b/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersCOGTiffLayer.vue
@@ -40,6 +40,7 @@ const layer = new WebGLTileLayer({
     source: createLayerSource(),
     opacity: opacity.value,
     id: source.value.url,
+    uuid: geotiffConfig.uuid,
 })
 
 useAddLayerToMap(layer, olMap, () => zIndex)

--- a/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersExternalWMTSLayer.vue
+++ b/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersExternalWMTSLayer.vue
@@ -64,6 +64,7 @@ const dimensions = computed(() => {
 
 const layer = new TileLayer({
     id: layerId.value,
+    uuid: externalWmtsLayerConfig.uuid,
     opacity: opacity.value,
 })
 

--- a/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersGPXLayer.vue
+++ b/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersGPXLayer.vue
@@ -47,6 +47,7 @@ the getExtent() function and a wrong extent causes the features to sometimes dis
 from the screen.  */
 const layer = new VectorLayer({
     id: layerId.value,
+    uuid: gpxLayerConfig.uuid,
     opacity: opacity.value,
 })
 

--- a/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersGeoJSONLayer.vue
+++ b/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersGeoJSONLayer.vue
@@ -39,7 +39,11 @@ const geoJsonData = computed(() => geoJsonConfig.geoJsonData)
 const geoJsonStyle = computed(() => geoJsonConfig.geoJsonStyle)
 const isLoading = computed(() => geoJsonConfig.isLoading)
 
-const layer = new VectorLayer({ id: layerId.value, opacity: opacity.value })
+const layer = new VectorLayer({
+    id: layerId.value,
+    uuid: geoJsonConfig.uuid,
+    opacity: opacity.value,
+})
 
 function setGeoJsonStyle() {
     if (!geoJsonStyle.value) {

--- a/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
+++ b/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersKMLLayer.vue
@@ -58,6 +58,7 @@ the getExtent() function and a wrong extent causes the features to sometimes dis
 from the screen.  */
 const layer = new VectorLayer({
     id: layerId.value,
+    uuid: kmlLayerConfig.uuid,
     opacity: opacity.value,
 })
 

--- a/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersRectangleSelectionFeedback.vue
+++ b/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersRectangleSelectionFeedback.vue
@@ -3,6 +3,7 @@ import Feature from 'ol/Feature'
 import { Polygon } from 'ol/geom'
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
+import { v4 as uuidv4 } from 'uuid'
 import { computed, inject, watch } from 'vue'
 import { useStore } from 'vuex'
 
@@ -27,6 +28,7 @@ const selectionPolygon = computed(() => {
 const map = inject('olMap')
 const vectorLayer = new VectorLayer({
     id: 'rectangleSelectionFeedback',
+    uuid: uuidv4(),
     source: new VectorSource({
         features: [],
     }),

--- a/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
+++ b/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersVectorLayer.vue
@@ -40,6 +40,7 @@ const styleUrl = computed(() => `${vectorLayerConfig.baseUrl}styles/${layerId.va
 
 const layer = new MapLibreLayer({
     id: layerId.value,
+    uuid: vectorLayerConfig.uuid,
     opacity: opacity.value,
 })
 setMapLibreStyle(styleUrl.value)

--- a/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersVisibleLayers.vue
+++ b/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersVisibleLayers.vue
@@ -35,7 +35,7 @@ const { getZIndexForLayer } = useLayerZIndexCalculation()
 <template>
     <OpenLayersInternalLayer
         v-for="layer in filteredVisibleLayers"
-        :key="layer.id"
+        :key="layer.id + layer.uuid"
         :layer-config="layer"
         :z-index="getZIndexForLayer(layer)"
     />

--- a/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersWMSLayer.vue
+++ b/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersWMSLayer.vue
@@ -84,12 +84,14 @@ let layer
 if (gutter.value !== -1) {
     layer = new TileLayer({
         id: layerId.value,
+        uuid: wmsLayerConfig.uuid,
         opacity: opacity.value,
         source: createSourceForProjection(),
     })
 } else {
     layer = new ImageLayer({
         id: layerId.value,
+        uuid: wmsLayerConfig.uuid,
         opacity: opacity.value,
         source: createSourceForProjection(),
     })

--- a/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersWMTSLayer.vue
+++ b/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersWMTSLayer.vue
@@ -57,6 +57,7 @@ const wmtsTimeConfig = computed(() => {
 
 const layer = new TileLayer({
     id: layerId.value,
+    uuid: wmtsLayerConfig.uuid,
     opacity: opacity.value,
     source: createWMTSSourceForProjection(),
 })

--- a/packages/mapviewer/src/modules/menu/components/debug/DebugLayerFinder.vue
+++ b/packages/mapviewer/src/modules/menu/components/debug/DebugLayerFinder.vue
@@ -125,7 +125,7 @@ function toggleLayerType(type) {
             <div class="layer-list card-body overflow-y-auto p-0 m-0">
                 <div
                     v-for="(layer, index) in filteredLayers"
-                    :key="layer.id"
+                    :key="layer.id + layer.uuid"
                     class="d-flex justify-content-end align-content-center mb-1 p-1"
                     :class="{ 'bg-body-secondary': index % 2 === 0 }"
                 >

--- a/packages/mapviewer/src/router/storeSync/LayerParamConfig.class.js
+++ b/packages/mapviewer/src/router/storeSync/LayerParamConfig.class.js
@@ -21,7 +21,6 @@ import ErrorMessage from '@/utils/ErrorMessage.class'
 import { flattenExtent } from '@/utils/extentUtils'
 import { getExtentOfGeometries } from '@/utils/geoJsonUtils'
 import WarningMessage from '@/utils/WarningMessage.class'
-
 /**
  * Parse layers such as described in
  * https://github.com/geoadmin/web-mapviewer/blob/develop/adr/2021_03_16_url_param_structure.md#layerid

--- a/packages/mapviewer/src/store/modules/__tests__/layers.store.spec.js
+++ b/packages/mapviewer/src/store/modules/__tests__/layers.store.spec.js
@@ -84,8 +84,13 @@ describe('Background layer is correctly set', () => {
 
 describe('Add layer creates copy of layers config (so that we may add multiple time the same layer)', () => {
     const checkRefNotEqButDeepEq = (expected, result) => {
-        expect(result).to.not.be.eq(expected)
-        expect(result).to.deep.eq(expected)
+        // The uuid should not get cloned but be generated new
+        const { uuid: expectedUuid, ...expectedWithoutUuid } = expected
+        const { uuid: resultUuid, ...resultWithoutUuid } = result
+
+        expect(result).to.not.equal(expected)
+        expect(resultUuid).to.not.equal(expectedUuid)
+        expect(resultWithoutUuid).to.deep.equal(expectedWithoutUuid)
     }
 
     beforeEach(() => {

--- a/packages/mapviewer/tests/cypress/tests-e2e/compareSlider.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/compareSlider.cy.js
@@ -326,6 +326,31 @@ describe('Testing of the compare slider', () => {
             }
         )
     })
+
+    context('With two times the same layer', () => {
+        it('layers are independent layers with different uuids', () => {
+            cy.goToMapView(
+                {
+                    layers: [
+                        'test.timeenabled.wmts.layer@year=2015',
+                        'test.timeenabled.wmts.layer@year=2021',
+                    ].join(';'),
+                    compareRatio: '0.3',
+                },
+                true
+            )
+            cy.readStoreValue('getters.visibleLayers').should((visibleLayers) => {
+                expect(visibleLayers).to.be.an('Array')
+                expect(visibleLayers.length).to.deep.equal(2)
+                visibleLayers.forEach((_, index) => {
+                    expect(visibleLayers[index]).to.be.an('Object')
+                    expect(visibleLayers[index].uuid).to.not.be.undefined
+                })
+                const [uuid1, uuid2] = visibleLayers.map((layer) => layer.uuid)
+                expect(uuid1).to.not.equal(uuid2)
+            })
+        })
+    })
 })
 
 describe('The compare Slider and the menu elements should not be available in 3d', () => {

--- a/packages/mapviewer/tests/cypress/tests-e2e/layers.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/layers.cy.js
@@ -14,7 +14,7 @@ import { transformLayerIntoUrlString } from '@/router/storeSync/layersParamParse
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_replacer_parameter
  */
 const stringifyWithoutLangOrNull = (key, value) =>
-    key === 'lang' || value === null ? undefined : value
+    key === 'lang' || key === 'uuid' || value === null ? undefined : value
 
 describe('Test of layer handling', () => {
     const bgLayer = 'test.background.layer2'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ catalogs:
     typescript-eslint:
       specifier: ^8.29.1
       version: 8.29.1
+    uuid:
+      specifier: ^11.1.0
+      version: 11.1.0
     vite:
       specifier: ^6.2.6
       version: 6.2.6
@@ -603,6 +606,9 @@ importers:
       sortablejs:
         specifier: 'catalog:'
         version: 1.15.6
+      uuid:
+        specifier: 'catalog:'
+        version: 11.1.0
       vue:
         specifier: 'catalog:'
         version: 3.5.13(typescript@5.8.3)
@@ -5248,6 +5254,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -11246,6 +11256,8 @@ snapshots:
   url-template@2.0.8: {}
 
   util-deprecate@1.0.2: {}
+
+  uuid@11.1.0: {}
 
   uuid@8.3.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -89,6 +89,7 @@ catalog:
     tailwindcss: ^4.1.3
     typescript: ^5.8.3
     typescript-eslint: ^8.29.1
+    uuid: "^11.1.0"
     vite-node: ^3.1.1
     vite-plugin-dts: ^4.5.3
     vite-plugin-static-copy: ^2.3.1


### PR DESCRIPTION
[Test link with layers from the ticket](https://sys-map.dev.bgdi.ch/preview/fix-pb-1602-duplicates-layer-compare/index.html#/map?lang=en&center=2660000,1190000&z=1&topic=ech&compareRatio=0.504&layers=ch.bafu.luftreinhaltung-feinstaub_pm10@year=2020,,1;ch.bafu.luftreinhaltung-feinstaub_pm10@year=2001,,1&bgLayer=ch.swisstopo.pixelkarte-farbe)

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1602-duplicates-layer-compare/index.html)