### PR TITLE
PB-1621 : Fix compass icon alignement

### DIFF
--- a/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersCompassButton.vue
+++ b/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersCompassButton.vue
@@ -78,6 +78,7 @@ const onRotate = (mapEvent) => {
 .compass-button {
     &-icon {
         height: $map-button-diameter - 5px;
+        width: $map-button-diameter;
     }
 }
 </style>


### PR DESCRIPTION
Specifying a width on the css class seems to fix it.
![image](https://github.com/user-attachments/assets/d2cfdadb-d6c0-4eb6-811e-d6d136b4be22)


[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-1621-center-orientation-arrow/index.html)