### PR TITLE
PB-1522 : DPI responsive print margin

### DIFF
--- a/packages/mapviewer/src/config/print.config.js
+++ b/packages/mapviewer/src/config/print.config.js
@@ -18,3 +18,5 @@ export const PRINT_DIMENSIONS = {
 }
 
 export const PRINT_DEFAULT_DPI = 96
+
+export const PRINT_MARGIN_IN_MILLIMETERS = 4

--- a/packages/mapviewer/src/views/PrintView.vue
+++ b/packages/mapviewer/src/views/PrintView.vue
@@ -6,9 +6,13 @@ import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 import { useStore } from 'vuex'
 
-import { getGenerateQRCodeUrl } from '@/api/qrcode.api.js'
-import { createShortLink } from '@/api/shortlink.api.js'
-import { PRINT_DEFAULT_DPI, PRINT_DIMENSIONS } from '@/config/print.config'
+import { getGenerateQRCodeUrl } from '@/api/qrcode.api'
+import { createShortLink } from '@/api/shortlink.api'
+import {
+    PRINT_DEFAULT_DPI,
+    PRINT_DIMENSIONS,
+    PRINT_MARGIN_IN_MILLIMETERS,
+} from '@/config/print.config'
 import InfoboxModule from '@/modules/infobox/InfoboxModule.vue'
 import MapFooter from '@/modules/map/components/footer/MapFooter.vue'
 import OpenLayersPrintResolutionEnforcer from '@/modules/map/components/openlayers/OpenLayersPrintResolutionEnforcer.vue'
@@ -62,6 +66,7 @@ const printContainerStyle = computed(() => {
     return {
         width: `${printContainerSize.value.width}px`,
         height: `${printContainerSize.value.height}px`,
+        padding: `${(PRINT_MARGIN_IN_MILLIMETERS * printDPI.value) / inchToMillimeter}px`,
     }
 })
 const mapScaleWidth = computed(() => {


### PR DESCRIPTION
We will move the generation of margin in the viewer, instead of dealing with that on the backend. This is because it's way easier to keep the "true-to-scale" when shrinking the map viewport (and let it recalculate everything) instead of resizing the flatten map and thus changing the scale of the image.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-1522-dpi-responsive-print-margin/index.html)