### PR TITLE
PB-1320: Support More Thousand Separator on Search

### DIFF
--- a/packages/mapviewer/src/utils/coordinates/__test__/coordinateExtractors.spec.js
+++ b/packages/mapviewer/src/utils/coordinates/__test__/coordinateExtractors.spec.js
@@ -505,14 +505,17 @@ describe('Unit test functions from coordinateExtractors.js', () => {
                     expectedProjection,
                     { acceptableDelta, testInverted: true }
                 )
-                checkXY(
-                    numberWithThousandSeparator(x, ' '),
-                    numberWithThousandSeparator(y, ' '),
-                    x,
-                    y,
-                    expectedProjection,
-                    { acceptableDelta, testInverted: true, thousandSpaceSeparator: true }
-                )
+                const thousandSeparatorChars = `'\`’´`
+                for (const separator of thousandSeparatorChars) {
+                    checkXY(
+                        numberWithThousandSeparator(x, separator),
+                        numberWithThousandSeparator(y, separator),
+                        x,
+                        y,
+                        expectedProjection,
+                        { acceptableDelta, testInverted: true, thousandSpaceSeparator: true }
+                    )
+                }
             })
             it("Returns coordinates when there's thousands separator and input is entered backward", () => {
                 checkXY(

--- a/packages/mapviewer/src/utils/coordinates/coordinateExtractors.js
+++ b/packages/mapviewer/src/utils/coordinates/coordinateExtractors.js
@@ -95,9 +95,13 @@ function extractWGS84Coordinates(text) {
     return undefined
 }
 
+const thousandSeparatorRegex = /['`’´ ]/g
 // LV95, LV03, metric WebMercator (EPSG:3857)
 const REGEX_METRIC_COORDINATES =
-    /^(?<coord1>\d{1,3}(['`´ ]?\d{3})*(\.\d+)?)\s*[,/ \t]\s*(?<coord2>\d{1,3}(['`´ ]?\d{3})*(\.\d+)?)$/i
+    new RegExp(
+        `^(?<coord1>\\d{1,3}(${thousandSeparatorRegex.source}?\\d{3})*(\\.\\d+)?)\\s*[,/ \\t]\\s*(?<coord2>\\d{1,3}(${thousandSeparatorRegex.source}?\\d{3})*(\\.\\d+)?)$`,
+        'i'
+    )
 
 /**
  * @param {String} text
@@ -156,8 +160,6 @@ function extractMgrsCoordinates(text) {
 
 const LV95_BOUNDS_IN_WGS84 = LV95.getBoundsAs(WGS84)
 const LV95_BOUNDS_IN_METRIC_MERCATOR = LV95.getBoundsAs(WEBMERCATOR)
-
-const thousandSeparatorRegex = /['`´ ]/g
 
 /**
  * @param {RegExpExecArray | undefined} regexMatches Matches from REGEX_METRIC_COORDINATES


### PR DESCRIPTION

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-1320-support-more-separator-on-search/index.html)

Result from the sample coordinate from the user: ` 692’910 238’550`

![image](https://github.com/user-attachments/assets/4783ccf1-1b29-4b89-b4d4-6fbed69e1629)


[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-1320-support-more-separator-on-search/index.html)