### PR TITLE
Showing a banner informing our users about the current outage - #patch

### DIFF
--- a/packages/mapviewer/src/modules/i18n/locales/de.json
+++ b/packages/mapviewer/src/modules/i18n/locales/de.json
@@ -490,6 +490,7 @@
     "operation_successful": "Erfolg!",
     "orange": "Orange",
     "orient_map_north": "Karte einnorden",
+    "outage_warning": "WARNUNG: Das Anzeigen und Ausdrucken von Karten ist zurzeit beeinträchtigt. Aktuellste Informationen zur Störung finden Sie <a target=\"_blank\" href=\"https://www.geo.admin.ch/de/wms-wmts-incident-de\">hier</a>.",
     "outside_valid_year_range": "Das eingegebene Jahr liegt ausserhalb des verfügbaren Bereichs:",
     "page_description": "map.geo.admin.ch ist die Kartenplattform der schweizerischen Eidgenossenschaft. Zugang zu Karten, Geoinformationen, -daten, -dienste und Metadaten der Schweiz.",
     "page_title": "Karten der Schweiz - Schweizerische Eidgenossenschaft - map.geo.admin.ch",

--- a/packages/mapviewer/src/modules/i18n/locales/en.json
+++ b/packages/mapviewer/src/modules/i18n/locales/en.json
@@ -490,6 +490,7 @@
     "operation_successful": "Operation successful!",
     "orange": "orange",
     "orient_map_north": "Orient the map",
+    "outage_warning": "WARNING: The display and printout of maps is currently disrupted. You can find the latest information about the issue <a target=\"_blank\" href=\"https://www.geo.admin.ch/en/wms-wmts-incident-en\">here</a>.",
     "outside_valid_year_range": "The entered year is outside of the available range:",
     "page_description": "map.geo.admin.ch is the mapping platform of the Swiss Confederation. Access federal geographical information, maps, data, services and metadata of Switzerland.",
     "page_title": "Maps of Switzerland - Swiss Confederation  - map.geo.admin.ch",

--- a/packages/mapviewer/src/modules/i18n/locales/fr.json
+++ b/packages/mapviewer/src/modules/i18n/locales/fr.json
@@ -490,6 +490,7 @@
     "operation_successful": "Succès !",
     "orange": "orange",
     "orient_map_north": "Orienter la carte",
+    "outage_warning": "AVERTISSEMENT : l'affichage et l'impression des cartes sont actuellement perturbés. Vous trouverez les dernières informations concernant cette perturbation <a target=\"_blank\" href=\"https://www.geo.admin.ch/fr/wms-wmts-incident-fr\">ici</a>.",
     "outside_valid_year_range": "L'année indiquée se situe en dehors de la plage disponible :",
     "page_description": "map.geo.admin.ch est la plateforme cartographique de la Confédération suisse et des cantons. Elle donne accès aux cartes, géoinformations, géodonnées, géoservices et métadonnées de la Suisse.",
     "page_title": "Cartes de la Suisse - Confédération suisse - map.geo.admin.ch",

--- a/packages/mapviewer/src/modules/i18n/locales/it.json
+++ b/packages/mapviewer/src/modules/i18n/locales/it.json
@@ -490,6 +490,7 @@
     "operation_successful": "Successo!",
     "orange": "arancione",
     "orient_map_north": "Orientare la mappa",
+    "outage_warning": "ATTENZIONE: la visualizzazione e la stampa delle mappe sono attualmente compromesse. Le informazioni più aggiornate sul malfunzionamento sono disponibili <a target=\"_blank\" href=\"https://www.geo.admin.ch/it/wms-wmts-incident-it\">qui</a>.",
     "outside_valid_year_range": "L'anno inserito è al di fuori dell'intervallo disponibile:",
     "page_description": "map.geo.admin.ch è la piattaforma cartografica della Confederazione svizzera e dei cantoni. Dà accesso alle mappe, alle geoinformazioni, ai geodati, ai geoservizi e ai metadati della Svizzera.",
     "page_title": "Carta della Svizzera - Confederazione svizzera - map.geo.admin.ch",

--- a/packages/mapviewer/src/modules/i18n/locales/rm.json
+++ b/packages/mapviewer/src/modules/i18n/locales/rm.json
@@ -488,6 +488,7 @@
     "operation_successful": "Success! ",
     "orange": "oransch",
     "orient_map_north": "Orientar la carta",
+    "outage_warning": "WARNUNG: Das Anzeigen und Ausdrucken von Karten ist zurzeit beeinträchtigt. Aktuellste Informationen zur Störung finden Sie <a target=\"_blank\" href=\"https://www.geo.admin.ch/de/wms-wmts-incident-de\">hier</a>.",
     "outside_valid_year_range": "L'onn entrà sa chatta ordaifer il sectur disponibe:",
     "page_description": "map.geo.admin.ch è la plattafurma da chartas da la Confederaziun svizra. Access a las chartas, geoinfurmaziuns, a las geodatas, als geoservetschs ed a las metadatas da la Svizra.",
     "page_title": "Chartas da la Svizra - Confederaziun svizra - map.geo.admin.ch",

--- a/packages/mapviewer/src/utils/components/FeedbackPopup.vue
+++ b/packages/mapviewer/src/utils/components/FeedbackPopup.vue
@@ -37,7 +37,9 @@ const warning = computed(() => {
             title="warning"
             @close="store.dispatch('removeWarning', { warning, ...dispatcher })"
         >
-            <div>{{ t(warning.msg, warning.params) }}</div>
+            <!-- eslint-disable vue/no-v-html-->
+            <div v-html="t(warning.msg, warning.params)"></div>
+            <!-- eslint-enable vue/no-v-html-->
         </WarningWindow>
     </div>
 </template>

--- a/packages/mapviewer/src/views/MapView.vue
+++ b/packages/mapviewer/src/views/MapView.vue
@@ -1,7 +1,8 @@
 <script setup>
-import { computed, defineAsyncComponent } from 'vue'
+import { computed, defineAsyncComponent, onMounted } from 'vue'
 import { useStore } from 'vuex'
 
+import { IS_TESTING_WITH_CYPRESS } from '@/config/staging.config.js'
 import InfoboxModule from '@/modules/infobox/InfoboxModule.vue'
 import CesiumMouseTracker from '@/modules/map/components/cesium/CesiumMouseTracker.vue'
 import BackgroundSelector from '@/modules/map/components/footer/backgroundSelector/BackgroundSelector.vue'
@@ -18,6 +19,7 @@ import { UIModes } from '@/store/modules/ui.store'
 import AppVersion from '@/utils/components/AppVersion.vue'
 import DragDropOverlay from '@/utils/components/DragDropOverlay.vue'
 import LoadingBar from '@/utils/components/LoadingBar.vue'
+import WarningMessage from '@/utils/WarningMessage.class'
 
 const DrawingModule = defineAsyncComponent(() => import('@/modules/drawing/DrawingModule.vue'))
 
@@ -31,6 +33,19 @@ const showDragAndDropOverlay = computed(() => store.state.ui.showDragAndDropOver
 const loadDrawingModule = computed(() => {
     return isDrawingMode.value && !is3DActive.value
 })
+
+onMounted(() => {
+    addOutageWarning()
+})
+
+function addOutageWarning() {
+    if (!IS_TESTING_WITH_CYPRESS) {
+        store.dispatch('addWarnings', {
+            warnings: [new WarningMessage('outage_warning')],
+            dispatcher: 'MapView.vue',
+        })
+    }
+}
 </script>
 
 <template>


### PR DESCRIPTION
Showing a banner informing our users about the current outage
Should be reverted as soon as the outage is over

[Test link](https://sys-map.int.bgdi.ch/preview/wms_outage_banner/index.html)