### PR TITLE
PB-1427: Support uppercase language parameter

### DIFF
--- a/packages/mapviewer/src/modules/menu/components/help/MenuHelpSection.vue
+++ b/packages/mapviewer/src/modules/menu/components/help/MenuHelpSection.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 
@@ -26,7 +26,14 @@ const store = useStore()
 const hasGiveFeedbackButton = computed(() => store.getters.hasGiveFeedbackButton)
 const hasReportProblemButton = computed(() => store.getters.hasReportProblemButton)
 
-const currentLang = ref(store.state.i18n.lang)
+const currentLang = computed(() => store.state.i18n.lang)
+
+// this is needed to pass the selected value to the changelang function
+const selectedLang = ref(currentLang.value)
+
+watch(currentLang, () => {
+    selectedLang.value = currentLang.value
+})
 
 function changeLang(lang) {
     store.dispatch('setLang', {
@@ -111,10 +118,10 @@ defineExpose({
         </div>
         <template #extra-button>
             <select
-                v-model="currentLang"
+                v-model="selectedLang"
                 class="form-control form-control-sm menu-lang-switch bg-light text-dark"
                 data-cy="mobile-lang-selector"
-                @change="changeLang(currentLang)"
+                @change="changeLang(selectedLang)"
                 @click.stop
             >
                 <option

--- a/packages/mapviewer/src/router/storeSync/storeSync.config.js
+++ b/packages/mapviewer/src/router/storeSync/storeSync.config.js
@@ -35,7 +35,11 @@ const storeSyncConfig = [
         keepInUrlWhenDefault: true,
         valueType: String,
         validateUrlInput: (store, query) =>
-            getStandardValidationResponse(query, SUPPORTED_LANG.includes(query), 'lang'),
+            getStandardValidationResponse(
+                query,
+                SUPPORTED_LANG.includes(query.toLowerCase()),
+                'lang'
+            ),
     }),
     new NoSimpleZoomParamConfig(),
     new SimpleUrlParamConfig({

--- a/packages/mapviewer/src/store/modules/i18n.store.js
+++ b/packages/mapviewer/src/store/modules/i18n.store.js
@@ -28,8 +28,8 @@ const actions = {
 const mutations = {}
 
 mutations[SET_LANG_MUTATION_KEY] = function (state, { lang }) {
-    state.lang = lang
-    i18n.global.locale = langToLocal(lang)
+    state.lang = lang.toLowerCase()
+    i18n.global.locale = langToLocal(lang.toLowerCase())
 }
 
 export default {

--- a/packages/mapviewer/tests/cypress/tests-e2e/changeLanguage.cy.js
+++ b/packages/mapviewer/tests/cypress/tests-e2e/changeLanguage.cy.js
@@ -2,6 +2,8 @@
 
 import { isMobile } from 'tests/cypress/support/utils'
 
+import { SUPPORTED_LANG } from '@/modules/i18n'
+
 function checkLanguage(lang) {
     // Check language in store
     cy.readStoreValue('state.i18n.lang').should('eq', lang)
@@ -66,6 +68,19 @@ function checkLanguage(lang) {
 }
 
 describe('Change language', () => {
+    context('on startup', () => {
+        it('should show the correct language if we ask for it, even if the param is in uppercase', () => {
+            SUPPORTED_LANG.forEach((lang) => {
+                cy.goToMapView({ lang: lang })
+                checkLanguage(lang)
+            })
+
+            SUPPORTED_LANG.forEach((lang) => {
+                cy.goToMapView({ lang: lang.toUpperCase() })
+                checkLanguage(lang)
+            })
+        })
+    })
     context('in mobile view', () => {
         it('should change the language', () => {
             cy.goToMapView()
@@ -74,9 +89,7 @@ describe('Change language', () => {
             checkLanguage('en') // Initial language is 'en'
 
             // Check for all available languages
-            const availableLanguages = ['de', 'fr', 'it', 'rm', 'en']
-
-            availableLanguages.forEach((lang) => {
+            SUPPORTED_LANG.forEach((lang) => {
                 cy.clickOnLanguage(lang)
                 checkLanguage(lang)
             })
@@ -96,9 +109,7 @@ describe('Change language', () => {
                 checkLanguage('en') // Initial language is 'en'
 
                 // Check for all available languages
-                const availableLanguages = ['de', 'fr', 'it', 'rm', 'en']
-
-                availableLanguages.forEach((lang) => {
+                SUPPORTED_LANG.forEach((lang) => {
                     cy.clickOnLanguage(lang)
                     checkLanguage(lang)
                 })


### PR DESCRIPTION
Issue: some people can't use lowercase letters for the `lang` URL parameter and wanted to be able to use uppercase letters

Fix: we let people input uppercase letters in the `lang` URL parameter and force it to lowercase on our side.

Also: added some tests

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1427-accept-uppercase-lang-param/index.html)