### PR TITLE
PB-1670: clarify lack of precision of mouse tracked LV03 coordinates

### DIFF
--- a/packages/mapviewer/src/modules/map/components/cesium/CesiumMouseTracker.vue
+++ b/packages/mapviewer/src/modules/map/components/cesium/CesiumMouseTracker.vue
@@ -4,11 +4,12 @@ import log from '@geoadmin/log'
 import { round } from '@geoadmin/numbers'
 import { Cartographic, Math, ScreenSpaceEventHandler, ScreenSpaceEventType } from 'cesium'
 import proj4 from 'proj4'
-import { computed, inject, onMounted, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue'
+import { computed, inject, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 
-import allFormats, { LV03Format, LV95Format } from '@/utils/coordinates/coordinateFormat'
+import getHumanReadableCoordinate from '@/modules/map/components/common/mouseTrackerUtils'
+import allFormats, { LV95Format } from '@/utils/coordinates/coordinateFormat'
 
 const mousePosition = useTemplateRef('mousePosition')
 const displayedFormatId = ref(LV95Format.id)
@@ -64,10 +65,6 @@ function setupHandler() {
     }, ScreenSpaceEventType.MOUSE_MOVE)
 }
 
-function showCoordinateLabel(displayedFormat) {
-    return displayedFormat?.id === LV95Format.id || displayedFormat?.id === LV03Format.id
-}
-
 function setDisplayedFormatWithId() {
     store.dispatch('setDisplayedFormatId', {
         displayedFormatId: displayedFormatId.value,
@@ -78,10 +75,11 @@ function setDisplayedFormatWithId() {
 function formatCoordinate(coordinate) {
     const displayedFormat = allFormats.find((format) => format.id === displayedFormatId.value)
     if (displayedFormat) {
-        return `${showCoordinateLabel(displayedFormat) ? t('coordinates_label') : ''} ${displayedFormat.format(
-            [coordinate[0], coordinate[1]],
-            projection.value
-        )}, ${t('elevation')}: ${round(coordinate[2], 2)} m`
+        return `${getHumanReadableCoordinate({
+            coordinates: [coordinate[0], coordinate[1]],
+            projection: projection.value,
+            displayedFormat,
+        })}, ${t('elevation')}: ${round(coordinate[2], 2)} m`
     } else {
         log.error('Unknown coordinates display format', displayedFormatId.value)
     }

--- a/packages/mapviewer/src/modules/map/components/common/mouseTrackerUtils.js
+++ b/packages/mapviewer/src/modules/map/components/common/mouseTrackerUtils.js
@@ -1,0 +1,42 @@
+import { LV03 } from '@geoadmin/coordinates'
+import { round } from '@geoadmin/numbers'
+import proj4 from 'proj4'
+
+import i18n from '@/modules/i18n'
+import { LV03Format, LV95Format } from '@/utils/coordinates/coordinateFormat'
+
+/**
+ * Transform the coordinate, expressed in the given projection, into the wanted display format.
+ *
+ * There's a catch with LV03, where the precision of our transformation/reprojection with mouse
+ * tracked coordinate isn't 100% precise (because transforming between LV95 and LV03 is much more
+ * complex than a "simple" matrix reprojection, see the transformation vectors here:
+ * https://s.geo.admin.ch/onq5koks0hnf and the REFRAME service we usually use for this here:
+ * https://www.swisstopo.admin.ch/en/coordinate-conversion-reframe). So for this case we add a
+ * little "approx." text before the coordinate, and round them to the nearest integer.
+ *
+ * Having precise coordinate in LV03 can be achieved by right-clicking on the map, as this part of
+ * the app is using the REFRAME service. Here, as we are transforming coordinate multiple times per
+ * second, that would not be a good idea...
+ *
+ * @param {SingleCoordinate} coordinates
+ * @param {CoordinateSystem} projection
+ * @param {CoordinateFormat} displayedFormat
+ * @returns {string}
+ */
+export default function getHumanReadableCoordinate({ coordinates, projection, displayedFormat }) {
+    if (displayedFormat.id === LV95Format.id) {
+        return `${i18n.global.t('coordinates_label')} ${displayedFormat.format(coordinates, projection)}`
+    } else if (displayedFormat.id === LV03Format.id) {
+        // as we round the values, we have to project here ourselves (the format will otherwise proj4 them and we will lose our rounding)
+        const lv03Coordinates =
+            projection.epsg === LV03.epsg
+                ? coordinates
+                : proj4(projection.epsg, LV03.epsg, coordinates)
+        return `${i18n.global.t('coordinates_label')} ${i18n.global.t('approx_abbr')} ${displayedFormat.format(
+            lv03Coordinates.map((value) => round(value)),
+            LV03
+        )}`
+    }
+    return displayedFormat.format(coordinates, projection, true)
+}


### PR DESCRIPTION
As pointed out by some of our users, the dynamically generated coordinates on the bottom part of the map with the mouse are not precise when dealing with LV03. They are generated without taking into consideration the real deformation between LV95 and LV03, and are calculated based on a simple matrix reprojection to be more dynamic (we are not using the REFRAME service after each mouse move, that would be overkill).

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-1670-lv03-circa-for-mouse-track/index.html)