### PR TITLE
PB-1579: add support for local BigTIFF

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "private": true,
     "scripts": {
         "build-all": "pnpm run -r build",
+        "build-libs": "pnpm run -r build --filter=!web-mapviewer",
         "build:dev": "pnpm -r run build:dev",
         "build:dev:watch": "pnpm -r --parallel --if-present run build:dev:watch --filter=!web-mapviewer",
         "build:int": "pnpm -r run build:int",

--- a/packages/mapviewer/src/modules/menu/components/advancedTools/ImportFile/parser/CloudOptimizedGeoTIFFParser.class.js
+++ b/packages/mapviewer/src/modules/menu/components/advancedTools/ImportFile/parser/CloudOptimizedGeoTIFFParser.class.js
@@ -15,7 +15,12 @@ export class CloudOptimizedGeoTIFFParser extends FileParser {
     constructor() {
         super({
             fileExtensions: ['.tif', '.tiff'],
-            fileTypeLittleEndianSignature: [0x49, 0x49, 0x2a, 0x00],
+            fileTypeLittleEndianSignature: [
+                // Standard TIFF
+                [0x49, 0x49, 0x2a, 0x00],
+                // BigTIFF
+                [0x49, 0x49, 0x2b, 0x00],
+            ],
             fileContentTypes: [
                 'image/tiff',
                 'image/tiff;subtype=geotiff',
@@ -43,14 +48,12 @@ export class CloudOptimizedGeoTIFFParser extends FileParser {
         const imageGeoKeys = firstImage.getGeoKeys()
         const imageGeoKey = imageGeoKeys?.ProjectedCSTypeGeoKey
         const imageGeoKeyName = imageGeoKeys?.GTCitationGeoKey ?? ''
-        const cogProjection = allCoordinateSystems.find(
-            (coordinateSystem) => {
-                if (imageGeoKey !== USER_DEFINED_CS) {
-                    return coordinateSystem.epsgNumber === imageGeoKey
-                }
-                return imageGeoKeyName.indexOf(coordinateSystem.technicalName) !== -1
+        const cogProjection = allCoordinateSystems.find((coordinateSystem) => {
+            if (imageGeoKey !== USER_DEFINED_CS) {
+                return coordinateSystem.epsgNumber === imageGeoKey
             }
-        )
+            return imageGeoKeyName.indexOf(coordinateSystem.technicalName) !== -1
+        })
         if (!cogProjection) {
             throw new UnknownProjectionError(
                 `Unknown projection found in COG EPSG:${imageGeoKey}`,

--- a/packages/mapviewer/src/modules/menu/components/advancedTools/ImportFile/parser/FileParser.class.js
+++ b/packages/mapviewer/src/modules/menu/components/advancedTools/ImportFile/parser/FileParser.class.js
@@ -21,7 +21,7 @@ import { checkOnlineFileCompliance, getFileContentFromUrl } from '@/api/files.ap
 export default class FileParser {
     /**
      * @param {String} config.displayedName Name used to describe this file type to the end user
-     * @param {Number[]} config.fileTypeLittleEndianSignature Little endian signature (aka magic
+     * @param {Number[][]} config.fileTypeLittleEndianSignature Little endian signature (aka magic
      *   numbers), if any, for this file type. Will be used to check the first 4 bytes of the file.
      * @param {String[]} config.fileExtensions Which file extensions this file type is carried with
      *   (case-insensitive)
@@ -74,10 +74,14 @@ export default class FileParser {
         const fileArrayBuffer = await fileSource.arrayBuffer()
         // if a little endian signature was found, and we know one to match against, we prioritize this way of
         // detecting if this file is a valid candidate
-        if (fileArrayBuffer.byteLength >= 4 && this.fileTypeLittleEndianSignature.length === 4) {
+        if (
+            fileArrayBuffer.byteLength >= 4 &&
+            this.fileTypeLittleEndianSignature.length > 0 &&
+            this.fileTypeLittleEndianSignature.every((signature) => signature.length === 4)
+        ) {
             const littleEndianSignature = new Uint8Array(fileArrayBuffer.slice(0, 4))
-            return this.fileTypeLittleEndianSignature.every(
-                (byte, index) => byte === littleEndianSignature[index]
+            return this.fileTypeLittleEndianSignature.find((signature) =>
+                signature.every((byte, index) => byte === littleEndianSignature[index])
             )
         }
         // if no known little endian signature for this file type we fall back to check the file extension

--- a/packages/mapviewer/src/modules/menu/components/advancedTools/ImportFile/parser/KMZParser.class.js
+++ b/packages/mapviewer/src/modules/menu/components/advancedTools/ImportFile/parser/KMZParser.class.js
@@ -29,7 +29,7 @@ export default class KMZParser extends FileParser {
             fileExtensions: ['.kmz'],
             fileContentTypes: ['application/vnd.google-earth.kmz'],
             // ZIP file signature
-            fileTypeLittleEndianSignature: ZIP_FILE_LITTLE_ENDIAN_SIGNATURE,
+            fileTypeLittleEndianSignature: [ZIP_FILE_LITTLE_ENDIAN_SIGNATURE],
             validateFileContent: isZipContent,
         })
     }


### PR DESCRIPTION
we were missing the little endian signature for BigTIFF (which is different than normal TIFFs) to be able to parse a local BigTIFF file.

It was working fine with URLs already because we do not test against little endian signature in this case, and let GeoTIFF.js library do its magic, so nothing to change there.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-1579-local-bigtiff-support/index.html)