### PR TITLE
PB-1054 : Remove mouse events from useMovableElement and replace with pointer events

### DIFF
--- a/packages/mapviewer/src/modules/map/components/MapPopover.vue
+++ b/packages/mapviewer/src/modules/map/components/MapPopover.vue
@@ -105,9 +105,10 @@ const popoverLimits = computed(() => {
 
 onMounted(() => {
     if (mode === MapPopoverMode.FLOATING && popover.value && popoverHeader.value) {
-        useMovableElement(popover.value, {
-            grabElement: popoverHeader,
-            offset: popoverLimits,
+        useMovableElement({
+            element: popover.value,
+            grabElement: popoverHeader.value,
+            offset: popoverLimits.value,
         })
     }
 })

--- a/packages/mapviewer/src/utils/components/SimpleWindow.vue
+++ b/packages/mapviewer/src/utils/components/SimpleWindow.vue
@@ -78,7 +78,8 @@ onMounted(() => {
     if (movable) {
         const windowElement = windowRef.value
         const headerElement = headerRef.value
-        useMovableElement(windowElement, {
+        useMovableElement({
+            element: windowElement,
             grabElement: headerElement,
             initialPositionClasses: [initialPositionClass.value],
             offset: { bottom: 0, right: 0, left: 0 },


### PR DESCRIPTION
Mouse events have been removed in favour of pointer events for better compatibility with mobile devices and touch screens.

[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-1054-tooltip-touch-events/index.html)