### PR TITLE
PB-1680 : Fix icon selector border

### DIFF
--- a/packages/mapviewer/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
+++ b/packages/mapviewer/src/modules/infobox/components/styling/DrawingStyleIconSelector.vue
@@ -127,11 +127,11 @@ function onCurrentIconChange(icon) {
 
         <div
             v-if="currentIconSet && currentIconSet.icons.length > 0"
-            class="icon-selector border-2 bg-light rounded"
+            class="icon-selector bg-light rounded border border-gray-300"
             :class="{ 'transparent-bottom': !showAllSymbols }"
         >
             <div
-                class="rounded d-flex align-items-center p-2"
+                class="d-flex align-items-center rounded p-2"
                 data-cy="drawing-style-toggle-all-icons-button"
                 @click="toggleShowAllSymbols()"
             >


### PR DESCRIPTION
Also changed the border class to be tailwind-compliant

Here's the result : 
![image](https://github.com/user-attachments/assets/6f274585-4b18-4a83-b8c0-b3b1f0bae1e0)


[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-1680-icon-selector-bug/index.html)