### PR TITLE
PB-1691 : Remove pin and highlight position offset in 3D view

### DIFF
--- a/packages/mapviewer/src/config/cesium.config.js
+++ b/packages/mapviewer/src/config/cesium.config.js
@@ -35,6 +35,9 @@ export const CAMERA_MIN_PITCH = -Math.PI / 2
  */
 export const CAMERA_MAX_PITCH = Math.PI / 4
 
+/** Billboard horizontal offset to align it with the highlight */
+export const DEFAULT_MARKER_HORIZONTAL_OFFSET = 40
+
 /**
  * Distance on which depth test will be disabled for primitive to avoid cutting by terrain
  *

--- a/packages/mapviewer/src/modules/map/components/cesium/CesiumKMLLayer.vue
+++ b/packages/mapviewer/src/modules/map/components/cesium/CesiumKMLLayer.vue
@@ -1,9 +1,18 @@
 <script setup>
 import log from '@geoadmin/log'
-import { ArcType, Color, HeightReference, KmlDataSource, LabelStyle, VerticalOrigin } from 'cesium'
+import {
+    ArcType,
+    Color,
+    HeightReference,
+    HorizontalOrigin,
+    KmlDataSource,
+    LabelStyle,
+    VerticalOrigin,
+} from 'cesium'
 import { computed, inject, toRef, watch } from 'vue'
 
 import KMLLayer from '@/api/layers/KMLLayer.class'
+import { DEFAULT_MARKER_HORIZONTAL_OFFSET } from '@/config/cesium.config'
 import useAddDataSourceLayer from '@/modules/map/components/cesium/utils/useAddDataSourceLayer.composable'
 import { getFeatureDescriptionMap } from '@/utils/kmlUtils'
 
@@ -72,8 +81,24 @@ function applyStyleToKmlEntity(entity, opacity) {
         }
     }
     if (entity.billboard) {
+        let imageUrl = null
+
+        if (entity.billboard.image) {
+            const imageValue = entity.billboard.image.getValue()
+
+            if (typeof imageValue === 'string') {
+                imageUrl = imageValue
+            } else if (imageValue && imageValue.url) {
+                imageUrl = imageValue.url
+            }
+        }
+
+        const isDefaultMarker = !!imageUrl?.includes('001-marker')
+
         entity.billboard.heightReference = HeightReference.CLAMP_TO_GROUND
-        entity.billboard.verticalOrigin = VerticalOrigin.BOTTOM
+        entity.billboard.verticalOrigin = VerticalOrigin.CENTER
+        entity.billboard.horizontalOrigin =
+            HorizontalOrigin.CENTER + isDefaultMarker * DEFAULT_MARKER_HORIZONTAL_OFFSET
         entity.billboard.color = Color.WHITE.withAlpha(opacity)
     }
     if (entity.label) {


### PR DESCRIPTION
[Test link](https://sys-map.dev.bgdi.ch/preview/task-pb-1691-pin-position-3d/index.html)

The Marker icon has an offset in 2d space, in order to display it anchored on the tip, which
cause the offset visible in 3d. Our solution is to add a conditional check in 3d
to properly display markers, as all other icons don't have this problem.

Here's the result : 

![image](https://github.com/user-attachments/assets/306a3e4f-a8b1-46b3-bbe9-a869363a6c01)


[Test link](https://sys-map.dev.bgdi.ch/preview/task-pb-1691-pin-position-3d/index.html)