### PR TITLE
PB-1703: Add support for .png files in reportProblem window

### DIFF
--- a/packages/mapviewer/src/modules/i18n/locales/de.json
+++ b/packages/mapviewer/src/modules/i18n/locales/de.json
@@ -249,7 +249,7 @@
     "feedback_more_info_text": "Weitere Informationen zu den Kategorien",
     "feedback_more_info_url": "https://www.geo.admin.ch/de/kartenviewer-navigation-und-orientierung#Problem-melden",
     "feedback_permalink": "Folgender Link wird übermittelt: ",
-    "feedback_placeholder": "Fügen Sie eine .pdf, .zip, .jpg, .jpeg, .kml, .kmz oder .gpx Datei hinzu",
+    "feedback_placeholder": "Fügen Sie eine .pdf, .zip, .jpg, .jpeg, .png, .kml, .kmz oder .gpx Datei hinzu",
     "feedback_rating_text": "Teilen Sie uns mit, wie Sie sich mit unserem Kartenviewer fühlen",
     "feedback_rating_title": "Wie würden Sie Ihre Erfahrung bewerten ? (erforderlich)",
     "feedback_success_message": "Danke für Ihre Nachricht. Diese wurde erfolgreich übermittelt.",

--- a/packages/mapviewer/src/modules/i18n/locales/en.json
+++ b/packages/mapviewer/src/modules/i18n/locales/en.json
@@ -249,7 +249,7 @@
     "feedback_more_info_text": "More information on the categories",
     "feedback_more_info_url": "https://www.geo.admin.ch/en/map-viewer-help-navigation-and-orientation#Report-a-problem",
     "feedback_permalink": "The following URL will be transferred: ",
-    "feedback_placeholder": "Attach a pdf, zip, jpg, jpeg, kml, kmz or gpx file",
+    "feedback_placeholder": "Attach a pdf, zip, jpg, jpeg, png, kml, kmz or gpx file",
     "feedback_rating_text": "Tell us what you think about our new map viewer",
     "feedback_rating_title": "How would you rate your experience ? (required)",
     "feedback_success_message": "Your message was successfully sent. Thank you.",

--- a/packages/mapviewer/src/modules/i18n/locales/fr.json
+++ b/packages/mapviewer/src/modules/i18n/locales/fr.json
@@ -249,7 +249,7 @@
     "feedback_more_info_text": "Plus d'information sur les catégories",
     "feedback_more_info_url": "https://www.geo.admin.ch/fr/visualiseur-de-cartes-navigation-et-orientiation#Signaler-un-probl%C3%A8me",
     "feedback_permalink": "Le lien suivant sera transféré: ",
-    "feedback_placeholder": "Joindre un pdf, zip, jpg, jpeg, kml, kmz ou gpx",
+    "feedback_placeholder": "Joindre un pdf, zip, jpg, jpeg, png, kml, kmz ou gpx",
     "feedback_rating_text": "Faites-nous part de votre avis sur notre nouveau visualiseur de carte",
     "feedback_rating_title": "Comment évalueriez-vous votre expérience ? (requis)",
     "feedback_success_message": "Votre message a été envoyé avec succès. Merci.",

--- a/packages/mapviewer/src/modules/i18n/locales/it.json
+++ b/packages/mapviewer/src/modules/i18n/locales/it.json
@@ -249,7 +249,7 @@
     "feedback_more_info_text": "Maggiori informazioni sulle categorie",
     "feedback_more_info_url": "https://www.geo.admin.ch/it/visualizzatore-di-mappe-navigazione-e-orientazione#Segnalare-un-problema",
     "feedback_permalink": "Il seguente link verrá inviato: ",
-    "feedback_placeholder": "Aggiungere un pdf, zip, jpeg, kml, kmz o gpx",
+    "feedback_placeholder": "Aggiungere un pdf, zip, jpeg, png, kml, kmz o gpx",
     "feedback_rating_text": "Diteci cosa ne pensate del nostro nuovo visualizzatore di carte",
     "feedback_rating_title": "Come valuta la sua esperienza ? (obbligatorio)",
     "feedback_success_message": "Il suo messaggio è stato inviato con successo. Grazie.",

--- a/packages/mapviewer/src/modules/i18n/locales/rm.json
+++ b/packages/mapviewer/src/modules/i18n/locales/rm.json
@@ -247,7 +247,7 @@
     "feedback_more_info_text": "Ulteriuras infurmaziuns davart las categorias",
     "feedback_more_info_url": "https://www.geo.admin.ch/de/kartenviewer-navigation-und-orientierung#Problem-melden#Die-Problem-Melden-Kategorien",
     "feedback_permalink": "Il suandant link vegn transmess:",
-    "feedback_placeholder": "Agiuntai ina datoteca .pdf, .zip, .jpg, .jpeg, .kml, .kmz u .gpx",
+    "feedback_placeholder": "Agiuntai ina datoteca .pdf, .zip, .jpg, .jpeg, .png, .kml, .kmz u .gpx",
     "feedback_rating_text": "Teilen Sie uns Ihre Meinung zu unserem neuen Kartenviewer mit",
     "feedback_rating_title": "Co giuditgais Vus Vossa experientscha? (obligatoric)",
     "feedback_success_message": "Messadi trasmess cun success. Grazia.",

--- a/packages/mapviewer/src/modules/menu/components/help/ReportProblemButton.vue
+++ b/packages/mapviewer/src/modules/menu/components/help/ReportProblemButton.vue
@@ -20,7 +20,7 @@ import TextAreaInput from '@/utils/components/TextAreaInput.vue'
 const dispatcher = { dispatcher: 'ReportProblemButton.vue' }
 const temporaryKmlId = getKmlUrl('temporary-kml-for-reporting-a-problem')
 
-const acceptedFileTypes = ['.kml', '.gpx', '.pdf', '.zip', '.jpg', '.jpeg', '.kmz']
+const acceptedFileTypes = ['.kml', '.gpx', '.pdf', '.zip', '.jpg', '.jpeg', '.png', '.kmz']
 
 const { t } = useI18n()
 const store = useStore()
@@ -237,7 +237,7 @@ function selectItem(dropdownItem) {
             class="report-problem"
             data-cy="report-problem-form"
         >
-            <div class="mb-2 fw-bold">
+            <div class="fw-bold mb-2">
                 {{ t('feedback_category') }}
             </div>
             <DropdownButton
@@ -367,14 +367,14 @@ function selectItem(dropdownItem) {
             />
             <div
                 ref="validationResult"
-                class="invalid-feedback text-end mt-2"
+                class="invalid-feedback mt-2 text-end"
             >
                 {{ t('form_invalid') }}
             </div>
             <div
                 v-if="request.failed"
                 ref="requestResults"
-                class="text-end text-danger mt-2"
+                class="text-danger mt-2 text-end"
                 data-cy="report-problem-failed-text"
             >
                 <small>{{ t('send_failed') }}</small>
@@ -392,7 +392,7 @@ function selectItem(dropdownItem) {
             </h6>
             <button
                 ref="reportProblemCloseSuccessful"
-                class="my-2 btn btn-light float-end"
+                class="btn btn-light float-end my-2"
                 data-cy="report-problem-close-successful"
                 @click="closeAndCleanForm"
             >


### PR DESCRIPTION
This will be merged after the changes made to the `service-feedback` [backend](https://github.com/geoadmin/service-feedback/pull/45)

[Test link](https://sys-map.dev.bgdi.ch/preview/task-pb-1703-allow-png-report-problem/index.html)