### PR TITLE
PB-1357 : Enable depth testing for labels

### DIFF
--- a/packages/mapviewer/src/modules/map/components/cesium/utils/swissnamesStyle.js
+++ b/packages/mapviewer/src/modules/map/components/cesium/utils/swissnamesStyle.js
@@ -9,8 +9,8 @@ export const CESIUM_SWISSNAMES3D_STYLE = new Cesium3DTileStyle({
     show: true,
     labelStyle: 2,
     labelText: '${DISPLAY_TEXT}',
-    // no depth test for labels
-    disableDepthTestDistance: Number.POSITIVE_INFINITY,
+    // depth testing is enabled to hide labels behind terrain
+    disableDepthTestDistance: 0,
     anchorLineEnabled: true,
     anchorLineColor: "color('white')",
     heightOffset: {


### PR DESCRIPTION
This seems to fix the issue of labels being shown despite being behind terrain. Previously, it seems we weren't doing any depth testing for labels (perhaps intentionally?) so I've enabled it back.

Before : 
![image](https://github.com/user-attachments/assets/055743ea-2fda-4cd4-9e13-850f7c081e7d)

After : 
![image](https://github.com/user-attachments/assets/d8ecf26e-293b-45b3-9cd4-27dda33ef7b6)


[Test link](https://sys-map.dev.bgdi.ch/preview/bug-pb-1357-hide-3d-labels-behind-terrain/index.html)