### PR TITLE
PB-1699: White listing internal services used as an external provider

### DIFF
--- a/packages/mapviewer/src/config/layers.config.ts
+++ b/packages/mapviewer/src/config/layers.config.ts
@@ -1,6 +1,0 @@
-/**
- * List of whitelisted URLS regexes for external layers. External layers which baseUrl
- * match one of these regexes won't show a disclaimer
- */
-
-export const EXTERNAL_PROVIDER_WHITELISTED_URL_REGEXES : Array<RegExp> = [/^(.+\.)?geo\.admin\.ch.*$/g]

--- a/packages/mapviewer/src/config/layers.config.ts
+++ b/packages/mapviewer/src/config/layers.config.ts
@@ -1,0 +1,6 @@
+/**
+ * List of whitelisted URLS regexes for external layers. External layers which baseUrl
+ * match one of these regexes won't show a disclaimer
+ */
+
+export const EXTERNAL_PROVIDER_WHITELISTED_URL_REGEXES : Array<RegExp> = [/^(.+\.)?geo\.admin\.ch.*$/g]

--- a/packages/mapviewer/src/config/regex.config.ts
+++ b/packages/mapviewer/src/config/regex.config.ts
@@ -1,0 +1,14 @@
+
+/**
+ * This Regular expression matches our own internal backend or the localhost
+ */
+export const LOCAL_OR_INTERNAL_URL_REGEX: RegExp = /^(https:\/\/[^/]*(bgdi\.ch|geo\.admin\.ch)|https?:\/\/localhost)/
+
+/**
+ * List of whitelisted URLS regexes for external layers. External layers which baseUrl
+ * match one of these regexes won't show a disclaimer.
+ */
+export const EXTERNAL_PROVIDER_WHITELISTED_URL_REGEXES : Array<RegExp> = [LOCAL_OR_INTERNAL_URL_REGEX]
+
+
+

--- a/packages/mapviewer/src/store/modules/layers.store.js
+++ b/packages/mapviewer/src/store/modules/layers.store.js
@@ -4,7 +4,7 @@ import { ErrorMessage } from '@geoadmin/log/Message'
 
 import AbstractLayer from '@/api/layers/AbstractLayer.class'
 import LayerTypes from '@/api/layers/LayerTypes.enum'
-import { EXTERNAL_PROVIDER_WHITELISTED_URL_REGEXES } from '@/config/layers.config'
+import { EXTERNAL_PROVIDER_WHITELISTED_URL_REGEXES } from '@/config/regex.config'
 import { DEFAULT_OLDEST_YEAR, DEFAULT_YOUNGEST_YEAR } from '@/config/time.config'
 import { getExtentIntersectionWithCurrentProjection } from '@/utils/extentUtils'
 import { getGpxExtent } from '@/utils/gpxUtils'

--- a/packages/mapviewer/src/utils/kmlUtils.js
+++ b/packages/mapviewer/src/utils/kmlUtils.js
@@ -19,6 +19,7 @@ import { extractOlFeatureCoordinates } from '@/api/features/features.api'
 import { proxifyUrl } from '@/api/file-proxy.api'
 import { DEFAULT_TITLE_OFFSET, DrawingIcon } from '@/api/icon.api'
 import KmlStyles from '@/api/layers/KmlStyles.enum'
+import { LOCAL_OR_INTERNAL_URL_REGEX } from '@/config/regex.config'
 import {
     allStylingSizes,
     allStylingTextPlacements,
@@ -86,8 +87,9 @@ export function getKmlExtent(content) {
 }
 
 /**
- * Get the description of all features in the KML content in form of a Map with the feature ID as key
- * 
+ * Get the description of all features in the KML content in form of a Map with the feature ID as
+ * key
+ *
  * @param {string} content KML content
  * @returns {Map<string, string>} Map of feature ID to description
  */
@@ -532,7 +534,7 @@ function detectTextPlacement(textScale, iconScale, anchor, iconSize, text, curre
 const nonGeoadminIconUrls = new Set()
 export function iconUrlProxyFy(url, corsIssueCallback = null, httpIssueCallBack = null) {
     // We only proxyfy URL that are not from our backend.
-    if (!/^(https:\/\/[^/]*(bgdi\.ch|geo\.admin\.ch)|https?:\/\/localhost)/.test(url)) {
+    if (!LOCAL_OR_INTERNAL_URL_REGEX.test(url)) {
         if (url.startsWith('http:') && httpIssueCallBack) {
             log.warn(`KML Icon url ${url} has an http scheme`)
             httpIssueCallBack(url)

--- a/packages/mapviewer/tests/cypress/fixtures/external-wms-getcap-1.fixture.xml
+++ b/packages/mapviewer/tests/cypress/fixtures/external-wms-getcap-1.fixture.xml
@@ -19,7 +19,7 @@
         </KeywordList>
         <OnlineResource
             xmlns:xlink="http://www.w3.org/1999/xlink"
-            xlink:href="https://wms.geo.admin.ch/?"
+            xlink:href="https://fake.wms.base-1.url/?"
         />
         <ContactInformation>
             <ContactPersonPrimary>


### PR DESCRIPTION
Issue: When importing layers from our own services, a disclaimer was visible, saying the sources were provided by a third party.

Fix: We "white list" all sources coming from a "*.map.geo.admin.ch" domain, removing the disclaimer.

[Test link](https://sys-map.dev.bgdi.ch/preview/feat-pb-1699-whitelist-swisstopo-external-layers/index.html)