### PR TITLE
PB-1752: fix timeslider wms

### DIFF
--- a/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersWMSLayer.vue
+++ b/packages/mapviewer/src/modules/map/components/openlayers/OpenLayersWMSLayer.vue
@@ -111,7 +111,8 @@ watch(projection, () => {
     setExtent()
 })
 
-watch(wmsUrlParams, layer.getSource().updateParams(wmsUrlParams.value))
+watch(wmsUrlParams, () => layer.getSource().updateParams(wmsUrlParams.value))
+
 watch(() => wmsLayerConfig.extent, setExtent)
 
 function createSourceForProjection() {


### PR DESCRIPTION
[Test link with url from ticket](https://sys-map.dev.bgdi.ch/preview/fix-pb-1752-fix-timeslider-wms/index.html#/map?lang=fr&center=2653530.19,1189865.23&z=1.461&topic=ech&layers=ch.swisstopo.pixelkarte-farbe-pk25.noscale@year=1989;ch.swisstopo.pixelkarte-pk25.metadata@year=1989&bgLayer=void&featureInfo=default&timeSlider=1989)
[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1752-fix-timeslider-wms/index.html)