### PR TITLE
PB-1816: excludes service-print3 from service-worker caching

### DIFF
--- a/packages/mapviewer/src/service-workers.ts
+++ b/packages/mapviewer/src/service-workers.ts
@@ -50,7 +50,12 @@ if (!IS_TESTING_WITH_CYPRESS) {
 
     // setting up a cache instance for offline app assets (HTML/JS/CSS)
     registerRoute(
-        new NavigationRoute(createHandlerBoundToURL('index.html'), { allowlist }),
+        new NavigationRoute(createHandlerBoundToURL('index.html'), {
+            allowlist,
+            // exclude print explicitly as SW is sometimes messing with the download URL on Firefox
+            // (injecting the cached index.html file instead of providing the PDF from the server)
+            denylist: [/.*\/api\/print3\/.*/],
+        }),
         new StaleWhileRevalidate({
             cacheName: 'app-cache',
         })


### PR DESCRIPTION
It looks like ServiceWorker/Workbox is providing the index HTML page when Firefox is attempting to download the PDF report from service-print3.

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1816-exclude-service-print-from-cache/index.html)