### PR TITLE
PB-1827: change service-worker strategy to network first

### DIFF
--- a/packages/mapviewer/src/config/baseUrl.config.js
+++ b/packages/mapviewer/src/config/baseUrl.config.js
@@ -207,7 +207,5 @@ export function getVectorTilesBaseUrl() {
     return getBaseUrl('vectorTiles')
 }
 
-export const CURRENT_APP_BASE_URL = enforceEndingSlashInUrl(window.location.origin)
-
 export const internalDomainRegex =
     import.meta.env.VITE_APP_INTERNAL_DOMAIN_REGEX ?? /^https:\/\/[^/]*(bgdi|geo\.admin)\.ch/

--- a/packages/mapviewer/vite.config.mts
+++ b/packages/mapviewer/vite.config.mts
@@ -116,8 +116,6 @@ export default defineConfig(({ mode }) => {
                 : VitePWA({
                       devOptions: {
                           enabled: true,
-                          navigateFallback: 'index.html',
-                          suppressWarnings: true,
                           type: 'module',
                       },
 


### PR DESCRIPTION
and trying to keep the fix for Firefox print working

Network first means the Service-Worker will attempt to load the resource online regardless of the cache status, and if the network responds it will update the cache with the new answer.
We need a good e2e test coverage (with something like Playwright) to be confident enough to change the strategy back to StaleWhileRevalidate

Giving a full URL to the "Manifest generation function" is a bad idea, and the service worker isn't loading anymore, reverting to relative `index.html` path, and editing the API print regex to match a regex found in the VitePWA documentation

Adding a "BETA" badge to the feature, to have a better "expectation management" and signify that this could have some bugs still.

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1827-change-service-worker-strategy/index.html)