### PR TITLE
PB-1834: Layer "Notifications for maps an geodata" not loading

### DIFF
--- a/packages/mapviewer/src/modules/map/components/openlayers/utils/styleFromLiterals.js
+++ b/packages/mapviewer/src/modules/map/components/openlayers/utils/styleFromLiterals.js
@@ -234,8 +234,7 @@ OlStyleForPropertyValue.prototype.getOlStyleForResolution_ = function (olStyles,
 
 OlStyleForPropertyValue.prototype.log_ = function (value, id) {
     const logValue = value === '' ? '<empty string>' : value
-    log(
-        'debug',
+    log.debug(
         `Feature ID: ${id}. No matching style found for key ${this.key} and value ${logValue}.`
     )
 }


### PR DESCRIPTION
fix wrong call to the log function

[Test link with ch.swisstopo.meldungen-karten_geodaten layer](https://sys-map.dev.bgdi.ch/preview/fix-pb-1834-wrong-call-to-log/index.html#/map?lang=en&center=2660000,1190000&z=1&topic=ech&layers=ch.swisstopo.zeitreihen@year=1864,f;ch.bfs.gebaeude_wohnungs_register,f;ch.bav.haltestellen-oev,f;ch.swisstopo.swisstlm3d-wanderwege,f;ch.vbs.schiessanzeigen,f;ch.astra.wanderland-sperrungen_umleitungen,f;ch.swisstopo.meldungen-karten_geodaten&bgLayer=ch.swisstopo.pixelkarte-farbe)

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1834-wrong-call-to-log/index.html)