### PR TITLE
PB-1828: Fix description always shown.

### DIFF
--- a/packages/mapviewer/src/store/modules/features.store.js
+++ b/packages/mapviewer/src/store/modules/features.store.js
@@ -730,8 +730,12 @@ export default {
         changeFeatureTitle(state, { feature, title }) {
             feature.title = title
         },
-        changeFeatureDescription(state, { feature, description }) {
+        changeFeatureDescription(state, { feature, description, showDescriptionOnMap }) {
             feature.description = description
+            // Only update showDescriptionOnMap if it's provided
+            if (showDescriptionOnMap !== undefined) {
+                feature.showDescriptionOnMap = showDescriptionOnMap
+            }
         },
         changeFeatureShownDescriptionOnMap(state, { feature, showDescriptionOnMap }) {
             feature.showDescriptionOnMap = showDescriptionOnMap

--- a/packages/mapviewer/src/utils/kmlUtils.js
+++ b/packages/mapviewer/src/utils/kmlUtils.js
@@ -451,7 +451,9 @@ export function getEditableFeatureFromKmlFeature(kmlFeature, availableIconSets) 
         title,
         textOffset
     )
-    const showDescriptionOnMap = kmlFeature.get('showDescriptionOnMap') ?? false
+    // Convert string to boolean - KML properties are parsed as strings
+    const showDescriptionOnMapValue = kmlFeature.get('showDescriptionOnMap')
+    const showDescriptionOnMap = showDescriptionOnMapValue === 'true' || showDescriptionOnMapValue === true
     if (iconArgs?.isLegacy && iconStyle && icon) {
         // The legacy drawing uses icons from old URLs, some of them have already been removed
         // like the versioned URLs (/{version}/img/maki/{image}-{size}@{scale}x.png) while others


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/59291162-1cee-453e-90f4-3a99fdf62868)


[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1828-description-always-displayed/index.html)