### PR TITLE
PB 1823: Allow QR Code to be generated again when not in cache

### DIFF
--- a/packages/mapviewer/src/service-workers.ts
+++ b/packages/mapviewer/src/service-workers.ts
@@ -45,7 +45,7 @@ if (!IS_TESTING_WITH_CYPRESS) {
             allowlist,
             // exclude print explicitly as SW is sometimes messing with the download URL on Firefox
             // (injecting the cached index.html file instead of providing the PDF from the server)
-            denylist: [/^\/api\/print3/],
+            denylist: [/^\/api\/print3/, /^\/api\/qrcode/],
         }),
         new NetworkFirst({
             cacheName: 'geoadmin-app-cache',


### PR DESCRIPTION
Issue: When we want to generate a QRCode on edge or firefox (and sometimes on chrome), we are hitting the service worker cache instead, which is trying to inject the manifest.

Fix: We exclude the QRCode api from the routes