### PR TITLE
New Release v1.58.0 - #minor

### DIFF
--- a/packages/mapviewer/src/modules/map/components/openlayers/utils/styleFromLiterals.js
+++ b/packages/mapviewer/src/modules/map/components/openlayers/utils/styleFromLiterals.js
@@ -234,8 +234,7 @@ OlStyleForPropertyValue.prototype.getOlStyleForResolution_ = function (olStyles,
 
 OlStyleForPropertyValue.prototype.log_ = function (value, id) {
     const logValue = value === '' ? '<empty string>' : value
-    log(
-        'debug',
+    log.debug(
         `Feature ID: ${id}. No matching style found for key ${this.key} and value ${logValue}.`
     )
 }

--- a/packages/mapviewer/src/service-workers.ts
+++ b/packages/mapviewer/src/service-workers.ts
@@ -45,7 +45,7 @@ if (!IS_TESTING_WITH_CYPRESS) {
             allowlist,
             // exclude print explicitly as SW is sometimes messing with the download URL on Firefox
             // (injecting the cached index.html file instead of providing the PDF from the server)
-            denylist: [/^\/api\/print3/],
+            denylist: [/^\/api\/print3/, /^\/api\/qrcode/],
         }),
         new NetworkFirst({
             cacheName: 'geoadmin-app-cache',


### PR DESCRIPTION
Issue: When introducing support for offline use of the mapviewer, we introduced a situation where QR code generation wouldn't work as soon as it was used once.

Cause: The service-worker used to cache the mapviewer for local use also cached the URL for the QR code, which was then called by the mapviewer instead of the service in the backend.

Fix: We exclude the QR Code from the caching, as we did with service print

[Test link](https://sys-map.int.bgdi.ch/preview/develop/index.html)