### PR TITLE
PB-1823: Extend the Service Worker deny list to all API calls

### DIFF
--- a/packages/mapviewer/src/service-workers.ts
+++ b/packages/mapviewer/src/service-workers.ts
@@ -43,9 +43,10 @@ if (!IS_TESTING_WITH_CYPRESS) {
     registerRoute(
         new NavigationRoute(createHandlerBoundToURL(`index.html`), {
             allowlist,
-            // exclude print explicitly as SW is sometimes messing with the download URL on Firefox
-            // (injecting the cached index.html file instead of providing the PDF from the server)
-            denylist: [/^\/api\/print3/, /^\/api\/qrcode/],
+            // exclude all api calls, as the service worker might interacts with those in a way
+            // that can shut down the service from the user's perspective
+            // (injecting the cached index.html file instead of providing the expected output)
+            denylist: [/^\/api\//,],
         }),
         new NetworkFirst({
             cacheName: 'geoadmin-app-cache',

--- a/packages/mapviewer/src/service-workers.ts
+++ b/packages/mapviewer/src/service-workers.ts
@@ -43,10 +43,15 @@ if (!IS_TESTING_WITH_CYPRESS) {
     registerRoute(
         new NavigationRoute(createHandlerBoundToURL(`index.html`), {
             allowlist,
-            // exclude all api calls, as the service worker might interacts with those in a way
-            // that can shut down the service from the user's perspective
-            // (injecting the cached index.html file instead of providing the expected output)
-            denylist: [/^\/api\//,],
+            denylist: [
+                // exclude all api calls, as the service worker might interacts with those in a way
+                // that can shut down the service from the user's perspective
+                // (injecting the cached index.html file instead of providing the expected output)
+                /^\/api\//,
+                // excluding the embed legacy endpoint, as it stops the redirection to the
+                // `legacyEmbed` route and display map views instead of embed views
+                /^\/embed/,
+            ],
         }),
         new NetworkFirst({
             cacheName: 'geoadmin-app-cache',


### PR DESCRIPTION
Issue: We currently don't have any unsolved issue, but using the service-worker tends to break api calls, as it already happened with the QRCode and the Print.

Fix: To be on the safe side, we extend the deny list to all API calls, excluding them from the caching system.

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1823-extend-service-worker-deny-list/index.html)