### PR TITLE
PB-1872: term of use in english iframe menu returns a 404

### DIFF
--- a/packages/mapviewer/src/modules/i18n/locales/en.json
+++ b/packages/mapviewer/src/modules/i18n/locales/en.json
@@ -474,7 +474,7 @@
     "offline_cache_obsolete": "A newer version of the application is available. Please reload the page via the refresh button.",
     "offline_clear_db_error": "Error clearing  saved maps. Please try again.",
     "offline_delete_data": "Delete map",
-    "offline_dl_succeed": "Download successfull!",
+    "offline_dl_succeed": "Download successful!",
     "offline_hide_extent": "Hide extent",
     "offline_kml_too_big": "A KML flle is too large (> 1MB). It will be not saved.",
     "offline_less_than_95": "Problem: the map was not stored completely. Please retry.",

--- a/packages/mapviewer/src/modules/i18n/locales/en.json
+++ b/packages/mapviewer/src/modules/i18n/locales/en.json
@@ -591,7 +591,7 @@
     "settings": "Configuration",
     "settlement": "Settlement",
     "share": "Share",
-    "share_disclaimer": "You can embed the map into your website or blog. <a href='https://www.geo.admin.ch/en/web-integration-iframe/' target='_blank'>Terms of use</a>",
+    "share_disclaimer": "You can embed the map into your website or blog. <a href='https://www.geo.admin.ch/de/web-integration-iframe/' target='_blank'>Terms of use</a>",
     "share_file_disclaimer": "Your drawing is automatically saved for one year. By using this service, you agree to the <a href='https://www.geo.admin.ch/en/general-terms-of-use-fsdi/' target='_blank'>the terms of use</a>.",
     "share_file_link_title_admin": "You will be able to modify your drawing by using the following link: ",
     "share_less": "Embed:",

--- a/packages/mapviewer/src/modules/i18n/locales/rm.json
+++ b/packages/mapviewer/src/modules/i18n/locales/rm.json
@@ -220,6 +220,8 @@
     "emapis_service_link_label": "info@blw.admin.ch",
     "embed_map": "Integrar charta",
     "energie": "Energia",
+    "energie_service_link_href": "http://www.bfe.admin.ch/geoinformation/index.html?lang=de",
+    "energie_service_link_label": "www.map.energie.admin.ch",
     "error": "Sbagl",
     "export": "Exportar",
     "export_kml": "Exportar",

--- a/packages/mapviewer/src/store/plugins/geolocation-management.plugin.js
+++ b/packages/mapviewer/src/store/plugins/geolocation-management.plugin.js
@@ -73,7 +73,7 @@ const handlePositionAndDispatchToStore = (position, store) => {
         store.state.geolocation,
         `error count=${errorCount}`
     )
-    errorCount = 0 // reset the error count on each successfull position
+    errorCount = 0 // reset the error count on each successful position
     const positionProjected = readPosition(position, store.state.position.projection)
     // Accuracy in in meter, so we don't need the decimal part and avoid dispatching event
     // if the accuracy did not change more than one metter


### PR DESCRIPTION
Issue: the terms of use link in the iframe integration menu, in english, returns a 404 since the page doesn't exist

Fix: We link to the german one.

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1872-change-iframe-term-of-use-link/index.html)