### PR TITLE
PB-1823: also ignore preview sites from ServiceWorker cache

### DIFF
--- a/packages/mapviewer/src/service-workers.ts
+++ b/packages/mapviewer/src/service-workers.ts
@@ -51,6 +51,8 @@ if (!IS_TESTING_WITH_CYPRESS) {
                 // excluding the embed legacy endpoint, as it stops the redirection to the
                 // `legacyEmbed` route and display map views instead of embed views
                 /^\/embed/,
+                // preview sites must be excluded too (we want the latest code, not some cached version)
+                /^\/preview\//,
             ],
         }),
         new NetworkFirst({


### PR DESCRIPTION
so that we may see our DEV/INT deployment preview without needing to clear any cache