### PR TITLE
PB-1383: Fix cypress tests | 3d

### DIFF
--- a/packages/viewer/tests/cypress/support/commands.ts
+++ b/packages/viewer/tests/cypress/support/commands.ts
@@ -153,7 +153,7 @@ function goToView(
     let flattenedQueryParams: string = ''
     Object.entries(queryParams).forEach(([key, value]) => {
         if (typeof value === 'boolean') {
-            if (value === false) {
+            if (value) {
                 // for true boolean param, only the key is required
                 flattenedQueryParams += `${key}&`
             }

--- a/packages/viewer/tests/cypress/tests-e2e/3d/click.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/3d/click.cy.js
@@ -13,9 +13,11 @@ describe('Testing click', () => {
         const mercatorCoords = proj4(WGS84.epsg, WEBMERCATOR.epsg, [lon, lat])
 
         cy.goToMapView({
-            '3d': true,
-            center: mercatorCoords.join(','),
-            sr: WEBMERCATOR.epsgNumber,
+            queryParams : {
+                '3d': true,
+                center: mercatorCoords.join(','),
+                sr: WEBMERCATOR.epsgNumber,
+            },
         })
         cy.waitUntilCesiumTilesLoaded()
         cy.get('[data-cy="cesium-map"] .cesium-viewer').click()

--- a/packages/viewer/tests/cypress/tests-e2e/3d/featureSelection.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/3d/featureSelection.cy.js
@@ -19,9 +19,12 @@ describe('Testing the feature selection in 3D', () => {
             const fileName = 'external-kml-file.kml'
             const localKmlFile = `import-tool/${fileName}`
             cy.goToMapView({
-                '3d': true,
-                layers: 'test.wms.layer',
-            })
+                queryParams:{
+                        '3d': true,
+                        layers: 'test.wms.layer',
+                    }
+                },
+            )
             cy.waitUntilCesiumTilesLoaded()
 
 

--- a/packages/viewer/tests/cypress/tests-e2e/3d/geolocation.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/3d/geolocation.cy.js
@@ -31,9 +31,13 @@ describe('Geolocation on 3D cypress', () => {
                     geoLatitude,
                 ])
 
-                cy.goToMapView({ '3d': true }, true, {
-                    latitude: geoLatitude,
-                    longitude: geoLongitude,
+                cy.goToMapView({
+                    queryParams: { '3d': true },
+                    withHash: true,
+                    geolocationMockupOptions: {
+                        latitude: geoLatitude,
+                        longitude: geoLongitude,
+                    },
                 })
                 cy.waitUntilCesiumTilesLoaded()
 
@@ -77,12 +81,26 @@ describe('Geolocation on 3D cypress', () => {
             // The test is too fragile in CI (sometimes pass, sometimes not) due to rendered crassh
             it.skip('access from outside Switzerland shows an error message', () => {
                 // null island
-                cy.goToMapView({ '3d': true }, true, { latitude: 0, longitude: 0 })
+                cy.goToMapView({
+                    queryParams: { '3d': true },
+                    withHash: true,
+                    geolocationMockupOptions: {
+                        latitude: 0,
+                        longitude: 0,
+                    },
+                })
                 getGeolocationButtonAndClickIt()
                 testErrorMessage('geoloc_out_of_bounds')
 
                 // Java island
-                cy.goToMapView({ '3d': true }, true, { latitude: -7.71, longitude: 110.37 })
+                cy.goToMapView({
+                    queryParams: { '3d': true },
+                    withHash: true,
+                    geolocationMockupOptions: {
+                        latitude: -7.71,
+                        longitude: 110.37,
+                    },
+                })
                 getGeolocationButtonAndClickIt()
                 testErrorMessage('geoloc_out_of_bounds')
             })

--- a/packages/viewer/tests/cypress/tests-e2e/3d/layers.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/3d/layers.cy.js
@@ -37,7 +37,9 @@ describe('Test of layer handling in 3D', () => {
             body: { results: [] },
         }).as('search-locations')
         cy.goToMapView({
-            '3d': true,
+            queryParams: {
+                '3d': true,
+            },
         })
         cy.waitUntilCesiumTilesLoaded()
         cy.openMenuIfMobile()
@@ -85,8 +87,10 @@ describe('Test of layer handling in 3D', () => {
         cy.log('checking a WMTS layer without 3D specific configuration')
         const wmtsLayerIdWithout3DConfig = 'test.timeenabled.wmts.layer'
         cy.goToMapView({
-            '3d': true,
-            layers: `${wmtsLayerIdWithout3DConfig},,0.5`,
+            queryParams: {
+                '3d': true,
+                layers: `${wmtsLayerIdWithout3DConfig},,0.5`,
+            }
         })
         cy.waitUntilCesiumTilesLoaded()
         cy.window().its('cesiumViewer').then((viewer) => {
@@ -141,11 +145,13 @@ describe('Test of layer handling in 3D', () => {
             const timedLayerMetadata = layersMetadata[timeEnabledLayerId]
             cy.getRandomTimestampFromSeries(timedLayerMetadata).then((randomTimestampFromLayer) => {
                 cy.goToMapView({
-                    '3d': true,
-                    layers: `${timeEnabledLayerId}@year=${randomTimestampFromLayer.substring(
-                        0,
-                        4
-                    )}`,
+                    queryParams: {
+                        '3d': true,
+                        layers: `${timeEnabledLayerId}@year=${randomTimestampFromLayer.substring(
+                            0,
+                            4
+                        )}`,
+                    },
                 })
                 cy.waitUntilCesiumTilesLoaded()
                 cy.window().its('cesiumViewer').then((viewer) => {
@@ -159,13 +165,14 @@ describe('Test of layer handling in 3D', () => {
     it('reorders visible layers when corresponding buttons are pressed', () => {
         const firstLayerId = 'test.wms.layer'
         const secondLayerId = 'test.wmts.layer'
-        cy.goToMapView(
-            {
+        cy.goToMapView({
+            queryParams: {
                 '3d': true,
                 sr: WEBMERCATOR.epsgNumber,
                 layers: `${firstLayerId};${secondLayerId}`,
             },
-            true
+            withHash: true,
+        }
         ) // with hash, so that we can have external layer support
         cy.waitUntilCesiumTilesLoaded()
         cy.openMenuIfMobile()
@@ -196,8 +203,10 @@ describe('Test of layer handling in 3D', () => {
     it('add GeoJson layer with opacity from URL param', () => {
         const geojsonlayerId = 'test.geojson.layer'
         cy.goToMapView({
-            '3d': true,
-            layers: `${geojsonlayerId},,0.5`,
+                queryParams: {
+                '3d': true,
+                layers: `${geojsonlayerId},,0.5`,
+            },
         })
         cy.wait(['@geojson-data', '@geojson-style'])
         cy.waitUntilCesiumTilesLoaded()
@@ -208,8 +217,10 @@ describe('Test of layer handling in 3D', () => {
     it('removes a layer from the visible layers when the "remove" button is pressed', () => {
         const geojsonlayerId = 'test.geojson.layer'
         cy.goToMapView({
-            '3d': true,
-            layers: `${geojsonlayerId}`,
+            queryParams: {
+                '3d': true,
+                layers: `${geojsonlayerId}`,
+            },
         })
         cy.waitUntilCesiumTilesLoaded()
         cy.wait(['@geojson-data', '@geojson-style'])
@@ -224,8 +235,10 @@ describe('Test of layer handling in 3D', () => {
     })
     it('uses the 3D configuration of a layer if one exists', () => {
         cy.goToMapView({
-            '3d': true,
-            layers: 'test.background.layer,,0.8',
+            queryParams: {
+                '3d': true,
+                layers: 'test.background.layer,,0.8',
+            },
         })
         cy.waitUntilCesiumTilesLoaded()
         cy.window().its('cesiumViewer').then((viewer) => {
@@ -262,8 +275,10 @@ describe('Test of layer handling in 3D', () => {
         cy.log('Go to 3D and add a WMS layer')
         const expectedWmsLayerId = 'test.wms.layer'
         cy.goToMapView({
-            '3d': true,
-            layers: expectedWmsLayerId,
+            queryParams: {
+                '3d': true,
+                layers: expectedWmsLayerId,
+            },
         })
         cy.waitUntilCesiumTilesLoaded()
         cy.window().its('cesiumViewer').then((viewer) => {
@@ -336,7 +351,9 @@ describe('Test of layer handling in 3D', () => {
         cy.getExternalWmsMockConfig().then((layerObjects) => {
             const mockExternalWms2 = layerObjects[1]
             const layers = [layerObjects[1]].map(transformLayerIntoUrlString).join(';')
-            cy.goToMapView({ '3d': true, layers })
+            cy.goToMapView({
+                queryParams: {'3d': true, layers },
+            })
             cy.log('Go to 3D and add a WMS layer')
             // This layer extent got transformed from EPSG:4326 to EPSG:2056
             const layerExtentInLV95 = [2485071.58, 1075346.31, 2828515.82, 1299941.79]

--- a/packages/viewer/tests/cypress/tests-e2e/3d/navigation.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/3d/navigation.cy.js
@@ -12,7 +12,7 @@ describe('Testing 3D navigation', () => {
     context('camera limits', () => {
         beforeEach(() => {
             cy.goToMapView({
-                '3d': true,
+                queryParams: {'3d': true}
             })
         })
         it('minimum distance from the terrain', () => {
@@ -95,7 +95,7 @@ describe('Testing 3D navigation', () => {
 
     it('2d camera does not go out of bounds if url parameter is out of bounds', () => {
         cy.goToMapView({
-            center: '0,0',
+            queryParams:{center: '0,0'}
         })
         cy.log('check if center is moved to out of bounds location')
         cy.readStoreValue('state.position').should((positionStore) => {
@@ -104,8 +104,10 @@ describe('Testing 3D navigation', () => {
     })
     it('3d camera does not go out of bounds if url parameter is out of bounds', () => {
         cy.goToMapView({
-            '3d': true,
-            camera: '0,0',
+            queryParams: {
+                '3d': true,
+                camera: '0,0',
+            },
         })
         cy.waitUntilCesiumTilesLoaded()
         cy.log('check if camera is moved to out of bounds location')

--- a/packages/viewer/tests/cypress/tests-e2e/3d/transitionTo3d.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/3d/transitionTo3d.cy.js
@@ -48,7 +48,7 @@ describe('Testing transitioning between 2D and 3D', () => {
             })
             it('correctly parses the 3D param at startup if present', () => {
                 cy.goToMapView({
-                    '3d': true,
+                    queryParams: {'3d': true }
                 })
                 cy.readStoreValue('state.cesium.active').should('be.true')
             })
@@ -64,15 +64,17 @@ describe('Testing transitioning between 2D and 3D', () => {
                     roll: 12,
                 }
                 cy.goToMapView({
-                    '3d': true,
-                    camera: [
-                        expectedCameraPosition.x,
-                        expectedCameraPosition.y,
-                        expectedCameraPosition.z,
-                        expectedCameraPosition.pitch,
-                        expectedCameraPosition.heading,
-                        expectedCameraPosition.roll,
-                    ].join(','),
+                    queryParams: {
+                        '3d': true,
+                        camera: [
+                            expectedCameraPosition.x,
+                            expectedCameraPosition.y,
+                            expectedCameraPosition.z,
+                            expectedCameraPosition.pitch,
+                            expectedCameraPosition.heading,
+                            expectedCameraPosition.roll,
+                        ].join(','),
+                    },
                 })
                 cy.readStoreValue('state.position.camera').then((camera) => {
                     expect(camera).to.be.an('Object')
@@ -97,8 +99,10 @@ describe('Testing transitioning between 2D and 3D', () => {
             const lat = 46
             const lon = 7
             cy.goToMapView({
-                center: proj4(WGS84.epsg, DEFAULT_PROJECTION.epsg, [lon, lat]),
-                z: 9,
+                queryParams: {
+                    center: proj4(WGS84.epsg, DEFAULT_PROJECTION.epsg, [lon, lat]),
+                    z: 9,
+                },
             })
             cy.get('[data-cy="3d-button"]').click()
             cy.window().its('cesiumViewer').then((viewer) => {


### PR DESCRIPTION
- Issue 1: in the commands.ts file, we handled the booleans wrongly trying to add them to the viewer only if they were false instead of only when they are true, which is how it should be.

- Issue 2: We changed the signature of the "goToMapView", and the test methods were using the old syntax

Fix: We handle booleans correctly and changed the signature.