### PR TITLE
PB-1383: change `goToView` signatures in cypress:

### DIFF
--- a/packages/viewer/tests/cypress/tests-e2e/changeLanguage.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/changeLanguage.cy.js
@@ -71,12 +71,16 @@ describe('Change language', () => {
     context('on startup', () => {
         it('should show the correct language if we ask for it, even if the param is in uppercase', () => {
             SUPPORTED_LANG.forEach((lang) => {
-                cy.goToMapView({ lang: lang })
+                cy.goToMapView({
+                    queryParams:{ lang: lang }
+                })
                 checkLanguage(lang)
             })
 
             SUPPORTED_LANG.forEach((lang) => {
-                cy.goToMapView({ lang: lang.toUpperCase() })
+                cy.goToMapView({
+                    queryParams:{ lang: lang.toUpperCase() }
+                })
                 checkLanguage(lang)
             })
         })

--- a/packages/viewer/tests/cypress/tests-e2e/compareSlider.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/compareSlider.cy.js
@@ -16,47 +16,50 @@ describe('Testing of the compare slider', () => {
     context('Comportment of compare slider at startup', () => {
         context('Starting the app with different parameters', () => {
             it('does not shows up at startup with no compare slider parameter', () => {
-                cy.goToMapView(
+                cy.goToMapView({
+                    queryParams:
                     {
                         layers: ['test-1.wms.layer', 'test-2.wms.layer,,'].join(';'),
                     },
-                    true
-                )
+                    withHash: true,
+                })
 
                 expectCompareRatioToBe(null)
                 expectCompareSliderToBeActive(false)
                 cy.get('[data-cy="compareSlider"]').should('not.exist')
             })
             it('does not shows up with layers and the compare ratio parameter out of bounds or not a number', () => {
-                cy.goToMapView(
-                    {
-                        layers: ['test-1.wms.layer', 'test-2.wms.layer,,'].join(';'),
-                        compareRatio: '1.4',
-                    },
-                    true
-                )
+                cy.goToMapView({
+                    queryParams:
+                        {
+                            layers: ['test-1.wms.layer', 'test-2.wms.layer,,'].join(';'),
+                            compareRatio: '1.4',
+                        },
+                    withHash: true,
+                })
                 expectCompareRatioToBe(null)
                 expectCompareSliderToBeActive(false)
 
                 cy.get('[data-cy="compareSlider"]').should('not.exist')
-                cy.goToMapView(
-                    {
-                        layers: ['test-1.wms.layer', 'test-2.wms.layer,,'].join(';'),
-                        compareRatio: '-0.3',
-                    },
-                    true
-                )
+                cy.goToMapView({
+                    queryParams:
+                        {
+                            layers: ['test-1.wms.layer', 'test-2.wms.layer,,'].join(';'),
+                            compareRatio: '-0.3',
+                        },
+                    withHash: true,
+                })
                 expectCompareRatioToBe(null)
                 expectCompareSliderToBeActive(false)
 
                 cy.get('[data-cy="compareSlider"]').should('not.exist')
-                cy.goToMapView(
-                    {
-                        layers: ['test-1.wms.layer', 'test-2.wms.layer,,'].join(';'),
-                        compareRatio: 'aRandomText',
-                    },
-                    true
-                )
+                cy.goToMapView({
+                    queryParams:
+                        {
+                            layers: ['test-1.wms.layer', 'test-2.wms.layer,,'].join(';'),
+                            compareRatio: 'aRandomText',
+                        withHash: true},
+                    })
                 expectCompareRatioToBe(null)
                 expectCompareSliderToBeActive(false)
 
@@ -80,13 +83,14 @@ describe('Testing of the compare slider', () => {
         }
         context('Moving the compare slider', () => {
             it('moves when we click on it and drag the mouse', () => {
-                cy.goToMapView(
-                    {
-                        layers: 'test-1.wms.layer',
-                        compareRatio: '0.3',
-                    },
-                    true
-                )
+                cy.goToMapView({
+                    queryParams:
+                        {
+                            layers: 'test-1.wms.layer',
+                            compareRatio: '0.3',
+                        },
+                    withHash:true,
+                })
                 // initial slider position is width * 0.3 -20
                 cy.get('[data-cy="compareSlider"]').then((slider) => {
                     cy.readStoreValue('state.ui.width').then((width) => {
@@ -169,13 +173,14 @@ describe('Testing of the compare slider', () => {
                 cy.intercept('**/MapServer/**/htmlPopup**', {
                     fixture: 'html-popup.fixture.html',
                 })
-                cy.goToMapView(
-                    {
-                        layers: layerIds.join(';'),
-                        compareRatio: '0.5',
-                    },
-                    true
-                )
+                cy.goToMapView({
+                    queryParams:
+                        {
+                            layers: layerIds.join(';'),
+                            compareRatio: '0.5',
+                        },
+                    withHash: true,
+                })
                 cy.log('changing the order of the layers and check which on is cut')
 
                 // in initial state, only feature 2 should be visible
@@ -247,7 +252,7 @@ describe('Testing of the compare slider', () => {
                     // TODO : PB-262 : with stored ratio, we should be able to activate it,
                     // see it's red, and still not see the compare slider.
                     // So we'll need to check that the button color switched to red / the activated value is true
-                    cy.goToMapView({}, true)
+                    cy.goToMapView({ withHash: true})
                     cy.openMenuIfMobile()
                     cy.get('[data-cy="menu-tray-tool-section"]').click()
                     cy.get('[data-cy="menu-advanced-tools-compare"]').click()
@@ -264,10 +269,13 @@ describe('Testing of the compare slider', () => {
                 })
                 it('stays "active" when we remove the last layer', () => {
                     const compareRatioValue = 0.3
-                    cy.goToMapView(
-                        { layers: 'test-1.wms.layer', compareRatio: `${compareRatioValue}` },
-                        true
-                    )
+                    cy.goToMapView({
+                        queryParams:{
+                            layers: 'test-1.wms.layer',
+                            compareRatio: `${compareRatioValue}`,
+                        },
+                        withHash: true,
+                    })
 
                     cy.readStoreValue('state.layers.activeLayers').should('have.length', 1)
                     cy.readStoreValue('state.ui.compareRatio').should('eq', compareRatioValue)
@@ -288,13 +296,14 @@ describe('Testing of the compare slider', () => {
                     cy.get('[data-cy="compareSlider"]').should('not.exist')
                 })
                 it('appears and is functional when layers are present in 2d', () => {
-                    cy.goToMapView(
-                        {
-                            layers: ['test-1.wms.layer', 'test-2.wms.layer,,'].join(';'),
-                            compareRatio: '0.3',
-                        },
-                        true
-                    )
+                    cy.goToMapView({
+                        queryParams:
+                            {
+                                layers: ['test-1.wms.layer', 'test-2.wms.layer,,'].join(';'),
+                                compareRatio: '0.3',
+                            },
+                        withHash: true,
+                    })
                     cy.get('[data-cy="compareSlider"]').should('be.visible')
                     cy.openMenuIfMobile()
                     cy.get('[data-cy="menu-tray-tool-section"]').click()
@@ -329,16 +338,16 @@ describe('Testing of the compare slider', () => {
 
     context('With two times the same layer', () => {
         it('layers are independent layers with different uuids', () => {
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     layers: [
                         'test.timeenabled.wmts.layer@year=2015',
                         'test.timeenabled.wmts.layer@year=2021',
                     ].join(';'),
                     compareRatio: '0.3',
                 },
-                true
-            )
+                withHash: true,
+            })
             cy.readStoreValue('getters.visibleLayers').should((visibleLayers) => {
                 expect(visibleLayers).to.be.an('Array')
                 expect(visibleLayers.length).to.deep.equal(2)
@@ -356,15 +365,15 @@ describe('Testing of the compare slider', () => {
 describe('The compare Slider and the menu elements should not be available in 3d', () => {
     context('compare slider non availability in 3d', () => {
         it('does not shows up with layers, a compare slider parameter set, but in 3d', () => {
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     layers: ['test-1.wms.layer', 'test-2.wms.layer,,'].join(';'),
                     compareRatio: '0.4',
                     '3d': true,
                     sr: WEBMERCATOR.epsgNumber,
                 },
-                true
-            )
+                withHash: true,
+            })
             cy.get('[data-cy="compareSlider"]').should('not.exist')
 
             cy.readStoreValue('state.ui.compareRatio').then((compareRatio) => {
@@ -374,12 +383,12 @@ describe('The compare Slider and the menu elements should not be available in 3d
     })
     context('Compare menu component with 3d', () => {
         it('disappears when it is available in 2d and we swith to 3d', () => {
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     sr: WEBMERCATOR.epsgNumber,
                 },
-                true
-            )
+                withHash: true,
+            })
             cy.openMenuIfMobile()
             cy.get('[data-cy="menu-tray-tool-section"]').click()
             cy.get('[data-cy="menu-advanced-tools-compare"]').should('be.visible')

--- a/packages/viewer/tests/cypress/tests-e2e/crosshair.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/crosshair.cy.js
@@ -71,9 +71,7 @@ describe('Testing the crosshair URL param', () => {
             })
         })
         it('adds the crosshair at the center of the map if only the crosshair param is given', () => {
-            cy.goToMapView({
-                crosshair: CrossHairs.point,
-            })
+            cy.goToMapView({queryParams: {crosshair: CrossHairs.point}})
             cy.readStoreValue('state.position').then((positionStore) => {
                 expect(positionStore.crossHair).to.eq(CrossHairs.point)
                 expect(positionStore.crossHairPosition).to.eql(positionStore.center)
@@ -82,7 +80,7 @@ describe('Testing the crosshair URL param', () => {
         it('sets the crosshair at the given coordinate if provided in the URL (and not at map center)', () => {
             const crossHairPosition = DEFAULT_PROJECTION.bounds.center.map((value) => value + 1000)
             cy.goToMapView({
-                crosshair: `${CrossHairs.bowl},${crossHairPosition.join(',')}`,
+                queryParams: {crosshair: `${CrossHairs.bowl},${crossHairPosition.join(',')}`}
             })
             cy.readStoreValue('state.position').then((positionStore) => {
                 expect(positionStore.crossHair).to.eq(CrossHairs.bowl)
@@ -92,17 +90,13 @@ describe('Testing the crosshair URL param', () => {
     })
     context('Changes of URL param value while the app has been loaded', () => {
         it('Changes the crosshair types correctly if changed after app load', () => {
-            cy.goToMapView({
-                crosshair: CrossHairs.point,
-            })
+            cy.goToMapView({queryParams:{crosshair: CrossHairs.point}})
             cy.readStoreValue('state.position.crossHair').should('eq', CrossHairs.point)
             changeUrlParam('crosshair', CrossHairs.marker)
             cy.readStoreValue('state.position.crossHair').should('eq', CrossHairs.marker)
         })
         it('Changes the crosshair position if set after app reload', () => {
-            cy.goToMapView({
-                crosshair: CrossHairs.cross,
-            })
+            cy.goToMapView({queryParams:{crosshair: CrossHairs.cross}})
             cy.readStoreValue('state.position').then((positionStore) => {
                 expect(positionStore.crossHair).to.eq(CrossHairs.cross)
                 expect(positionStore.crossHairPosition).to.eql(positionStore.center)
@@ -123,9 +117,7 @@ describe('Testing the crosshair URL param', () => {
             })
         })
         it('removes the crosshair if the URL param is removed (or set to null)', () => {
-            cy.goToMapView({
-                crosshair: CrossHairs.circle,
-            })
+            cy.goToMapView({queryParams:{crosshair: CrossHairs.circle}})
             cy.readStoreValue('state.position').then((positionStore) => {
                 expect(positionStore.crossHair).to.eq(CrossHairs.circle)
                 expect(positionStore.crossHairPosition).to.eql(positionStore.center)

--- a/packages/viewer/tests/cypress/tests-e2e/drawing.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/drawing.cy.js
@@ -534,7 +534,7 @@ describe('Drawing module tests', () => {
             // OL waits 250ms before deciding a click is a single click (and then start the event chain)
             // and as we do not have a layer that will fire identify features to wait on, we have to resort
             // to wait arbitrarily 250ms
-             
+
             cy.wait(250)
             readCoordinateClipboard('feature-detail-coordinate-copy', "2'660'013.50, 1'185'172.00")
         })
@@ -799,12 +799,10 @@ describe('Drawing module tests', () => {
                     expect(line.getGeometry().getCoordinates().length).to.eq(2)
                 })
 
-            cy.goToMapView(
-                {
-                    zoom: 6,
-                },
-                false
-            )
+            cy.goToMapView({
+                queryParams:{zoom: 6},
+                withHash: false,
+            })
 
             cy.log('Feature Area Info should be in meters below unit threshold')
             cy.goToDrawing()
@@ -1089,7 +1087,10 @@ describe('Drawing module tests', () => {
             cy.log(
                 'opening up the app and centering it directly on the single marker feature from the fixture'
             )
-            cy.goToDrawing({ layers: kmlUrlParam, center: center.join(',') }, true)
+            cy.goToDrawing({
+                queryParams:{layers: kmlUrlParam, center: center.join(',')},
+                withHash: true,
+            })
             cy.wait(['@get-kml-metadata', '@get-kml'])
 
             cy.log(
@@ -1176,7 +1177,10 @@ describe('Drawing module tests', () => {
             cy.log(
                 'opening up the app and centering it directly on the single marker feature from the fixture'
             )
-            cy.goToMapView({ adminId: kmlFileAdminId, E: center[0], N: center[1] }, false)
+            cy.goToMapView({
+                queryParams:{adminId: kmlFileAdminId, E: center[0], N: center[1] },
+                withHash: false,
+            })
             cy.wait([
                 '@get-kml-metadata-by-admin-id',
                 // as we come from outside any import tool, all file parser will be tried consecutively, and each of them
@@ -1247,8 +1251,9 @@ describe('Drawing module tests', () => {
 
             const fileId = 'zBnMZymwTLSNg__5f8yv6g'
             cy.log('load map with an injected kml layer containing an empty KML')
-            cy.goToMapView({
-                layers: [`KML|https://sys-public.dev.bgdi.ch/api/kml/files/${fileId}`].join(';'),
+            cy.goToMapView({queryParams:{
+                    layers: [`KML|https://sys-public.dev.bgdi.ch/api/kml/files/${fileId}`].join(';'),
+                },
             })
 
             cy.wait('@get-empty-kml')

--- a/packages/viewer/tests/cypress/tests-e2e/featureSelection.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/featureSelection.cy.js
@@ -70,13 +70,13 @@ describe('Testing the feature selection', () => {
         }
 
         function goToMapViewWithFeatureSelection(featureInfoPosition = null) {
-            const params = {
+            const queryParams = {
                 layers: `${standardLayer}@features=1:2:3:4:5:6:7:8:9:10`,
             }
             if (featureInfoPosition) {
-                params.featureInfo = featureInfoPosition
+                queryParams.featureInfo = featureInfoPosition
             }
-            cy.goToMapView(params)
+            cy.goToMapView(queryParams)
         }
 
         it('Adds pre-selected features and place the tooltip according to URL param on a narrow width screen', () => {
@@ -120,8 +120,9 @@ describe('Testing the feature selection', () => {
         it('Synchronise URL and feature selection', () => {
             const expectedFeatureIds = [1234, 5678]
             const mapSelector = '[data-cy="ol-map"]'
-            cy.goToMapView({
+            cy.goToMapView({queryParams:{
                 layers: `${standardLayer};${timeLayer}@year=2018,f`,
+                },
             })
             // ------------------------------------------------------------------------------------------------
             cy.url().should((url) => {
@@ -359,9 +360,7 @@ describe('Testing the feature selection', () => {
             // Import KML file
             const fileName = 'external-kml-file.kml'
             const localKmlFile = `import-tool/${fileName}`
-            cy.goToMapView({
-                layers: 'test.wms.layer',
-            })
+            cy.goToMapView({queryParams:{layers: 'test.wms.layer'}})
             cy.wait(['@routeChange', '@layerConfig', '@topics', '@topic-ech'])
 
             const featureCountWithKml = DEFAULT_FEATURE_COUNT_RECTANGLE_SELECTION + 1
@@ -474,9 +473,7 @@ describe('Testing the feature selection', () => {
             cy.log(
                 'sending a single feature as response, checking that the "Load more" button is not added'
             )
-            cy.goToMapView({
-                layers: 'test.wms.layer',
-            })
+            cy.goToMapView({queryParams:{layers: 'test.wms.layer'}})
             cy.wait('@routeChange')
 
             cy.intercept('**identify**', {
@@ -583,9 +580,7 @@ describe('Testing the feature selection', () => {
             // Import KML file
             const fileName = 'external-kml-file.kml'
             const localKmlFile = `import-tool/${fileName}`
-            cy.goToMapView({
-                layers: 'test.wms.layer',
-            })
+            cy.goToMapView({queryParams:{layers: 'test.wms.layer'}})
             cy.wait(['@routeChange', '@layerConfig', '@topics', '@topic-ech'])
 
             cy.openMenuIfMobile()

--- a/packages/viewer/tests/cypress/tests-e2e/footer.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/footer.cy.js
@@ -7,9 +7,7 @@ import { UIModes } from '@/store/modules/ui.store'
 describe('Testing the footer content / tools', () => {
     it('shows/hide the scale line depending on the map resolution, while in Mercator', () => {
         cy.viewport(1920, 1080)
-        cy.goToMapView({
-            sr: WEBMERCATOR.epsgNumber,
-        })
+        cy.goToMapView({queryParams:{sr: WEBMERCATOR.epsgNumber}})
 
         // Scale line not visible on standard startup, as the standard zoom level is 7,
         // which mean a higher resolution as the acceptable threshold for scale line to be visible.
@@ -56,9 +54,7 @@ describe('Testing the footer content / tools', () => {
             cy.readStoreValue('getters.currentBackgroundLayer').should('be.null')
         }
 
-        cy.goToMapView({
-            bgLayer: 'void',
-        })
+        cy.goToMapView({queryParams:{bgLayer: 'void'}})
         // checking the rounded background wheel (mobile/tablet only)
         cy.viewport('iphone-se2')
         testBackgroundWheel()

--- a/packages/viewer/tests/cypress/tests-e2e/geodesicDrawing.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/geodesicDrawing.cy.js
@@ -112,7 +112,10 @@ const generateTestsInPacific = (testFunc) => {
 // a worldwide coverage, and even then we have to assess if we want it or not)
 describe.skip('Correct handling of geodesic geometries', () => {
     beforeEach(() => {
-        cy.goToDrawing({ z: 10, sr: 3857 }, true)
+        cy.goToDrawing({
+            queryParams:{ z: 10, sr: 3857 },
+            withHash:true
+        })
     })
     context(
         'Check that the modify and select interactions are aware that the linestring geometry is geodesic',

--- a/packages/viewer/tests/cypress/tests-e2e/geolocation.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/geolocation.cy.js
@@ -36,7 +36,7 @@ describe('Geolocation cypress', () => {
         () => {
             testCases.forEach(({ description, is3D }) => {
                 it(`Prompt the user to authorize geolocation when the geolocation button is clicked for the first time ${description}`, () => {
-                    cy.goToMapView({ '3d': is3D })
+                    cy.goToMapView({queryParams:{'3d': is3D}})
                     getGeolocationButtonAndClickIt()
                     cy.on('window:alert', () => {
                         throw new Error(
@@ -61,7 +61,7 @@ describe('Geolocation cypress', () => {
         () => {
             testCases.forEach(({ description, is3D }) => {
                 it(`Doesn't prompt the user if geolocation has previously been authorized ${description}`, () => {
-                    cy.goToMapView({ '3d': is3D }, true)
+                    cy.goToMapView({queryParams:{'3d': is3D }, withHash:true})
                     getGeolocationButtonAndClickIt()
                     cy.on('window:alert', () => {
                         throw new Error('Should not prompt for geolocation API permission again')
@@ -88,17 +88,17 @@ describe('Geolocation cypress', () => {
                     geoLatitude,
                 ])
 
-                cy.goToMapView(
-                    {
+                cy.goToMapView({
+                    queryParams:{
                         center: proj4(WGS84.epsg, DEFAULT_PROJECTION.epsg, [
                             startingLongitude,
                             startingLatitude,
                         ]).join(','),
                         z: startingZoom,
                     },
-                    true,
-                    { latitude: geoLatitude, longitude: geoLongitude }
-                )
+                    withHash: true,
+                    geolocationMockupOptions: { latitude: geoLatitude, longitude: geoLongitude },
+                })
 
                 // check initial center and zoom
                 checkStorePosition('state.position.center', x0, y0)
@@ -138,12 +138,18 @@ describe('Geolocation cypress', () => {
             })
             it('access from outside Switzerland shows an error message', () => {
                 // null island
-                cy.goToMapView({}, true, { latitude: 0, longitude: 0 })
+                cy.goToMapView({
+                    withHash:true,
+                    geolocationMockupOptions: { latitude: 0, longitude: 0 },
+                })
                 getGeolocationButtonAndClickIt()
                 testErrorMessage('geoloc_out_of_bounds')
 
                 // Java island
-                cy.goToMapView({}, true, { latitude: -7.71, longitude: 110.37 })
+                cy.goToMapView({
+                    withHash: true,
+                    geolocationMockupOptions: { latitude: -7.71, longitude: 110.37 },
+                })
                 getGeolocationButtonAndClickIt()
                 testErrorMessage('geoloc_out_of_bounds')
             })
@@ -153,23 +159,35 @@ describe('Geolocation cypress', () => {
     context('Test geolocation when geolocation is failed to be retrieved', () => {
         testCases.forEach(({ description, is3D }) => {
             it(`shows an error telling the user geolocation is denied ${description}`, () => {
-                cy.goToMapView({ '3d': is3D }, true, {
-                    errorCode: GeolocationPositionError.PERMISSION_DENIED,
+                cy.goToMapView({
+                    queryParams:{'3d': is3D },
+                    withHash: true,
+                    geolocationMockupOptions: {
+                        errorCode: GeolocationPositionError.PERMISSION_DENIED,
+                    },
                 })
                 getGeolocationButtonAndClickIt()
                 testErrorMessage('geoloc_permission_denied')
             })
 
             it(`shows an alert telling the user geolocation is not able to be retrieved due to time out ${description}`, () => {
-                cy.goToMapView({ '3d': is3D }, true, {
-                    errorCode: GeolocationPositionError.TIMEOUT,
+                cy.goToMapView({
+                    queryParams: {'3d': is3D },
+                    withHash: true,
+                    geolocationMockupOptions: {
+                        errorCode: GeolocationPositionError.TIMEOUT,
+                    },
                 })
                 getGeolocationButtonAndClickIt()
                 testErrorMessage('geoloc_time_out')
             })
             it(`shows an alert telling the user geolocation is not available for other reason ${description}`, () => {
-                cy.goToMapView({ '3d': is3D }, true, {
-                    errorCode: GeolocationPositionError.POSITION_UNAVAILABLE,
+                cy.goToMapView({
+                    queryParams:{'3d': is3D },
+                    withHash: true,
+                    geolocationMockupOptions: {
+                        errorCode: GeolocationPositionError.POSITION_UNAVAILABLE,
+                    },
                 })
                 getGeolocationButtonAndClickIt()
                 testErrorMessage('geoloc_unknown')

--- a/packages/viewer/tests/cypress/tests-e2e/header.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/header.cy.js
@@ -105,8 +105,10 @@ describe('Test functions for the header / search bar', () => {
 
         it('Reload the app with current topic/lang when clicking on the swiss flag', () => {
             cy.goToMapView({
-                lang: 'fr',
-                topic: 'test-topic-standard',
+                queryParams:{
+                    lang: 'fr',
+                    topic: 'test-topic-standard',
+                },
             })
             clickOnLogo()
             // checking that topic and lang are still the same
@@ -116,8 +118,10 @@ describe('Test functions for the header / search bar', () => {
             // desktop only
             it('reloads the app the same way as above when click on the confederation text', () => {
                 cy.goToMapView({
-                    lang: 'fr',
-                    topic: 'test-topic-standard',
+                    queryParams:{
+                        lang: 'fr',
+                        topic: 'test-topic-standard',
+                    },
                 })
                 clickOnConfederationText()
                 // checking that topic and lang are still the same
@@ -136,9 +140,11 @@ describe('Test functions for the header / search bar', () => {
             // Check if the background layer is changed, when reset the app, the default background layer should be used
             // We go to different topic and change the background layer (that is different from the default one)
             cy.goToMapView({
-                lang: 'en',
-                topic: 'test-topic-standard-different-default-background',
-                bgLayer: 'test.background.layer2',
+                queryParams:{
+                    lang: 'en',
+                    topic: 'test-topic-standard-different-default-background',
+                    bgLayer: 'test.background.layer2',
+                },
             })
             checkLangAndTopic('en', 'test-topic-standard-different-default-background')
             checkCurrentBackgroundLayer('test.background.layer2')

--- a/packages/viewer/tests/cypress/tests-e2e/importToolFile.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/importToolFile.cy.js
@@ -55,7 +55,7 @@ describe('The Import File Tool', () => {
     }
 
     it('Import KML file', () => {
-        cy.goToMapView({}, true)
+        cy.goToMapView({withHash: true})
         cy.readStoreValue('state.layers.activeLayers').should('be.empty')
         cy.openMenuIfMobile()
         cy.get('[data-cy="menu-tray-tool-section"]:visible').click()
@@ -642,17 +642,18 @@ describe('The Import File Tool', () => {
             }
         )
 
-        cy.goToMapView(
-            {
-                layers: [
-                    `KML|${outOfBoundKMLUrl}`,
-                    `KML|${invalidFileOnlineUrl}`,
-                    `KML|${onlineUrlNotReachable}`,
-                    `KML|${validOnlineUrlWithInvalidContentType}`,
-                ].join(';'),
-            },
-            true
-        )
+        cy.goToMapView({
+            queryParams:
+                {
+                    layers: [
+                        `KML|${outOfBoundKMLUrl}`,
+                        `KML|${invalidFileOnlineUrl}`,
+                        `KML|${onlineUrlNotReachable}`,
+                        `KML|${validOnlineUrlWithInvalidContentType}`,
+                    ].join(';'),
+                },
+            withHash: true,
+        })
         cy.openMenuIfMobile()
 
         //---------------------------------------------------------------------
@@ -952,7 +953,7 @@ describe('The Import File Tool', () => {
         const gpxFileName = 'external-gpx-file.gpx'
         const gpxFileFixture = `import-tool/${gpxFileName}`
 
-        cy.goToMapView({}, true)
+        cy.goToMapView({withHash: true})
         cy.readStoreValue('state.layers.activeLayers').should('be.empty')
         cy.openMenuIfMobile()
         cy.get('[data-cy="menu-tray-tool-section"]:visible').click()

--- a/packages/viewer/tests/cypress/tests-e2e/importToolMaps.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/importToolMaps.cy.js
@@ -4,7 +4,7 @@ import { isMobile } from '../support/utils.js'
 describe('The Import Maps Tool', () => {
     const bgLayer = 'test.background.layer2'
     beforeEach(() => {
-        cy.goToMapView({}, true)
+        cy.goToMapView({withHash: true})
         cy.openMenuIfMobile()
     })
     it('Import external wms layers', () => {
@@ -552,12 +552,13 @@ describe('The Import Maps Tool', () => {
             },
             (request) => request.reply({ fixture: '256.png' })
         ).as('layer-1-getMap')
-        cy.goToMapView(
-            {
-                layers: 'WMS|https://fake.wms.base-1.url/?|ch.swisstopo-vd.official-survey',
-            },
-            true
-        )
+        cy.goToMapView({
+            queryParams:
+                {
+                    layers: 'WMS|https://fake.wms.base-1.url/?|ch.swisstopo-vd.official-survey',
+                },
+            withHash: true,
+        })
         cy.openMenuIfMobile()
         cy.readStoreValue('state.layers.activeLayers').should('have.length', 1)
         //cy.get('[data-cy="menu-active-layers"]').should('be.visible').click()

--- a/packages/viewer/tests/cypress/tests-e2e/infobox.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/infobox.cy.js
@@ -103,14 +103,14 @@ describe('The infobox', () => {
     })
     context('OpenLayers map', () => {
         beforeEach(() => {
-            cy.goToMapView({ layers: layer })
+            cy.goToMapView({queryParams:{layers: layer }})
         })
         generateInfoboxTestsForMapSelector('[data-cy="ol-map"]')
     })
 
     context('Changes the language of the infobox', () => {
         beforeEach(() => {
-            cy.goToMapView({ layers: layer })
+            cy.goToMapView({queryParams: {layers: layer }})
             cy.intercept('**/MapServer/**/htmlPopup**&lang=de**', {
                 fixture: 'html-popup-german.fixture.html',
             }).as('htmlPopupGerman')
@@ -144,14 +144,21 @@ describe('The infobox', () => {
     // TODO : BGDIINF_SB-3181
     context.skip('Cesium map', () => {
         beforeEach(() => {
-            cy.goToMapView({ layers: layer, '3d': true, sr: WEBMERCATOR.epsgNumber }, true)
+            cy.goToMapView({
+                queryParams: {
+                    layers: layer,
+                    '3d': true,
+                    sr: WEBMERCATOR.epsgNumber,
+                },
+                withHash: true,
+            })
             cy.waitUntilCesiumTilesLoaded()
         })
         // generateInfoboxTestsForMapSelector('[data-cy="cesium-map"]')
     })
     context('transition from 2D to 3D (and back to 2D)', () => {
         beforeEach(() => {
-            cy.goToMapView({ layers: layer })
+            cy.goToMapView({queryParams: {layers: layer }})
 
             cy.get('[data-cy="ol-map"]').click()
             cy.waitUntilState((_, getters) => {

--- a/packages/viewer/tests/cypress/tests-e2e/legacyParamImport.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/legacyParamImport.cy.js
@@ -15,14 +15,14 @@ describe('Test on legacy param import', () => {
             const lat = 47.3
             const lon = 7.3
             const zoom = 10.4
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     lat,
                     lon,
                     zoom: zoom,
                 },
-                false
-            )
+                withHash: false,
+            })
 
             // checking in the store that the position has not changed from what was in the URL
             cy.readStoreValue('state.position.zoom').should('eq', zoom)
@@ -36,13 +36,13 @@ describe('Test on legacy param import', () => {
             const lat = 47
             const lon = 7.5
             const zoom = 12
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     center: proj4(WGS84.epsg, DEFAULT_PROJECTION.epsg, [lon, lat]).join(','),
                     z: zoom,
                 },
-                true
-            )
+                withHash: true,
+            })
 
             // checking in the store that the position has not changed from what was in the URL
             cy.readStoreValue('state.position.zoom').should('eq', zoom)
@@ -56,14 +56,14 @@ describe('Test on legacy param import', () => {
             const E = 2660000
             const N = 1200000
             const lv95zoom = 8
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     E,
                     N,
                     zoom: lv95zoom,
                 },
-                false
-            )
+                withHash: false,
+            })
 
             cy.readStoreValue('state.position.zoom').should('eq', lv95zoom)
 
@@ -78,13 +78,13 @@ describe('Test on legacy param import', () => {
         it('center where expected when given a X, Y coordinate in LV95', () => {
             // NOTE on the old viewer Y := correspond to x in EPSG definition
             // NOTE on the old viewer X := correspond to y in EPSG definition
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     Y: 2660000,
                     X: 1200000,
                 },
-                false
-            )
+                withHash: false,
+            })
             // checking that we are reprojected to lon: 8.2267733° lat: 46.9483767°
             // (according to https://epsg.io/transform#s_srs=2056&t_srs=4326&x=2660000.0000000&y=1200000.0000000)
             cy.readStoreValue('getters.centerEpsg4326').should((center) => {
@@ -96,13 +96,14 @@ describe('Test on legacy param import', () => {
         it('center where expected when given a X, Y coordinate in LV03', () => {
             // NOTE on the old viewer Y := correspond to x in EPSG definition
             // NOTE on the old viewer X := correspond to y in EPSG definition
-            cy.goToMapView(
+            cy.goToMapView({
+                queryParams:
                 {
                     Y: 600000,
                     X: 200000,
                 },
-                false
-            )
+                withHash: false,
+            })
             // checking that we are reprojected to lon: 7.438632° lat: 46.9510828°
             // (according to https://epsg.io/transform#s_srs=21781&t_srs=4326&x=600000.0000000&y=200000.0000000)
             cy.readStoreValue('getters.centerEpsg4326').should((center) => {
@@ -149,14 +150,14 @@ describe('Test on legacy param import', () => {
         })
 
         it('Combines all old layers_*** params into the new one', () => {
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     layers: 'test.wms.layer,test.wmts.layer',
                     layers_opacity: '0.6,0.5',
                     layers_visibility: 'true,false',
                 },
-                false
-            )
+                withHash: false,
+            })
             cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
                 expect(activeLayers).to.be.an('Array').length(2)
                 const [wmsLayer, wmtsLayer] = activeLayers
@@ -169,14 +170,14 @@ describe('Test on legacy param import', () => {
             })
         })
         it('is able to import an external KML from a legacy param', () => {
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     layers: `KML||${kmlServiceBaseUrl}${kmlServiceFilePath}`,
                     layers_opacity: '0.6',
                     layers_visibility: 'true',
                 },
-                false
-            )
+                withHash: false,
+            })
             cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
                 expect(activeLayers).to.be.an('Array').length(1)
                 const [kmlLayer] = activeLayers
@@ -187,12 +188,12 @@ describe('Test on legacy param import', () => {
             })
         })
         it('is able to import an external KML from a legacy adminId query param', () => {
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     adminId: adminId,
                 },
-                false
-            )
+                withHash: false,
+            })
             cy.wait('@get-kml-metada-by-admin-id')
             cy.wait('@get-kml')
             cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
@@ -205,12 +206,12 @@ describe('Test on legacy param import', () => {
             })
         })
         it("don't keep KML adminId in URL after import", () => {
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     adminId: adminId,
                 },
-                false
-            )
+                withHash: false,
+            })
             cy.wait('@get-kml-metada-by-admin-id')
             cy.wait('@get-kml')
             cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
@@ -224,15 +225,15 @@ describe('Test on legacy param import', () => {
             cy.url().should('not.contain', adminId)
         })
         it('is able to import an external KML from a legacy adminId query param with other layers', () => {
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     adminId: adminId,
                     layers: 'test.wms.layer,test.wmts.layer',
                     layers_opacity: '0.6,0.5',
                     layers_visibility: 'true,false',
                 },
-                false
-            )
+                withHash: false,
+            })
             cy.wait('@get-kml-metada-by-admin-id')
             cy.wait('@get-kml')
             cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
@@ -270,12 +271,12 @@ describe('Test on legacy param import', () => {
                     ],
                 },
             }).as('search-locations')
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     swisssearch: '1530 Payerne',
                 },
-                false
-            )
+                withHash: false,
+            })
             cy.readStoreValue('state.search.query').should('eq', '1530 Payerne')
             cy.url().should('not.contain', 'swisssearch')
             cy.get('[data-cy="searchbar"]').click()
@@ -293,15 +294,15 @@ describe('Test on legacy param import', () => {
         it('External WMS layer', () => {
             cy.getExternalWmsMockConfig().then((mockConfig) => {
                 const [mockExternalWms1] = mockConfig
-                cy.goToMapView(
-                    {
+                cy.goToMapView({
+                    queryParams:{
                         layers: `test.wms.layer,WMS||${mockExternalWms1.name}||${mockExternalWms1.baseUrl}||${mockExternalWms1.id}||1.3.0`,
                         layers_opacity: '1,1',
                         layers_visibility: 'false,true',
                         layers_timestamp: ',',
                     },
-                    false
-                )
+                    withHash: false,
+                })
                 cy.wait(`@externalWMS-GetCap-${mockExternalWms1.baseUrl}`)
                 cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
                     expect(activeLayers).to.be.an('Array').length(2)
@@ -323,15 +324,15 @@ describe('Test on legacy param import', () => {
         it('External WMTS layer', () => {
             cy.getExternalWmtsMockConfig().then((mockConfig) => {
                 const [mockExternalWmts1] = mockConfig
-                cy.goToMapView(
-                    {
+                cy.goToMapView({
+                    queryParams:{
                         layers: `test.wmts.layer,WMTS||${mockExternalWmts1.id}||${mockExternalWmts1.baseUrl}`,
                         layers_opacity: '1,1',
                         layers_visibility: 'false,true',
                         layers_timestamp: '18641231,',
                     },
-                    false
-                )
+                    withHash: false,
+                })
                 cy.wait(`@externalWMTS-GetCap-${mockExternalWmts1.baseUrl}`)
                 cy.readStoreValue('state.layers.activeLayers').then((activeLayers) => {
                     expect(activeLayers).to.be.an('Array').length(2)
@@ -367,16 +368,16 @@ describe('Test on legacy param import', () => {
         const pitch = -45
 
         it('transfers camera parameter from legacy URL to the new URL', () => {
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     lat,
                     lon,
                     elevation,
                     heading,
                     pitch,
                 },
-                false
-            )
+                withHash: false,
+            })
 
             // checking in the store that the parameters have been converted into the new 3D parameters
             cy.readStoreValue('state.cesium.active').should('eq', true) // cesium should be active
@@ -398,14 +399,14 @@ describe('Test on legacy param import', () => {
         })
 
         it('transfers camera parameter from legacy URL to the new URL only heading', () => {
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     lat,
                     lon,
                     heading,
                 },
-                false
-            )
+                withHash: false,
+            })
 
             // checking in the store that the parameters have been converted into the new 3D parameters
             cy.readStoreValue('state.cesium.active').should('eq', true) // cesium should be active
@@ -424,14 +425,14 @@ describe('Test on legacy param import', () => {
         // camera=7.038834,46.766017,193985.5,-47,319,
         // camera=8.225457,46.858429,738575.8,-90,,
         it('transfers camera parameter from legacy URL to the new URL only elevation', () => {
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     lat,
                     lon,
                     elevation,
                 },
-                false
-            )
+                withHash: false,
+            })
 
             // checking in the store that the parameters have been converted into the new 3D parameters
             cy.readStoreValue('state.cesium.active').should('eq', true) // cesium should be active
@@ -453,13 +454,13 @@ describe('Test on legacy param import', () => {
     context('Extra Parameter Imports', () => {
         it('shows the compare slider at the correct position', () => {
             /*  */
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     layers: 'test-1.wms.layer',
                     swipe_ratio: '0.3',
                 },
-                false
-            )
+                withHash: false,
+            })
             // initial slider position is width * 0.3 -20
             cy.get('[data-cy="compareSlider"]').then((slider) => {
                 cy.readStoreValue('state.ui.width').should((width) => {
@@ -472,14 +473,15 @@ describe('Test on legacy param import', () => {
             cy.get('[data-cy="compareSlider"]').should('be.visible')
         })
     })
+    // TODO: define why it is skipped, and solve the issue.
     it.skip('should show the time slider on startup when setting it in the URL', () => {
-        cy.goToMapView(
-            {
+        cy.goToMapView({
+            queryParams:{
                 layers: `test.timeenabled.wmts.layer`,
                 time: 2019,
             },
-            false
-        )
+            withHash: false,
+        })
         cy.get('[data-cy="time-slider-current-year"]').should('contain', 2019)
     })
     context('Feature Pre Selection Import', () => {
@@ -499,12 +501,12 @@ describe('Test on legacy param import', () => {
                 // ---------------------------------------------------------------------------------
                 cy.log('When showTooltip is not specified, we should have no tooltip')
 
-                cy.goToMapView(
-                    {
+                cy.goToMapView({
+                    queryParams:{
                         'ch.babs.kulturgueter': featuresIds.join(','),
                     },
-                    false
-                )
+                    withHash: false,
+                })
                 checkFeatures(featuresIds)
                 cy.readStoreValue('state.ui.featureInfoPosition').should(
                     'be.equal',
@@ -517,13 +519,13 @@ describe('Test on legacy param import', () => {
                     'When showTooltip is true, featureInfo should be bottom panel on devices with width < 400 px '
                 )
 
-                cy.goToMapView(
-                    {
+                cy.goToMapView({
+                    queryParams:{
                         'ch.babs.kulturgueter': featuresIds.join(','),
                         showTooltip: 'true',
                     },
-                    false
-                )
+                    withHash: false,
+                })
                 checkFeatures(featuresIds)
                 cy.readStoreValue('state.ui.featureInfoPosition').should(
                     'be.equal',
@@ -536,13 +538,13 @@ describe('Test on legacy param import', () => {
                     'When showTooltip is true, featureInfo should be default on devices with width >= 400 px '
                 )
                 cy.viewport(400, 800)
-                cy.goToMapView(
-                    {
+                cy.goToMapView({
+                    queryParams:{
                         'ch.babs.kulturgueter': featuresIds.join(','),
                         showTooltip: 'true',
                     },
-                    false
-                )
+                    withHash: false,
+                })
                 checkFeatures(featuresIds)
                 cy.readStoreValue('state.ui.featureInfoPosition').should(
                     'be.equal',
@@ -553,13 +555,13 @@ describe('Test on legacy param import', () => {
                 // ---------------------------------------------------------------------------------
                 cy.log('When showTooltip is given a fantasist value, we should have no tooltip')
 
-                cy.goToMapView(
-                    {
+                cy.goToMapView({
+                    queryParams:{
                         'ch.babs.kulturgueter': featuresIds.join(','),
                         showTooltip: 'aFantasyValue',
                     },
-                    false
-                )
+                    withHash: false,
+                })
                 checkFeatures(featuresIds)
                 cy.readStoreValue('state.ui.featureInfoPosition').should(
                     'be.equal',

--- a/packages/viewer/tests/cypress/tests-e2e/menuTray.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/menuTray.cy.js
@@ -125,7 +125,10 @@ function measureMenu(shouldHaveMaxSize) {
  * @param {any} nbSelectedLayers Number of menu items in the active layers list
  */
 function init(nbLayers, nbSelectedLayers) {
-    cy.goToMapView({}, false, {}, getFixturesAndIntercepts(nbLayers, nbSelectedLayers))
+    cy.goToMapView({
+        withHash: false,
+        fixturesAndIntercepts: getFixturesAndIntercepts(nbLayers, nbSelectedLayers),
+    })
     cy.readStoreValue('getters')
         .as('storeGetters')
         .then((getters) => {
@@ -145,7 +148,7 @@ function init(nbLayers, nbSelectedLayers) {
 
 function waitForAnimationsToFinish() {
     // animations last 0.2s
-    cy.wait(200)  
+    cy.wait(200)
 }
 
 /**

--- a/packages/viewer/tests/cypress/tests-e2e/mouseposition.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/mouseposition.cy.js
@@ -107,8 +107,10 @@ describe('Test mouse position and interactions', () => {
         })
         beforeEach(() => {
             cy.goToMapView({
-                center: center.join(','),
-                z: DEFAULT_PROJECTION.getDefaultZoom() + 3,
+                queryParams:{
+                    center: center.join(','),
+                    z: DEFAULT_PROJECTION.getDefaultZoom() + 3,
+                },
             })
         })
         it('shows coordinate under the mouse cursor in the footer, according to the selected projection format', () => {
@@ -138,8 +140,10 @@ describe('Test mouse position and interactions', () => {
         })
         beforeEach(() => {
             cy.goToMapView({
-                center: center.join(','),
-                z: DEFAULT_PROJECTION.getDefaultZoom() + 2.23,
+                queryParams:{
+                    center: center.join(','),
+                    z: DEFAULT_PROJECTION.getDefaultZoom() + 2.23,
+                },
             })
         })
         it('shows the LocationPopUp when rightclick occurs on the map', () => {

--- a/packages/viewer/tests/cypress/tests-e2e/print.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/print.cy.js
@@ -257,14 +257,14 @@ describe('Testing print', () => {
             }).as('kmlHeadRequest')
             cy.intercept('GET', '**/**.kml', { fixture: kmlFixture }).as('kmlGetRequest')
 
-            cy.goToMapView(
-                {
+            cy.goToMapView({
+                queryParams:{
                     layers: `KML|${getServiceKmlBaseUrl()}some-kml-file.kml`,
                     z: 9,
                     center,
                 },
-                true
-            )
+                withHash: true,
+            })
             cy.wait(['@kmlHeadRequest', '@kmlGetRequest'])
             cy.readStoreValue('state.layers.activeLayers').should('have.length', 1)
 
@@ -280,15 +280,17 @@ describe('Testing print', () => {
 
         it('should send a print request to mapfishprint (with layers added)', () => {
             cy.goToMapView({
-                layers: [
-                    'test-1.wms.layer',
-                    'test-2.wms.layer,,',
-                    'test-3.wms.layer,f',
-                    'test-4.wms.layer,f,0.4',
-                    // add duplicate layer to test duplicate attributions
-                    'test.wmts.layer,,0.5',
-                    'test.wmts.layer,,0.8',
-                ].join(';'),
+                queryParams: {
+                    layers: [
+                        'test-1.wms.layer',
+                        'test-2.wms.layer,,',
+                        'test-3.wms.layer,f',
+                        'test-4.wms.layer,f,0.4',
+                        // add duplicate layer to test duplicate attributions
+                        'test.wmts.layer,,0.5',
+                        'test.wmts.layer,,0.8',
+                    ].join(';'),
+                },
             })
             launchPrint({
                 withLegend: true,
@@ -623,14 +625,14 @@ describe('Testing print', () => {
                 layerObjects.forEach((layer) => {
                     layer.visible = true
                 })
-                cy.goToMapView(
-                    {
+                cy.goToMapView({
+                    queryParams:{
                         layers: layerObjects
                             .map((object) => transformLayerIntoUrlString(object))
                             .join(';'),
                     },
-                    true
-                )
+                    withHash: true,
+                })
 
                 cy.get('[data-cy="menu-print-section"]').should('be.visible').click()
                 cy.get('[data-cy="menu-print-form"]').should('be.visible')
@@ -710,14 +712,14 @@ describe('Testing print', () => {
                 layerObjects.forEach((layer) => {
                     layer.visible = true
                 })
-                cy.goToMapView(
-                    {
+                cy.goToMapView({
+                    queryParams:{
                         layers: layerObjects
                             .map((object) => transformLayerIntoUrlString(object))
                             .join(';'),
                     },
-                    true
-                )
+                    withHash: true,
+                })
 
                 launchPrint({
                     withLegend: true,

--- a/packages/viewer/tests/cypress/tests-e2e/search/search-results.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/search/search-results.cy.js
@@ -492,13 +492,14 @@ describe('Test the search bar result handling', () => {
                 ],
             },
         }).as('search-locations')
-        cy.goToMapView(
-            {
-                swisssearch: '1530 Payerne',
-                swisssearch_autoselect: 'true',
-            },
-            false
-        )
+        cy.goToMapView({
+            queryParams:
+                {
+                    swisssearch: '1530 Payerne',
+                    swisssearch_autoselect: 'true',
+                },
+            withHash: false,
+        })
         cy.readStoreValue('state.search.query').should('eq', '1530 Payerne')
         cy.url().should('not.contain', 'swisssearch')
         cy.url().should('not.contain', 'swisssearch_autoselect')
@@ -546,12 +547,13 @@ describe('Test the search bar result handling', () => {
         cy.log('Legacy parser / router (without #map part in the URL)')
         // --------------------------------------------------------------------------- //
         cy.log('Swisssearch only -> center to swisssearch coordinates')
-        cy.goToMapView(
-            {
-                swisssearch: swissSearchString,
-            },
-            false
-        )
+        cy.goToMapView({
+            queryParams:
+                {
+                    swisssearch: swissSearchString,
+                },
+            withHash: false,
+        })
         testQueryPositionCrosshairStore({
             searchQuery: swissSearchString,
             expectedCenter: swissSearchXYCoordinates,
@@ -564,13 +566,14 @@ describe('Test the search bar result handling', () => {
         cy.log(
             'Swisssearch with crosshair -> center to swisssearch coordinates with crosshair in swisssearch coordinate'
         )
-        cy.goToMapView(
-            {
-                swisssearch: swissSearchString,
-                crosshair: CrossHairs.cross,
-            },
-            false
-        )
+        cy.goToMapView({
+            queryParams:
+                {
+                    swisssearch: swissSearchString,
+                    crosshair: CrossHairs.cross,
+                },
+            withHash: false,
+        })
         testQueryPositionCrosshairStore({
             searchQuery: swissSearchString,
             expectedCenter: swissSearchXYCoordinates,
@@ -584,12 +587,13 @@ describe('Test the search bar result handling', () => {
 
         // --------------------------------------------------------------------------- //
         cy.log('Swisssearch only -> center to swisssearch coordinates')
-        cy.goToMapView(
-            {
-                swisssearch: swissSearchString,
-            },
-            true
-        )
+        cy.goToMapView({
+            queryParams:
+                {
+                    swisssearch: swissSearchString,
+                },
+            withHash: true,
+        })
         testQueryPositionCrosshairStore({
             searchQuery: swissSearchString,
             expectedCenter: swissSearchXYCoordinates,
@@ -602,13 +606,14 @@ describe('Test the search bar result handling', () => {
         cy.log(
             'Swisssearch with crosshair -> center to swisssearch coordinates with crosshair in swisssearch coordinate'
         )
-        cy.goToMapView(
-            {
-                swisssearch: swissSearchString,
-                crosshair: CrossHairs.cross,
-            },
-            true
-        )
+        cy.goToMapView({
+            queryParams:
+                {
+                    swisssearch: swissSearchString,
+                    crosshair: CrossHairs.cross,
+                },
+            withHash: true,
+        })
         testQueryPositionCrosshairStore({
             searchQuery: swissSearchString,
             expectedCenter: swissSearchXYCoordinates,
@@ -621,13 +626,14 @@ describe('Test the search bar result handling', () => {
         cy.log(
             'Swisssearch with crosshair and crosshair location -> center to swisssearch coordinates with crosshair in crosshair coordinate'
         )
-        cy.goToMapView(
+        cy.goToMapView({
+            queryParams:
             {
                 swisssearch: swissSearchString,
                 crosshair: `${CrossHairs.cross},${crossHairX},${crossHairY}`,
             },
-            true
-        )
+            withHash: true,
+        })
         testQueryPositionCrosshairStore({
             searchQuery: swissSearchString,
             expectedCenter: swissSearchXYCoordinates,

--- a/packages/viewer/tests/cypress/tests-e2e/shareShortLink.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/shareShortLink.cy.js
@@ -313,7 +313,7 @@ describe('Testing the share menu', () => {
                 cy.get('[data-cy="menu-button"]').click()
 
                 // Test local import
-                cy.goToMapView({}, true)
+                cy.goToMapView({ withHash: true })
                 cy.readStoreValue('state.layers.activeLayers').should('be.empty')
                 cy.openMenuIfMobile()
                 cy.get('[data-cy="menu-tray-tool-section"]:visible').click()

--- a/packages/viewer/tests/cypress/tests-e2e/timeCompareSlider.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/timeCompareSlider.cy.js
@@ -75,9 +75,11 @@ describe('Open Time and Compare Slider together', () => {
             cy.viewport(1920, 1080)
 
             cy.goToMapView({
-                layers: [`${timedLayerId}@year=${preSelectedYear}`, testLayer1, testLayer2].join(
-                    ';'
-                ),
+                queryParams:{
+                    layers: [`${timedLayerId}@year=${preSelectedYear}`, testLayer1, testLayer2].join(
+                        ';'
+                    ),
+                },
             })
 
             // Initial state, no slider should be active
@@ -167,9 +169,11 @@ describe('Open Time and Compare Slider together', () => {
             cy.viewport(1920, 1080)
 
             cy.goToMapView({
-                layers: [`${timedLayerId}@year=${preSelectedYear}`, testLayer1, testLayer2].join(
-                    ';'
-                ),
+                queryParams:{
+                    layers: [`${timedLayerId}@year=${preSelectedYear}`, testLayer1, testLayer2].join(
+                        ';'
+                    ),
+                },
             })
 
             // Initial state, no slider should be active
@@ -215,7 +219,9 @@ describe('Open Time and Compare Slider together', () => {
             cy.viewport(1920, 1080)
             const newSelectedTimeStamp = '20200101'
             cy.goToMapView({
-                layers: [`${timedLayerId}@year=${preSelectedYear}`].join(';'),
+                queryParams:{
+                    layers: [`${timedLayerId}@year=${preSelectedYear}`].join(';'),
+                },
             })
 
             // Duplicate the time enabled layer

--- a/packages/viewer/tests/cypress/tests-e2e/timeSlider.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/timeSlider.cy.js
@@ -31,24 +31,18 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             cy.viewport(1920, 1080)
             //----------------------------------------------------------------------------------------------------
             cy.log(': Invisible time layer given. time slider button should not appear')
-            cy.goToMapView({
-                layers: `${timedLayerId},f`,
-            })
+            cy.goToMapView({ queryParams:{ layers: `${timedLayerId},f` }})
             cy.get('[data-cy="time-slider-button"]').should('not.exist')
 
             // ----------------------------------------------------------------------------------------------------
             cy.log('visible non time enabled Layer, the button should not be visible')
-            cy.goToMapView({
-                layers: standard_layer,
-            })
+            cy.goToMapView({ queryParams: { layers: standard_layer }})
             cy.get('[data-cy="time-slider-button"]').should('not.exist')
 
             // ----------------------------------------------------------------------------------------------------
             cy.log('The following few tests use the same goToMapView call')
             cy.log('With a visible time enabled Layer, the button should be visible')
-            cy.goToMapView({
-                layers: `${timedLayerId}@year=${preSelectedYear}`,
-            })
+            cy.goToMapView({ queryParams: { layers: `${timedLayerId}@year=${preSelectedYear}` }})
             cy.get('[data-cy="time-slider-button"]').should('be.visible')
             // ----------------------------------------------------------------------------------------------------
             cy.log(
@@ -87,7 +81,7 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             // proper way would be to use cy.tick, but I can't get it to work
             // it somehow gets into a race condition and the rendering isn't updated
             // after the debouncing is done
-             
+
             cy.wait(1000)
             cy.get('[data-cy="time-slider-button"]').click()
             cy.openMenuIfMobile()
@@ -132,8 +126,10 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             )
 
             cy.goToMapView({
-                layers: `${timedLayerId}@year=2019,f,;${timedLayerIdWithOddYear}@year=2009;${timedLayerIdWithAllYear}@year=2009`,
-                timeSlider: 2013,
+                queryParams:{
+                    layers: `${timedLayerId}@year=2019,f,;${timedLayerIdWithOddYear}@year=2009;${timedLayerIdWithAllYear}@year=2009`,
+                    timeSlider: 2013
+                },
             })
             cy.get('[data-cy="time-slider-bar-cursor-year"]')
                 .as('timeSliderYearCursor')
@@ -206,7 +202,7 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
                 'If there is data common to all layers, the time slider goes to the youngest year in common'
             )
             cy.get('[data-cy="swiss-flag"]').as('swissFlag').click()
-            cy.goToMapView({ layers: `${timedLayerId};${timedLayerIdWithOddYear}` })
+            cy.goToMapView({ queryParams: {layers: `${timedLayerId};${timedLayerIdWithOddYear}` }})
             cy.get('[data-cy="time-slider-button"]').as('timeSliderButton').click()
             cy.get('@timeSliderYearCursor').should('have.value', '2021')
             cy.url().should((url) => url.includes('timeSlider=2021'))
@@ -217,8 +213,10 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
 
             cy.get('@swissFlag').click()
             cy.goToMapView({
-                layers: `${timedLayerId},f`,
-                timeSlider: 2003,
+                queryParams:{
+                    layers: `${timedLayerId},f`,
+                    timeSlider: 2003,
+                },
             })
             cy.get('@timeSliderButton').should('not.exist')
             cy.url().should((url) => !url.includes('timeSlider='))
@@ -231,7 +229,9 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
 
             cy.get('@swissFlag').click()
             cy.goToMapView({
-                layers: `${timedLayerId};${timedLayerIdWithOddYear};${timedLayerIdWithAllYear}`,
+                queryParams:{
+                    layers: `${timedLayerId};${timedLayerIdWithOddYear};${timedLayerIdWithAllYear}`,
+                },
             })
             cy.get('@timeSliderButton').click()
 
@@ -254,12 +254,12 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
                     'Loading the app with a time slider value present in config but outside of default range should work without raising errors'
                 )
                 cy.get('@swissFlag').click()
-                cy.goToMapView({ layers: timedLayerId, timeSlider: oldestYearInConfig })
+                cy.goToMapView({ queryParams: { layers: timedLayerId, timeSlider: oldestYearInConfig }})
                 cy.get('@timeSliderYearCursor').should('have.value', oldestYearInConfig)
                 cy.url().should((url) => !url.includes('timeSlider='))
 
                 cy.get('@swissFlag').click()
-                cy.goToMapView({ layers: timedLayerId, timeSlider: youngestYearInConfig })
+                cy.goToMapView({ queryParams: { layers: timedLayerId, timeSlider: youngestYearInConfig }})
                 cy.get('@timeSliderYearCursor').should('have.value', youngestYearInConfig)
                 cy.url().should((url) => !url.includes('timeSlider='))
             })
@@ -268,15 +268,15 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             cy.log('The time slider should not appear and the url should not show the parameter')
 
             cy.get('@swissFlag').click()
-            cy.goToMapView({ layers: timedLayerId, timeSlider: DEFAULT_OLDEST_YEAR - 1250 })
+            cy.goToMapView({ queryParams: { layers: timedLayerId, timeSlider: DEFAULT_OLDEST_YEAR - 1250 }})
             cy.get('@timeSliderYearCursor').should('not.exist')
             cy.url().should((url) => !url.includes('timeSlider='))
 
-            cy.goToMapView({ layers: timedLayerId, timeSlider: DEFAULT_YOUNGEST_YEAR + 1250 })
+            cy.goToMapView({ queryParams: { layers: timedLayerId, timeSlider: DEFAULT_YOUNGEST_YEAR + 1250 }})
             cy.get('@timeSliderYearCursor').should('not.exist')
             cy.url().should((url) => !url.includes('timeSlider='))
 
-            cy.goToMapView({ layers: timedLayerId, timeSlider: 'aCompletelyInvalidValue' })
+            cy.goToMapView({ queryParams: { layers: timedLayerId, timeSlider: 'aCompletelyInvalidValue' }})
             cy.get('@timeSliderYearCursor').should('not.exist')
             cy.url().should((url) => !url.includes('timeSlider='))
 
@@ -288,7 +288,7 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
 
         it('behaves correctly when years are being entered in the input', () => {
             cy.viewport(1920, 1080)
-            cy.goToMapView({ layers: `${timedLayerId}@year=2019`, timeSlider: 2017 })
+            cy.goToMapView({ queryParams: { layers: `${timedLayerId}@year=2019`, timeSlider: 2017 }})
             cy.get(`[data-cy="button-open-visible-layer-settings-${timedLayerId}-0"]`).click()
             cy.get(`[data-cy="button-duplicate-layer-${timedLayerId}-0"]`).click()
             cy.get(`[data-cy="button-toggle-visibility-layer-${timedLayerId}-0"]`).click()
@@ -339,7 +339,7 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
                     // proper way would be to use cy.tick, but I can't get it to work
                     // it somehow gets into a race condition and the rendering isn't updated
                     // after the debouncing is done
-                     
+
                     cy.wait(750)
 
                     cy.get('[data-cy="time-slider-bar-cursor-arrow"]')
@@ -353,8 +353,10 @@ describe('Cypress tests covering the time slider, its functionalities and its UR
             // ----------------------------------------------------------------------------------------------------
             cy.log('Going to the map, the dropdown appears')
             cy.goToMapView({
-                layers: `${timedLayerId}@year=${preSelectedYear}`,
-                timeSlider: preSelectedYear,
+                queryParams:{
+                    layers: `${timedLayerId}@year=${preSelectedYear}`,
+                    timeSlider: preSelectedYear,
+                },
             })
             cy.get('[data-cy="time-slider-bar"]').should('not.be.visible')
             cy.get('[data-cy="time-slider-dropdown"]').should('be.visible')

--- a/packages/viewer/tests/cypress/tests-e2e/topics.cy.js
+++ b/packages/viewer/tests/cypress/tests-e2e/topics.cy.js
@@ -69,8 +69,10 @@ describe('Topics', () => {
     it('handle topic changes correctly', () => {
         cy.log('loads topic correctly at app startup')
         cy.goToMapView({
-            layers: 'test.wmts.layer',
-            bgLayer: 'void',
+            queryParams: {
+                layers: 'test.wmts.layer',
+                bgLayer: 'void',
+            },
         })
         // checking that all topics have been loaded
         cy.fixture('topics.fixture').then((mockupTopics) => {
@@ -262,8 +264,10 @@ describe('Topics', () => {
             'Opens nodes in the topic tree if set in the URL and are different from the default in topic'
         )
         cy.goToMapView({
-            topic: 'test-topic-with-active-layers',
-            catalogNodes: 'test-topic-with-active-layers,2,5',
+            queryParams:{
+                topic: 'test-topic-with-active-layers',
+                catalogNodes: 'test-topic-with-active-layers,2,5',
+            },
         })
         cy.openMenuIfMobile()
 
@@ -288,8 +292,10 @@ describe('Topics', () => {
         cy.viewport(1920, 1080)
 
         cy.goToMapView({
-            layers: 'test.wmts.layer',
-            bgLayer: 'void',
+            queryParams:{
+                layers: 'test.wmts.layer',
+                bgLayer: 'void',
+            },
         })
         cy.wait(['@topics', '@topic-ech', '@layerConfig', '@routeChange', '@routeChange'])
         cy.log('it opens the layer legend popup when clicking the info button')


### PR DESCRIPTION
- Issue: the `goToMapView` and `goToEmbedView` functions have had their signatures changed to use options as parameters, but tests were not changed to reflect those changes.

- Fix: We changed the signature of all those functions.

[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-1383-fix-tests-signatures/index.html)