### PR TITLE
PB-2246: hide label stems when labels begin fading

### DIFF
--- a/packages/mapviewer/src/modules/map/components/cesium/utils/useSwissnamesLabelsRenderer.composable.js
+++ b/packages/mapviewer/src/modules/map/components/cesium/utils/useSwissnamesLabelsRenderer.composable.js
@@ -75,10 +75,16 @@ function addLabel(collection, feature, position, distanceDisplayCondition) {
 function addFeature(labelCollection, connectorCollection, feature) {
     const groundPosition = getPosition(feature, 'groundHeight')
     const labelPosition = getPosition(feature, 'labelHeight')
-    const distance = new DistanceDisplayCondition(0, feature.getProperty('maxDistance'))
+    const maxDistance = feature.getProperty('maxDistance')
+    const labelDistance = new DistanceDisplayCondition(0, maxDistance)
+    const connectorDistance = new DistanceDisplayCondition(0, maxDistance * FADE_START_RATIO)
     return {
-        connector: addConnector(connectorCollection, [groundPosition, labelPosition], distance),
-        label: addLabel(labelCollection, feature, labelPosition, distance),
+        connector: addConnector(
+            connectorCollection,
+            [groundPosition, labelPosition],
+            connectorDistance
+        ),
+        label: addLabel(labelCollection, feature, labelPosition, labelDistance),
     }
 }
 


### PR DESCRIPTION
## Description

Hide 3D label stems at the distance where their labels begin fading. This avoids detached stems without per-frame updates or a custom shader.



[Test link](https://sys-map.dev.bgdi.ch/preview/fix-pb-2246-hide-label-stems-during-fade/index.html)