### PR TITLE
chore: limit Cesium building tile cache

### DIFF
--- a/packages/mapviewer/src/modules/map/components/cesium/CesiumVectorLayer.vue
+++ b/packages/mapviewer/src/modules/map/components/cesium/CesiumVectorLayer.vue
@@ -36,6 +36,9 @@ useAddPrimitiveLayer(
     Cesium3DTileset.fromUrl(url.value, {
         // with default value 16 we do not load a lot of building tiles (leading to gaps)
         maximumScreenSpaceError: layerId.value === CESIUM_BUILDING_LAYER_ID ? 10 : 16,
+        cacheBytes: layerId.value === CESIUM_BUILDING_LAYER_ID ? 256 * 1024 ** 2 : undefined,
+        maximumCacheOverflowBytes:
+            layerId.value === CESIUM_BUILDING_LAYER_ID ? 128 * 1024 ** 2 : undefined,
     }),
     opacity
 )


### PR DESCRIPTION
## Description

Limit the Cesium Swissbuildings3D tile cache to 256 MiB with 128 MiB overflow. This bounds retained building tile content without changing screen-space error or active rendering detail. Other Cesium tilesets keep their defaults.

## Benchmark

- Paired the deployed PR against the same build with Cesium's 512/512 MiB defaults restored at runtime
- Covered 16 locations, repeated nationwide eviction/revisit passes, rapid combined navigation, seeded random navigation, and building-layer recreation
- Peak building-tile payload: 255.99 MiB capped versus 511.97 MiB control (50% lower)
- Screen-space error stayed at 10; 95/96 paired location checkpoints had identical selected building triangles and draw commands
- The remaining checkpoint was a non-reproduced camera landing issue; a focused follow-up passed 60/60 landings with each cache setting
- No Cesium render errors, page exceptions, browser crashes, WebGL context losses, or unhandled rejections
- Mapviewer unit tests: 334 passed, 3 skipped; ESLint and existing CI pass

This verifies the Cesium building-tile payload reduction and functional equivalence for the tested scenarios. It does not claim a 50% reduction in total browser RSS.

[Test link](https://sys-map.dev.bgdi.ch/preview/chore-limit-cesium-building-cache/index.html)


[Test link](https://sys-map.dev.bgdi.ch/preview/chore-limit-cesium-building-cache/index.html)